### PR TITLE
Solved some VM errors

### DIFF
--- a/firecracker/microvm.py
+++ b/firecracker/microvm.py
@@ -81,7 +81,7 @@ class MicroVM:
     drives: List[Drive]
     init_timeout: float
     mounted_rootfs: Optional[Path] = None
-    _unix_socket: Server
+    _unix_socket: Optional[Server] = None
 
     @property
     def namespace_path(self):

--- a/firecracker/microvm.py
+++ b/firecracker/microvm.py
@@ -467,7 +467,7 @@ class MicroVM:
             await asyncio.sleep(1)
             root_fs = self.mounted_rootfs.name
             system(f"dmsetup remove {root_fs}")
-            if self.use_jailer:
+            if self.use_jailer and Path(self.jailer_path).is_dir():
                 shutil.rmtree(self.jailer_path)
 
         if self._unix_socket:

--- a/vm_supervisor/run.py
+++ b/vm_supervisor/run.py
@@ -49,7 +49,6 @@ async def build_event_scope(event) -> Dict[str, Any]:
 
 
 async def create_vm_execution(vm_hash: ItemHash) -> VmExecution:
-    execution: Optional[VmExecution] = None
     message, original_message = await load_updated_message(vm_hash)
     pool.message_cache[vm_hash] = message
 
@@ -81,7 +80,7 @@ async def create_vm_execution(vm_hash: ItemHash) -> VmExecution:
         logger.exception(error)
         pool.forget_vm(vm_hash=vm_hash)
 
-    if not execution or execution.vm:
+    if not execution.vm:
         raise ValueError("The VM has not been created")
 
     return execution
@@ -252,8 +251,9 @@ async def start_persistent_vm(vm_hash: ItemHash, pubsub: PubSub) -> VmExecution:
     if not execution:
         logger.info(f"Starting persistent virtual machine with id: {vm_hash}")
         execution = await create_vm_execution(vm_hash=vm_hash)
-        # If the VM was already running in lambda mode, it should not expire
-        # as long as it is also scheduled as long-running
+
+    # If the VM was already running in lambda mode, it should not expire
+    # as long as it is also scheduled as long-running
     execution.persistent = True
     execution.cancel_expiration()
 

--- a/vm_supervisor/run.py
+++ b/vm_supervisor/run.py
@@ -16,6 +16,7 @@ from .messages import load_updated_message
 from .models import VmExecution
 from .pool import VmPool
 from .pubsub import PubSub
+from .utils import HostNotFoundError
 from .vm.firecracker.program import (
     FileTooLargeError,
     ResourceDownloadError,
@@ -75,6 +76,12 @@ async def create_vm_execution(vm_hash: ItemHash) -> VmExecution:
         logger.exception(error)
         pool.forget_vm(vm_hash=vm_hash)
         raise HTTPInternalServerError(reason="Error during runtime initialisation")
+    except HostNotFoundError as error:
+        logger.exception(error)
+        pool.forget_vm(vm_hash=vm_hash)
+        raise HTTPInternalServerError(
+            reason="Error during vm initialisation, vm ping without response"
+        )
 
     if not execution.vm:
         raise ValueError("The VM has not been created")

--- a/vm_supervisor/storage.py
+++ b/vm_supervisor/storage.py
@@ -193,9 +193,7 @@ async def create_ext4(path: Path, size_mib: int) -> bool:
         logger.debug(f"File already exists, skipping ext4 creation on {path}")
         return False
     tmp_path = f"{path}.tmp"
-    await run_in_subprocess(
-        ["dd", "if=/dev/zero", f"of={tmp_path}", "bs=1M", f"count={size_mib}"]
-    )
+    await run_in_subprocess(["fallocate", "-l", f"{size_mib}M", str(tmp_path)])
     await run_in_subprocess(["mkfs.ext4", tmp_path])
     await chown_to_jailman(Path(tmp_path))
     Path(tmp_path).rename(path)
@@ -213,9 +211,7 @@ async def create_volume_file(
         # Ensure that the parent directory exists
         path.parent.mkdir(exist_ok=True)
         # Create an empty file the right size
-        await run_in_subprocess(
-            ["dd", "if=/dev/zero", f"of={path}", "bs=1M", f"count={volume.size_mib}"]
-        )
+        await run_in_subprocess(["fallocate", "-l", f"{volume.size_mib}M", str(path)])
         await chown_to_jailman(path)
     return path
 

--- a/vm_supervisor/vm/firecracker/instance.py
+++ b/vm_supervisor/vm/firecracker/instance.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import json
 import logging
 from pathlib import Path
@@ -236,9 +237,11 @@ class AlephFirecrackerInstance(AlephFirecrackerExecutable):
     def _create_metadata_file(self) -> bytes:
         """Creates metadata configuration file for cloud-init tool"""
 
+        hostname = base64.b32encode(self.vm_hash).decode().strip("=").lower()
+
         metadata = {
             "instance-id": f"iid-instance-{self.vm_id}",
-            "local-hostname": str(self.vm_hash),
+            "local-hostname": hostname,
         }
 
         return json.dumps(metadata).encode()

--- a/vm_supervisor/vm/firecracker/instance.py
+++ b/vm_supervisor/vm/firecracker/instance.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -189,6 +190,8 @@ class AlephFirecrackerInstance(AlephFirecrackerExecutable):
             "disable_root": False,
             "ssh_pwauth": False,
             "ssh_authorized_keys": ssh_authorized_keys,
+            # Avoid the resize error because we already do it on the VM disk creation stage
+            "resize_rootfs": False,
         }
 
         cloud_config_header = "#cloud-config\n"
@@ -230,27 +233,42 @@ class AlephFirecrackerInstance(AlephFirecrackerExecutable):
             network, default_flow_style=False, sort_keys=False
         ).encode()
 
