### PR TITLE
Fix: only start snapshots for instances

### DIFF
--- a/vm_supervisor/models.py
+++ b/vm_supervisor/models.py
@@ -5,7 +5,7 @@ import uuid
 from asyncio import Task
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, Optional, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 from aleph_message.models import (
     ExecutableContent,
@@ -20,6 +20,7 @@ from .network.interfaces import TapInterface
 
 if TYPE_CHECKING:
     from .snapshot_manager import SnapshotManager
+
 from .pubsub import PubSub
 from .utils import create_task_log_exceptions, dumps_for_json
 from .vm import AlephFirecrackerInstance

--- a/vm_supervisor/models.py
+++ b/vm_supervisor/models.py
@@ -97,7 +97,7 @@ class VmExecution:
         vm_hash: ItemHash,
         message: ExecutableContent,
         original: ExecutableContent,
-        snapshot_manager: SnapshotManager,
+        snapshot_manager: "SnapshotManager",
     ):
         self.uuid = uuid.uuid1()  # uuid1() includes the hardware address and timestamp
         self.vm_hash = vm_hash

--- a/vm_supervisor/models.py
+++ b/vm_supervisor/models.py
@@ -5,7 +5,7 @@ import uuid
 from asyncio import Task
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, TYPE_CHECKING
 
 from aleph_message.models import (
     ExecutableContent,
@@ -17,8 +17,10 @@ from aleph_message.models import (
 from .conf import settings
 from .metrics import ExecutionRecord, save_execution_data, save_record
 from .network.interfaces import TapInterface
+
+if TYPE_CHECKING:
+    from .snapshot_manager import SnapshotManager
 from .pubsub import PubSub
-from .snapshot_manager import SnapshotManager
 from .utils import create_task_log_exceptions, dumps_for_json
 from .vm import AlephFirecrackerInstance
 from .vm.firecracker.executable import AlephFirecrackerExecutable

--- a/vm_supervisor/pool.py
+++ b/vm_supervisor/pool.py
@@ -3,9 +3,9 @@ import logging
 from typing import Dict, Iterable, Optional
 
 from aleph_message.models import ExecutableMessage, ItemHash
+from aleph_message.models.execution.instance import InstanceContent
 
 from vm_supervisor.network.hostnetwork import Network, make_ipv6_allocator
-
 from .conf import settings
 from .models import ExecutableContent, VmExecution
 from .snapshot_manager import SnapshotManager
@@ -71,7 +71,8 @@ class VmPool:
         await execution.create(vm_id=vm_id, tap_interface=tap_interface)
 
         # Start VM snapshots automatically
-        await self.snapshot_manager.start_for(execution=execution)
+        if isinstance(message, InstanceContent):
+            await self.snapshot_manager.start_for(execution=execution)
 
         return execution
 
@@ -133,8 +134,6 @@ class VmPool:
         await asyncio.gather(
             *(execution.stop() for vm_hash, execution in self.executions.items())
         )
-
-        await self.snapshot_manager.stop_all()
 
     def get_persistent_executions(self) -> Iterable[VmExecution]:
         for vm_hash, execution in self.executions.items():

--- a/vm_supervisor/pool.py
+++ b/vm_supervisor/pool.py
@@ -57,7 +57,12 @@ class VmPool:
         self, vm_hash: ItemHash, message: ExecutableContent, original: ExecutableContent
     ) -> VmExecution:
         """Create a new Aleph Firecracker VM from an Aleph function message."""
-        execution = VmExecution(vm_hash=vm_hash, message=message, original=original)
+        execution = VmExecution(
+            vm_hash=vm_hash,
+            message=message,
+            original=original,
+            snapshot_manager=self.snapshot_manager,
+        )
         self.executions[vm_hash] = execution
         await execution.prepare()
         vm_id = self.get_unique_vm_id()

--- a/vm_supervisor/pool.py
+++ b/vm_supervisor/pool.py
@@ -6,6 +6,7 @@ from aleph_message.models import ExecutableMessage, ItemHash
 from aleph_message.models.execution.instance import InstanceContent
 
 from vm_supervisor.network.hostnetwork import Network, make_ipv6_allocator
+
 from .conf import settings
 from .models import ExecutableContent, VmExecution
 from .snapshot_manager import SnapshotManager

--- a/vm_supervisor/snapshot_manager.py
+++ b/vm_supervisor/snapshot_manager.py
@@ -103,7 +103,7 @@ class SnapshotManager:
         self, execution: VmExecution, frequency: Optional[int] = None
     ) -> None:
         if not execution.is_instance:
-            raise TypeError("VM execution should be an Instance only")
+            raise NotImplementedError("Snapshots are not implemented for programs.")
 
         if not frequency:
             frequency = settings.SNAPSHOT_FREQUENCY
@@ -119,10 +119,13 @@ class SnapshotManager:
         await snapshot_execution.start()
 
     async def stop_for(self, vm_hash: ItemHash) -> None:
-        if not self.executions[vm_hash]:
-            raise ValueError(f"Snapshot execution not running for VM {vm_hash}")
+        try:
+            snapshot_execution = self.executions.pop(vm_hash)
+        except KeyError:
+            logger.warning("Could not find snapshot task for instance %s", vm_hash)
+            return
 
-        await self.executions[vm_hash].stop()
+        await snapshot_execution.stop()
 
     async def stop_all(self) -> None:
         await asyncio.gather(


### PR DESCRIPTION
Problems:
* the supervisor attempts to start snapshot jobs for programs, which we do not want to support.
* the supervisor does not stop the snapshot job for an instance when the instance is stopped.

Solutions:
* add a check to avoid the issue.
* pass the snapshot manager object to each VM execution to stop the snapshot task when the execution is stopped.