### PR TITLE
Fix: Program runtime could use newer Debian 12

### DIFF
--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -23,6 +23,26 @@ jobs:
           name: aleph-vm.debian-11.deb
           path: packaging/target/aleph-vm.debian-11.deb
 
+  build_deb_debian_12:
+    name: "Build Debian Package"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch the whole history for all tags and branches (required for aleph.__version__)
+          fetch-depth: 0
+
+      - run: |
+          cd packaging && make all-podman-debian-12 && cd ..
+          ls packaging/target
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: aleph-vm.debian-12.deb
+          path: packaging/target/aleph-vm.debian-12.deb
+
   build_deb_ubuntu_22_04:
     name: "Build Ubuntu Package"
     runs-on: ubuntu-latest
@@ -43,7 +63,7 @@ jobs:
           name: aleph-vm.ubuntu-22.04.deb
           path: packaging/target/aleph-vm.ubuntu-22.04.deb
 
-  build_rootfs:
+  build_rootfs_debian_11:
     name: "Build runtime aleph-debian-11-python"
     runs-on: ubuntu-latest
 
@@ -64,6 +84,26 @@ jobs:
           name: aleph-debian-11-python.squashfs
           path: runtimes/aleph-debian-11-python/rootfs.squashfs
 
+  build_rootfs_debian_12:
+    name: "Build runtime aleph-debian-12-python"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Workaround github issue https://github.com/actions/runner-images/issues/7192
+        run: sudo echo RESET grub-efi/install_devices | sudo debconf-communicate grub-pc
+
+      - run: |
+          sudo apt update
+          sudo apt install -y debootstrap
+          cd runtimes/aleph-debian-12-python && sudo ./create_disk_image.sh && cd ../..
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: aleph-debian-12-python.squashfs
+          path: runtimes/aleph-debian-12-python/rootfs.squashfs
 
   build_example_venv_volume:
     name: "Build example squashfs volume using Docker"

--- a/.github/workflows/test-build-examples.yml
+++ b/.github/workflows/test-build-examples.yml
@@ -25,7 +25,7 @@ jobs:
           sudo chown $(whoami) /opt/packages
 
       - run: |
-          pip3 install aleph-client
+          pip3 install aleph-sdk-python
 
       - run: |
           ls -la

--- a/.github/workflows/test-new-runtime-examples.yml
+++ b/.github/workflows/test-new-runtime-examples.yml
@@ -3,8 +3,8 @@ on:
   push
 
 jobs:
-  run_debian_11:
-    name: "Test new runtime on Droplet with Debian 11"
+  run_debian_12:
+    name: "Test new runtime on Droplet with Debian 12"
     runs-on: ubuntu-latest
     concurrency: droplet-aleph-vm-runtime
 
@@ -35,7 +35,7 @@ jobs:
       - name: Create the Droplet
         run: |
           doctl compute droplet create \
-          --image debian-11-x64 \
+          --image debian-12-x64 \
           --size c-2 \
           --region fra1 \
           --vpc-uuid 992896c8-c089-4da3-9288-f81e28c095a4 \
@@ -47,16 +47,16 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y debootstrap
-          cd runtimes/aleph-debian-11-python && sudo ./create_disk_image.sh && cd ../..
+          cd runtimes/aleph-debian-12-python && sudo ./create_disk_image.sh && cd ../..
 
       - uses: actions/upload-artifact@v3
         with:
-          name: aleph-debian-11-python.squashfs
-          path: runtimes/aleph-debian-11-python/rootfs.squashfs
+          name: aleph-debian-12-python.squashfs
+          path: runtimes/aleph-debian-12-python/rootfs.squashfs
 
       - name: Build Debian Package
         run: |
-          cd packaging && make all-podman-debian-11 && cd ..
+          cd packaging && make all-podman-debian-12 && cd ..
           ls packaging/target
 
       - name: Wait for the system to setup and boot
