### PR TITLE
Feature: assign public IPv6 ranges to VMs

### DIFF
--- a/docker/vm_supervisor-dev.dockerfile
+++ b/docker/vm_supervisor-dev.dockerfile
@@ -5,7 +5,7 @@ FROM debian:bullseye
 RUN apt-get update && apt-get -y upgrade && apt-get install -y \
     sudo acl curl squashfs-tools git \
     python3 python3-aiohttp python3-alembic python3-msgpack python3-pip python3-aiodns python3-aioredis\
-    python3-nftables python3-psutil python3-setproctitle python3-sqlalchemy python3-packaging python3-cpuinfo \
+    python3-nftables python3-psutil python3-setproctitle python3-sqlalchemy python3-packaging python3-cpuinfo ndppd \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd jailman

--- a/firecracker/microvm.py
+++ b/firecracker/microvm.py
@@ -6,11 +6,14 @@ import shutil
 import string
 from asyncio import Task
 from asyncio.base_events import Server
+from dataclasses import dataclass
 from os import getuid
 from pathlib import Path
 from pwd import getpwnam
 from tempfile import NamedTemporaryFile
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Any, Dict
+
+import msgpack
 
 from .config import Drive, FirecrackerConfig
 
@@ -56,6 +59,14 @@ async def setfacl():
         logger.warning(f"[stdout]\n{stdout.decode()}")
     if stderr:
         logger.warning(f"[stderr]\n{stderr.decode()}")
+
+
+@dataclass
+class RuntimeConfiguration:
+    version: str
+
+    def supports_ipv6(self) -> bool:
+        return self.version != "1.0.0"
 
 
 class MicroVM:
@@ -110,6 +121,7 @@ class MicroVM:
         self.jailer_bin_path = jailer_bin_path
         self.drives = []
         self.init_timeout = init_timeout
+        self.runtime_config = None
 
     def to_dict(self):
         return {
@@ -278,8 +290,7 @@ class MicroVM:
             return path_on_host
 
     def enable_device_mapper_rootfs(self, path_on_host: Path) -> Path:
-        """Mount a rootfs to the VM.
-        """
+        """Mount a rootfs to the VM."""
         self.mounted_rootfs = path_on_host
         if not self.use_jailer:
             return path_on_host
@@ -358,15 +369,28 @@ class MicroVM:
         logger.debug("Waiting for init...")
         queue = asyncio.Queue()
 
-        async def unix_client_connected(*_):
-            await queue.put(True)
+        async def unix_client_connected(
+            reader: asyncio.StreamReader, _writer: asyncio.StreamWriter
+        ):
+            data = await reader.read(1_000_000)
+            if data:
+                config_dict: Dict[str, Any] = msgpack.loads(data)
+                runtime_config = RuntimeConfiguration(version=config_dict["version"])
+            else:
+                # Older runtimes do not send a config. Use a default.
+                runtime_config = RuntimeConfiguration(version="1.0.0")
+
+            logger.debug("Runtime version: %s", runtime_config)
+            await queue.put(runtime_config)
 
         self._unix_socket = await asyncio.start_unix_server(
             unix_client_connected, path=f"{self.vsock_path}_52"
         )
         system(f"chown jailman:jailman {self.vsock_path}_52")
         try:
-            await asyncio.wait_for(queue.get(), timeout=self.init_timeout)
+            self.runtime_config = await asyncio.wait_for(
+                queue.get(), timeout=self.init_timeout
+            )
             logger.debug("...signal from init received")
         except asyncio.TimeoutError:
             logger.warning("Never received signal from init")

--- a/packaging/aleph-vm/DEBIAN/control
+++ b/packaging/aleph-vm/DEBIAN/control
@@ -3,6 +3,6 @@ Version: 0.1.8
 Architecture: all
 Maintainer: Aleph.im
 Description: Aleph.im VM execution engine
-Depends: python3,python3-pip,python3-aiohttp,python3-msgpack,python3-aiodns,python3-alembic,python3-sqlalchemy,python3-setproctitle,redis,python3-aioredis,python3-psutil,sudo,acl,curl,systemd-container,squashfs-tools,debootstrap,python3-packaging,python3-cpuinfo,python3-nftables,python3-jsonschema,cloud-image-utils
+Depends: python3,python3-pip,python3-aiohttp,python3-msgpack,python3-aiodns,python3-alembic,python3-sqlalchemy,python3-setproctitle,redis,python3-aioredis,python3-psutil,sudo,acl,curl,systemd-container,squashfs-tools,debootstrap,python3-packaging,python3-cpuinfo,python3-nftables,python3-jsonschema,cloud-image-utils,ndppd
 Section: aleph-im
 Priority: Extra

--- a/runtimes/aleph-debian-11-python/init1.py
+++ b/runtimes/aleph-debian-11-python/init1.py
@@ -31,6 +31,7 @@ import msgpack
 
 logger.debug("Imports finished")
 
+__version__ = "2.0.0"
 ASGIApplication = NewType("ASGIApplication", Any)
 
 
@@ -86,6 +87,7 @@ s.listen()
 # Send the host that we are ready
 s0 = socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM)
 s0.connect((2, 52))
