### PR TITLE
Feature: VMs could not be persisted

### DIFF
--- a/docker/vm_supervisor-dev.dockerfile
+++ b/docker/vm_supervisor-dev.dockerfile
@@ -19,7 +19,7 @@ RUN curl -fsSL -o /opt/firecracker/vmlinux.bin https://s3.amazonaws.com/spec.ccf
 RUN ln /opt/firecracker/release-*/firecracker-v* /opt/firecracker/firecracker
 RUN ln /opt/firecracker/release-*/jailer-v* /opt/firecracker/jailer
 
-RUN pip3 install typing-extensions 'aleph-message>=0.1.19'
+RUN pip3 install typing-extensions 'aleph-message==0.2.2'
 
 RUN mkdir -p /var/lib/aleph/vm/jailer
 

--- a/examples/volumes/Dockerfile
+++ b/examples/volumes/Dockerfile
@@ -6,6 +6,6 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m venv /opt/venv
-RUN /opt/venv/bin/pip install 'aleph-message>=0.1.19'
+RUN /opt/venv/bin/pip install 'aleph-message==0.2.2'
 
 CMD mksquashfs /opt/venv /mnt/volume-venv.squashfs

--- a/guest_api/__main__.py
+++ b/guest_api/__main__.py
@@ -151,7 +151,7 @@ async def list_keys_from_cache(request: web.Request):
 
     redis: aioredis.Redis = await get_redis()
     result = await redis.keys(f"{prefix}:{pattern}")
-    keys = [key.decode()[len(prefix) + 1:] for key in result]
+    keys = [key.decode()[len(prefix) + 1 :] for key in result]
     return web.json_response(keys)
 
 

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -16,7 +16,7 @@ debian-package-code:
 	cp ../examples/message_from_aleph.json ./aleph-vm/opt/aleph-vm/examples/message_from_aleph.json
 	cp -r ../examples/data ./aleph-vm/opt/aleph-vm/examples/data
 	mkdir -p ./aleph-vm/opt/aleph-vm/examples/volumes
-	pip3 install --target ./aleph-vm/opt/aleph-vm/ 'aleph-message>=0.1.19'
+	pip3 install --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.2.2'
 	python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux

--- a/vm_supervisor/README.md
+++ b/vm_supervisor/README.md
@@ -87,7 +87,7 @@ is used to parse and validate Aleph messages.
 ```shell
 apt install -y --no-install-recommends --no-install-suggests python3-pip
 pip3 install pydantic[dotenv]
-pip3 install aleph-message
+pip3 install 'aleph-message==0.2.2'
 ```
 
 ### 2.f. Create the jailer working directory:

--- a/vm_supervisor/conf.py
+++ b/vm_supervisor/conf.py
@@ -106,6 +106,11 @@ class Settings(BaseSettings):
     MAX_PROGRAM_ARCHIVE_SIZE = 10_000_000  # 10 MB
     MAX_DATA_ARCHIVE_SIZE = 10_000_000  # 10 MB
 
