### PR TITLE
Fix: no HTTPs in IPv4 diagnostic check

### DIFF
--- a/examples/example_fastapi/main.py
+++ b/examples/example_fastapi/main.py
@@ -98,18 +98,11 @@ async def ip_address():
 
 @app.get("/ip/4")
 async def connect_ipv4():
-    """Connect to the Quad9 VPN provider using their IPv4 address.
-    The webserver on that address returns a 404 error, so we accept that response code.
-    """
-    timeout = aiohttp.ClientTimeout(total=5)
-    async with aiohttp.ClientSession(
-        connector=aiohttp.TCPConnector(), timeout=timeout
-    ) as session:
-        async with session.get("https://9.9.9.9") as resp:
-            # We expect this endpoint to return a 404 error
-            if resp.status != 404:
-                resp.raise_for_status()
-            return {"result": True, "headers": resp.headers}
+    """Connect to the Quad9 VPN provider using their IPv4 address."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(5)
+    sock.connect(("9.9.9.9", 53))
+    return {"result": True}
 
 
 @app.get("/ip/6")

--- a/vm_supervisor/status.py
+++ b/vm_supervisor/status.py
@@ -68,7 +68,6 @@ async def check_ipv4(session: ClientSession) -> bool:
     try:
         result: Dict = await get_json_from_vm(session, "/ip/4")
         assert result["result"] is True
-        assert "headers" in result
         return True
     except ClientResponseError:
         return False


### PR DESCRIPTION
Problem: a node operator reports a timeout when attempting to connect to `https://9.9.9.9`. However, he can ping `9.9.9.9` just fine.

Solution: as the diagnostic check is targeted at IPv4 connectivity only, use a socket to attempt to connect to 9.9.9.9:53 directly.