### PR TITLE
Fix: add nftables package to VM supervisor Dockerfile

### DIFF
--- a/docker/vm_supervisor-dev.dockerfile
+++ b/docker/vm_supervisor-dev.dockerfile
@@ -4,7 +4,7 @@ FROM debian:bullseye
 
 RUN apt-get update && apt-get -y upgrade && apt-get install -y \
     sudo acl curl squashfs-tools git \
-    python3 python3-aiohttp python3-msgpack python3-pip python3-aiodns python3-aioredis  \
+    python3 python3-aiohttp python3-msgpack python3-pip python3-aiodns python3-aioredis python3-nftables \
     python3-psutil python3-setproctitle python3-sqlalchemy python3-packaging python3-cpuinfo \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Problem: the VM supervisor Docker image does not work because of a missing dependency.

Solution: add `python3-nftables` to the Dockerfile.