### PR TITLE
Fix: Sentry SDK was absent from most installs

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -17,7 +17,7 @@ debian-package-code:
 	cp ../examples/instance_message_from_aleph.json ./aleph-vm/opt/aleph-vm/examples/instance_message_from_aleph.json
 	cp -r ../examples/data ./aleph-vm/opt/aleph-vm/examples/data
 	mkdir -p ./aleph-vm/opt/aleph-vm/examples/volumes
-	pip3 install --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.4.0' 'jwskate==0.8.0' 'eth-account==0.9.0'
+	pip3 install --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.4.0' 'jwskate==0.8.0' 'eth-account==0.9.0' 'sentry-sdk==1.31.0'
 	python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux download-ipfs-kubo


### PR DESCRIPTION
Problem: Setting a value for `SENTRY_DNS` often did not work because the Sentry SDK was not installed.

The Sentry SDK has a very limited number of dependencies.

Solution: Install the Sentry SDK by default from the Debian packages.
