### PR TITLE
Problem: MicroVM had no str which made log ugly

### DIFF
--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -88,6 +88,9 @@ class MicroVM:
     mounted_rootfs: Optional[Path] = None
     _unix_socket: Optional[Server] = None
 
+    def __str__(self):
+        return f"<MicroVM {self.vm_id}>"
+
     @property
     def namespace_path(self):
         firecracker_bin_name = os.path.basename(self.firecracker_bin_path)

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -88,8 +88,11 @@ class MicroVM:
     mounted_rootfs: Optional[Path] = None
     _unix_socket: Optional[Server] = None
 
-    def __str__(self):
+    def __repr__(self):
         return f"<MicroVM {self.vm_id}>"
+
+    def __str__(self):
+        return f"vm-{self.vm_id}"
 
     @property
     def namespace_path(self):


### PR DESCRIPTION
This made representation in the log like this
`<aleph.vm.hypervisors.firecracker.microvm.MicroVM object at 0x7fa7f4f1ca90> 2092.023134 |V DEBUG | Init received msg`

Solution : Add a `__str__` method on MicroVM