### PR TITLE
Fix: install FastAPI from PyPI in Debian 12 runtime

### DIFF
--- a/runtimes/aleph-debian-11-python/create_disk_image.sh
+++ b/runtimes/aleph-debian-11-python/create_disk_image.sh
@@ -17,18 +17,15 @@ apt-get install -y --no-install-recommends --no-install-suggests \
   python3-minimal \
   openssh-server \
   socat libsecp256k1-0 \
-  \
   python3-aiohttp python3-msgpack \
   python3-setuptools \
   python3-pip python3-cytoolz python3-pydantic \
   iproute2 unzip \
   nodejs npm \
   build-essential python3-dev \
-  \
   docker.io \
   cgroupfs-mount \
   nftables \
-  \
   iputils-ping curl
 
 pip3 install 'fastapi~=0.95.1'

--- a/runtimes/aleph-debian-12-python/create_disk_image.sh
+++ b/runtimes/aleph-debian-12-python/create_disk_image.sh
@@ -33,7 +33,7 @@ pip3 install --break-system-packages 'fastapi~=0.103.1'
 
 echo "Pip installing aleph-sdk-python"
 mkdir -p /opt/aleph/libs
-pip3 install --target /opt/aleph/libs 'aleph-sdk-python==0.7.0'
+pip3 install --target /opt/aleph/libs 'aleph-sdk-python==0.7.0' 'fastapi~=0.103.1'
 
 # Compile Python code to bytecode for faster execution
 python3 -m compileall -f /usr/local/lib/python3.11

--- a/runtimes/aleph-debian-12-python/create_disk_image.sh
+++ b/runtimes/aleph-debian-12-python/create_disk_image.sh
@@ -17,7 +17,6 @@ apt-get install -y --no-install-recommends --no-install-suggests \
   python3-minimal \
   openssh-server \
   socat libsecp256k1-1 \
-  \
   python3-aiohttp python3-msgpack \
   python3-setuptools python3-venv \
   python3-pip python3-cytoolz python3-pydantic \
@@ -25,12 +24,12 @@ apt-get install -y --no-install-recommends --no-install-suggests \
   nodejs npm \
   build-essential python3-dev \
   python3-fastapi \
-  \
   docker.io \
   cgroupfs-mount \
   nftables \
-  \
   iputils-ping curl
+
+pip3 install --break-system-packages 'fastapi~=0.103.1'
 
 echo "Pip installing aleph-sdk-python"
 mkdir -p /opt/aleph/libs

--- a/runtimes/aleph-debian-12-python/create_disk_image.sh
+++ b/runtimes/aleph-debian-12-python/create_disk_image.sh
@@ -29,8 +29,6 @@ apt-get install -y --no-install-recommends --no-install-suggests \
   nftables \
   iputils-ping curl
 
-pip3 install --break-system-packages 'fastapi~=0.103.1'
-
 echo "Pip installing aleph-sdk-python"
 mkdir -p /opt/aleph/libs
 pip3 install --target /opt/aleph/libs 'aleph-sdk-python==0.7.0' 'fastapi~=0.103.1'


### PR DESCRIPTION
Problem: Debian 12 runtime has FastAPI 0.92.0 (installed from apt) while Debian 11 runtime has FastAPI 0.95.1. Some VMs previously running on the Debian 11 runtime do not run on the Debian 12 runtime because of this issue.

Solution: install the latest version of FastAPI from PyPI.