@@ -68,7 +68,7 @@ jobs:
         run: |
           export DROPLET_IPV4="$(doctl compute droplet get aleph-vm-ci-runtime --output json | ./.github/scripts/extract_droplet_ipv4.py)"
           ssh-keyscan -H ${DROPLET_IPV4} > ~/.ssh/known_hosts
-          scp runtimes/aleph-debian-11-python/rootfs.squashfs root@${DROPLET_IPV4}:/opt
+          scp runtimes/aleph-debian-12-python/rootfs.squashfs root@${DROPLET_IPV4}:/opt
 
       - name: Install Aleph-VM on the Droplet
         run: |
@@ -80,9 +80,9 @@ jobs:
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o DPkg::Lock::Timeout=60 install -y docker.io apparmor-profiles"
           ssh root@${DROPLET_IPV4} "docker run -d -p 127.0.0.1:4021:4021/tcp --restart=always --name vm-connector alephim/vm-connector:alpha"
           
-          scp packaging/target/aleph-vm.debian-11.deb root@${DROPLET_IPV4}:/opt
+          scp packaging/target/aleph-vm.debian-12.deb root@${DROPLET_IPV4}:/opt
           scp -pr ./examples root@${DROPLET_IPV4}:/opt/
-          ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt -o DPkg::Lock::Timeout=60 install -y /opt/aleph-vm.debian-11.deb"
+          ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt -o DPkg::Lock::Timeout=60 install -y /opt/aleph-vm.debian-12.deb"
           ssh root@${DROPLET_IPV4} "echo ALEPH_VM_SUPERVISOR_HOST=0.0.0.0 >> /etc/aleph-vm/supervisor.env"
           ssh root@${DROPLET_IPV4} "echo ALEPH_VM_FAKE_DATA_PROGRAM=/opt/examples/example_fastapi >> /etc/aleph-vm/supervisor.env"
           ssh root@${DROPLET_IPV4} "echo ALEPH_VM_FAKE_DATA_RUNTIME=/opt/rootfs.squashfs >> /etc/aleph-vm/supervisor.env"

--- a/runtimes/aleph-debian-12-python/create_disk_image.sh
+++ b/runtimes/aleph-debian-12-python/create_disk_image.sh
@@ -52,13 +52,6 @@ ln -s agetty /etc/init.d/agetty.ttyS0
 echo ttyS0 > /etc/securetty
 EOT
 
-
-# Generate SSH host keys
-#systemd-nspawn -D ./rootfs/ ssh-keygen -q -N "" -t dsa -f /etc/ssh/ssh_host_dsa_key
-#systemd-nspawn -D ./rootfs/ ssh-keygen -q -N "" -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key
-#systemd-nspawn -D ./rootfs/ ssh-keygen -q -N "" -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key
-#systemd-nspawn -D ./rootfs/ ssh-keygen -q -N "" -t ed25519 -f /etc/ssh/ssh_host_ed25519_key
-
 cat <<EOT > ./rootfs/etc/inittab
 # /etc/inittab
 

