### PR TITLE
Fix: Give in total 60 second to the VM to respond the ping

### DIFF
--- a/vm_supervisor/vm/firecracker/instance.py
+++ b/vm_supervisor/vm/firecracker/instance.py
@@ -142,8 +142,8 @@ class AlephFirecrackerInstance(AlephFirecrackerExecutable):
 
         ip = ip.split("/", 1)[0]
 
-        attempts = 10
-        timeout_seconds = 1.0
+        attempts = 30
+        timeout_seconds = 2.0
 
         for attempt in range(attempts):
             try:


### PR DESCRIPTION
Problem: Sometimes initiate a VM take a bit more time that used to, but finally starts.

Solution: Just to avoid HostNotFound errors, increase the ping attempts and the timeout to 60 seconds in total.