+s0.sendall(msgpack.dumps({"version": __version__}))
 s0.close()
 
 # Configure aleph-client to use the guest API

--- a/runtimes/aleph-debian-11-python/init1.py
+++ b/runtimes/aleph-debian-11-python/init1.py
@@ -65,7 +65,9 @@ class ConfigurationPayload:
     encoding: Encoding = None
     entrypoint: str = None
     ip: Optional[str] = None
+    ipv6: Optional[str] = None
     route: Optional[str] = None
+    ipv6_gateway: Optional[str] = None
     dns_servers: List[str] = field(default_factory=list)
     volumes: List[Volume] = field(default_factory=list)
     variables: Optional[Dict[str, str]] = None
@@ -108,7 +110,11 @@ def setup_variables(variables: Optional[Dict[str, str]]):
 
 
 def setup_network(
-    ip: Optional[str], route: Optional[str], dns_servers: Optional[List[str]] = None
+    ip: Optional[str],
+    ipv6: Optional[str],
+    route: Optional[str],
+    ipv6_gateway: Optional[str],
+    dns_servers: Optional[List[str]] = None,
 ):
     """Setup the system with info from the host."""
     dns_servers = dns_servers or []
@@ -116,29 +122,41 @@ def setup_network(
         logger.info("No network interface eth0")
         return
 
-    if not ip:
+    if not (ip or ipv6):
         logger.info("No network IP")
         return
 
-    logger.debug("Setting up networking")
+    # Configure loopback networking
     system("ip addr add 127.0.0.1/8 dev lo brd + scope host")
     system("ip addr add ::1/128 dev lo")
     system("ip link set lo up")
-    if "/" in ip:
-        # Forward compatibility with future supervisors that pass the mask with the IP.
-        system(f"ip addr add {ip} dev eth0")
-    else:
-        logger.warning(
-            "Not passing the mask with the IP is deprecated and will be unsupported"
-        )
-        system(f"ip addr add {ip}/24 dev eth0")
-    system("ip link set eth0 up")
 
-    if route:
-        system(f"ip route add default via {route} dev eth0")
-        logger.debug(f"IP and route set: {ip} via {route}")
-    else:
-        logger.warning("IP set with no network route")
+    if ip:
+        logger.debug("Setting up IPv4")
+
+        # Forward compatibility with future supervisors that pass the mask with the IP.
+        if "/" not in ip:
+            logger.warning(
+                "Not passing the mask with the IP is deprecated and will be unsupported"
+            )
+            ip = f"{ip}/24"
+
+        system(f"ip addr add {ip} dev eth0")
+
+        if route:
+            system(f"ip route add default via {route} dev eth0")
+            logger.debug(f"IP and route set: {ip} via {route}")
+        else:
+            logger.warning("IPv4 set with no network route")
+
+    if ipv6:
+        logger.debug("Setting up IPv6")
+        system(f"ip addr add {ipv6} dev eth0")
+        system(f"ip -6 route add default via {ipv6_gateway} dev eth0")
+        logger.debug(f"IPv6 setup to address {ipv6}")
+
+    if ip or ipv6:
+        system("ip link set eth0 up")
 
     with open("/etc/resolv.conf", "wb") as resolvconf_fd:
         for server in dns_servers:
@@ -478,7 +496,13 @@ def setup_system(config: ConfigurationPayload):
 
     setup_variables(config.variables)
     setup_volumes(config.volumes)
-    setup_network(config.ip, config.route, config.dns_servers)
+    setup_network(
+        ip=config.ip,
+        ipv6=config.ipv6,
+        route=config.route,
+        ipv6_gateway=config.ipv6_gateway,
+        dns_servers=config.dns_servers,
+    )
     setup_input_data(config.input_data)
     logger.debug("Setup finished")
 

--- a/tests/supervisor/test_ipv6_allocator.py
+++ b/tests/supervisor/test_ipv6_allocator.py
@@ -1,0 +1,23 @@
+import os
+
+# Avoid failures linked to settings when initializing the global VmPool object
+os.environ["ALEPH_VM_ALLOW_VM_NETWORKING"] = "False"
+
+from ipaddress import IPv6Network
+
+from aleph_message.models import ItemHash
+
+from vm_supervisor.network.hostnetwork import StaticIPv6Allocator
+
+
+def test_static_ipv6_allocator():
+    allocator = StaticIPv6Allocator(
+        ipv6_range=IPv6Network("1111:2222:3333:4444::/64"), subnet_prefix=124
+    )
+    ip_subnet = allocator.allocate_vm_ipv6_subnet(
+        vm_id=3,
+        vm_hash=ItemHash(
+            "8920215b2e961a4d4c59a8ceb2803af53f91530ff53d6704273ab4d380bc6446"
+        ),
+    )
+    assert ip_subnet == IPv6Network("1111:2222:3333:4444:0001:8920:215b:2e90/124")

--- a/vm_supervisor/README.md
+++ b/vm_supervisor/README.md
@@ -57,7 +57,7 @@ when running the VM Supervisor.
 ```shell
 apt update
 apt install -y git python3 python3-aiohttp python3-msgpack python3-aiodns python3-sqlalchemy python3-setproctitle redis python3-aioredis \
- python3-psutil sudo acl curl systemd-container squashfs-tools debootstrap python3-nftables python3-jsonschema
+ python3-psutil sudo acl curl systemd-container squashfs-tools debootstrap python3-nftables python3-jsonschema ndppd
 useradd jailman
 ```
 

--- a/vm_supervisor/conf.py
+++ b/vm_supervisor/conf.py
@@ -20,6 +20,11 @@ class DnsResolver(str, Enum):
     resolvectl = "resolvectl"  # Systemd-resolved, common on Ubuntu
 
 
+class IPv6AllocationPolicy(str, Enum):
+    static = "static"  # Compute the IP address based on the VM item hash.
+    dynamic = "dynamic"  # Assign an available IP address.
+
+
 def etc_resolv_conf_dns_servers():
     with open("/etc/resolv.conf", "r") as resolv_file:
         for line in resolv_file.readlines():
@@ -89,6 +94,18 @@ class Settings(BaseSettings):
     IPV4_NETWORK_PREFIX_LENGTH = Field(
         default=24,
         description="Individual VM network prefix length in bits",
+    )
+    IPV6_ADDRESS_POOL: str = Field(
+        default="fc00:1:2:3::/64",
+        description="IPv6 address range assigned to the host. Example: 1111:2222:3333:4444::/64. "
+        "Defaults to a local address range for compatibility with hosts not yet configured for IPv6.",
+    )
+    IPV6_ALLOCATION_POLICY: IPv6AllocationPolicy = Field(
+        default=IPv6AllocationPolicy.static
+    )
+    IPV6_SUBNET_PREFIX: int = Field(
+        default=124,
+        description="IPv6 subnet prefix for VMs. Made configurable for testing.",
     )
     NFTABLES_CHAIN_PREFIX = "aleph"
 

--- a/vm_supervisor/network/hostnetwork.py
+++ b/vm_supervisor/network/hostnetwork.py
@@ -1,26 +1,160 @@
 import logging
+from ipaddress import IPv6Network
 from pathlib import Path
+from typing import Optional, Protocol
 
+from aleph_message.models import ItemHash
+
+from vm_supervisor.conf import IPv6AllocationPolicy
+
+from ..vm.vm_type import VmType
 from .firewall import initialize_nftables, setup_nftables_for_vm, teardown_nftables
 from .interfaces import TapInterface
 from .ipaddresses import IPv4NetworkWithInterfaces
+from .ndp_proxy import NdpProxy
 
 logger = logging.getLogger(__name__)
 
 
+def _read_file_as_int(config_file: Path) -> int:
+    return int(config_file.read_text())
+
+
 def get_ipv4_forwarding_state() -> int:
-    """Reads the current ipv4 forwarding setting from the hosts, converts it to int and returns it"""
-    return int(Path("/proc/sys/net/ipv4/ip_forward").read_text())
+    """Reads the current IPv4 forwarding setting from the host, converts it to int and returns it"""
+    return _read_file_as_int(Path("/proc/sys/net/ipv4/ip_forward"))
+
+
+def get_ipv6_forwarding_state() -> int:
+    """Reads the current IPv6 forwarding setting from the host, converts it to int and returns it"""
+    return _read_file_as_int(Path("/proc/sys/net/ipv6/conf/all/forwarding"))
+
+
+class IPv6Allocator(Protocol):
+    def allocate_vm_ipv6_subnet(
+        self, vm_id: int, vm_hash: ItemHash, vm_type: VmType
+    ) -> IPv6Network:
+        ...
+
+
+class StaticIPv6Allocator(IPv6Allocator):
+    """
+    Static IPv6 allocator.
+    Computes IPv6 addresses based on the machine type and VM hash. The algorithm works
+    as follows:
+
+    | Component | CRN /64 range | VM type | Item hash prefix | Instance range |
+    |-----------|---------------|---------|------------------|----------------|
+    | Length    | 64 bits       | 16 bits | 44 bits          | 4 bits         |
+    """
+
+    VM_TYPE_PREFIX = {
+        VmType.microvm: "1",
+        VmType.persistent_program: "2",
+        VmType.instance: "3",
+    }
+
+    def __init__(self, ipv6_range: IPv6Network, subnet_prefix: int):
+        if ipv6_range.prefixlen != 64:
+            raise ValueError(
+                "The static IP address allocation scheme requires a /64 subnet"
+            )
+        if subnet_prefix < 124:
+            raise ValueError("The IPv6 subnet prefix cannot be larger than /124.")
+
+        self.ipv6_range = ipv6_range
+        self.subnet_prefix = subnet_prefix
+
+    def allocate_vm_ipv6_subnet(
+        self, vm_id: int, vm_hash: ItemHash, vm_type: VmType
+    ) -> IPv6Network:
+        ipv6_elems = self.ipv6_range.exploded.split(":")[:4]
+        ipv6_elems += [self.VM_TYPE_PREFIX[vm_type]]
+
+        # Add the item hash of the VM as the last 44 bits of the IPv6 address.
+        # The last 4 bits are left for use to the VM owner as a /124 subnet.
+        ipv6_elems += [vm_hash[0:4], vm_hash[4:8], vm_hash[8:11] + "0"]
+
+        return IPv6Network(":".join(ipv6_elems) + "/124")
+
+
+class DynamicIPv6Allocator(IPv6Allocator):
+    """
+    A dynamic allocator, for testing purposes.
+    This allocator slices the input IPv6 address range in subnets of the same size
+    and iterates through them. The first subnet is assumed to be reserved for use by the host,
+    as we use this allocator in situations where the address range is small and the host
+    subnet cannot be isolated from the VM subnets (ex: /124 network on Digital Ocean for the CI).
+    """
+
+    def __init__(self, ipv6_range: IPv6Network, subnet_prefix: int):
+        self.ipv6_range = ipv6_range
+        self.vm_subnet_prefix = subnet_prefix
+
+        self.subnets_generator = ipv6_range.subnets(new_prefix=subnet_prefix)
+        # Assume the first subnet is reserved for the host
+        _ = next(self.subnets_generator)
+
+    def allocate_vm_ipv6_subnet(
+        self, vm_id: int, vm_hash: ItemHash, vm_type: VmType
+    ) -> IPv6Network:
+        return next(self.subnets_generator)
+
+
+def make_ipv6_allocator(
+    allocation_policy: IPv6AllocationPolicy, address_pool: str, subnet_prefix: int
+) -> IPv6Allocator:
+    if allocation_policy == IPv6AllocationPolicy.static:
+        return StaticIPv6Allocator(
+            ipv6_range=IPv6Network(address_pool), subnet_prefix=subnet_prefix
+        )
+
+    return DynamicIPv6Allocator(
+        ipv6_range=IPv6Network(address_pool), subnet_prefix=subnet_prefix
+    )
 
 
 class Network:
-    ipv4_forward_state_before_setup: int
-    address_pool: IPv4NetworkWithInterfaces = IPv4NetworkWithInterfaces("172.16.0.0/12")
+    ipv4_forward_state_before_setup: Optional[int]
+    ipv6_forward_state_before_setup: Optional[int]
+    ipv4_address_pool: IPv4NetworkWithInterfaces = IPv4NetworkWithInterfaces(
+        "172.16.0.0/12"
+    )
+    ipv6_address_pool: IPv6Network
     network_size: int
     external_interface: str
 
+    IPV6_SUBNET_PREFIX: int = 124
+
+    def __init__(
+        self,
+        vm_ipv4_address_pool_range: str,
+        vm_network_size: int,
+        external_interface: str,
+        ipv6_allocator: IPv6Allocator,
+    ) -> None:
+        """Sets up the Network class with some information it needs so future function calls work as expected"""
+        self.ipv4_address_pool = IPv4NetworkWithInterfaces(vm_ipv4_address_pool_range)
+        if not self.ipv4_address_pool.is_private:
+            logger.warning(
+                f"Using a network range that is not private: {self.ipv4_address_pool}"
+            )
+        self.ipv6_allocator = ipv6_allocator
+
+        self.network_size = vm_network_size
+        self.external_interface = external_interface
+        self.ipv4_forward_state_before_setup = None
+        self.ipv6_forward_state_before_setup = None
+
+        self.enable_ipv4_forwarding()
+        self.enable_ipv6_forwarding()
+
+        self.ndp_proxy = NdpProxy(host_network_interface=external_interface)
+
+        initialize_nftables()
+
     def get_network_for_tap(self, vm_id: int) -> IPv4NetworkWithInterfaces:
-        subnets = list(self.address_pool.subnets(new_prefix=self.network_size))
+        subnets = list(self.ipv4_address_pool.subnets(new_prefix=self.network_size))
         return subnets[vm_id]
 
     def enable_ipv4_forwarding(self) -> None:
@@ -33,32 +167,51 @@ class Network:
     def reset_ipv4_forwarding_state(self) -> None:
         """Returns the hosts IPv4 forwarding state how it was before we enabled it"""
         logger.debug("Resetting IPv4 forwarding state to state before we enabled it")
+        if self.ipv4_forward_state_before_setup is None:
+            return
+
         if self.ipv4_forward_state_before_setup != get_ipv4_forwarding_state():
             Path("/proc/sys/net/ipv4/ip_forward").write_text(
                 str(self.ipv4_forward_state_before_setup)
             )
 
-    def __init__(
-        self, vm_address_pool_range: str, vm_network_size: int, external_interface: str
-    ) -> None:
-        """Sets up the Network class with some information it needs so future function calls work as expected"""
-        self.address_pool = IPv4NetworkWithInterfaces(vm_address_pool_range)
-        if not self.address_pool.is_private:
-            logger.warning(
-                f"Using a network range that is not private: {self.address_pool}"
+    def enable_ipv6_forwarding(self) -> None:
+        """Saves the host IPv6 forwarding state, and if it was disabled, enables it"""
+        logger.debug("Enabling IPv6 forwarding")
+        self.ipv6_forward_state_before_setup = get_ipv6_forwarding_state()
+        if not self.ipv6_forward_state_before_setup:
+            Path("/proc/sys/net/ipv6/conf/all/forwarding").write_text("1")
+
+    def reset_ipv6_forwarding_state(self) -> None:
+        """Returns the host IPv6 forwarding state how it was before we enabled it"""
+        logger.debug("Resetting IPv6 forwarding state to state before we enabled it")
+        if self.ipv6_forward_state_before_setup is None:
+            return
+
+        if self.ipv6_forward_state_before_setup != get_ipv6_forwarding_state():
+            Path("/proc/sys/net/ipv6/conf/all/forwarding").write_text(
+                str(self.ipv6_forward_state_before_setup)
             )
-        self.network_size = vm_network_size
-        self.external_interface = external_interface
-        self.enable_ipv4_forwarding()
-        initialize_nftables()
 
     def teardown(self) -> None:
         teardown_nftables()
         self.reset_ipv4_forwarding_state()
+        self.reset_ipv6_forwarding_state()
 
-    async def create_tap(self, vm_id: int) -> TapInterface:
+    async def create_tap(
+        self, vm_id: int, vm_hash: ItemHash, vm_type: VmType
+    ) -> TapInterface:
         """Create TAP interface to be used by VM"""
-        interface = TapInterface(f"vmtap{vm_id}", self.get_network_for_tap(vm_id))
+        interface = TapInterface(
+            f"vmtap{vm_id}",
+            ip_network=self.get_network_for_tap(vm_id),
+            ipv6_network=self.ipv6_allocator.allocate_vm_ipv6_subnet(
+                vm_id=vm_id,
+                vm_hash=vm_hash,
+                vm_type=vm_type,
+            ),
+            ndp_proxy=self.ndp_proxy,
+        )
         await interface.create()
         setup_nftables_for_vm(vm_id, interface)
         return interface

--- a/vm_supervisor/network/interfaces.py
+++ b/vm_supervisor/network/interfaces.py
@@ -1,10 +1,11 @@
 import asyncio
 import logging
 import shutil
-from ipaddress import IPv4Interface
+from ipaddress import IPv4Interface, IPv6Address, IPv6Interface, IPv6Network
 from subprocess import run
 
 from .ipaddresses import IPv4NetworkWithInterfaces
+from .ndp_proxy import NdpProxy
 
 logger = logging.getLogger(__name__)
 
@@ -12,10 +13,19 @@ logger = logging.getLogger(__name__)
 class TapInterface:
     device_name: str
     ip_network: IPv4NetworkWithInterfaces
+    ipv6_network: IPv6Network
 
-    def __init__(self, device_name: str, ip_network: IPv4NetworkWithInterfaces):
+    def __init__(
+        self,
+        device_name: str,
+        ip_network: IPv4NetworkWithInterfaces,
+        ipv6_network: IPv6Network,
+        ndp_proxy: NdpProxy,
+    ):
         self.device_name: str = device_name
         self.ip_network: IPv4NetworkWithInterfaces = ip_network
+        self.ipv6_network = ipv6_network
+        self.ndp_proxy = ndp_proxy
 
     @property
     def guest_ip(self) -> IPv4Interface:
@@ -24,6 +34,14 @@ class TapInterface:
     @property
     def host_ip(self) -> IPv4Interface:
         return self.ip_network[1]
+
+    @property
+    def guest_ipv6(self) -> IPv6Interface:
+        return IPv6Interface(f"{self.ipv6_network[1]}/{self.ipv6_network.prefixlen}")
+
+    @property
+    def host_ipv6(self) -> IPv6Interface:
+        return IPv6Interface(f"{self.ipv6_network[0]}/{self.ipv6_network.prefixlen}")
 
     async def create(self):
         logger.debug("Create network interface")
@@ -40,7 +58,19 @@ class TapInterface:
                 self.device_name,
             ]
         )
