### PR TITLE
Fix: Initializing VM Pool had side effects

### DIFF
--- a/src/aleph/vm/network/hostnetwork.py
+++ b/src/aleph/vm/network/hostnetwork.py
@@ -134,7 +134,6 @@ class Network:
 
         self.network_size = vm_network_size
         self.external_interface = external_interface
-        self.network_interface = external_interface
         self.ipv4_forwarding_enabled = ipv4_forwarding_enabled
         self.ipv6_forwarding_enabled = ipv6_forwarding_enabled
         self.use_ndp_proxy = use_ndp_proxy

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -26,6 +26,7 @@ from .pubsub import PubSub
 logger = logging.getLogger(__name__)
 
 pool = VmPool()
+pool.setup()
 
 
 async def build_asgi_scope(path: str, request: web.Request) -> dict[str, Any]:

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -105,4 +105,4 @@ def run():
             raise
     finally:
         if settings.ALLOW_VM_NETWORKING:
-            pool.network.teardown()
+            pool.teardown()

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -55,6 +55,16 @@ class VmPool:
         logger.debug("Initializing SnapshotManager ...")
         self.snapshot_manager.run_snapshots()
 
+    def setup(self) -> None:
+        """Set up the VM pool and the network."""
+        if self.network:
+            self.network.setup()
+
+    def teardown(self) -> None:
+        """Stop the VM pool and the network properly."""
+        if self.network:
+            self.network.teardown()
+
     async def create_a_vm(
         self, vm_hash: ItemHash, message: ExecutableContent, original: ExecutableContent
     ) -> VmExecution:


### PR DESCRIPTION
Problem: Initializing the VM Pool had the side effect of setting up the network interfaces.

Solution: Move the setup of the networking in a separate method of the Network class, that has to be called explicitly.
