### PR TITLE
Fix: The Kubo IPFS service was not hardened

### DIFF
--- a/packaging/aleph-vm/DEBIAN/postinst
+++ b/packaging/aleph-vm/DEBIAN/postinst
@@ -9,10 +9,18 @@ rm -fr /srv/jailer  # Upgrade from < 0.1.11
 rm -fr /tmp/aleph   # Upgrade from < 0.1.11
 mkdir -p /var/lib/aleph/vm/jailer
 
+# Create the IPFS directory if it does not exist
+if [ ! -d "/var/lib/ipfs" ]; then
+    mkdir -p /var/lib/ipfs
+    # Set appropriate permissions if needed
+    chown ipfs:ipfs /var/lib/ipfs
+fi
+
 # Systemd is absent from containers
 if ! [[ -v container ]]; then
   systemctl daemon-reload
   systemctl enable ipfs.service
+  systemctl restart ipfs.service
   systemctl enable aleph-vm-supervisor.service
   systemctl restart aleph-vm-supervisor.service
 fi

--- a/packaging/aleph-vm/DEBIAN/postrm
+++ b/packaging/aleph-vm/DEBIAN/postrm
@@ -5,4 +5,9 @@ rm -fr /srv/jailer  # Upgrade from < 0.1.11
 rm -fr /tmp/aleph/  # Upgrade from < 0.1.11
 rm -r /var/lib/aleph/vm/jailer
 
+if [ "$1" = "purge" ]; then
+    # Remove the directory when the package is purged
+    rm -rf /var/lib/ipfs
+fi
+
 systemctl daemon-reload

--- a/packaging/aleph-vm/DEBIAN/preinst
+++ b/packaging/aleph-vm/DEBIAN/preinst
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -uf -o pipefail
 
+# Documentation: https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
+
 # Systemd is absent from containers
 if ! [[ -v container ]]; then
   # Stop the service during an upgrade.
@@ -9,3 +11,7 @@ if ! [[ -v container ]]; then
 fi
 
 set -e
+
+# We will not delete this user on uninstall since there may be files owned by that user in /var/lib/ipfs
+addgroup --system ipfs
+adduser --system --ingroup ipfs ipfs

--- a/packaging/aleph-vm/etc/systemd/system/ipfs.service
+++ b/packaging/aleph-vm/etc/systemd/system/ipfs.service
@@ -1,3 +1,5 @@
+# Source: https://github.com/ipfs/kubo/blob/master/misc/systemd/ipfs-hardened.service
+
 # This file will be overwritten on package upgrades, avoid customizations here.
 #
 # To make persistent changes, create file in
@@ -12,12 +14,42 @@
 #
 # For more info about custom unit files see systemd.unit(5).
 
+# This service file enables systemd-hardening features compatible with IPFS,
+# while breaking compatibility with the fuse-mount function. Use this one only
+# if you don't need the fuse-mount functionality.
+
 [Unit]
 Description=InterPlanetary File System (IPFS) daemon
 Documentation=https://docs.ipfs.tech/
 After=network.target
 
 [Service]
+# hardening
+ReadOnlyPaths="/opt/kubo/"
+ReadWritePaths="/var/lib/ipfs/"
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+PrivateDevices=true
+DevicePolicy=closed
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+ProtectHostname=true
+PrivateTmp=true
+ProtectClock=true
+LockPersonality=true
+RestrictNamespaces=true
+RestrictRealtime=true
+MemoryDenyWriteExecute=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged
+ProtectHome=true
+RemoveIPC=true
+RestrictSUIDSGID=true
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
 # enable for 1-1024 port listening
 #AmbientCapabilities=CAP_NET_BIND_SERVICE
@@ -37,9 +69,10 @@ MemorySwapMax=0
 TimeoutStartSec=infinity
 
 Type=notify
-StateDirectory=ipfs
-Environment=IPFS_PATH="${HOME}"
-ExecStart=/opt/kubo/ipfs daemon --init --init-profile=server --migrate
+User=ipfs
+Group=ipfs
+Environment=IPFS_PATH="/var/lib/ipfs"
+ExecStart=/opt/kubo/ipfs daemon --init --migrate --init-profile=server
 Restart=on-failure
 KillSignal=SIGINT
 


### PR DESCRIPTION
Systemd provides hardening tools to improve the security of the host.

This uses the hardened service file from the Kubo repository.
