### PR TITLE
Fix: Diagnostic did not expose platform information

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -27,21 +27,25 @@ jobs:
         run: |
           black --check ./vm_supervisor
           black --check ./runtimes/aleph-debian-11-python/init1.py
+          black --check ./examples/example_fastapi/
 
       - name: Test with isort
         run: |
           isort --check-only --profile=black ./vm_supervisor
           isort --check-only --profile=black ./runtimes/aleph-debian-11-python/init1.py
+          isort --check-only --profile=black ./examples/example_fastapi/
 
       - name: Test with MyPy
         run: |
           mypy --ignore-missing-imports ./vm_supervisor
           mypy --ignore-missing-imports ./runtimes/aleph-debian-11-python/init1.py
+          mypy --ignore-missing-imports ./examples/example_fastapi/
 
       - name: Test with flake8
         run: |
           flake8 --extend-ignore E501 ./vm_supervisor
           flake8 --extend-ignore E501,E402 ./runtimes/aleph-debian-11-python/init1.py
+          flake8 --extend-ignore E501,E402 ./examples/example_fastapi/
 
   code-quality-shell:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Solution: Expose os-release, Python version and installed Python packages via the example_fastapi diagnostic VM.
