### PR TITLE
Fix: Pytest failed due to missing argument

### DIFF
--- a/tests/supervisor/test_ipv6_allocator.py
+++ b/tests/supervisor/test_ipv6_allocator.py
@@ -1,5 +1,7 @@
 import os
 
+from vm_supervisor.vm.vm_type import VmType
+
 # Avoid failures linked to settings when initializing the global VmPool object
 os.environ["ALEPH_VM_ALLOW_VM_NETWORKING"] = "False"
 
@@ -19,5 +21,6 @@ def test_static_ipv6_allocator():
         vm_hash=ItemHash(
             "8920215b2e961a4d4c59a8ceb2803af53f91530ff53d6704273ab4d380bc6446"
         ),
+        vm_type=VmType.microvm,
     )
     assert ip_subnet == IPv6Network("1111:2222:3333:4444:0001:8920:215b:2e90/124")

--- a/vm_supervisor/views/__init__.py
+++ b/vm_supervisor/views/__init__.py
@@ -13,7 +13,6 @@ from aleph_message.models import ItemHash
 from pydantic import ValidationError
 
 from packaging.version import InvalidVersion, Version
-
 from vm_supervisor import status
 from vm_supervisor.conf import settings
 from vm_supervisor.metrics import get_execution_records


### PR DESCRIPTION
The method `allocator.allocate_vm_ipv6_subnet` now requires the argument `vm_type`, which was not provided in the tests.
