### PR TITLE
Feature: microVM runtime version

### DIFF
--- a/firecracker/microvm.py
+++ b/firecracker/microvm.py
@@ -62,11 +62,11 @@ async def setfacl():
 
 
 @dataclass
-class RuntimeConfig:
+class RuntimeConfiguration:
     version: str
 
     def supports_ipv6(self) -> bool:
-        return self.version != "0.1.0"
+        return self.version != "1.0.0"
 
 
 class MicroVM:
@@ -375,10 +375,10 @@ class MicroVM:
             data = await reader.read(1_000_000)
             if data:
                 config_dict: Dict[str, Any] = msgpack.loads(data)
-                runtime_config = RuntimeConfig(version=config_dict["version"])
+                runtime_config = RuntimeConfiguration(version=config_dict["version"])
             else:
                 # Older runtimes do not send a config. Use a default.
-                runtime_config = RuntimeConfig(version="0.1.0")
+                runtime_config = RuntimeConfiguration(version="1.0.0")
 
             logger.debug("Runtime version: %s", runtime_config)
             await queue.put(runtime_config)

--- a/runtimes/aleph-debian-11-python/init1.py
+++ b/runtimes/aleph-debian-11-python/init1.py
@@ -31,7 +31,7 @@ import msgpack
 
 logger.debug("Imports finished")
 
-__version__ = "0.2.0"
+__version__ = "2.0.0"
 ASGIApplication = NewType("ASGIApplication", Any)
 
 

--- a/runtimes/aleph-debian-11-python/init1.py
+++ b/runtimes/aleph-debian-11-python/init1.py
@@ -31,6 +31,7 @@ import msgpack
 
 logger.debug("Imports finished")
 
+__version__ = "0.2.0"
 ASGIApplication = NewType("ASGIApplication", Any)
 
 
@@ -86,6 +87,7 @@ s.listen()
 # Send the host that we are ready
 s0 = socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM)
 s0.connect((2, 52))
+s0.sendall(msgpack.dumps({"version": __version__}))
 s0.close()
 
 # Configure aleph-client to use the guest API

--- a/vm_supervisor/utils.py
+++ b/vm_supervisor/utils.py
@@ -19,6 +19,7 @@ def msgpackable(cls):
     """
     Class decorator that adds an `as_msgpack()` method to dataclasses.
     """
+
     def as_msgpack(self) -> bytes:
         return msgpack.dumps(dataclasses.asdict(self), use_bin_type=True)
 

--- a/vm_supervisor/utils.py
+++ b/vm_supervisor/utils.py
@@ -27,6 +27,7 @@ def msgpackable(cls):
         raise TypeError("Decorated class must be a dataclass")
 
     cls.as_msgpack = as_msgpack
+    return cls
 
 
 def b32_to_b16(hash: str) -> bytes:

--- a/vm_supervisor/utils.py
+++ b/vm_supervisor/utils.py
@@ -15,19 +15,14 @@ import msgpack
 logger = logging.getLogger(__name__)
 
 
-def msgpackable(cls):
-    """
-    Class decorator that adds an `as_msgpack()` method to dataclasses.
-    """
+class MsgpackSerializable:
+    def __init_subclass__(cls, *args, **kwargs):
+        if not is_dataclass(cls):
+            raise TypeError("Decorated class must be a dataclass")
+        super().__init_subclass__(*args, **kwargs)
 
     def as_msgpack(self) -> bytes:
-        return msgpack.dumps(dataclasses.asdict(self), use_bin_type=True)
-
-    if not is_dataclass(cls):
-        raise TypeError("Decorated class must be a dataclass")
-
-    cls.as_msgpack = as_msgpack
-    return cls
+        return msgpack.dumps(dataclasses.asdict(self), use_bin_type=True)  # type: ignore
 
 
 def b32_to_b16(hash: str) -> bytes:

--- a/vm_supervisor/utils.py
+++ b/vm_supervisor/utils.py
@@ -16,13 +16,16 @@ logger = logging.getLogger(__name__)
 
 
 class MsgpackSerializable:
-    def __init_subclass__(cls, *args, **kwargs):
-        if not is_dataclass(cls):
-            raise TypeError("Decorated class must be a dataclass")
+    def __post_init__(self, *args, **kwargs):
+        if not is_dataclass(self):
+            raise TypeError(f"Decorated class must be a dataclass: {self}")
         super().__init_subclass__(*args, **kwargs)
 
     def as_msgpack(self) -> bytes:
-        return msgpack.dumps(dataclasses.asdict(self), use_bin_type=True)  # type: ignore
+        if is_dataclass(self):
+            return msgpack.dumps(dataclasses.asdict(self), use_bin_type=True)  # type: ignore
+        else:
+            raise TypeError(f"Decorated class must be a dataclass: {self}")
 
 
 def b32_to_b16(hash: str) -> bytes:

--- a/vm_supervisor/utils.py
+++ b/vm_supervisor/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import dataclasses
 import hashlib
 import json
 import logging
@@ -9,8 +10,22 @@ from dataclasses import is_dataclass
 from typing import Any, Coroutine, Dict, List, Optional
 
 import aiodns
+import msgpack
 
 logger = logging.getLogger(__name__)
+
+
+def msgpackable(cls):
+    """
+    Class decorator that adds an `as_msgpack()` method to dataclasses.
+    """
+    def as_msgpack(self) -> bytes:
+        return msgpack.dumps(dataclasses.asdict(self), use_bin_type=True)
+
+    if not is_dataclass(cls):
+        raise TypeError("Decorated class must be a dataclass")
+
+    cls.as_msgpack = as_msgpack
 
 
 def b32_to_b16(hash: str) -> bytes:

--- a/vm_supervisor/vm/firecracker/program.py
+++ b/vm_supervisor/vm/firecracker/program.py
@@ -412,7 +412,7 @@ class AlephFirecrackerProgram(AlephFirecrackerExecutable[ProgramVmConfiguration]
         )
         # Convert the configuration in a format compatible with the runtime
         versioned_config = program_config.to_runtime_format(runtime_config)
-        payload = versioned_config.as_msgpack(runtime_config=runtime_config)
+        payload = versioned_config.as_msgpack()
         length = f"{len(payload)}\n".encode()
         writer.write(b"CONNECT 52\n" + length + payload)
         await writer.drain()

--- a/vm_supervisor/vm/firecracker/program.py
+++ b/vm_supervisor/vm/firecracker/program.py
@@ -116,9 +116,7 @@ class ConfigurationPayloadV1(ConfigurationPayload):
     entrypoint: str
     code: Optional[bytes]
     ip: Optional[str]
-    ipv6: Optional[str]
     route: Optional[str]
-    ipv6_gateway: Optional[str]
     dns_servers: List[str]
     volumes: List[Volume]
     variables: Optional[Dict[str, str]]
@@ -173,7 +171,9 @@ class ProgramConfiguration:
             return ConfigurationPayloadV1.from_program_config(self)
 
         if runtime_config.version != "2.0.0":
-            logger.warning("Unsupported runtime version: %s", runtime_config.version)
+            logger.warning(
+                "This runtime version may be unsupported: %s", runtime_config.version
+            )
 
         return ConfigurationPayloadV2.from_program_config(self)
 


### PR DESCRIPTION
Problem: the supervisor cannot deduce the version of the init process of the microVM runtime. This leads to compatibility issues when adding new features (like IPv6 support in this case).

Solution: define a version for the init process and send this value to the supervisor when the VM boots. This version is then used to gatekeep features when configuring the VM.