+    def _create_metadata_file(self) -> bytes:
+        """Creates metadata configuration file for cloud-init tool"""
+
+        metadata = {
+            "instance-id": f"iid-instance-{self.vm_id}",
+            "local-hostname": str(self.vm_hash),
+        }
+
+        return json.dumps(metadata).encode()
+
     async def _create_cloud_init_drive(self) -> Drive:
         """Creates the cloud-init volume to configure and setup the VM"""
 
         disk_image_path = settings.EXECUTION_ROOT / f"cloud-init-{self.vm_hash}.img"
 
-        with NamedTemporaryFile() as main_config_file:
+        with NamedTemporaryFile() as user_data_config_file:
             user_data = self._encode_user_data()
-            main_config_file.write(user_data)
-            main_config_file.flush()
+            user_data_config_file.write(user_data)
+            user_data_config_file.flush()
             with NamedTemporaryFile() as network_config_file:
                 network_config = self._create_network_file()
                 network_config_file.write(network_config)
                 network_config_file.flush()
+                with NamedTemporaryFile() as metadata_config_file:
+                    metadata_config = self._create_metadata_file()
+                    metadata_config_file.write(metadata_config)
+                    metadata_config_file.flush()
 
-                await run_in_subprocess(
-                    [
-                        "cloud-localds",
-                        f"--network-config={network_config_file.name}",
-                        str(disk_image_path),
-                        main_config_file.name,
-                    ]
-                )
+                    await run_in_subprocess(
+                        [
+                            "cloud-localds",
+                            f"--network-config={network_config_file.name}",
+                            str(disk_image_path),
+                            user_data_config_file.name,
+                            metadata_config_file.name,
+                        ]
+                    )
 
         return self.fvm.enable_drive(disk_image_path, read_only=True)

--- a/vm_supervisor/vm/firecracker/program.py
+++ b/vm_supervisor/vm/firecracker/program.py
@@ -34,6 +34,7 @@ from ...utils import MsgpackSerializable
 from .executable import (
     AlephFirecrackerExecutable,
     AlephFirecrackerResources,
+    ResourceDownloadError,
     VmInitNotConnected,
     VmSetupError,
     Volume,
@@ -44,19 +45,6 @@ logger = logging.getLogger(__name__)
 
 class FileTooLargeError(Exception):
     pass
-
-
-class ResourceDownloadError(ClientResponseError):
-    """An error occurred while downloading a VM resource file"""
-
-    def __init__(self, error: ClientResponseError):
-        super().__init__(
-            request_info=error.request_info,
-            history=error.history,
-            status=error.status,
-            message=error.message,
-            headers=error.headers,
-        )
 
 
 def read_input_data(path_to_data: Optional[Path]) -> Optional[bytes]:


### PR DESCRIPTION
Solved shutdown errors that prevent the VM to try again to be scheduled on the CRN.
Errors:
- Property `_unix_socket` is not used on instances yet, so initialize to `None` by default.
- If the VM don't respond to a ping, should forget the VM to be able to try to power up later.
- Improvement: Use `fallocate` instead `dd` command to create empty files.
- Fixed cloud-init issue that only executes the configuration on the first boot. Now, if the VM ID has changed, the cloud-init configuration re-runs again.
- Ensure that the allocation process don't stop, either, on a VM failure.