### PR TITLE
Fix: Users could now identify missing hash

### DIFF
--- a/vm_supervisor/messages.py
+++ b/vm_supervisor/messages.py
@@ -18,7 +18,8 @@ async def try_get_message(ref: str) -> ProgramMessage:
         raise HTTPServiceUnavailable(reason="Aleph Connector unavailable")
     except ClientResponseError as error:
         if error.status == 404:
-            raise HTTPNotFound(reason="Hash not found")
+            raise HTTPNotFound(reason="Hash not found",
+                               body=f"Hash not found: {ref}")
         else:
             raise
 
@@ -30,7 +31,8 @@ async def get_latest_ref(item_hash: str) -> str:
         raise HTTPServiceUnavailable(reason="Aleph Connector unavailable")
     except ClientResponseError as error:
         if error.status == 404:
-            raise HTTPNotFound(reason="Hash not found")
+            raise HTTPNotFound(reason="Hash not found",
+                               body=f"Hash not found: {item_hash}")
         else:
             raise
 


### PR DESCRIPTION
The supervisor was returning 404 Hash not found when any dependency of the program was missing with no further detail.

This helps the user debugging by returning the missing hash.