### PR TITLE
Fix: start IPFS daemon with the server profile

### DIFF
--- a/packaging/aleph-vm/etc/systemd/system/ipfs.service
+++ b/packaging/aleph-vm/etc/systemd/system/ipfs.service
@@ -39,7 +39,7 @@ TimeoutStartSec=infinity
 Type=notify
 StateDirectory=ipfs
 Environment=IPFS_PATH="${HOME}"
-ExecStart=/opt/kubo/ipfs daemon --init --migrate
+ExecStart=/opt/kubo/ipfs daemon --init --init-profile=server --migrate
 Restart=on-failure
 KillSignal=SIGINT
 


### PR DESCRIPTION
Problem: in normal mode, the IPFS daemon advertises itself with private addresses. Some cloud providers do not like this at all and will send abuse notices related to port scanning.

Solution: start the daemon with the server profile, which only advertises the node with public addresses and avoids port scanning.