### PR TITLE
Fixes regarding concurrency

### DIFF
--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -269,12 +269,12 @@ async def start_persistent_vm(vm_hash: ItemHash, pubsub: Optional[PubSub], pool:
         logger.info(f"Starting persistent virtual machine with id: {vm_hash}")
         execution = await create_vm_execution(vm_hash=vm_hash, pool=pool)
 
+    await execution.becomes_ready()
+
     # If the VM was already running in lambda mode, it should not expire
     # as long as it is also scheduled as long-running
     execution.persistent = True
     execution.cancel_expiration()
-
-    await execution.becomes_ready()
 
     if pubsub and settings.WATCH_FOR_UPDATES:
         execution.start_watching_for_updates(pubsub=pubsub)

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -69,13 +69,20 @@ class VmPool:
         self, vm_hash: ItemHash, message: ExecutableContent, original: ExecutableContent
     ) -> VmExecution:
         """Create a new Aleph Firecracker VM from an Aleph function message."""
-        execution = VmExecution(
-            vm_hash=vm_hash,
-            message=message,
-            original=original,
-            snapshot_manager=self.snapshot_manager,
-        )
-        self.executions[vm_hash] = execution
+
+        # Check if an execution is already present for this VM, then return it.
+        # Do not `await` in this section.
+        try:
+            return self.executions[vm_hash]
+        except KeyError:
+            execution = VmExecution(
+                vm_hash=vm_hash,
+                message=message,
+                original=original,
+                snapshot_manager=self.snapshot_manager,
+            )
+            self.executions[vm_hash] = execution
+
         await execution.prepare()
         vm_id = self.get_unique_vm_id()
 


### PR DESCRIPTION
This branch adds 3 fixes regarding the concurrency of launching the same VM multiple times
in a short period of time, before the setup of the other instances has finished.

- Fix: Ordering issue in starting persistent VM
- Fix: Two executions for the same VM could be prepared in parallel
- Fix: A VM could be prepared in parallel
