### PR TITLE
Fix: IPv6 forwarding caused issue on some development servers.

### DIFF
--- a/vm_supervisor/conf.py
+++ b/vm_supervisor/conf.py
@@ -107,6 +107,10 @@ class Settings(BaseSettings):
         default=124,
         description="IPv6 subnet prefix for VMs. Made configurable for testing.",
     )
+    IPV6_FORWARDING_ENABLED: bool = Field(
+        default=True,
+        description="Enable IPv6 forwarding on the host. Required for IPv6 connectivity in VMs."
+    )
     NFTABLES_CHAIN_PREFIX = "aleph"
     USE_NDP_PROXY: bool = Field(
         default=True,

--- a/vm_supervisor/pool.py
+++ b/vm_supervisor/pool.py
@@ -41,6 +41,8 @@ class VmPool:
                     address_pool=settings.IPV6_ADDRESS_POOL,
                     subnet_prefix=settings.IPV6_SUBNET_PREFIX,
                 ),
+                use_ndp_proxy=settings.USE_NDP_PROXY,
+                ipv6_forwarding_enabled=settings.IPV6_FORWARDING_ENABLED,
             )
             if settings.ALLOW_VM_NETWORKING
             else None


### PR DESCRIPTION
Solution: Add a setting to disable IPv6 forwarding. Forwarding is enabled by default.
