### PR TITLE
Fix: Users reported errors with key `family` absent from entry

### DIFF
--- a/vm_supervisor/network/firewall.py
+++ b/vm_supervisor/network/firewall.py
@@ -88,8 +88,9 @@ def check_if_table_exists(family: str, table: str) -> bool:
         if (
             isinstance(entry, dict)
             and "table" in entry
-            and entry["family"] == family
-            and entry["name"] == table
+            # Key "family" was reported by users as not always present, so we use .get() instead of [].
+            and entry.get("family") == family
+            and entry.get("name") == table
         ):
             return True
     return False


### PR DESCRIPTION
On Debian 11:

```
python3[1910876]:     if not check_if_table_exists("ip", table):
python3[1910876]:   File "/opt/aleph-vm/vm_supervisor/network/firewall.py", line 91, in check_if_table_exists
python3[1910876]:     and entry["family"] == family
python3[1910876]: KeyError: 'family'
```

Same commit as #345 but on the main branch instead of the release branch.