### PR TITLE
Problem: Log system won't work when we switch to systemd

### DIFF
--- a/packaging/aleph-vm/DEBIAN/control
+++ b/packaging/aleph-vm/DEBIAN/control
@@ -3,6 +3,6 @@ Version: 0.1.8
 Architecture: all
 Maintainer: Aleph.im
 Description: Aleph.im VM execution engine
-Depends: python3,python3-pip,python3-aiohttp,python3-msgpack,python3-aiodns,python3-alembic,python3-sqlalchemy,python3-setproctitle,redis,python3-aioredis,python3-psutil,sudo,acl,curl,systemd-container,squashfs-tools,debootstrap,python3-packaging,python3-cpuinfo,python3-nftables,python3-jsonschema,cloud-image-utils,ndppd,python3-yaml,python3-dotenv,python3-schedule,qemu-system-x86,qemu-utils
+Depends: python3,python3-pip,python3-aiohttp,python3-msgpack,python3-aiodns,python3-alembic,python3-sqlalchemy,python3-setproctitle,redis,python3-aioredis,python3-psutil,sudo,acl,curl,systemd-container,squashfs-tools,debootstrap,python3-packaging,python3-cpuinfo,python3-nftables,python3-jsonschema,cloud-image-utils,ndppd,python3-yaml,python3-dotenv,python3-schedule,qemu-system-x86,qemu-utils,python3-systemd
 Section: aleph-im
 Priority: Extra

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ dependencies = [
   "msgpack~=1.0.7",
   "packaging~=23.2",
   "jsonschema==4.19.1",
-  "qmp==0.0.1"
+  "qmp==0.0.1",
+  "systemd-python"
 ]
 
 [project.urls]

--- a/src/aleph/vm/controllers/firecracker/executable.py
+++ b/src/aleph/vm/controllers/firecracker/executable.py
@@ -283,7 +283,7 @@ class AlephFirecrackerExecutable(Generic[ConfigurationType], AlephVmControllerIn
     async def create_snapshot(self) -> CompressedDiskVolumeSnapshot:
         raise NotImplementedError()
 
-    async def get_log_queue(self) -> asyncio.Queue:
+    def get_log_queue(self) -> asyncio.Queue:
         queue: asyncio.Queue = asyncio.Queue(maxsize=1000)
         # Limit the number of queues per VM
 
@@ -293,7 +293,7 @@ class AlephFirecrackerExecutable(Generic[ConfigurationType], AlephVmControllerIn
         self.fvm.log_queues.append(queue)
         return queue
 
-    async def unregister_queue(self, queue: asyncio.Queue):
+    def unregister_queue(self, queue: asyncio.Queue):
         if queue in self.fvm.log_queues:
             self.fvm.log_queues.remove(queue)
         queue.empty()

--- a/src/aleph/vm/controllers/qemu/instance.py
+++ b/src/aleph/vm/controllers/qemu/instance.py
@@ -327,7 +327,7 @@ class AlephQemuInstance(Generic[ConfigurationType], CloudInitMixin, AlephVmContr
         return self.stdout_task, self.stderr_task
 
     def _get_qmpclient(self) -> Optional[qmp.QEMUMonitorProtocol]:
-        if not self.qmp_socket_path:
+        if not (self.qmp_socket_path and self.qmp_socket_path.exists()):
             return None
         client = qmp.QEMUMonitorProtocol(str(self.qmp_socket_path))
         client.connect()
@@ -340,7 +340,7 @@ class AlephQemuInstance(Generic[ConfigurationType], CloudInitMixin, AlephVmContr
             if not resp == {}:
                 logger.warning("unexpected answer from VM", resp)
             client.close()
-            self.qmp_socket_path = None
+        self.qmp_socket_path = None
 
     async def get_log_queue(self) -> asyncio.Queue:
         queue: asyncio.Queue = asyncio.Queue(maxsize=1000)

--- a/src/aleph/vm/controllers/qemu/instance.py
+++ b/src/aleph/vm/controllers/qemu/instance.py
@@ -80,7 +80,7 @@ class AlephQemuResources(AlephFirecrackerResources):
 ConfigurationType = TypeVar("ConfigurationType")
 
 
-async def handle_logs(stdout_identifier, stderr_identifier, handle_log_message, skip_past=False):
+async def handle_logs(stdout_identifier, stderr_identifier, handle_log_message, skip_past=True):
     r = journal.Reader()
     r.add_match(SYSLOG_IDENTIFIER=stdout_identifier)
     r.add_match(SYSLOG_IDENTIFIER=stderr_identifier)

--- a/src/aleph/vm/controllers/qemu/instance.py
+++ b/src/aleph/vm/controllers/qemu/instance.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 from asyncio import Task
 from asyncio.subprocess import Process
-from typing import Callable, Dict, Generic, Optional, Tuple, TypeVar, Union, TypedDict
+from typing import Callable, Dict, Generic, Optional, Tuple, TypedDict, TypeVar, Union
 
 import psutil
 import qmp

--- a/src/aleph/vm/controllers/qemu/instance.py
+++ b/src/aleph/vm/controllers/qemu/instance.py
@@ -188,7 +188,7 @@ class AlephQemuInstance(Generic[ConfigurationType], CloudInitMixin, AlephVmContr
 
     @property
     def _journal_stderr_name(self) -> str:
-        return f"vm-{self.vm_hash}-stdout"
+        return f"vm-{self.vm_hash}-stderr"
 
     async def start(self):
         logger.debug(f"Starting Qemu: {self} ")


### PR DESCRIPTION
Solution : Log the VM logs in journald and query journald when we need to retrieve the logs.

For this I create two log streams per VM, one for stdout and one for stderr, using the ability from the journald api to just directly retrieve a file descriptor that we can pass to subprocess_exec.

This way should allow for maximum performance since we don't need to handle the insertion in the log system in python but we let journald directly manage it.

I only did the Qemu controller as a demonstration I will do the other part and the systemd integration if the teams validate this approach.


Note that this is using the official systemd python binding (the one that is packaged in debian, as python3-systemd) and not the `systemd` package in Pypi which is another project completly (and it is very confusing since it also import as `import systemd`.
if you need it from pypi it's under `python-systemd`