### PR TITLE
Fix: Remove hardcoded 172.0.0.0/8 range from use to comply with RFC1918 

### DIFF
--- a/firecracker/microvm.py
+++ b/firecracker/microvm.py
@@ -71,6 +71,8 @@ class MicroVM:
     config_file_path: Optional[Path] = None
     drives: List[Drive]
     init_timeout: float
+    guest_ip: Optional[str]
+    host_ip: Optional[str]
 
     _unix_socket: Server
 
@@ -97,14 +99,6 @@ class MicroVM:
         else:
             return f"{VSOCK_PATH}"
 
-    @property
-    def guest_ip(self):
-        return f"172.{self.vm_id // 256}.{self.vm_id % 256}.2"
-
-    @property
-    def host_ip(self):
-        return f"172.{self.vm_id // 256}.{self.vm_id % 256}.1"
-
     def __init__(
         self,
         vm_id: int,
@@ -112,6 +106,8 @@ class MicroVM:
         use_jailer: bool = True,
         jailer_bin_path: Optional[str] = None,
         init_timeout: float = 5.0,
+        guest_ip: Optional[str] = None,
+        host_ip: Optional[str] = None,
     ):
         self.vm_id = vm_id
         self.use_jailer = use_jailer
@@ -119,6 +115,8 @@ class MicroVM:
         self.jailer_bin_path = jailer_bin_path
         self.drives = []
         self.init_timeout = init_timeout
