### PR TITLE
Feature: Init version was hard to fetch from programs

### DIFF
--- a/runtimes/aleph-debian-11-python/init1.py
+++ b/runtimes/aleph-debian-11-python/init1.py
@@ -92,6 +92,7 @@ s0.sendall(msgpack.dumps({"version": __version__}))
 s0.close()
 
 # Configure aleph-client to use the guest API
+os.environ["ALEPH_INIT_VERSION"] = __version__
 os.environ["ALEPH_API_HOST"] = "http://localhost"
 os.environ["ALEPH_API_UNIX_SOCKET"] = "/tmp/socat-socket"
 os.environ["ALEPH_REMOTE_CRYPTO_HOST"] = "http://localhost"


### PR DESCRIPTION
Problem: The version of init1.py defines some of the capabilities of the platform. This was not exposed to programs running inside virtual machines.

Solution: Expose the version as an environment variable.