--- a/runtimes/aleph-debian-12-python/create_disk_image.sh
+++ b/runtimes/aleph-debian-12-python/create_disk_image.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+
+rm ./rootfs.squashfs
+
+set -euf
+
+rm -fr ./rootfs
+mkdir ./rootfs
+
+debootstrap --variant=minbase bookworm ./rootfs http://deb.debian.org/debian/
+
+chroot ./rootfs /bin/sh <<EOT
+
+set -euf
+
+apt-get install -y --no-install-recommends --no-install-suggests \
+  python3-minimal \
+  openssh-server \
+  socat libsecp256k1-1 \
+  \
+  python3-aiohttp python3-msgpack \
+  python3-setuptools python3-venv \
+  python3-pip python3-cytoolz python3-pydantic \
+  iproute2 unzip \
+  nodejs npm \
+  build-essential python3-dev \
+  python3-fastapi \
+  \
+  docker.io \
+  cgroupfs-mount \
+  nftables \
+  \
+  iputils-ping curl
+
+echo "Pip installing aleph-sdk-python"
+mkdir -p /opt/aleph/libs
+pip3 install --target /opt/aleph/libs 'aleph-sdk-python==0.7.0'
+
+# Compile Python code to bytecode for faster execution
+python3 -m compileall -f /usr/local/lib/python3.11
+python3 -m compileall -f /opt/aleph/libs
+
+echo "PubkeyAuthentication yes" >> /etc/ssh/sshd_config
+echo "PasswordAuthentication no" >> /etc/ssh/sshd_config
+echo "ChallengeResponseAuthentication no" >> /etc/ssh/sshd_config
+echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+
+mkdir -p /overlay
+
+# Set up a login terminal on the serial console (ttyS0):
+ln -s agetty /etc/init.d/agetty.ttyS0
+echo ttyS0 > /etc/securetty
+EOT
+
+
+# Generate SSH host keys
+#systemd-nspawn -D ./rootfs/ ssh-keygen -q -N "" -t dsa -f /etc/ssh/ssh_host_dsa_key
+#systemd-nspawn -D ./rootfs/ ssh-keygen -q -N "" -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key
+#systemd-nspawn -D ./rootfs/ ssh-keygen -q -N "" -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key
+#systemd-nspawn -D ./rootfs/ ssh-keygen -q -N "" -t ed25519 -f /etc/ssh/ssh_host_ed25519_key
+
+cat <<EOT > ./rootfs/etc/inittab
+# /etc/inittab
+
+::sysinit:/sbin/init sysinit
+::sysinit:/sbin/init boot
+::wait:/sbin/init default
+
+# Set up a couple of getty's
+tty1::respawn:/sbin/getty 38400 tty1
+tty2::respawn:/sbin/getty 38400 tty2
+tty3::respawn:/sbin/getty 38400 tty3
+tty4::respawn:/sbin/getty 38400 tty4
+tty5::respawn:/sbin/getty 38400 tty5
+tty6::respawn:/sbin/getty 38400 tty6
+
+# Put a getty on the serial port
+ttyS0::respawn:/sbin/getty -L ttyS0 115200 vt100
+
+# Stuff to do for the 3-finger salute
+::ctrlaltdel:/sbin/reboot
+
+# Stuff to do before rebooting
+::shutdown:/sbin/init shutdown
+EOT
+
+# Reduce size
+rm -fr ./rootfs/root/.cache
+rm -fr ./rootfs/var/cache
+mkdir -p ./rootfs/var/cache/apt/archives/partial
+rm -fr ./rootfs/usr/share/doc
+rm -fr ./rootfs/usr/share/man
+rm -fr ./rootfs/var/lib/apt/lists/
+
+# Custom init
+cp ./init0.sh ./rootfs/sbin/init
+cp ./init1.py ./rootfs/root/init1.py
+cp ./loading.html ./rootfs/root/loading.html
+chmod +x ./rootfs/sbin/init
+chmod +x ./rootfs/root/init1.py
+
+mksquashfs ./rootfs/ ./rootfs.squashfs

