### PR TITLE
Feature: Load balancer could not distinguish outdated supervisors

### DIFF
--- a/packaging/aleph-vm/DEBIAN/control
+++ b/packaging/aleph-vm/DEBIAN/control
@@ -3,6 +3,6 @@ Version: 0.1.8
 Architecture: all
 Maintainer: Aleph.im
 Description: Aleph.im VM execution engine
-Depends: python3,python3-pip,python3-aiohttp,python3-msgpack,python3-aiodns,python3-sqlalchemy,python3-setproctitle,redis,python3-aioredis,python3-psutil,sudo,acl,curl,systemd-container,squashfs-tools,debootstrap
+Depends: python3,python3-pip,python3-aiohttp,python3-msgpack,python3-aiodns,python3-sqlalchemy,python3-setproctitle,redis,python3-aioredis,python3-psutil,sudo,acl,curl,systemd-container,squashfs-tools,debootstrap,python3-packaging
 Section: aleph-im
 Priority: Extra

--- a/vm_supervisor/supervisor.py
+++ b/vm_supervisor/supervisor.py
@@ -23,7 +23,7 @@ from .views import (
     about_executions,
     about_config,
     status_check_fastapi,
-    about_execution_records,
+    about_execution_records, status_check_version,
 )
 
 logger = logging.getLogger(__name__)
@@ -51,6 +51,7 @@ app.add_routes(
         web.get("/about/executions/records", about_execution_records),
         web.get("/about/config", about_config),
         web.get("/status/check/fastapi", status_check_fastapi),
+        web.get("/status/check/version", status_check_version),
         web.route("*", "/vm/{ref}{suffix:.*}", run_code_from_path),
         web.route("*", "/{suffix:.*}", run_code_from_hostname),
     ]


### PR DESCRIPTION
The load balancer could not check if a supervisor is running the latest release using the status of a GET response.

This is useful for the healthcheck of the Traefik Proxy to ensure that backend CRNs are running the latest version.