+        self.guest_ip = guest_ip
+        self.host_ip = host_ip
 
     def to_dict(self):
         return {
@@ -316,7 +314,7 @@ class MicroVM:
         self.network_tap = host_dev_name
 
         system(f"ip tuntap add {host_dev_name} mode tap")
-        system(f"ip addr add {self.host_ip}/24 dev {host_dev_name}")
+        system(f"ip addr add {self.host_ip} dev {host_dev_name}")
         system(f"ip link set {host_dev_name} up")
         system('sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward"')
         # TODO: Don't fill iptables with duplicate rules; purge rules on delete

--- a/runtimes/aleph-alpine-3.13-python/init1.py
+++ b/runtimes/aleph-alpine-3.13-python/init1.py
@@ -123,11 +123,11 @@ def setup_network(
     system("ip addr add 127.0.0.1/8 dev lo brd + scope host")
     system("ip addr add ::1/128 dev lo")
     system("ip link set lo up")
-    system(f"ip addr add {ip}/24 dev eth0")
+    system(f"ip addr add {ip} dev eth0")
     system("ip link set eth0 up")
 
     if route:
-        system(f"ip route add default via {route} dev eth0")
+        system(f"ip route add default via {route.split('/')[0]} dev eth0")
         logger.debug("IP and route set")
     else:
         logger.warning("IP set with no network route")

--- a/vm_supervisor/conf.py
+++ b/vm_supervisor/conf.py
@@ -72,17 +72,22 @@ class Settings(BaseSettings):
     REUSE_TIMEOUT: float = 60 * 60.0
     WATCH_FOR_MESSAGES = True
     WATCH_FOR_UPDATES = True
-    NETWORK_INTERFACE = "eth0"
-    DNS_RESOLUTION: Optional[DnsResolver] = DnsResolver.resolv_conf
-    DNS_NAMESERVERS: Optional[List[str]] = None
 
     API_SERVER = "https://official.aleph.cloud"
     USE_JAILER = True
     # System logs make boot ~2x slower
     PRINT_SYSTEM_LOGS = False
     DEBUG_ASYNCIO = False
+
     # Networking does not work inside Docker/Podman
     ALLOW_VM_NETWORKING = True
+    NETWORK_INTERFACE = "eth0"
+    IPV4_ADDRESS_POOL = "172.16.0.0/12"
+    IPV4_NETWORK_SIZE = 24
+
+    DNS_RESOLUTION: Optional[DnsResolver] = DnsResolver.resolv_conf
+    DNS_NAMESERVERS: Optional[List[str]] = None
+
     FIRECRACKER_PATH = "/opt/firecracker/firecracker"
     JAILER_PATH = "/opt/firecracker/jailer"
     LINUX_PATH = "/opt/firecracker/vmlinux.bin"

--- a/vm_supervisor/pool.py
+++ b/vm_supervisor/pool.py
@@ -44,8 +44,10 @@ class VmPool:
         This identifier is used to name the network interface and in the IPv4 range
         dedicated to the VM.
         """
+        _, network_range = settings.IPV4_ADDRESS_POOL.split("/")
+        available_bits = int(network_range) - settings.IPV4_NETWORK_SIZE
         self.counter += 1
-        if self.counter < 255**2:
+        if self.counter < 2**available_bits:
             # In common cases, use the counter itself as the vm_id. This makes it
             # easier to debug.
             return self.counter

--- a/vm_supervisor/utils.py
+++ b/vm_supervisor/utils.py
@@ -3,7 +3,7 @@ import json
 import logging
 from base64 import b32decode, b16encode
 from dataclasses import is_dataclass, asdict as dataclass_as_dict
-from typing import Any, Optional, Coroutine
+from typing import Any, Optional, Coroutine, Tuple, Iterable
 
 import aiodns
 
@@ -51,3 +51,53 @@ async def run_and_log_exception(coro: Coroutine):
 def create_task_log_exceptions(coro: Coroutine, *, name=None):
     """Ensure that exceptions running in coroutines are logged."""
     return asyncio.create_task(run_and_log_exception(coro), name=name)
+
+
+def ipstr_to_int(ip_string: str) -> Tuple[int, int]:
+    """Convert an IP address string with subnet mask to an integer
+    representation of the IP and the mask separately.
+    """
+    ip, mask = ip_string.split("/")
+    ip_int = sum(
+        int(octet) * 256**idx for idx, octet in enumerate(reversed(ip.split(".")))
+    )
+    return ip_int, int(mask)
+
+
+def int_to_ipstr(ip_int: int, mask: int) -> str:
+    """Converts an integer representation of an IP address and a subnetmask
+    and turns it into a string representation
+    """
+    ip_integers: Iterable[int] = (
+        (ip_int >> (8 * i)) & 0xFF for i in reversed(range(4))
+    )
+    ip_string: str = ".".join(str(i) for i in ip_integers)
+    return f"{ip_string}/{mask}"
+
+
+def get_ip_addresses(
+    vm_id: int, address_pool: str, ip_network_size: int
+) -> Tuple[str, str]:
+    """Calculates the host and guest ip from vm_id and returns it as their string representations with subnetmask"""
+    network_pool, pool_size = ipstr_to_int(address_pool)
+    pool_netmask = 0xFFFFFFFF << 32 - pool_size
+    network_part = vm_id << 32 - ip_network_size
+    network_part_mask = 2 ** (ip_network_size - pool_size) - 1 << 32 - ip_network_size
+    host = 1
+    guest = 2
+    hosts_mask = 2 ** (32 - ip_network_size) - 1
+
+    host_ip = (
+        (network_pool & pool_netmask)
+        | (network_part & network_part_mask)
+        | (host & hosts_mask)
+    )
+    guest_ip = (
+        (network_pool & pool_netmask)
+        | (network_part & network_part_mask)
+        | (guest & hosts_mask)
+    )
+
+    return int_to_ipstr(host_ip, ip_network_size), int_to_ipstr(
+        guest_ip, ip_network_size
+    )

--- a/vm_supervisor/vm/firecracker_microvm.py
+++ b/vm_supervisor/vm/firecracker_microvm.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import msgpack
 
+from ..utils import get_ip_addresses
+
 try:
     import psutil as psutil
 except ImportError:
@@ -211,6 +213,8 @@ class AlephFirecrackerVM:
     hardware_resources: MachineResources
     fvm: Optional[MicroVM] = None
     guest_api_process: Optional[Process] = None
+    host_ip: Optional[str] = None
+    guest_ip: Optional[str] = None
 
     def __init__(
         self,
@@ -260,12 +264,19 @@ class AlephFirecrackerVM:
     async def setup(self):
         logger.debug("setup started")
         await setfacl()
+        host_ip, guest_ip = get_ip_addresses(
+            self.vm_id,
+            address_pool=settings.IPV4_ADDRESS_POOL,
+            ip_network_size=settings.IPV4_NETWORK_SIZE,
+        )
         fvm = MicroVM(
             vm_id=self.vm_id,
             firecracker_bin_path=settings.FIRECRACKER_PATH,
             use_jailer=settings.USE_JAILER,
             jailer_bin_path=settings.JAILER_PATH,
             init_timeout=settings.INIT_TIMEOUT,
+            host_ip=host_ip,
+            guest_ip=guest_ip,
         )
         fvm.prepare_jailer()
 


### PR DESCRIPTION
Previously, 172.0.0.0/8 range was hardcoded to be used as the pool for which to assign IP addresses out of. As this was in violation of RFC1918, this needed to change. As this meant reworking the code anyway, it was changed so the range is configurable. The code to determine the IPs was also moved up to the supervisor level instead of the vm level, as that is more appropriate place for the code to be. Fixes the first point of Issue #237 