### PR TITLE
Make JAILER_BASE_DIR dependend on execution root

### DIFF
--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -195,6 +195,9 @@ class Settings(BaseSettings):
     PERSISTENT_VOLUMES_DIR: Path = Field(
         None, description="Persistent volumes location. Default to EXECUTION_ROOT/volumes/persistent/"
     )
+    JAILER_BASE_DIR: Path = Field(
+        None
+    )
 
     MAX_PROGRAM_ARCHIVE_SIZE = 10_000_000  # 10 MB
     MAX_DATA_ARCHIVE_SIZE = 10_000_000  # 10 MB
@@ -347,6 +350,9 @@ class Settings(BaseSettings):
             self.PERSISTENT_VOLUMES_DIR = self.EXECUTION_ROOT / "volumes" / "persistent"
         if not self.EXECUTION_LOG_DIRECTORY:
             self.EXECUTION_LOG_DIRECTORY = self.EXECUTION_ROOT / "executions"
+        if not self.JAILER_BASE_DIR:
+            self.JAILER_BASE_DIR = self.EXECUTION_ROOT / "jailer"
+
 
     class Config:
         env_prefix = "ALEPH_VM_"

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -195,9 +195,7 @@ class Settings(BaseSettings):
     PERSISTENT_VOLUMES_DIR: Path = Field(
         None, description="Persistent volumes location. Default to EXECUTION_ROOT/volumes/persistent/"
     )
-    JAILER_BASE_DIR: Path = Field(
-        None
-    )
+    JAILER_BASE_DIR: Path = Field(None)
 
     MAX_PROGRAM_ARCHIVE_SIZE = 10_000_000  # 10 MB
     MAX_DATA_ARCHIVE_SIZE = 10_000_000  # 10 MB
@@ -352,7 +350,6 @@ class Settings(BaseSettings):
             self.EXECUTION_LOG_DIRECTORY = self.EXECUTION_ROOT / "executions"
         if not self.JAILER_BASE_DIR:
             self.JAILER_BASE_DIR = self.EXECUTION_ROOT / "jailer"
-
 
     class Config:
         env_prefix = "ALEPH_VM_"

