### PR TITLE
Exclude IPv6 DNS servers when configuring VMs

### DIFF
--- a/tests/supervisor/test_resolvectl_dns_servers.py
+++ b/tests/supervisor/test_resolvectl_dns_servers.py
@@ -1,0 +1,34 @@
+# Avoid failures linked to nftables when initializing the global VmPool object
+import os
+os.environ["ALEPH_VM_ALLOW_VM_NETWORKING"] = "False"
+
+from vm_supervisor.conf import resolvectl_dns_servers, resolvectl_dns_servers_ipv4
+
+
+def test_resolvectl(mocker):
+    with mocker.patch(
+        "vm_supervisor.conf.check_output",
+        return_value="Link 2 (eth0): 109.88.203.3 62.197.111.140\n",
+    ):
+        servers = {"109.88.203.3", "62.197.111.140"}
+
+        dns_servers = set(resolvectl_dns_servers("eth0"))
+        assert dns_servers == servers
+
+        dns_servers_ipv4 = set(resolvectl_dns_servers_ipv4("eth0"))
+        assert dns_servers_ipv4 == servers
+
+
+def test_resolvectl_ipv6(mocker):
+    with mocker.patch(
+        "vm_supervisor.conf.check_output",
+        return_value="Link 2 (eth0): 109.88.203.3 62.197.111.140 2a02:2788:fff0:7::3\n        2a02:2788:fff0:5::140\n",
+    ):
+        ipv4_servers = {"109.88.203.3", "62.197.111.140"}
+        ipv6_servers = {"2a02:2788:fff0:7::3", "2a02:2788:fff0:5::140"}
+
+        dns_servers = set(resolvectl_dns_servers("eth0"))
+        assert dns_servers == ipv4_servers | ipv6_servers
+
+        dns_servers_ipv4 = set(resolvectl_dns_servers_ipv4("eth0"))
+        assert dns_servers_ipv4 == ipv4_servers

--- a/vm_supervisor/conf.py
+++ b/vm_supervisor/conf.py
@@ -5,7 +5,7 @@ from enum import Enum
 from os.path import isfile, join, exists, abspath, isdir
 from pathlib import Path
 from subprocess import check_output
-from typing import NewType, Optional, List, Dict, Any
+from typing import NewType, Optional, List, Dict, Any, Iterable
 
 from pydantic import BaseSettings, Field
 
@@ -27,14 +27,16 @@ def etc_resolv_conf_dns_servers():
                 yield ip[0]
 
 
-def resolvectl_dns_servers(interface):
+def resolvectl_dns_servers(interface: str) -> Iterable[str]:
     """
-    On Ubuntu 22.04, DNS servers can be queries using `resolvectl dns`.
-     The command `systemd-resolve` used in Ubuntu 20.04 is not found.
+    Use resolvectl to list available DNS servers (IPv4 and IPv6).
+
+    Note: we used to use systemd-resolve for Ubuntu 20.04 and Debian.
+    This command is not available anymore on Ubuntu 22.04 and is actually a symlink
+    to resolvectl.
 
     Example output for `resolvectl dns -i eth0`:
-    Link 2 (eth0): 67.207.67.3 67.207.67.2
-
+    Link 2 (eth0): 67.207.67.3 67.207.67.2 2a02:2788:fff0:5::140
     """
     output: bytes = check_output(["/usr/bin/resolvectl", "dns", "-i", interface])
     link, servers = output.split(b":")

--- a/vm_supervisor/conf.py
+++ b/vm_supervisor/conf.py
@@ -38,10 +38,10 @@ def resolvectl_dns_servers(interface: str) -> Iterable[str]:
     Example output for `resolvectl dns -i eth0`:
     Link 2 (eth0): 67.207.67.3 67.207.67.2 2a02:2788:fff0:5::140
     """
-    output: bytes = check_output(["/usr/bin/resolvectl", "dns", "-i", interface])
-    link, servers = output.split(b":")
-    for server in servers.split(b" "):
-        yield server.decode().strip()
+    output = check_output(["/usr/bin/resolvectl", "dns", "-i", interface], text=True)
+    link, servers = output.split(":")
+    for server in servers.split(" "):
+        yield server.strip()
 
 
 class Settings(BaseSettings):

--- a/vm_supervisor/conf.py
+++ b/vm_supervisor/conf.py
@@ -39,7 +39,8 @@ def resolvectl_dns_servers(interface: str) -> Iterable[str]:
     Link 2 (eth0): 67.207.67.3 67.207.67.2 2a02:2788:fff0:5::140
     """
     output = check_output(["/usr/bin/resolvectl", "dns", "-i", interface], text=True)
-    link, servers = output.split(":")
+    # Split on the first colon only to support IPv6 addresses.
+    link, servers = output.split(":", maxsplit=1)
     for server in servers.split(" "):
         yield server.strip()
 

--- a/vm_supervisor/conf.py
+++ b/vm_supervisor/conf.py
@@ -41,7 +41,7 @@ def resolvectl_dns_servers(interface: str) -> Iterable[str]:
     output = check_output(["/usr/bin/resolvectl", "dns", "-i", interface], text=True)
     # Split on the first colon only to support IPv6 addresses.
     link, servers = output.split(":", maxsplit=1)
-    for server in servers.split(" "):
+    for server in servers.split():
         yield server.strip()
 
 


### PR DESCRIPTION
Problem: VMs do not support IPv6 networking, and therefore cannot make use of IPv6 DNS servers. Specifying one in resolv.conf blocks network access from inside the VM.

Solution: Filter out IPv6 DNS servers from the output of resolvectl

Additional fixes:
* Support parsing IPv6 addresses from resolvectl output
* Support newlines in resolvectl output
* Doc and type hints.

Added unit tests.