### PR TITLE
Fix: forget_vm called twice when VM init times out

### DIFF
--- a/vm_supervisor/pool.py
+++ b/vm_supervisor/pool.py
@@ -47,7 +47,10 @@ class VmPool:
             return None
 
     def forget_vm(self, vm_hash: VmHash) -> None:
-        self.executions.pop(vm_hash)
+        try:
+            del self.executions[vm_hash]
+        except KeyError:
+            pass
 
     async def stop(self):
         """Stop all VMs in the pool."""


### PR DESCRIPTION
Solution: Allow execution to be already missing.

See Sentry error https://sentry.io/organizations/alephim/issues/3001246903/?project=6193637&query=is%3Aunresolved