### PR TITLE
Feature: version endpoint

### DIFF
--- a/vm_supervisor/supervisor.py
+++ b/vm_supervisor/supervisor.py
@@ -27,6 +27,7 @@ from .views import (
     about_execution_records,
     status_check_version,
     update_allocations,
+    version,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,6 +58,7 @@ app.add_routes(
         web.post("/control/allocations", update_allocations),
         web.get("/status/check/fastapi", status_check_fastapi),
         web.get("/status/check/version", status_check_version),
+        web.get("/version", version),
         web.route("*", "/vm/{ref}{suffix:.*}", run_code_from_path),
         web.route("*", "/{suffix:.*}", run_code_from_hostname),
     ]

--- a/vm_supervisor/views.py
+++ b/vm_supervisor/views.py
@@ -150,6 +150,11 @@ async def status_check_fastapi(request: web.Request):
         return web.json_response(result, status=200 if all(result.values()) else 503)
 
 
+async def version(request: web.Request):
+    """Returns the version of the VM supervisor."""
+    return {"version": __version__}
+
+
 async def status_check_version(request: web.Request):
     """Check if the software is running a version equal or newer than the given one"""
     reference_str: Optional[str] = request.query.get("reference")


### PR DESCRIPTION
Problem: retrieving the version of the VM supervisor directly can be useful for monitoring and debugging.

Solution: add an endpoint that returns the software version. The response has the same format as the /version endpoint of Core Channel Nodes.