### PR TITLE
Problem: CACHE_ROOT & EXECUTION_ROOT not respected

### DIFF
--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -173,17 +173,26 @@ class Settings(BaseSettings):
     CONNECTOR_URL = Url("http://localhost:4021")
 
     CACHE_ROOT = Path("/var/cache/aleph/vm")
-    MESSAGE_CACHE = CACHE_ROOT / "message"
-    CODE_CACHE = CACHE_ROOT / "code"
-    RUNTIME_CACHE = CACHE_ROOT / "runtime"
-    DATA_CACHE = CACHE_ROOT / "data"
+    MESSAGE_CACHE: Optional[Path] = Field(
+        None,
+        description="Default to CACHE_ROOT/message",
+    )
+    CODE_CACHE: Optional[Path] = Field(None, description="Default to CACHE_ROOT/code")
+    RUNTIME_CACHE: Optional[Path] = Field(None, description="Default to CACHE_ROOT/runtime")
+    DATA_CACHE: Optional[Path] = Field(None, description="Default to CACHE_ROOT/data")
 
     EXECUTION_ROOT = Path("/var/lib/aleph/vm")
-    EXECUTION_DATABASE = EXECUTION_ROOT / "executions.sqlite3"
+    EXECUTION_DATABASE: Optional[Path] = Field(
+        None, description="Location of database file. Default to EXECUTION_ROOT/executions.sqlite3"
+    )
     EXECUTION_LOG_ENABLED = False
-    EXECUTION_LOG_DIRECTORY = EXECUTION_ROOT / "executions"
+    EXECUTION_LOG_DIRECTORY: Optional[Path] = Field(
+        None, description="Location of executions log. Default to EXECUTION_ROOT/executions/"
+    )
 
-    PERSISTENT_VOLUMES_DIR = EXECUTION_ROOT / "volumes" / "persistent"
+    PERSISTENT_VOLUMES_DIR: Optional[Path] = Field(
+        None, description="Persistent volumes location. Default to EXECUTION_ROOT/volumes/persistent/"
+    )
 
     MAX_PROGRAM_ARCHIVE_SIZE = 10_000_000  # 10 MB
     MAX_DATA_ARCHIVE_SIZE = 10_000_000  # 10 MB
@@ -280,11 +289,26 @@ class Settings(BaseSettings):
         assert is_command_available("ndppd"), "Command `ndppd` not found, run `apt install ndppd`"
 
     def setup(self):
+        if not self.MESSAGE_CACHE:
+            self.MESSAGE_CACHE = self.CACHE_ROOT / "message"
+        if not self.CODE_CACHE:
+            self.CODE_CACHE = self.CACHE_ROOT / "code"
+        if not self.RUNTIME_CACHE:
+            self.RUNTIME_CACHE = self.CACHE_ROOT / "runtime"
+        if not self.DATA_CACHE:
+            self.DATA_CACHE = self.CACHE_ROOT / "data"
+
         os.makedirs(self.MESSAGE_CACHE, exist_ok=True)
         os.makedirs(self.CODE_CACHE, exist_ok=True)
         os.makedirs(self.RUNTIME_CACHE, exist_ok=True)
         os.makedirs(self.DATA_CACHE, exist_ok=True)
+
         os.makedirs(self.EXECUTION_ROOT, exist_ok=True)
+        if not self.PERSISTENT_VOLUMES_DIR:
+            self.PERSISTENT_VOLUMES_DIR = self.EXECUTION_ROOT / "volumes" / "persistent"
+        if not self.EXECUTION_LOG_DIRECTORY:
+            self.EXECUTION_LOG_DIRECTORY = self.EXECUTION_ROOT / "executions"
+
         os.makedirs(self.EXECUTION_LOG_DIRECTORY, exist_ok=True)
         os.makedirs(self.PERSISTENT_VOLUMES_DIR, exist_ok=True)
 


### PR DESCRIPTION
The value set by the user for CACHE_ROOT and EXECUTION_ROOT were not respected when calculating the default value of MESSAGE_CACHE, CODE_CACHE, EXECUTION_DATABASE, etc...

Solution:
This was caused by the default value being defined at class definition, this patch move the defaults computation into Settings.check() so we have the user passed settings.

Reproduce the problem:
1. Without setting MESSAGE_CACHE
2. set CACHE_ROOT (via environment variable ALEPH_VM_CACHE_ROOT)
3. Print the settings  e.g ALEPH_VM_CACHE_ROOT=/tmp/ aleph-vm --do-not-run --print-settings

What was happening:
MESSAGE_CACHE = /var/cache/aleph/vm/message

What is expected and is happening now:
MESSAGE_CACHE = /tmp/message