### PR TITLE
Fix: Stability issues when checking crash handling in monitored endpoint

### DIFF
--- a/vm_supervisor/views.py
+++ b/vm_supervisor/views.py
@@ -141,7 +141,6 @@ async def status_check_fastapi(request: web.Request):
             "cache": await status.check_cache(session),
             "persistent_storage": await status.check_persistent_storage(session),
             "error_handling": await status.check_error_raised(session),
-            "crash_handling": await status.check_crash_and_restart(session),
         }
         return web.json_response(result, status=200 if all(result.values()) else 503)
 


### PR DESCRIPTION
## Problem:
The endpoint '/status/check/fastapi' is monitored by multiple operators
and therefore called very frequently. The crash handling check results
in a new virtual machine being started at every call, and memory leaks
(likely pipes accumulating) can cause the supervisor to crash after
some time with 'Too many open files'.

## Solution:
In the short term, avoid calling the crash check in the monitored endpoint.
In the longer term, investigate and fix the accumulating file descriptors.