### PR TITLE
Problem: Exception when stopping multiple VM via allocation endpoint

### DIFF
--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -251,8 +251,9 @@ async def update_allocations(request: web.Request):
 
     # First free resources from persistent programs and instances that are not scheduled anymore.
     allocations = allocation.persistent_vms | allocation.instances
-    for execution in pool.get_persistent_executions():
-        if execution.vm_hash not in allocations:
+    # Make a copy since the pool is modified
+    for execution in list(pool.executions.values()):
+        if execution.vm_hash not in allocations and execution.is_running:
             vm_type = "instance" if execution.is_instance else "persistent program"
             logger.info("Stopping %s %s", vm_type, execution.vm_hash)
             await execution.stop()


### PR DESCRIPTION
RuntimeError: dictionary changed size during iteration

Solution:
make a copy of the executions list before altering it

To reproduce.
----

You will need to set ALEPH_VM_ALLOCATION_TOKEN_HASH= and pass the corresponding signatures:

Launch both debian VMs
```http
POST http://localhost:4020/control/allocations
Content-Type: application/json
X-Auth-Signature: test
Accept: application/json

{"persistent_vms": [], "instances": ["67705389842a0a1b95eaa408b009741027964edc805997475e95c505d642edd8", "3fc0aa9569da840c43e7bd2033c3c580abb46b007527d6d20f2d4e98e867f7af"]}
```
Stop all instances
```http
POST http://localhost:4020/control/allocations
Content-Type: application/json
X-Auth-Signature: test
Accept: application/json

{"persistent_vms": [], "instances": []}
```

```pyhon3-traceback
Traceback (most recent call last):
  File "/home/ubuntu/.virtualenvs/aleph-vm/lib/python3.10/site-packages/aiohttp/web_protocol.py", line 433, in _handle_request
    resp = await request_handler(request)
  File "/home/ubuntu/.virtualenvs/aleph-vm/lib/python3.10/site-packages/aiohttp/web_app.py", line 504, in _handle
    resp = await handler(request)
  File "/home/ubuntu/.virtualenvs/aleph-vm/lib/python3.10/site-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
  File "/home/ubuntu/remote-aleph/src/aleph/vm/orchestrator/supervisor.py", line 52, in server_version_middleware
    resp: web.StreamResponse = await handler(request)
  File "/home/ubuntu/remote-aleph/src/aleph/vm/orchestrator/views/__init__.py", line 254, in update_allocations
    for execution in pool.get_persistent_executions():
  File "/home/ubuntu/remote-aleph/src/aleph/vm/pool.py", line 178, in get_persistent_executions
    for _vm_hash, execution in self.executions.items():
RuntimeError: dictionary changed size during iteration
```