### PR TITLE
Automate network and DNS settings

### DIFF
--- a/.github/workflows/test-on-droplet-ubuntu-22.04.yml
+++ b/.github/workflows/test-on-droplet-ubuntu-22.04.yml
@@ -65,7 +65,6 @@ jobs:
           scp packaging/target/aleph-vm.ubuntu-22.04.deb root@${DROPLET_IPV4}:/opt
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt install -y /opt/aleph-vm.ubuntu-22.04.deb"
           ssh root@${DROPLET_IPV4} "echo ALEPH_VM_SUPERVISOR_HOST=0.0.0.0 >> /etc/aleph-vm/supervisor.env"
-          ssh root@${DROPLET_IPV4} "echo ALEPH_VM_DNS_RESOLUTION=resolvectl >> /etc/aleph-vm/supervisor.env"
           ssh root@${DROPLET_IPV4} "echo ALEPH_VM_ALLOCATION_TOKEN_HASH=9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08 >> /etc/aleph-vm/supervisor.env"
           ssh root@${DROPLET_IPV4} "systemctl restart aleph-vm-supervisor"
 

--- a/doc/INSTALL-Debian-12.md
+++ b/doc/INSTALL-Debian-12.md
@@ -56,7 +56,8 @@ ALEPH_VM_DOMAIN_NAME=vm.example.org
 
 #### Network configuration
 
-On some systems, the default network interface is not `eth0` and you will want to configure the default interface
+The default network interface is detected automatically from the IP routes. 
+On some systems, this is not the desired configuration and you will want to configure the default interface
 by adding:
 ```
 ALEPH_VM_NETWORK_INTERFACE=enp0s1

--- a/doc/INSTALL-Debian-12.md
+++ b/doc/INSTALL-Debian-12.md
@@ -56,19 +56,19 @@ ALEPH_VM_DOMAIN_NAME=vm.example.org
 
 #### Network configuration
 
+The network configuration is detected automatically.
+
 The default network interface is detected automatically from the IP routes. 
-On some systems, this is not the desired configuration and you will want to configure the default interface
-by adding:
+You can configure the default interface manually instead by adding:
 ```
 ALEPH_VM_NETWORK_INTERFACE=enp0s1
 ```
 (don't forget to replace `enp0s1` with the name of your default network interface).
 
-Debian 12 by default uses `/etc/resolv.conf` for DNS resolution. The VM Supervisor uses this by default.
-If your system uses [systemd-resolved](https://manpages.debian.org/bullseye/systemd/systemd-resolved.8.en.html)
-instead, uncomment and add the following setting:
+You can configure the DNS resolver manually by using one of the following options:
 ```
-#ALEPH_VM_DNS_RESOLUTION=resolvctl
+ALEPH_VM_DNS_RESOLUTION=resolvectl
+ALEPH_VM_DNS_RESOLUTION=resolv.conf
 ```
 
 > 💡 You can instead specify the DNS resolvers used by the VMs using `ALEPH_VM_DNS_NAMESERVERS=["1.2.3.4", "5.6.7.8"]`.

--- a/doc/INSTALL-Ubuntu-22.04.md
+++ b/doc/INSTALL-Ubuntu-22.04.md
@@ -56,21 +56,23 @@ ALEPH_VM_DOMAIN_NAME=vm.example.org
 
 #### Network configuration
 
-Ubuntu 22.04 by default uses [systemd-resolved](https://manpages.ubuntu.com/manpages/jammy/man8/systemd-resolved.service.8.html)
-for DNS resolution. The following setting configures the VM Supervisor to use it instead of reading the default `/etc/resolv.conf`.
-```
-ALEPH_VM_DNS_RESOLUTION=resolvectl
-```
-
-> 💡 You can instead specify the DNS resolvers used by the VMs using `ALEPH_VM_DNS_NAMESERVERS=["1.2.3.4", "5.6.7.8"]`.
+The network configuration is detected automatically.
 
 The default network interface is detected automatically from the IP routes. 
-On some systems, this is not the desired configuration and you will want to configure the default interface
-by adding:
+You can configure the default interface manually instead by adding:
 ```
 ALEPH_VM_NETWORK_INTERFACE=enp0s1
 ```
 (don't forget to replace `enp0s1` with the name of your default network interface).
+
+You can configure the DNS resolver manually by using one of the following options:
+```
+ALEPH_VM_DNS_RESOLUTION=resolvectl
+ALEPH_VM_DNS_RESOLUTION=resolv.conf
+```
+
+> 💡 You can instead specify the DNS resolvers used by the VMs using `ALEPH_VM_DNS_NAMESERVERS=["1.2.3.4", "5.6.7.8"]`.
+
 
 #### Volumes and partitions
 

--- a/doc/INSTALL-Ubuntu-22.04.md
+++ b/doc/INSTALL-Ubuntu-22.04.md
@@ -64,7 +64,8 @@ ALEPH_VM_DNS_RESOLUTION=resolvectl
 
 > 💡 You can instead specify the DNS resolvers used by the VMs using `ALEPH_VM_DNS_NAMESERVERS=["1.2.3.4", "5.6.7.8"]`.
 
-On some systems, the default network interface is not `eth0` and you will want to configure the default interface
+The default network interface is detected automatically from the IP routes. 
+On some systems, this is not the desired configuration and you will want to configure the default interface
 by adding:
 ```
 ALEPH_VM_NETWORK_INTERFACE=enp0s1


### PR DESCRIPTION
Operators had to specify network interface and DNS resolver while can be done automatically.

The network interfaces defaulted to `eth0`, which not the default on all supported systems.

This uses the default network interface instead, and should require less configuration from node operators and developers.

The DNS resolver defaulted to `resolv.conf`, which is not the default on all supported systems.

This adds an option to detect if systemd-resolved is available, and else defaults to `/etc/resolv.conf`.