### PR TITLE
Fix: Diagnosis VM used the old runtime.

### DIFF
--- a/vm_supervisor/conf.py
+++ b/vm_supervisor/conf.py
@@ -242,7 +242,7 @@ class Settings(BaseSettings):
     )
 
     CHECK_FASTAPI_VM_ID = (
-        "67705389842a0a1b95eaa408b009741027964edc805997475e95c505d642edd8"
+        "3fc0aa9569da840c43e7bd2033c3c580abb46b007527d6d20f2d4e98e867f7af"
     )
 
     # Developer options

--- a/vm_supervisor/status.py
+++ b/vm_supervisor/status.py
@@ -33,7 +33,7 @@ async def check_index(session: ClientSession) -> bool:
 async def check_lifespan(session: ClientSession) -> bool:
     try:
         result: Dict = await get_json_from_vm(session, "/lifespan")
-        return result["Lifetime"] is True
+        return result["Lifespan"] is True
     except ClientResponseError:
         return False
 

--- a/vm_supervisor/views/__init__.py
+++ b/vm_supervisor/views/__init__.py
@@ -150,7 +150,7 @@ async def status_check_fastapi(request: web.Request):
         result = {
             "index": await status.check_index(session),
             # TODO: lifespan is a new feature that requires a new runtime to be deployed
-            # "lifespan": await status.check_lifespan(session),
+            "lifespan": await status.check_lifespan(session),
             "environ": await status.check_environ(session),
             "messages": await status.check_messages(session),
             "dns": await status.check_dns(session),


### PR DESCRIPTION
This upgrades it to use the newer Debian 12 runtime.

The new diagnosis VM adds extra enpoints, and supports the newer "Lifespan" ASGI API.
