### PR TITLE
Fix configuration edge cases

### DIFF
--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -288,7 +288,8 @@ class Settings(BaseSettings):
             assert isfile(self.FAKE_DATA_VOLUME), "Local data volume .squashfs is missing"
 
         assert is_command_available("setfacl"), "Command `setfacl` not found, run `apt install acl`"
-        assert is_command_available("ndppd"), "Command `ndppd` not found, run `apt install ndppd`"
+        if self.USE_NDP_PROXY:
+            assert is_command_available("ndppd"), "Command `ndppd` not found, run `apt install ndppd`"
 
     def setup(self):
         os.makedirs(self.MESSAGE_CACHE, exist_ok=True)

--- a/src/aleph/vm/controllers/firecracker/executable.py
+++ b/src/aleph/vm/controllers/firecracker/executable.py
@@ -250,9 +250,11 @@ class AlephFirecrackerExecutable(Generic[ConfigurationType]):
             logger.debug("setup done")
         except Exception:
             # Stop the VM and clear network interfaces in case any error prevented the start of the virtual machine.
+            logger.error("VM startup failed, cleaning up network")
             await self.fvm.teardown()
             teardown_nftables_for_vm(self.vm_id)
-            await self.tap_interface.delete()
+            if self.tap_interface:
+                await self.tap_interface.delete()
             raise
 
         if self.enable_console:
@@ -291,7 +293,8 @@ class AlephFirecrackerExecutable(Generic[ConfigurationType]):
         if self.fvm:
             await self.fvm.teardown()
             teardown_nftables_for_vm(self.vm_id)
-            await self.tap_interface.delete()
+            if self.tap_interface:
+                await self.tap_interface.delete()
         await self.stop_guest_api()
 
     async def create_snapshot(self) -> CompressedDiskVolumeSnapshot:

--- a/src/aleph/vm/controllers/firecracker/executable.py
+++ b/src/aleph/vm/controllers/firecracker/executable.py
@@ -21,7 +21,7 @@ from aleph.vm.guest_api.__main__ import run_guest_api
 from aleph.vm.hypervisors.firecracker.microvm import FirecrackerConfig, MicroVM
 from aleph.vm.network.firewall import teardown_nftables_for_vm
 from aleph.vm.network.interfaces import TapInterface
-from aleph.vm.storage import get_volume_path, chown_to_jailman
+from aleph.vm.storage import chown_to_jailman, get_volume_path
 
 try:
     import psutil  # type: ignore [no-redef]

--- a/src/aleph/vm/controllers/firecracker/executable.py
+++ b/src/aleph/vm/controllers/firecracker/executable.py
@@ -21,7 +21,7 @@ from aleph.vm.guest_api.__main__ import run_guest_api
 from aleph.vm.hypervisors.firecracker.microvm import FirecrackerConfig, MicroVM
 from aleph.vm.network.firewall import teardown_nftables_for_vm
 from aleph.vm.network.interfaces import TapInterface
-from aleph.vm.storage import get_volume_path
+from aleph.vm.storage import get_volume_path, chown_to_jailman
 
 try:
     import psutil  # type: ignore [no-redef]
@@ -280,7 +280,7 @@ class AlephFirecrackerExecutable(Generic[ConfigurationType]):
         self.guest_api_process.start()
         while not exists(vsock_path):
             await asyncio.sleep(0.01)
-        subprocess.run(f"chown jailman:jailman {vsock_path}", shell=True, check=True)
+        await chown_to_jailman(Path(vsock_path))
         logger.debug(f"started guest API for {self.vm_id}")
 
     async def stop_guest_api(self):

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -377,7 +377,8 @@ class MicroVM:
             await queue.put(runtime_config)
 
         self._unix_socket = await asyncio.start_unix_server(unix_client_connected, path=f"{self.vsock_path}_52")
-        system(f"chown jailman:jailman {self.vsock_path}_52")
+        if self.use_jailer:
+            system(f"chown jailman:jailman {self.vsock_path}_52")
         try:
             self.runtime_config = await asyncio.wait_for(queue.get(), timeout=self.init_timeout)
             logger.debug("...signal from init received")

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -4,6 +4,7 @@ import logging
 import os.path
 import shutil
 import string
+import traceback
 from asyncio import Task
 from asyncio.base_events import Server
 from dataclasses import dataclass
@@ -40,7 +41,12 @@ class JSONBytesEncoder(json.JSONEncoder):
 
 def system(command):
     logger.debug(f"shell {command}")
-    return os.system(command)
+    ret = os.system(command)
+    if ret != 0:
+        logger.warning(f"Failed shell `{command}`: return code {ret}")
+        # print trace so we know who called this
+        traceback.print_stack()
+    return ret
 
 
 async def setfacl():

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -136,6 +136,8 @@ class MicroVM:
         }
 
     def prepare_jailer(self):
+        if not self.use_jailer:
+            return False
         system(f"rm -fr {self.jailer_path}")
 
         # system(f"rm -fr {self.jailer_path}/run/")

--- a/src/aleph/vm/network/firewall.py
+++ b/src/aleph/vm/network/firewall.py
@@ -47,6 +47,7 @@ def get_existing_nftables_ruleset() -> dict:
 
     if return_code != 0:
         logger.error(f"Unable to get nftables ruleset: {error}")
+        return {"nftables": []}
 
     nft_ruleset = json.loads(output)
     return nft_ruleset

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -105,6 +105,10 @@ async def create_vm_execution_or_raise_http_error(vm_hash: ItemHash, pool: VmPoo
         logger.exception(error)
         pool.forget_vm(vm_hash=vm_hash)
         raise HTTPInternalServerError(reason="Host did not respond to ping")
+    except Exception as error:
+        logger.exception(error)
+        pool.forget_vm(vm_hash=vm_hash)
+        raise HTTPInternalServerError(reason="unhandled error during initialisation")
 
 
 async def run_code_on_request(vm_hash: ItemHash, path: str, pool: VmPool, request: web.Request) -> web.Response:

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -108,7 +108,7 @@ async def create_vm_execution_or_raise_http_error(vm_hash: ItemHash, pool: VmPoo
     except Exception as error:
         logger.exception(error)
         pool.forget_vm(vm_hash=vm_hash)
-        raise HTTPInternalServerError(reason="unhandled error during initialisation")
+        raise HTTPInternalServerError(reason="unhandled error during initialisation") from error
 
 
 async def run_code_on_request(vm_hash: ItemHash, path: str, pool: VmPool, request: web.Request) -> web.Response:


### PR DESCRIPTION
This PR fix various crash and wrong warnings that were caused by a combination of configurations which  occurred when setting up my development environments.

These were mainly caused by:
- not having the jailman user (and USE_JAILER=0)
- not having the ndppd command (and USE_NDP=0)
- not running as root
-  disabling the network options via `--no-network`

The main solutions for theses were being more strict in respecting the user settings, better error handling and displaying better errors messages. 

Since it a lot of small fixes I estimated it was better to make them all in one PR