### PR TITLE
Fix: GitHub actions failed on Ubuntu due to Grub

### DIFF
--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -77,6 +77,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Workaround github issue https://github.com/actions/runner-images/issues/7192
+        if: startsWith(matrix.os, 'ubuntu-')
+        run: sudo echo RESET grub-efi/install_devices | sudo debconf-communicate grub-pc
+
       - run: |
           sudo apt update
           sudo apt install -y debootstrap

--- a/.github/workflows/test-build-examples.yml
+++ b/.github/workflows/test-build-examples.yml
@@ -13,6 +13,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Workaround github issue https://github.com/actions/runner-images/issues/7192
+        if: startsWith(matrix.os, 'ubuntu-')
+        run: sudo echo RESET grub-efi/install_devices | sudo debconf-communicate grub-pc
+
       - run: |
           sudo apt-get -y update
           sudo apt-get -y upgrade


### PR DESCRIPTION
Errors were encountered while processing:
  grub-efi-amd64-signed
needrestart is being skipped since dpkg has failed
