### PR TITLE
Fix: Curl did not error when test failed.

### DIFF
--- a/.github/workflows/test-on-droplet.yml
+++ b/.github/workflows/test-on-droplet.yml
@@ -65,8 +65,8 @@ jobs:
           export DROPLET_IPV4="$(doctl compute droplet get aleph-vm-ci --output json | ./.github/scripts/extract_droplet_ipv4.py)"
           
           sleep 3
-          curl --retry 5 "http://${DROPLET_IPV4}:4020/about/usage/system"
-          curl --retry 5 "http://${DROPLET_IPV4}:4020/status/check/fastapi"
+          curl --retry 5 --fail "http://${DROPLET_IPV4}:4020/about/usage/system"
+          curl --retry 5 --fail "http://${DROPLET_IPV4}:4020/status/check/fastapi"
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
Curl requires the `--fail` argument in order to return a code different than zero and raise and issue in the action.