### PR TITLE
Fix: AttributeError crashed VM teardown

### DIFF
--- a/vm_supervisor/vm/firecracker_microvm.py
+++ b/vm_supervisor/vm/firecracker_microvm.py
@@ -420,7 +420,7 @@ class AlephFirecrackerVM:
         logger.debug(f"started guest API for {self.vm_id}")
 
     async def stop_guest_api(self):
-        if self.guest_api_process:
+        if self.guest_api_process and self.guest_api_process._popen:
             self.guest_api_process.terminate()
 
     async def teardown(self):


### PR DESCRIPTION
During VM teardown, the field AlephFirecrackerVM().guest_api_process._popen
could be None, and the following traceback be raised:

```python
  File "/root/aleph-vm/vm_supervisor/models.py", line 116, in create
    await vm.teardown()
  File "/root/aleph-vm/vm_supervisor/vm/firecracker_microvm.py", line 429, in teardown
    await self.stop_guest_api()
  File "/root/aleph-vm/vm_supervisor/vm/firecracker_microvm.py", line 424, in stop_guest_api
    self.guest_api_process.terminate()
  File "/usr/lib/python3.8/multiprocessing/process.py", line 133, in terminate
    self._popen.terminate()
AttributeError: 'NoneType' object has no attribute 'terminate'
```