### PR TITLE
Fix: Annotation was not supported by Python 3.8

### DIFF
--- a/vm_supervisor/pubsub.py
+++ b/vm_supervisor/pubsub.py
@@ -5,13 +5,18 @@ Used to trigger VM shutdown on updates.
 
 import asyncio
 import logging
+import sys
 from typing import Dict, Hashable, Set
 
 logger = logging.getLogger(__name__)
 
 
 class PubSub:
-    subscribers: Dict[Hashable, Set[asyncio.Queue[set]]]
+    if sys.version_info >= (3, 9):
+        subscribers: Dict[Hashable, Set[asyncio.Queue[Set]]]
+    else:
+        # Support for Python 3.8 (Ubuntu 20.04)
+        subscribers: Dict[Hashable, Set[asyncio.Queue]]
 
     def __init__(self):
         self.subscribers = {}


### PR DESCRIPTION
We still support Ubuntu 20.04 that ships with Python 3.8.

Solution: Use a different typing annotation depending on the version of Python, making it easier to ditch the simpler annotation when Python 3.8 goes out of support.

Fixes #243
