### PR TITLE
WIP: Log level inside VMs was always DEBUG

### DIFF
--- a/runtimes/aleph-alpine-3.13-python/init1.py
+++ b/runtimes/aleph-alpine-3.13-python/init1.py
@@ -67,6 +67,7 @@ class ConfigurationPayload:
     dns_servers: List[str] = field(default_factory=list)
     volumes: List[Volume] = field(default_factory=list)
     variables: Optional[Dict[str, str]] = None
+    loglevel: Optional[int] = logging.DEBUG
 
 
 @dataclass
@@ -91,6 +92,13 @@ os.environ["ALEPH_REMOTE_CRYPTO_HOST"] = "http://localhost"
 os.environ["ALEPH_REMOTE_CRYPTO_UNIX_SOCKET"] = "/tmp/socat-socket"
 
 logger.debug("init1.py is launching")
+
+
+def setup_loglevel(loglevel: int):
+    logging.basicConfig(
+        level=loglevel,
+        format="%(relativeCreated)4f |V %(levelname)s | %(message)s",
+    )
 
 
 def setup_hostname(hostname: str):
@@ -427,6 +435,7 @@ def receive_config(client) -> ConfigurationPayload:
 
 
 def setup_system(config: ConfigurationPayload):
+    setup_loglevel(config.loglevel)
     setup_hostname(config.vm_hash)
     setup_variables(config.variables)
     setup_volumes(config.volumes)

--- a/vm_supervisor/conf.py
+++ b/vm_supervisor/conf.py
@@ -78,6 +78,8 @@ class Settings(BaseSettings):
 
     API_SERVER: str = "https://api2.aleph.im"
     USE_JAILER: bool = True
+    # Log level inside the VM
+    VM_LOG_LEVEL: int = Field(default=logging.INFO, description="Log level used inside the VM")
     # System logs make boot ~2x slower
     PRINT_SYSTEM_LOGS: bool = False
     # Networking does not work inside Docker/Podman

--- a/vm_supervisor/vm/firecracker_microvm.py
+++ b/vm_supervisor/vm/firecracker_microvm.py
@@ -94,6 +94,7 @@ class ConfigurationPayload:
     dns_servers: List[str] = field(default_factory=list)
     volumes: List[Volume] = field(default_factory=list)
     variables: Optional[Dict[str, str]] = None
+    loglevel: Optional[int] = logging.DEBUG
 
     def as_msgpack(self) -> bytes:
         return msgpack.dumps(dataclasses.asdict(self), use_bin_type=True)
@@ -389,6 +390,7 @@ class AlephFirecrackerVM:
             vm_hash=self.vm_hash,
             volumes=volumes,
             variables=self.resources.message_content.variables,
+            loglevel=settings.VM_LOG_LEVEL,
         )
         payload = config.as_msgpack()
         length = f"{len(payload)}\n".encode()


### PR DESCRIPTION
This sets the default level to INFO and a setting to configure the level wanted.

Warning: This breaks the ConfigurationPayload schema, VMs will need to update their runtime/init first.