### PR TITLE
Add default NODE_PATH env

### DIFF
--- a/runtimes/instance-debian-rootfs/init1.py
+++ b/runtimes/instance-debian-rootfs/init1.py
@@ -91,6 +91,9 @@ os.environ["ALEPH_API_UNIX_SOCKET"] = "/tmp/socat-socket"
 os.environ["ALEPH_REMOTE_CRYPTO_HOST"] = "http://localhost"
 os.environ["ALEPH_REMOTE_CRYPTO_UNIX_SOCKET"] = "/tmp/socat-socket"
 
+# Additional node modules from immutable volume
+os.environ["NODE_PATH"] = "/opt/node_modules"
+
 logger.debug("init1.py is launching")
 
 

--- a/vm_supervisor/README.md
+++ b/vm_supervisor/README.md
@@ -118,6 +118,10 @@ or in debug mode:
 ```shell
 python3 -m vm_supervisor -vv --system-logs
 ```
+or in test mode to run a single function:
+```shell
+python3 -m vm_supervisor -vv --system-logs -f examples/example_fastapi
+```
 
 Test accessing the service on
 http://localhost:4020/

--- a/vm_supervisor/README.md
+++ b/vm_supervisor/README.md
@@ -118,10 +118,6 @@ or in debug mode:
 ```shell
 python3 -m vm_supervisor -vv --system-logs
 ```
-or in test mode to run a single function:
-```shell
-python3 -m vm_supervisor -vv --system-logs -f examples/example_fastapi
-```
 
 Test accessing the service on
 http://localhost:4020/


### PR DESCRIPTION
Include `/opt/node_modules` in the module resolution for node.js in order to allow the [Dependency Volume Builder](https://github.com/aleph-im/aleph-cloud-tools/tree/main/dependency_builder) to target this directory when building a dependency volume.