### PR TITLE
Fix: Exceptions in coroutines were not logged

### DIFF
--- a/vm_supervisor/__main__.py
+++ b/vm_supervisor/__main__.py
@@ -8,6 +8,8 @@ from typing import List, Tuple, Dict, Callable
 
 from aiohttp.web import Response, Request
 
+from vm_supervisor.utils import exception_handler
+
 try:
     import sentry_sdk
 except ImportError:
@@ -71,6 +73,14 @@ def parse_args(args):
         help="set loglevel to DEBUG",
         action="store_const",
         const=logging.DEBUG,
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        dest="debug",
+        help="enable debug logging",
+        action="store_true",
+        default=False,
     )
     parser.add_argument(
         "-p",
@@ -240,8 +250,14 @@ def main():
 
     settings.check()
 
+    loop = asyncio.get_event_loop()
+
+    if args.debug:
+        loop.set_debug(True)
+
+    loop.set_exception_handler(exception_handler)
+
     if args.benchmark > 0:
-        loop = asyncio.get_event_loop()
         loop.run_until_complete(benchmark(runs=args.benchmark))
         print("Finished")
     elif args.do_not_run:

--- a/vm_supervisor/models.py
+++ b/vm_supervisor/models.py
@@ -11,7 +11,7 @@ from aleph_message.models import ProgramContent
 
 from .metrics import save_record, save_execution_data, ExecutionRecord
 from .pubsub import PubSub
-from .utils import dumps_for_json
+from .utils import dumps_for_json, create_task_log_exceptions
 from .vm import AlephFirecrackerVM
 from .vm.firecracker_microvm import AlephFirecrackerResources
 from .conf import settings
@@ -126,11 +126,11 @@ class VmExecution:
         if sys.version_info.major >= 3 and sys.version_info.minor >= 8:
             # Task can be named
             vm_id: str = str(self.vm.vm_id if self.vm else None)
-            self.expire_task = loop.create_task(
+            self.expire_task = create_task_log_exceptions(
                 self.expire(timeout), name=f"expire {vm_id}"
             )
         else:
-            self.expire_task = loop.create_task(self.expire(timeout))
+            self.expire_task = create_task_log_exceptions(self.expire(timeout))
         return self.expire_task
 
     async def expire(self, timeout: float) -> None:
@@ -169,8 +169,7 @@ class VmExecution:
 
     def start_watching_for_updates(self, pubsub: PubSub):
         if not self.update_task:
-            loop = asyncio.get_running_loop()
-            self.update_task = loop.create_task(self.watch_for_updates(pubsub=pubsub))
+            self.update_task = create_task_log_exceptions(self.watch_for_updates(pubsub=pubsub))
 
     async def watch_for_updates(self, pubsub: PubSub):
         await pubsub.msubscribe(

--- a/vm_supervisor/reactor.py
+++ b/vm_supervisor/reactor.py
@@ -1,12 +1,12 @@
-import asyncio
 import logging
-from typing import List, Dict, Coroutine
-
-from aleph_message.models.program import Subscription
+from typing import List, Coroutine
 
 from aleph_message.models import Message, ProgramMessage
+from aleph_message.models.program import Subscription
+
 from vm_supervisor.pubsub import PubSub
 from vm_supervisor.run import run_code_on_event
+from vm_supervisor.utils import create_task_log_exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -64,9 +64,8 @@ class Reactor:
                     break
 
         # Call all listeners asynchronously from the event loop:
-        loop = asyncio.get_event_loop()
         for coroutine in coroutines:
-            loop.create_task(coroutine)
+            create_task_log_exceptions(coroutine)
 
     def register(self, message: ProgramMessage):
         if message.content.on.message:

--- a/vm_supervisor/tasks.py
+++ b/vm_supervisor/tasks.py
@@ -17,6 +17,7 @@ from .messages import load_updated_message
 from .models import VmHash
 from .pubsub import PubSub
 from .reactor import Reactor
+from .utils import create_task_log_exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +124,7 @@ async def start_watch_for_messages_task(app: web.Application):
 
     app["pubsub"] = pubsub
     app["reactor"] = reactor
-    app["messages_listener"] = asyncio.create_task(watch_for_messages(pubsub, reactor))
+    app["messages_listener"] = create_task_log_exceptions(watch_for_messages(pubsub, reactor))
 
 
 async def stop_watch_for_messages_task(app: web.Application):

--- a/vm_supervisor/utils.py
+++ b/vm_supervisor/utils.py
@@ -1,9 +1,13 @@
+import asyncio
 import json
+import logging
 from base64 import b32decode, b16encode
 from dataclasses import is_dataclass, asdict as dataclass_as_dict
-from typing import Any, Optional
+from typing import Any, Optional, Coroutine, Dict
 
 import aiodns
+
+logger = logging.getLogger(__name__)
 
 
 def b32_to_b16(hash: str) -> bytes:
@@ -33,3 +37,23 @@ def to_json(o: Any):
 
 def dumps_for_json(o: Any, indent: Optional[int] = None):
     return json.dumps(o, default=to_json, indent=indent)
+
+
+async def run_and_log_exception(coro: Coroutine):
+    """Exceptions in coroutines may go unnoticed if they are not handled."""
+    try:
+        return await coro
+    except Exception as error:
+        logger.exception(error)
+        raise
+
+
+def create_task_log_exceptions(coro: Coroutine, *, name=None):
+    """Ensure that exceptions running in coroutines are logged."""
+    return asyncio.create_task(run_and_log_exception(coro), name=name)
+
+
+def exception_handler(loop, context: Dict):
+    logger.exception(
+        f"Exception with context {context}", exc_info=True,
+    )


### PR DESCRIPTION
The traceback for these exceptions did not appear anywhere.

This adds helpers to run coroutines in tasks with exception catching and logging and helps with spotting errors in coroutines.

It also registers an exception handler on the event loop, and a CLI option to enable the debug mode of Asyncio.