--- a/src/aleph/vm/controllers/__main__.py
+++ b/src/aleph/vm/controllers/__main__.py
@@ -72,7 +72,7 @@ async def run_instance(config: Configuration):
     execution = MicroVM(
         vm_id=config.vm_id,
         firecracker_bin_path=config.vm_configuration.firecracker_bin_path,
-        execution_root_folder=config.settings.EXECUTION_ROOT,
+        jailer_base_directory=config.settings.JAILER_BASE_DIR,
         use_jailer=config.vm_configuration.use_jailer,
         jailer_bin_path=config.vm_configuration.jailer_bin_path,
         init_timeout=config.vm_configuration.init_timeout,

--- a/src/aleph/vm/controllers/__main__.py
+++ b/src/aleph/vm/controllers/__main__.py
@@ -72,6 +72,7 @@ async def run_instance(config: Configuration):
     execution = MicroVM(
         vm_id=config.vm_id,
         firecracker_bin_path=config.vm_configuration.firecracker_bin_path,
+        execution_root_folder=config.settings.EXECUTION_ROOT,
         use_jailer=config.vm_configuration.use_jailer,
         jailer_bin_path=config.vm_configuration.jailer_bin_path,
         init_timeout=config.vm_configuration.init_timeout,

--- a/src/aleph/vm/controllers/firecracker/executable.py
+++ b/src/aleph/vm/controllers/firecracker/executable.py
@@ -174,6 +174,7 @@ class AlephFirecrackerExecutable(Generic[ConfigurationType]):
         self.fvm = MicroVM(
             vm_id=self.vm_id,
             firecracker_bin_path=settings.FIRECRACKER_PATH,
+            execution_root_folder=settings.EXECUTION_ROOT,
             use_jailer=settings.USE_JAILER,
             jailer_bin_path=settings.JAILER_PATH,
             init_timeout=settings.INIT_TIMEOUT,

--- a/src/aleph/vm/controllers/firecracker/executable.py
+++ b/src/aleph/vm/controllers/firecracker/executable.py
@@ -174,7 +174,7 @@ class AlephFirecrackerExecutable(Generic[ConfigurationType]):
         self.fvm = MicroVM(
             vm_id=self.vm_id,
             firecracker_bin_path=settings.FIRECRACKER_PATH,
-            execution_root_folder=settings.EXECUTION_ROOT,
+            jailer_base_directory=settings.JAILER_BASE_DIR,
             use_jailer=settings.USE_JAILER,
             jailer_bin_path=settings.JAILER_PATH,
             init_timeout=settings.INIT_TIMEOUT,

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -238,7 +238,7 @@ class MicroVM:
             "--gid",
             gid,
             "--chroot-base-dir",
-            self.jailer_base_directory,
+            str(self.jailer_base_directory),
             "--",
             "--config-file",
             "/tmp/" + str(self.config_file_path.name),

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -94,10 +94,6 @@ class MicroVM:
         return f"vm-{self.vm_id}"
 
     @property
-    def jailer_base_directory(self) -> Path:
-        return self.execution_root_folder / "jailer"
-
-    @property
     def namespace_path(self) -> str:
         firecracker_bin_name = os.path.basename(self.firecracker_bin_path)
         return str(self.jailer_base_directory / firecracker_bin_name / str(self.vm_id))
@@ -124,15 +120,14 @@ class MicroVM:
         self,
         vm_id: int,
         firecracker_bin_path: Path,
-        execution_root_folder: Path,
+        jailer_base_directory: Path,
         use_jailer: bool = True,
         jailer_bin_path: Optional[Path] = None,
-
         init_timeout: float = 5.0,
     ):
         self.vm_id = vm_id
         self.use_jailer = use_jailer
-        self.execution_root_folder = execution_root_folder
+        self.jailer_base_directory = jailer_base_directory
         self.firecracker_bin_path = firecracker_bin_path
         self.jailer_bin_path = jailer_bin_path
         self.drives = []

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -16,7 +16,6 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Optional
 
 import msgpack
-from aleph.vm.conf import settings
 
 from .config import Drive, FirecrackerConfig
 
@@ -96,7 +95,7 @@ class MicroVM:
 
     @property
     def jailer_base_directory(self) -> Path:
-        return settings.EXECUTION_ROOT / "jailer"
+        return self.execution_root_folder / "jailer"
 
     @property
     def namespace_path(self) -> str:
@@ -125,12 +124,15 @@ class MicroVM:
         self,
         vm_id: int,
         firecracker_bin_path: Path,
+        execution_root_folder: Path,
         use_jailer: bool = True,
         jailer_bin_path: Optional[Path] = None,
+
         init_timeout: float = 5.0,
     ):
         self.vm_id = vm_id
         self.use_jailer = use_jailer
+        self.execution_root_folder = execution_root_folder
         self.firecracker_bin_path = firecracker_bin_path
         self.jailer_bin_path = jailer_bin_path
         self.drives = []

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -16,13 +16,13 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Optional
 
 import msgpack
+from aleph.vm.conf import settings
 
 from .config import Drive, FirecrackerConfig
 
 logger = logging.getLogger(__name__)
 
 VSOCK_PATH = "/tmp/v.sock"
-JAILER_BASE_DIRECTORY = "/var/lib/aleph/vm/jailer"
 DEVICE_BASE_DIRECTORY = "/dev/mapper"
 
 
@@ -95,9 +95,13 @@ class MicroVM:
         return f"vm-{self.vm_id}"
 
     @property
-    def namespace_path(self):
+    def jailer_base_directory(self) -> Path:
+        return settings.EXECUTION_ROOT / "jailer"
+
+    @property
+    def namespace_path(self) -> str:
         firecracker_bin_name = os.path.basename(self.firecracker_bin_path)
-        return f"{JAILER_BASE_DIRECTORY}/{firecracker_bin_name}/{self.vm_id}"
+        return str(self.jailer_base_directory / firecracker_bin_name / str(self.vm_id))
 
     @property
     def jailer_path(self):
@@ -237,7 +241,7 @@ class MicroVM:
             "--gid",
             gid,
             "--chroot-base-dir",
-            JAILER_BASE_DIRECTORY,
+            self.jailer_base_directory,
             "--",
             "--config-file",
             "/tmp/" + str(self.config_file_path.name),
@@ -492,7 +496,8 @@ class MicroVM:
         logger.debug("Removing files")
         if self.config_file_path:
             self.config_file_path.unlink(missing_ok=True)
-        system(f"rm -fr {self.namespace_path}")
+        if Path(self.namespace_path).exists():
+            system(f"rm -fr {self.namespace_path}")
 
     def __del__(self):
         try:


### PR DESCRIPTION
it was hardcoded before on /var/lib/aleph so it wasn't respecting the proper user settings and was failling if the user didn't have the correct permission for this folder and was producing warning