### PR TITLE
Fix: Crash when getting version from apt

### DIFF
--- a/vm_supervisor/version.py
+++ b/vm_supervisor/version.py
@@ -21,7 +21,7 @@ def get_version_from_apt() -> Optional[str]:
         import apt
 
         return apt.Cache().get("aleph-vm").installed.version
-    except ImportError:
+    except (ImportError, AttributeError):
         logger.warning("apt version not available")
         return None
 


### PR DESCRIPTION
The supervisor would not start if the `apt` library is found but the `aleph-vm` package is not installed.

Solution: Handle cases when the package is not found and the apt cache returns None.