+        ipv6_gateway = self.host_ipv6
+        run(
+            [
+                ip_command,
+                "addr",
+                "add",
+                str(ipv6_gateway),
+                "dev",
+                self.device_name,
+            ]
+        )
         run([ip_command, "link", "set", self.device_name, "up"])
+        self.ndp_proxy.add_range(self.device_name, ipv6_gateway.network)
         logger.debug(f"Network interface created: {self.device_name}")
 
     async def delete(self) -> None:
@@ -48,4 +78,5 @@ class TapInterface:
         Then removes the interface from the host."""
         logger.debug(f"Removing interface {self.device_name}")
         await asyncio.sleep(0.1)  # Avoids Device/Resource busy bug
+        self.ndp_proxy.delete_range(self.device_name)
         run(["ip", "tuntap", "del", self.device_name, "mode", "tap"])

--- a/vm_supervisor/network/ndp_proxy.py
+++ b/vm_supervisor/network/ndp_proxy.py
@@ -1,0 +1,57 @@
+"""
+Neighbourhood Discovery Proxy (NDP) functionalities.
+
+Some cloud providers do not route the whole advertised IPv6 address range to servers, but instead
+only route one address. They will issue NDP requests to the network to determine if the other
+addresses in the range are used. This means that our server (be it the hypervisor or the VMs)
+has to answer to these requests to make the VMs routable.
+
+To achieve this, we use ndppd. Each time an update is required, we overwrite /etc/ndppd.conf
+and restart the service.
+"""
+import logging
+from dataclasses import dataclass
+from ipaddress import IPv6Network
+from pathlib import Path
+from subprocess import run
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class NdpRule:
+    address_range: IPv6Network
+
+
+class NdpProxy:
+    def __init__(self, host_network_interface: str):
+        self.host_network_interface = host_network_interface
+        self.interface_address_range_mapping: Dict[str, IPv6Network] = {}
+
+    @staticmethod
+    def _restart_ndppd():
+        logger.debug("Restarting ndppd")
+        run(["systemctl", "restart", "ndppd"])
+
+    def _update_ndppd_conf(self):
+        config = f"proxy {self.host_network_interface} {{\n"
+        for interface, address_range in self.interface_address_range_mapping.items():
+            config += f"  rule {address_range} {{\n    iface {interface}\n  }}\n"
+        config += "}\n"
+        Path("/etc/ndppd.conf").write_text(config)
+        self._restart_ndppd()
+
+    def add_range(self, interface: str, address_range: IPv6Network):
+        logger.debug("Proxying range %s -> %s", address_range, interface)
+        self.interface_address_range_mapping[interface] = address_range
+        self._update_ndppd_conf()
+
+    def delete_range(self, interface: str):
+        try:
+            address_range = self.interface_address_range_mapping.pop(interface)
+            logger.debug("Deactivated proxying for %s (%s)", interface, address_range)
+        except KeyError:
+            return
+
+        self._update_ndppd_conf()

--- a/vm_supervisor/utils.py
+++ b/vm_supervisor/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import dataclasses
 import hashlib
 import json
 import logging
@@ -9,8 +10,22 @@ from dataclasses import is_dataclass
 from typing import Any, Coroutine, Dict, List, Optional
 
 import aiodns
+import msgpack
 
 logger = logging.getLogger(__name__)
+
+
+class MsgpackSerializable:
+    def __post_init__(self, *args, **kwargs):
+        if not is_dataclass(self):
+            raise TypeError(f"Decorated class must be a dataclass: {self}")
+        super().__init_subclass__(*args, **kwargs)
+
+    def as_msgpack(self) -> bytes:
+        if is_dataclass(self):
+            return msgpack.dumps(dataclasses.asdict(self), use_bin_type=True)  # type: ignore
+        else:
+            raise TypeError(f"Decorated class must be a dataclass: {self}")
 
 
 def b32_to_b16(hash: str) -> bytes:

--- a/vm_supervisor/views.py
+++ b/vm_supervisor/views.py
@@ -62,7 +62,9 @@ async def run_code_from_hostname(request: web.Request) -> web.Response:
 
     message_ref_base32 = request.host.split(".")[0]
     if settings.FAKE_DATA_PROGRAM:
-        message_ref = ItemHash("fake-hash")
+        message_ref = ItemHash(
+            "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe"
+        )
     else:
         try:
             message_ref = ItemHash(b32_to_b16(message_ref_base32).decode())

--- a/vm_supervisor/vm/firecracker/executable.py
+++ b/vm_supervisor/vm/firecracker/executable.py
@@ -182,11 +182,25 @@ class AlephFirecrackerExecutable(Generic[ConfigurationType]):
         self.guest_api_process = None
         self._firecracker_config = None
 
-    def get_vm_ip(self):
-        return self.tap_interface.guest_ip.with_prefixlen
+    def get_vm_ip(self) -> Optional[str]:
+        if self.tap_interface:
+            return self.tap_interface.guest_ip.with_prefixlen
+        return None
 
-    def get_vm_route(self):
-        return str(self.tap_interface.host_ip).split("/", 1)[0]
+    def get_vm_route(self) -> Optional[str]:
+        if self.tap_interface:
+            return str(self.tap_interface.host_ip).split("/", 1)[0]
+        return None
+
+    def get_vm_ipv6(self) -> Optional[str]:
+        if self.tap_interface:
+            return self.tap_interface.guest_ipv6.with_prefixlen
+        return None
+
+    def get_vm_ipv6_gateway(self) -> Optional[str]:
+        if self.tap_interface:
+            return str(self.tap_interface.host_ipv6.ip)
+        return None
 
     def to_dict(self):
         """Dict representation of the virtual machine. Used to record resource usage and for JSON serialization."""

--- a/vm_supervisor/vm/firecracker/instance.py
+++ b/vm_supervisor/vm/firecracker/instance.py
@@ -170,6 +170,8 @@ class AlephFirecrackerInstance(AlephFirecrackerExecutable):
 
         ip = self.get_vm_ip()
         route = self.get_vm_route()
+        ipv6 = self.get_vm_ipv6()
+        ipv6_gateway = self.get_vm_ipv6_gateway()
 
         network = {
             "network": {
@@ -177,8 +179,9 @@ class AlephFirecrackerInstance(AlephFirecrackerExecutable):
                     "eth0": {
                         "dhcp4": False,
                         "dhcp6": False,
-                        "addresses": [str(ip)],
+                        "addresses": [ip, ipv6],
                         "gateway4": route,
+                        "gateway6": ipv6_gateway,
                         "nameservers": {
                             "addresses": settings.DNS_NAMESERVERS,
                         },

--- a/vm_supervisor/vm/vm_type.py
+++ b/vm_supervisor/vm/vm_type.py
@@ -1,0 +1,21 @@
+from enum import Enum
+
+from aleph_message.models import ExecutableContent, InstanceContent, ProgramContent
+
+
+class VmType(Enum):
+    microvm = 1
+    persistent_program = 2
+    instance = 3
+
+    @staticmethod
+    def from_message_content(content: ExecutableContent) -> "VmType":
+        if isinstance(content, InstanceContent):
+            return VmType.instance
+
+        elif isinstance(content, ProgramContent):
+            if content.on.persistent:
+                return VmType.persistent_program
+            return VmType.microvm
+
+        raise TypeError(f"Unexpected message content type: {type(content)}")


### PR DESCRIPTION
Problem: we want each VM to be reachable on the internet, with no restriction in terms of ports, protocols, etc.

Solution: slice up the IPv6 range attributed to each CRN and allocate a subnet to each VM.

By default, a /124 IPv6 range is assigned to each VM. The IPv6 range is based on the item hash of the VM. For a VM with item hash `cafecafecafecafe...` on a CRN with 1111:2222:3333:4444::/64, the VM will be reachable at 1111:2222:3333:4444:1:cafe:cafe:caf1.

We use NDP proxying by default, as some cloud operators do not route the full IPv6 range to the server.

This PR does not manage the problem of isolating the IPv6 address of the host. It is advised to isolate the host range in its own /80 (ex: `1111:2222:3333:4444:0::/80`). This can be achieved by either running the following script in a tmux/screen session:

```shell
ip addr del 1111:2222:3333:4444::/64 dev eth0
ip addr add 1111:2222:3333:4444:0::/80 dev eth0
```

or by modifying the configuration in /etc/networking or /etc/netplan.