### PR TITLE
Switch to a Debian based runtime, using SquashFS instead of ext4

### DIFF
--- a/.github/workflows/test-integration-fakedata.yml
+++ b/.github/workflows/test-integration-fakedata.yml
@@ -20,10 +20,10 @@ jobs:
           cd examples/volumes
           bash build_squashfs.sh
 
-      - name: Build the rootfs
+      - name: Update the rootfs
         run: |
-          cd runtimes/aleph-alpine-3.13-python/
-          cp /var/tmp/rootfs.ext4 ./
+          cd runtimes/aleph-debian-11-python/
+          cp -pr /var/tmp/rootfs-debian ./rootfs
           bash update_inits.sh
 #          bash ./create_disk_image.sh
 

--- a/docker/run_vm_supervisor.sh
+++ b/docker/run_vm_supervisor.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-docker build -ti -t aleph-vm-supervisor -f docker/vm_supervisor.dockerfile .
-docker run -ti --rm \
+podman build -ti -t aleph-vm-supervisor -f docker/vm_supervisor.dockerfile .
+podman run -ti --rm \
   -v $(pwd):/root/aleph-vm \
   --device /dev/kvm \
   aleph-vm-supervisor \

--- a/docker/vm_supervisor.dockerfile
+++ b/docker/vm_supervisor.dockerfile
@@ -18,7 +18,7 @@ RUN curl -fsSL https://github.com/firecracker-microvm/firecracker/releases/downl
 RUN ln /opt/firecracker/firecracker-v* /opt/firecracker/firecracker
 RUN ln /opt/firecracker/jailer-v* /opt/firecracker/jailer
 
-RUN pip3 install typing-extensions aleph-message>=0.1.8 pydantic
+RUN pip3 install typing-extensions aleph-message>=0.1.10 pydantic
 
 RUN mkdir /srv/jailer
 

--- a/runtimes/aleph-debian-11-python/create_disk_image.sh
+++ b/runtimes/aleph-debian-11-python/create_disk_image.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+umount /mnt/rootfs
+
+set -euf
+
+dd if=/dev/zero of=./rootfs.ext4 bs=1M count=1000
+mkfs.ext4 ./rootfs.ext4
+mkdir -p /mnt/rootfs
+mount ./rootfs.ext4 /mnt/rootfs
+
+debootstrap --variant=minbase bullseye /mnt/rootfs http://deb.debian.org/debian/
+
+chroot /mnt/rootfs /bin/sh <<EOT
+apt-get install -y --no-install-recommends --no-install-suggests \
+  python3-minimal \
+  openssh-server \
+  socat libsecp256k1-0 \
+  \
+  python3-aiohttp python3-msgpack \
+  python3-setuptools \
+  python3-pip python3-cytoolz \
+  iproute2 unzip
+
+pip3 install fastapi
+
+echo "Pip installing aleph-client"
+pip3 install 'aleph-client>=0.2.5' 'coincurve==15.0.0'
+
+# Compile all Python bytecode
+python3 -m compileall -f /usr/local/lib/python3.9
+
+#echo -e "toor\ntoor" | passwd root
+
+mkdir -p /overlay
+
+# Set up a login terminal on the serial console (ttyS0):
+ln -s agetty /etc/init.d/agetty.ttyS0
+echo ttyS0 > /etc/securetty
+EOT
+
+echo "PermitRootLogin yes" >> /mnt/rootfs/etc/ssh/sshd_config
+
+# Generate SSH host keys
+#systemd-nspawn -D /mnt/rootfs/ ssh-keygen -q -N "" -t dsa -f /etc/ssh/ssh_host_dsa_key
+#systemd-nspawn -D /mnt/rootfs/ ssh-keygen -q -N "" -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key
+#systemd-nspawn -D /mnt/rootfs/ ssh-keygen -q -N "" -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key
+#systemd-nspawn -D /mnt/rootfs/ ssh-keygen -q -N "" -t ed25519 -f /etc/ssh/ssh_host_ed25519_key
+
+cat <<EOT > /mnt/rootfs/etc/inittab
+# /etc/inittab
+
+::sysinit:/sbin/init sysinit
+::sysinit:/sbin/init boot
+::wait:/sbin/init default
+
+# Set up a couple of getty's
+tty1::respawn:/sbin/getty 38400 tty1
+tty2::respawn:/sbin/getty 38400 tty2
+tty3::respawn:/sbin/getty 38400 tty3
+tty4::respawn:/sbin/getty 38400 tty4
+tty5::respawn:/sbin/getty 38400 tty5
+tty6::respawn:/sbin/getty 38400 tty6
+
+# Put a getty on the serial port
+ttyS0::respawn:/sbin/getty -L ttyS0 115200 vt100
+
+# Stuff to do for the 3-finger salute
+::ctrlaltdel:/sbin/reboot
+
+# Stuff to do before rebooting
+::shutdown:/sbin/init shutdown
+EOT
+
+# Custom init
+cp ./init0.sh /mnt/rootfs/sbin/init
+cp ./init1.py /mnt/rootfs/root/init1.py
+chmod +x /mnt/rootfs/sbin/init
+chmod +x /mnt/rootfs/root/init1.py
+
+umount /mnt/rootfs

--- a/runtimes/aleph-debian-11-python/init0.sh
+++ b/runtimes/aleph-debian-11-python/init0.sh
@@ -1,0 +1,1 @@
+../aleph-alpine-3.13-python/init0.sh

--- a/runtimes/aleph-debian-11-python/init1.py
+++ b/runtimes/aleph-debian-11-python/init1.py
@@ -1,0 +1,1 @@
+../aleph-alpine-3.13-python/init1.py

--- a/runtimes/aleph-debian-11-python/update_inits.sh
+++ b/runtimes/aleph-debian-11-python/update_inits.sh
@@ -1,0 +1,1 @@
+../aleph-alpine-3.13-python/update_inits.sh

--- a/runtimes/aleph-debian-11-python/update_inits.sh
+++ b/runtimes/aleph-debian-11-python/update_inits.sh
@@ -1,1 +1,14 @@
-../aleph-alpine-3.13-python/update_inits.sh
+#!/bin/sh
+
+rm ./rootfs.squashfs
+
+set -euf
+
+cp ./init0.sh ./rootfs/sbin/init
+cp ./init1.py ./rootfs/root/init1.py
+chmod +x ./rootfs/sbin/init
+chmod +x ./rootfs/root/init1.py
+
+mksquashfs ./rootfs/ ./rootfs.squashfs
+
+echo "OK"

--- a/vm_supervisor/README.md
+++ b/vm_supervisor/README.md
@@ -57,7 +57,7 @@ when running the VM Supervisor.
 ```shell
 apt update
 apt install -y git python3 python3-aiohttp python3-msgpack python3-aiodns redis python3-aioredis \
- sudo acl curl systemd-container squashfs-tools
+ sudo acl curl systemd-container squashfs-tools debootstrap
 useradd jailman
 ```
 

--- a/vm_supervisor/storage.py
+++ b/vm_supervisor/storage.py
@@ -116,7 +116,7 @@ async def get_runtime_path(ref: str) -> FilePath:
     if settings.FAKE_DATA:
         return FilePath(
             os.path.abspath(
-                join(__file__, "../../runtimes/aleph-alpine-3.13-python/rootfs.ext4")
+                join(__file__, "../../runtimes/aleph-debian-11-python/rootfs.squashfs")
             )
         )
 


### PR DESCRIPTION
Fixes #38

Some stats:
- Alpine runtime weights 329M (ext4)
- Debian runtime weights 438M (ext4)
- Debian Squashfs weights 186M