### PR TITLE
Use cloud-init tool to setup an Instance

### DIFF
--- a/examples/instance_message_from_aleph.json
+++ b/examples/instance_message_from_aleph.json
@@ -19,7 +19,7 @@
         },
         "resources": {
             "vcpus": 1,
-            "memory": 128,
+            "memory": 512,
             "seconds": 30
         },
         "rootfs": {
@@ -28,14 +28,11 @@
                 "use_latest": true
             },
             "persistence": "host",
-            "size_mib": 20000
+            "size_mib": 5000
         },
-        "cloud_config": {
-            "password": "password",
-            "chpasswd": {
-                "expire": "False"
-            }
-        },
+        "authorized_keys": [
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHlGJRaIv/EzNT0eNqNB5DiGEbii28Fb2zCjuO/bMu7y amolinsdiaz@gmail.com"
+        ],
         "volumes": [
             {
                 "mount": "/opt/venv",

--- a/kernels/microvm-kernel-x86_64-5.10.config
+++ b/kernels/microvm-kernel-x86_64-5.10.config
@@ -2156,7 +2156,7 @@ CONFIG_OVERLAY_FS_REDIRECT_ALWAYS_FOLLOW=y
 #
 # CD-ROM/DVD Filesystems
 #
-# CONFIG_ISO9660_FS is not set
+CONFIG_ISO9660_FS=y
 # CONFIG_UDF_FS is not set
 # end of CD-ROM/DVD Filesystems
 

--- a/vm_supervisor/vm/firecracker/executable.py
+++ b/vm_supervisor/vm/firecracker/executable.py
@@ -182,6 +182,12 @@ class AlephFirecrackerExecutable(Generic[ConfigurationType]):
         self.guest_api_process = None
         self._firecracker_config = None
 
+    def get_vm_ip(self):
+        return self.tap_interface.guest_ip.with_prefixlen
+
+    def get_vm_route(self):
+        return str(self.tap_interface.host_ip).split("/", 1)[0]
+
     def to_dict(self):
         """Dict representation of the virtual machine. Used to record resource usage and for JSON serialization."""
         if self.fvm.proc and psutil:

--- a/vm_supervisor/vm/firecracker/instance.py
+++ b/vm_supervisor/vm/firecracker/instance.py
@@ -2,8 +2,10 @@ import asyncio
 import logging
 import subprocess
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import Optional
 
+import yaml
 from aleph_message.models import ItemHash
 from aleph_message.models.execution.environment import MachineResources
 
@@ -16,10 +18,12 @@ from firecracker.config import (
     Vsock,
 )
 from firecracker.microvm import setfacl
+from vm_supervisor.conf import settings
 from vm_supervisor.network.interfaces import TapInterface
 from vm_supervisor.storage import create_devmapper
 from vm_supervisor.utils import ping, HostNotFoundError
 
+from ...utils import run_in_subprocess
 from .executable import (
     AlephFirecrackerExecutable,
     AlephFirecrackerResources,
@@ -75,6 +79,8 @@ class AlephFirecrackerInstance(AlephFirecrackerExecutable):
         logger.debug("instance setup started")
         await setfacl()
 
+        cloud_init_drive = await self._create_cloud_init_drive()
+
         self._firecracker_config = FirecrackerConfig(
             boot_source=BootSource(
                 kernel_image_path=Path(
@@ -91,6 +97,7 @@ class AlephFirecrackerInstance(AlephFirecrackerExecutable):
                     is_root_device=True,
                     is_read_only=False,
                 ),
+                cloud_init_drive,
             ]
             + [
                 self.fvm.enable_drive(volume.path_on_host, read_only=volume.read_only)
@@ -133,5 +140,80 @@ class AlephFirecrackerInstance(AlephFirecrackerExecutable):
 
     async def configure(self):
         """Configure the VM by sending configuration info to it's init"""
-        # TODO: Implement Cloud-init interface
+        # Configuration of instances is sent during `self.setup()` by passing it via a volume.
         pass
+
+    def _encode_user_data(self) -> bytes:
+        """Creates user data configuration file for cloud-init tool"""
+
+        ssh_authorized_keys = self.resources.message_content.authorized_keys or []
+
+        config = {
+            "hostname": self.vm_hash,
+            "disable_root": False,
+            "ssh_pwauth": False,
+            "ssh_authorized_keys": ssh_authorized_keys,
+        }
+
+        cloud_config_header = "#cloud-config\n"
+        config_output = yaml.safe_dump(
+            config, default_flow_style=False, sort_keys=False
+        )
+
+        return (cloud_config_header + config_output).encode()
+
+    def _create_network_file(self) -> bytes:
+        """Creates network configuration file for cloud-init tool"""
+
+        assert (
+            self.enable_networking and self.tap_interface
+        ), f"Network not enabled for VM {self.vm_id}"
+
+        ip = self.get_vm_ip()
+        route = self.get_vm_route()
+
+        network = {
+            "network": {
+                "ethernets": {
+                    "eth0": {
+                        "dhcp4": False,
+                        "dhcp6": False,
+                        "addresses": [str(ip)],
+                        "gateway4": route,
+                        "nameservers": {
+                            "addresses": settings.DNS_NAMESERVERS,
+                        },
+                    },
+                },
+                "version": 2,
+            },
+        }
+
+        return yaml.safe_dump(
+            network, default_flow_style=False, sort_keys=False
+        ).encode()
+
+    async def _create_cloud_init_drive(self) -> Drive:
+        """Creates the cloud-init volume to configure and setup the VM"""
+
+        disk_image_path = settings.EXECUTION_ROOT / f"cloud-init-{self.vm_hash}.img"
+
+        with NamedTemporaryFile() as main_config_file:
+            user_data = self._encode_user_data()
+            main_config_file.write(user_data)
+            main_config_file.flush()
+            with NamedTemporaryFile() as network_config_file:
+                network_config = self._create_network_file()
+                network_config_file.write(network_config)
+                network_config_file.flush()
+
+                await run_in_subprocess(
+                    [
+                        "cloud-localds",
+                        f"--network-config={network_config_file.name}",
+                        str(disk_image_path),
+                        main_config_file.name,
+                    ]
+                )
+
+        return self.fvm.enable_drive(disk_image_path, read_only=True)

--- a/vm_supervisor/vm/firecracker/program.py
+++ b/vm_supervisor/vm/firecracker/program.py
@@ -319,8 +319,8 @@ class AlephFirecrackerProgram(AlephFirecrackerExecutable[ProgramVmConfiguration]
         # The ip and route should not contain the network mask in order to maintain
         # compatibility with the existing runtimes.
         if self.enable_networking and self.tap_interface:
-            ip = self.tap_interface.guest_ip.with_prefixlen.split("/", 1)[0]
-            route = str(self.tap_interface.host_ip).split("/", 1)[0]
+            ip = self.get_vm_ip().split("/", 1)[0]
+            route = self.get_vm_route()
         else:
             ip, route = None, None
 


### PR DESCRIPTION
Problem: Setup an instance using a cloud OS image file was impossible without a custom init file

Solution: Use the cloud-init tool already integrated in some cloud distributions to setup the network and system configuration.