### PR TITLE
Fix: Internal PubSub `msubscribe` failed

### DIFF
--- a/vm_supervisor/pubsub.py
+++ b/vm_supervisor/pubsub.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class PubSub:
-    subscribers: Dict[Hashable, Set[asyncio.Queue]]
+    subscribers: Dict[Hashable, Set[asyncio.Queue[set]]]
 
     def __init__(self):
         self.subscribers = {}
@@ -45,12 +45,11 @@ class PubSub:
 
         # Cleanup: remove the queue from the subscribers
         for key in keys:
-            for subscriber in self.subscribers.values():
+            for subscriber in list(self.subscribers.values()):
                 subscriber.discard(queue)
-                # Remove keys with no remaining queue
-                if not self.subscribers.get(key):
+                # Remove keys with no remaining queue (empty set remaining)
+                if self.subscribers.get(key) == set():
                     self.subscribers.pop(key)
-
         return
 
     async def publish(self, key, value):


### PR DESCRIPTION
Mutating the object being iterated caused inconsistency when iterating over subscribers.