### PR TITLE
Fix: Root login with shared password is insecure

### DIFF
--- a/runtimes/aleph-debian-11-python/create_disk_image.sh
+++ b/runtimes/aleph-debian-11-python/create_disk_image.sh
@@ -39,7 +39,10 @@ pip3 install 'aleph-client>=0.4.6' 'coincurve==15.0.0'
 # Compile all Python bytecode
 python3 -m compileall -f /usr/local/lib/python3.9
 
-echo "root:toor" | /usr/sbin/chpasswd
+echo "PubkeyAuthentication yes" >> /etc/ssh/sshd_config
+echo "PasswordAuthentication no" >> /etc/ssh/sshd_config
+echo "ChallengeResponseAuthentication no" >> /etc/ssh/sshd_config
+echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
 
 mkdir -p /overlay
 
@@ -48,7 +51,6 @@ ln -s agetty /etc/init.d/agetty.ttyS0
 echo ttyS0 > /etc/securetty
 EOT
 
-echo "PermitRootLogin yes" >> ./rootfs/etc/ssh/sshd_config
 
 # Generate SSH host keys
 #systemd-nspawn -D ./rootfs/ ssh-keygen -q -N "" -t dsa -f /etc/ssh/ssh_host_dsa_key

--- a/runtimes/instance-debian-rootfs/Dockerfile
+++ b/runtimes/instance-debian-rootfs/Dockerfile
@@ -35,7 +35,10 @@ RUN pip3 install 'aleph-client>=0.4.6' 'coincurve==15.0.0'
 RUN python3 -m compileall -f /usr/local/lib/python3.9
 
 # Enable root login by ssh
-RUN echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+RUN echo "PubkeyAuthentication yes" >> ./rootfs/etc/ssh/sshd_config
+RUN echo "PasswordAuthentication no" >> ./rootfs/etc/ssh/sshd_config
+RUN echo "ChallengeResponseAuthentication no" >> ./rootfs/etc/ssh/sshd_config
+RUN echo "PermitRootLogin yes" >> ./rootfs/etc/ssh/sshd_config
 
 # Generate SSH host keys
 #RUN systemd-nspawn -D ./rootfs/ ssh-keygen -q -N "" -t dsa -f /etc/ssh/ssh_host_dsa_key
@@ -46,9 +49,6 @@ RUN echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
 # Set up a login terminal on the serial console (ttyS0):
 RUN ln -s agetty /etc/init.d/agetty.ttyS0
 RUN echo ttyS0 > /etc/securetty
-
-# Set root password
-RUN echo "root:toor" | /usr/sbin/chpasswd
 
 # Reduce size
 RUN rm -fr /root/.cache


### PR DESCRIPTION
Problem: With the incoming support of IPv6, allowing login into virtual machines using SSH with a password becomes unacceptable.

Solution: Remove SSH password login from runtimes, as well as the root default password.
