### PR TITLE
Fix: NDP Proxy was sync and mandatory

### DIFF
--- a/firecracker/__init__.py
+++ b/firecracker/__init__.py
@@ -1,2 +1,2 @@
-from .microvm import MicroVM
 from .config import FirecrackerConfig
+from .microvm import MicroVM

--- a/firecracker/microvm.py
+++ b/firecracker/microvm.py
@@ -11,7 +11,7 @@ from os import getuid
 from pathlib import Path
 from pwd import getpwnam
 from tempfile import NamedTemporaryFile
-from typing import List, Optional, Tuple, Any, Dict
+from typing import Any, Dict, List, Optional, Tuple
 
 import msgpack
 

--- a/vm_supervisor/conf.py
+++ b/vm_supervisor/conf.py
@@ -108,6 +108,10 @@ class Settings(BaseSettings):
         description="IPv6 subnet prefix for VMs. Made configurable for testing.",
     )
     NFTABLES_CHAIN_PREFIX = "aleph"
+    USE_NDP_PROXY: bool = Field(
+        default=True,
+        description="Use the Neighbor Discovery Protocol Proxy to respond to Router Solicitation for instances on IPv6",
+    )
 
     DNS_RESOLUTION: Optional[DnsResolver] = DnsResolver.resolv_conf
     DNS_NAMESERVERS: Optional[List[str]] = None

--- a/vm_supervisor/network/hostnetwork.py
+++ b/vm_supervisor/network/hostnetwork.py
@@ -5,7 +5,7 @@ from typing import Optional, Protocol
 
 from aleph_message.models import ItemHash
 
-from vm_supervisor.conf import IPv6AllocationPolicy
+from vm_supervisor.conf import IPv6AllocationPolicy, settings
 
 from ..vm.vm_type import VmType
 from .firewall import initialize_nftables, setup_nftables_for_vm, teardown_nftables
@@ -123,6 +123,7 @@ class Network:
     ipv6_address_pool: IPv6Network
     network_size: int
     external_interface: str
+    ndp_proxy: Optional[NdpProxy] = None
 
     IPV6_SUBNET_PREFIX: int = 124
 
@@ -149,7 +150,8 @@ class Network:
         self.enable_ipv4_forwarding()
         self.enable_ipv6_forwarding()
 
-        self.ndp_proxy = NdpProxy(host_network_interface=external_interface)
+        if settings.USE_NDP_PROXY:
+            self.ndp_proxy = NdpProxy(host_network_interface=external_interface)
 
         initialize_nftables()
 

--- a/vm_supervisor/network/ndp_proxy.py
+++ b/vm_supervisor/network/ndp_proxy.py
@@ -13,8 +13,9 @@ import logging
 from dataclasses import dataclass
 from ipaddress import IPv6Network
 from pathlib import Path
-from subprocess import run
 from typing import Dict
+
+from vm_supervisor.utils import run_in_subprocess
 
 logger = logging.getLogger(__name__)
 
@@ -30,28 +31,28 @@ class NdpProxy:
         self.interface_address_range_mapping: Dict[str, IPv6Network] = {}
 
     @staticmethod
-    def _restart_ndppd():
+    async def _restart_ndppd():
         logger.debug("Restarting ndppd")
-        run(["systemctl", "restart", "ndppd"])
+        await run_in_subprocess(["systemctl", "restart", "ndppd"])
 
-    def _update_ndppd_conf(self):
+    async def _update_ndppd_conf(self):
         config = f"proxy {self.host_network_interface} {{\n"
         for interface, address_range in self.interface_address_range_mapping.items():
             config += f"  rule {address_range} {{\n    iface {interface}\n  }}\n"
         config += "}\n"
         Path("/etc/ndppd.conf").write_text(config)
-        self._restart_ndppd()
+        await self._restart_ndppd()
 
-    def add_range(self, interface: str, address_range: IPv6Network):
+    async def add_range(self, interface: str, address_range: IPv6Network):
         logger.debug("Proxying range %s -> %s", address_range, interface)
         self.interface_address_range_mapping[interface] = address_range
-        self._update_ndppd_conf()
+        await self._update_ndppd_conf()
 
-    def delete_range(self, interface: str):
+    async def delete_range(self, interface: str):
         try:
             address_range = self.interface_address_range_mapping.pop(interface)
             logger.debug("Deactivated proxying for %s (%s)", interface, address_range)
         except KeyError:
             return
 
-        self._update_ndppd_conf()
+        await self._update_ndppd_conf()


### PR DESCRIPTION
Problems:
1. Operations on the NDP Proxy were synchronous.
2. Developing on the supervisor required the installation of the NDP Proxy.

Solutions:
1. Make operations on the NDP Proxy asynchronous.
2. Add setting `USE_NDP_PROXY` that permits users to disable the NDP Proxy.
