### PR TITLE
Feature: User could not easily access the current version of the software

### DIFF
--- a/vm_supervisor/templates/index.html
+++ b/vm_supervisor/templates/index.html
@@ -107,6 +107,22 @@
         <a href="/status/check/fastapi">Diagnostics checks</a> |
         <a href="/vm/$check_fastapi_vm_id">Open diagnostic VM</a>
     </p>
+</section>
+<section>
+    <h2>Version</h2>
+    <p>
+        Running version <i>$version</i>.
+    </p>
+    <p>
+        <button id="status_check_button" onclick="fetchLatestRelease()">Check if this is the latest release</button>
+        <span id="status_latest_version" style="display: none">This is the latest release &#10004;&#65039;</span>
+        <span id="status_outdated_version" style="display: none">
+            The latest release is <a href="https://github.com/aleph-im/aleph-vm/releases/latest"></a> &#10060;
+        </span>
+        <p id="status_error_version" style="display: none">Your browser could not fetch the latest release:
+            <span id="status_error_version_reason"></span>
+        </p>
+    </p>
 
 </section>
 
@@ -146,6 +162,27 @@
     }
     fetchMoviesJSON();
 
+    async function fetchLatestRelease() {
+        const response = await fetch('https://api.github.com/repos/aleph-im/aleph-vm/releases/latest');
+        if (response.ok) {
+            const response_data = await response.json();
+            const latest_version = response_data['tag_name'];
+            document.getElementById("status_check_button").style.display = "none";
+            if (latest_version === "$version") {
+                document.getElementById("status_latest_version").style.display = "";
+            }
+            else {
+                const comment = document.getElementById("status_outdated_version");
+                comment.style.display = "";
+                comment.getElementsByTagName('a')[0].textContent = latest_version;
+            }
+        }
+        else {
+            document.getElementById("status_error_version").style.display = "";
+            document.getElementById("status_error_version_reason").innerText = response.status + " " + response.statusText;
+        }
+        return response.status;
+    }
 </script>
 
 </body>

--- a/vm_supervisor/views.py
+++ b/vm_supervisor/views.py
@@ -9,7 +9,7 @@ import aiohttp
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPNotFound
 
-from . import status
+from . import status, get_version_from_git
 from .conf import settings
 from .metrics import get_execution_records
 from .models import VmHash
@@ -125,6 +125,7 @@ async def index(request: web.Request):
             multiaddr_dns4=f"/dns4/{settings.DOMAIN_NAME}/tcp/443/https",
             multiaddr_dns6=f"/dns6/{settings.DOMAIN_NAME}/tcp/443/https",
             check_fastapi_vm_id=settings.CHECK_FASTAPI_VM_ID,
+            version=get_version_from_git(),
         )
     return web.Response(content_type="text/html", body=body)
 


### PR DESCRIPTION
The information is already in the HTTP headers, but those are not trivial to access.

Solution: Display the version info on the index page, and whether it is up-to-date.

Fetch information about the latest version from the browser, and only on demand, so no request to GitHub is done by the server.

Fixes #164 
![Screenshot 2022-05-03 at 15-20-32 Aleph im Compute Node](https://user-images.githubusercontent.com/404665/166460742-a3017348-8ab8-447e-90d4-1459af8f9bd2.png)
![Screenshot 2022-05-03 at 15-20-14 Aleph im Compute Node](https://user-images.githubusercontent.com/404665/166460746-c8b3fe8d-185d-4374-84e2-95f90998d6d1.png)
![Screenshot 2022-05-03 at 15-19-57 Aleph im Compute Node](https://user-images.githubusercontent.com/404665/166460748-208503e3-c490-4547-b1c0-73c37b8ad8de.png)
![Screenshot 2022-05-03 at 15-19-42 Aleph im Compute Node](https://user-images.githubusercontent.com/404665/166460751-b0151bd3-a40a-4d9e-87a5-56e4a6a0bf79.png)

