### PR TITLE
Fix: Pool stored VM with failed setup

### DIFF
--- a/vm_supervisor/pool.py
+++ b/vm_supervisor/pool.py
@@ -44,3 +44,6 @@ class VmPool:
             return execution
         else:
             return None
+
+    def forget_vm(self, vm_hash: VmHash) -> None:
+        self.executions.pop(vm_hash)

--- a/vm_supervisor/run.py
+++ b/vm_supervisor/run.py
@@ -50,12 +50,15 @@ async def run_code(vm_hash: VmHash, path: str, request: web.Request) -> web.Resp
             )
         except ResourceDownloadError as error:
             logger.exception(error)
+            pool.forget_vm(vm_hash=vm_hash)
             raise HTTPBadRequest(reason="Code, runtime or data not available")
         except VmSetupError as error:
             logger.exception(error)
+            pool.forget_vm(vm_hash=vm_hash)
             raise HTTPInternalServerError(reason="Error during program initialisation")
         except MicroVMFailedInit as error:
             logger.exception(error)
+            pool.forget_vm(vm_hash=vm_hash)
             raise HTTPInternalServerError(reason="Error during runtime initialisation")
 
     logger.debug(f"Using vm={execution.vm.vm_id}")


### PR DESCRIPTION
The first request was returning an error message to clients, but subsequent requests were keeping the connection open with no response.