--- a/runtimes/aleph-debian-12-python/init0.sh
+++ b/runtimes/aleph-debian-12-python/init0.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+set -euf
+
+mount -t proc proc /proc -o nosuid,noexec,nodev
+
+log() {
+    echo "$(awk '{print $1}' /proc/uptime)" '|S' "$@"
+}
+log "init0.sh is launching"
+
+# Switch root from read-only ext4 to to read-write overlay
+mkdir -p /overlay
+/bin/mount -t tmpfs -o noatime,mode=0755 tmpfs /overlay
+mkdir -p /overlay/root /overlay/work
+/bin/mount -o noatime,lowerdir=/,upperdir=/overlay/root,workdir=/overlay/work -t overlay "overlayfs:/overlay/root" /mnt
+mkdir -p /mnt/rom
+pivot_root /mnt /mnt/rom
+
+mount --move /rom/proc /proc
+mount --move /rom/dev /dev
+
+mkdir -p /dev/pts
+mkdir -p /dev/shm
+
+mount -t sysfs sys /sys -o nosuid,noexec,nodev
+mount -t tmpfs run /run -o mode=0755,nosuid,nodev
+#mount -t devtmpfs dev /dev -o mode=0755,nosuid
+mount -t devpts devpts /dev/pts -o mode=0620,gid=5,nosuid,noexec
+mount -t tmpfs shm /dev/shm -omode=1777,nosuid,nodev
+
+# Required by Docker
+cgroupfs-mount
+update-alternatives --set iptables /usr/sbin/iptables-legacy
+update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+# Enable the following to force the storage driver used by Docker.
+# See https://docs.docker.com/storage/storagedriver/select-storage-driver/
+#echo '{\n"storage-driver": "overlay2"\n}\n' > /etc/docker/daemon.json
+
+# List block devices
+lsblk
+
+#cat /proc/sys/kernel/random/entropy_avail
+
+# TODO: Move in init1
+mkdir -p /run/sshd
+/usr/sbin/sshd &
+log "SSH UP"
+
+log "Setup socat"
+socat UNIX-LISTEN:/tmp/socat-socket,fork,reuseaddr VSOCK-CONNECT:2:53 &
+log "Socat ready"
+
+export PYTHONPATH=/opt/aleph/libs
+
+# Replace this script with the manager
+exec /root/init1.py

--- a/runtimes/aleph-debian-12-python/init1.py
+++ b/runtimes/aleph-debian-12-python/init1.py
@@ -1,0 +1,1 @@
+../aleph-debian-11-python/init1.py

--- a/runtimes/aleph-debian-12-python/loading.html
+++ b/runtimes/aleph-debian-12-python/loading.html
@@ -1,0 +1,1 @@
+../aleph-debian-11-python/loading.html

--- a/runtimes/aleph-debian-12-python/update_inits.sh
+++ b/runtimes/aleph-debian-12-python/update_inits.sh
@@ -1,0 +1,1 @@
+../aleph-debian-11-python/update_inits.sh


### PR DESCRIPTION
This adds a new runtime based on Debian 12.

Use `diff` to compare the two versions since some files are copied.


```diff
sepal@basecamp ~/R/a/a/runtimes (hoh-runtime-debian-12)> diff aleph-debian-1*
diff '--color=auto' aleph-debian-11-python/create_disk_image.sh aleph-debian-12-python/create_disk_image.sh
10c10
< debootstrap --variant=minbase bullseye ./rootfs http://deb.debian.org/debian/
---
> debootstrap --variant=minbase bookworm ./rootfs http://deb.debian.org/debian/
19c19
<   socat libsecp256k1-0 \
---
>   socat libsecp256k1-1 \
22c22
<   python3-setuptools \
---
>   python3-setuptools python3-venv \
26a27
>   python3-fastapi \
34,40c35,41
< pip3 install 'fastapi~=0.95.1'
< 
< echo "Pip installing aleph-client"
< pip3 install 'aleph-sdk-python==0.7.0'
< 
< # Compile all Python bytecode
< python3 -m compileall -f /usr/local/lib/python3.9
---
> echo "Pip installing aleph-sdk-python"
> mkdir -p /opt/aleph/libs
> pip3 install --target /opt/aleph/libs 'aleph-sdk-python==0.7.0'
> 
> # Compile Python code to bytecode for faster execution
> python3 -m compileall -f /usr/local/lib/python3.11
> python3 -m compileall -f /opt/aleph/libs
diff '--color=auto' aleph-debian-11-python/init0.sh aleph-debian-12-python/init0.sh
54a55,56
> export PYTHONPATH=/opt/aleph/libs
> 
```

In the case of files that will remain compatible, symlinks are used to remove duplication issues.

```
loading.html -> ../aleph-debian-11-python/loading.html
update_inits.sh -> ../aleph-debian-11-python/update_inits.sh
```