### PR TITLE
Fix: Could not SSH into a program VM

### DIFF
--- a/firecracker/__init__.py
+++ b/firecracker/__init__.py
@@ -1,2 +1,2 @@
-from .microvm import MicroVM
 from .config import FirecrackerConfig
+from .microvm import MicroVM

--- a/firecracker/microvm.py
+++ b/firecracker/microvm.py
@@ -11,7 +11,7 @@ from os import getuid
 from pathlib import Path
 from pwd import getpwnam
 from tempfile import NamedTemporaryFile
-from typing import List, Optional, Tuple, Any, Dict
+from typing import Any, Dict, List, Optional, Tuple
 
 import msgpack
 

--- a/runtimes/aleph-debian-11-python/init1.py
+++ b/runtimes/aleph-debian-11-python/init1.py
@@ -72,6 +72,7 @@ class ConfigurationPayload:
     dns_servers: List[str] = field(default_factory=list)
     volumes: List[Volume] = field(default_factory=list)
     variables: Optional[Dict[str, str]] = None
+    authorized_keys: Optional[List[str]] = None
 
 
 @dataclass
@@ -173,6 +174,12 @@ def setup_input_data(input_data: bytes):
             open("/opt/input.zip", "wb").write(input_data)
             os.makedirs("/data", exist_ok=True)
             os.system("unzip -q /opt/input.zip -d /data")
+
+
+def setup_authorized_keys(authorized_keys: Optional[List[str]]) -> None:
+    path = Path("/root/.ssh/authorized_keys")
+    path.parent.mkdir(exist_ok=True)
+    path.write_text("\n".join(key for key in authorized_keys))
 
 
 def setup_volumes(volumes: List[Volume]):
@@ -506,6 +513,7 @@ def setup_system(config: ConfigurationPayload):
         dns_servers=config.dns_servers,
     )
     setup_input_data(config.input_data)
+    setup_authorized_keys(config.authorized_keys)
     logger.debug("Setup finished")
 
 

--- a/vm_supervisor/__main__.py
+++ b/vm_supervisor/__main__.py
@@ -21,7 +21,7 @@ import alembic.config
 from aleph_message.models import ItemHash
 
 from . import metrics, supervisor
-from .conf import make_db_url, settings
+from .conf import ALLOW_DEVELOPER_SSH_KEYS, make_db_url, settings
 from .pubsub import PubSub
 from .run import run_code_on_event, run_code_on_request, start_persistent_vm
 
@@ -145,6 +145,13 @@ def parse_args(args):
         type=str,
         default=settings.FAKE_INSTANCE_BASE,
         help="Filesystem path of the base for the rootfs of fake instances. An empty value signals a download instead.",
+    )
+    parser.add_argument(
+        "--developer-ssh-keys",
+        dest="use_developer_ssh_keys",
+        action="store_true",
+        default=False,
+        help="Authorize the developer's SSH keys to connect instead of those specified in the message",
     )
     return parser.parse_args(args)
 
@@ -298,8 +305,12 @@ def main():
         DEBUG_ASYNCIO=args.debug_asyncio,
         FAKE_INSTANCE_BASE=args.fake_instance_base,
     )
+
     if args.run_fake_instance:
         settings.USE_FAKE_INSTANCE_BASE = True
+
+    if args.use_developer_ssh_keys:
+        settings.USE_DEVELOPER_SSH_KEYS = ALLOW_DEVELOPER_SSH_KEYS
 
     if sentry_sdk:
         if settings.SENTRY_DSN:

--- a/vm_supervisor/conf.py
+++ b/vm_supervisor/conf.py
@@ -6,13 +6,16 @@ from enum import Enum
 from os.path import abspath, exists, isdir, isfile, join
 from pathlib import Path
 from subprocess import check_output
-from typing import Any, Dict, Iterable, List, NewType, Optional
+from typing import Any, Dict, Iterable, List, Literal, NewType, Optional, Union
 
 from pydantic import BaseSettings, Field
 
 logger = logging.getLogger(__name__)
 
 Url = NewType("Url", str)
+
+# This variable may not be set from an environment variable
+ALLOW_DEVELOPER_SSH_KEYS = object()
 
 
 class DnsResolver(str, Enum):
@@ -184,7 +187,12 @@ class Settings(BaseSettings):
         "67705389842a0a1b95eaa408b009741027964edc805997475e95c505d642edd8"
     )
 
+    # Developer options
+
     SENTRY_DSN: Optional[str] = None
+    DEVELOPER_SSH_KEYS: Optional[List[str]] = []
+    # Using an object here forces the value to come from Python code and not from an environment variable.
+    USE_DEVELOPER_SSH_KEYS: Union[Literal[False], object] = False
 
     # Fields
     SENSITIVE_FIELDS: List[str] = Field(

--- a/vm_supervisor/vm/firecracker/program.py
+++ b/vm_supervisor/vm/firecracker/program.py
@@ -144,6 +144,7 @@ class ConfigurationPayloadV2(ConfigurationPayloadV1):
 
     ipv6: Optional[str]
     ipv6_gateway: Optional[str]
+    authorized_keys: Optional[List[str]]
 
 
 @dataclass
@@ -163,6 +164,7 @@ class ProgramConfiguration:
     dns_servers: List[str] = field(default_factory=list)
     volumes: List[Volume] = field(default_factory=list)
     variables: Optional[Dict[str, str]] = None
+    authorized_keys: Optional[List[str]] = None
 
     def to_runtime_format(
         self, runtime_config: RuntimeConfiguration
@@ -392,6 +394,12 @@ class AlephFirecrackerProgram(AlephFirecrackerExecutable[ProgramVmConfiguration]
         runtime_config = self.fvm.runtime_config
         assert runtime_config
 
+        authorized_keys: Optional[List[str]]
+        if settings.USE_DEVELOPER_SSH_KEYS:
+            authorized_keys = settings.DEVELOPER_SSH_KEYS
+        else:
+            authorized_keys = self.resources.message_content.authorized_keys
+
         program_config = ProgramConfiguration(
             ip=ip,
             ipv6=ipv6,
@@ -406,6 +414,7 @@ class AlephFirecrackerProgram(AlephFirecrackerExecutable[ProgramVmConfiguration]
             vm_hash=self.vm_hash,
             volumes=volumes,
             variables=self.resources.message_content.variables,
+            authorized_keys=authorized_keys,
         )
         # Convert the configuration in a format compatible with the runtime
         versioned_config = program_config.to_runtime_format(runtime_config)


### PR DESCRIPTION
Problem: Users and developers could not specify SSH keys to connect inside the VM.

Solution: Add a configuration to VMs that forwards SSH public keys.

Allow developers to specify public keys in the configuration and enable these via a CLI argument.
When developer keys are used, keys from the message are ignored.