### PR TITLE
Feature: Admin could not distinguish guest_api among running processes

### DIFF
--- a/guest_api/__main__.py
+++ b/guest_api/__main__.py
@@ -6,6 +6,7 @@ from typing import Optional
 import aiohttp
 from aiohttp import web
 import aioredis
+from setproctitle import setproctitle
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +155,7 @@ async def list_keys_from_cache(request: web.Request):
 
 
 def run_guest_api(unix_socket_path, vm_hash: Optional[str] = None):
+    setproctitle(f"aleph-vm guest_api on {unix_socket_path}")
     app = web.Application()
     app["meta_vm_hash"] = vm_hash or "_"
 

--- a/packaging/aleph-vm/DEBIAN/control
+++ b/packaging/aleph-vm/DEBIAN/control
@@ -3,6 +3,6 @@ Version: 0.1.7-0
 Architecture: all
 Maintainer: Aleph.im
 Description: Aleph.im VM execution engine
-Depends: python3,python3-pip,python3-aiohttp,python3-msgpack,python3-aiodns,redis,python3-aioredis,python3-psutil,sudo,acl,curl,systemd-container,squashfs-tools,debootstrap
+Depends: python3,python3-pip,python3-aiohttp,python3-msgpack,python3-aiodns,python3-setproctitle,redis,python3-aioredis,python3-psutil,sudo,acl,curl,systemd-container,squashfs-tools,debootstrap
 Section: aleph-im
 Priority: Extra


### PR DESCRIPTION
This adds the use of `setproctitle` to change the title of the process for easier diagnostic.