+    # hashlib.sha256(b"secret-token").hexdigest()
+    ALLOCATION_TOKEN_HASH = (
+        "151ba92f2eb90bce67e912af2f7a5c17d8654b3d29895b042107ea312a7eebda"
+    )
+
     FAKE_DATA_PROGRAM: Optional[Path] = None
     BENCHMARK_FAKE_DATA_PROGRAM = Path(
         abspath(join(__file__, "../../examples/example_fastapi"))

--- a/vm_supervisor/models.py
+++ b/vm_supervisor/models.py
@@ -57,7 +57,7 @@ class VmExecution:
     expire_task: Optional[asyncio.Task] = None
     update_task: Optional[asyncio.Task] = None
 
-    marked_as_persistent: bool = False
+    persistent: bool = False
 
     @property
     def is_running(self):
@@ -124,7 +124,7 @@ class VmExecution:
             raise
 
     def stop_after_timeout(self, timeout: float = 5.0) -> Optional[Task]:
-        if self.marked_as_persistent:
+        if self.persistent:
             logger.debug("VM marked as long running. Ignoring timeout.")
             return
 

--- a/vm_supervisor/pool.py
+++ b/vm_supervisor/pool.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Dict, Optional
+from typing import Dict, Optional, Iterable
 
 from aleph_message.models import ProgramContent, ProgramMessage
 
@@ -94,3 +94,8 @@ class VmPool:
         await asyncio.gather(
             *(execution.stop() for vm_hash, execution in self.executions.items())
         )
+
+    def get_persistent_executions(self) -> Iterable[VmExecution]:
+        for vm_hash, execution in self.executions.items():
+            if execution.marked_as_persistent and execution.is_running:
+                yield execution

--- a/vm_supervisor/pool.py
+++ b/vm_supervisor/pool.py
@@ -97,5 +97,5 @@ class VmPool:
 
     def get_persistent_executions(self) -> Iterable[VmExecution]:
         for vm_hash, execution in self.executions.items():
-            if execution.marked_as_persistent and execution.is_running:
+            if execution.persistent and execution.is_running:
                 yield execution

--- a/vm_supervisor/resources.py
+++ b/vm_supervisor/resources.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from functools import lru_cache
+from typing import Set, Optional
 from typing import Tuple
 
 import cpuinfo
@@ -117,3 +118,9 @@ async def about_system_usage(request: web.Request):
     return web.json_response(
         text=usage.json(exclude_none=True),
     )
+
+
+class Allocation(BaseModel):
+    persistent_vms: Set[str]
+    on_demand_vms: Optional[Set[str]] = None
+    jobs: Optional[Set] = None

--- a/vm_supervisor/run.py
+++ b/vm_supervisor/run.py
@@ -214,3 +214,30 @@ async def run_code_on_event(vm_hash: VmHash, event, pubsub: PubSub):
             execution.stop_after_timeout(timeout=settings.REUSE_TIMEOUT)
         else:
             await execution.stop()
+
+
+async def start_persistent_vm(vm_hash: VmHash, pubsub: PubSub) -> VmExecution:
+    execution: Optional[VmExecution] = await pool.get_running_vm(vm_hash=vm_hash)
+
+    if not execution:
+        logger.info(f"Starting persistent VM {vm_hash}")
+        execution = await create_vm_execution(vm_hash=vm_hash)
+    # If the VM was already running in lambda mode, it should not expire
+    # as long as it is also scheduled as long-running
+    execution.marked_as_persistent = True
+    execution.cancel_expiration()
+
+    await execution.becomes_ready()
+
+    if settings.WATCH_FOR_UPDATES:
+        execution.start_watching_for_updates(pubsub=pubsub)
+
+    return execution
+
+
+async def stop_persistent_vm(vm_hash: VmHash) -> Optional[VmExecution]:
+    logger.info(f"Stopping persistent VM {vm_hash}")
+    execution = await pool.get_running_vm(vm_hash)
+    if execution:
+        await execution.stop()
+    return execution

--- a/vm_supervisor/run.py
+++ b/vm_supervisor/run.py
@@ -224,7 +224,7 @@ async def start_persistent_vm(vm_hash: VmHash, pubsub: PubSub) -> VmExecution:
         execution = await create_vm_execution(vm_hash=vm_hash)
     # If the VM was already running in lambda mode, it should not expire
     # as long as it is also scheduled as long-running
-    execution.marked_as_persistent = True
+    execution.persistent = True
     execution.cancel_expiration()
 
     await execution.becomes_ready()

--- a/vm_supervisor/supervisor.py
+++ b/vm_supervisor/supervisor.py
@@ -26,6 +26,7 @@ from .views import (
     status_check_fastapi,
     about_execution_records,
     status_check_version,
+    update_allocations,
 )
 
 logger = logging.getLogger(__name__)
@@ -53,6 +54,7 @@ app.add_routes(
         web.get("/about/executions/records", about_execution_records),
         web.get("/about/usage/system", about_system_usage),
         web.get("/about/config", about_config),
+        web.post("/control/allocations", update_allocations),
         web.get("/status/check/fastapi", status_check_fastapi),
         web.get("/status/check/version", status_check_version),
         web.route("*", "/vm/{ref}{suffix:.*}", run_code_from_path),

--- a/vm_supervisor/utils.py
+++ b/vm_supervisor/utils.py
@@ -3,7 +3,7 @@ import json
 import logging
 from base64 import b32decode, b16encode
 from dataclasses import is_dataclass, asdict as dataclass_as_dict
-from typing import Any, Optional, Coroutine, Dict
+from typing import Any, Optional, Coroutine
 
 import aiodns
 

--- a/vm_supervisor/views.py
+++ b/vm_supervisor/views.py
@@ -209,7 +209,7 @@ async def update_allocations(request: web.Request):
         if execution.vm_hash not in allocation.persistent_vms:
             logger.info(f"Stopping long running VM {execution.vm_hash}")
             await execution.stop()
-            execution.marked_as_persistent = False
+            execution.persistent = False
 
     # Log unsupported features
     if allocation.on_demand_vms:

--- a/vm_supervisor/views.py
+++ b/vm_supervisor/views.py
@@ -1,6 +1,7 @@
 import binascii
 import logging
 import os.path
+from hashlib import sha256
 from string import Template
 from typing import Awaitable, Optional
 
@@ -9,13 +10,16 @@ import aiohttp
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPNotFound
 from packaging.version import Version, InvalidVersion
+from pydantic import ValidationError
 
 from . import status
 from .version import __version__
 from .conf import settings
 from .metrics import get_execution_records
 from .models import VmHash
-from .run import run_code_on_request, pool
+from .pubsub import PubSub
+from .resources import Allocation
+from .run import run_code_on_request, pool, start_persistent_vm
 from .utils import b32_to_b16, get_ref_from_dns, dumps_for_json
 
 logger = logging.getLogger(__name__)
@@ -167,3 +171,50 @@ async def status_check_version(request: web.Request):
         )
     else:
         return web.HTTPForbidden(text=f"Outdated: version {current} < {reference}")
+
+
+def authenticate_api_request(request: web.Request) -> bool:
+    """Authenticate an API request to update the VM allocations."""
+    signature: bytes = request.headers.get("X-Auth-Signature").encode()
+
+    if not signature:
+        raise web.HTTPUnauthorized(text="Authentication token is missing")
+
+    # Use a simple authentication method: the hash of the signature should match the value in the settings
+    return sha256(signature).hexdigest() == settings.ALLOCATION_TOKEN_HASH
+
+
+async def update_allocations(request: web.Request):
+    if not authenticate_api_request(request):
+        return web.HTTPUnauthorized(text="Authentication token received is invalid")
+
+    try:
+        data = await request.json()
+        allocation = Allocation.parse_obj(data)
+    except ValidationError as error:
+        return web.json_response(
+            data=error.json(), status=web.HTTPBadRequest.status_code
+        )
+
+    pubsub: PubSub = request.app["pubsub"]
+
+    # Start VMs
+    for vm_hash in allocation.persistent_vms:
+        vm_hash = VmHash(vm_hash)
+        logger.info(f"Starting long running VM {vm_hash}")
+        await start_persistent_vm(vm_hash, pubsub)
+
+    # Stop VMs
+    for execution in pool.get_persistent_executions():
+        if execution.vm_hash not in allocation.persistent_vms:
+            logger.info(f"Stopping long running VM {execution.vm_hash}")
+            await execution.stop()
+            execution.marked_as_persistent = False
+
+    # Log unsupported features
+    if allocation.on_demand_vms:
+        logger.warning("Not supported yet: 'allocation.on_demand_vms'")
+    if allocation.jobs:
+        logger.warning("Not supported yet: 'allocation.on_demand_vms'")
+
+    return web.json_response(data={"success": True})


### PR DESCRIPTION
The supervisor only supported on request execution of virtual machines.

This add support for an external scheduler to send a list of VMs that should be started and persisted.

A temporary simple HTTP authentication method is used to authenticate the scheduler, this is planned to move to P2P messages from Core Channel Nodes.