### PR TITLE
CI: Building example volume using Docker failed

### DIFF
--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -44,9 +44,26 @@ jobs:
           sudo apt update
           sudo apt install -y debootstrap
           cd runtimes/aleph-debian-11-python && sudo ./create_disk_image.sh && cd ../..
-          cd examples/volumes && sudo ./build_squashfs.sh && cd ../..
 
       - uses: actions/upload-artifact@v2
         with:
           name: aleph-debian-11-python.squashfs
           path: runtimes/aleph-debian-11-python/rootfs.squashfs
+
+
+  build_example_venv_volume:
+    name: "Build example squashfs volume using Docker"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - run: |
+          docker build -t aleph-vm-build-squashfs -f examples/volumes/Dockerfile examples/volumes
+          docker run --rm -v "$(pwd)":/mnt aleph-vm-build-squashfs
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: example-volume-venv.squashfs
+          path: volume-venv.squashfs

--- a/examples/volumes/Dockerfile
+++ b/examples/volumes/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 
 RUN apt-get update && apt-get -y upgrade && apt-get install -y \
     python3-venv \


### PR DESCRIPTION
Due to an internal change in GitHub Actions, this started to fail.

This pull request fixes the issue and isolates the build of the runtime and the build of the example virtualenv volume.