### PR TITLE
Fix: Caddyfile syntax broken in 2.7.4

### DIFF
--- a/doc/INSTALL-Debian-11.md
+++ b/doc/INSTALL-Debian-11.md
@@ -121,9 +121,6 @@ cat >/etc/caddy/Caddyfile <<EOL
     }
 }
 vm.example.org:443 {
-    tls {
-        on_demand
-    }
     reverse_proxy http://127.0.0.1:4020 {
         # Forward Host header to the backend
         header_up Host {host}

--- a/doc/INSTALL-Debian-12.md
+++ b/doc/INSTALL-Debian-12.md
@@ -121,9 +121,6 @@ cat >/etc/caddy/Caddyfile <<EOL
     }
 }
 vm.example.org:443 {
-    tls {
-        on_demand
-    }
     reverse_proxy http://127.0.0.1:4020 {
         # Forward Host header to the backend
         header_up Host {host}

--- a/doc/INSTALL-Ubuntu-22.04.md
+++ b/doc/INSTALL-Ubuntu-22.04.md
@@ -120,9 +120,6 @@ sudo cat >/etc/caddy/Caddyfile <<EOL
     }
 }
 vm.example.org:443 {
-    tls {
-        on_demand
-    }
     reverse_proxy http://127.0.0.1:4020 {
         # Forward Host header to the backend
         header_up Host {host}


### PR DESCRIPTION
The syntax of the Caddyfile documented in the quick install guides is broken in Caddy 2.7.4.

This removes the unused `on_demand` section from the configuration, restoring compatibility with newer versions of Caddy.

We maintain the `on_demand_tls` section in case we may re-enable wildcard domains on the default config.


```diff
{
        on_demand_tls {
                interval 60s
                burst 5
        }
}
brain01.crn.alephians.com:443 {
-        tls {
-              on_demand
-        }
        reverse_proxy http://127.0.0.1:4020 {
                # Forward Host header to the backend
                header_up Host {host}
        }
}
```