### PR TITLE
Fix: Metrics graph not loading due to a "TypeError"

### DIFF
--- a/src/aleph/vm/orchestrator/views/static/helpers.js
+++ b/src/aleph/vm/orchestrator/views/static/helpers.js
@@ -35,9 +35,12 @@ const isLatestRelease = async () => {
 
 const buildMetricViewset = (metricsMsg, hostname, metricsResult) => {
     const thisNode = metricsMsg.content.metrics.crn.find(node => node.url === hostname)
-    const factory = keyName => ({ time: thisNode.measured_at, value: thisNode[keyName] * 100 })
-    const keys = ['base_latency', 'base_latency_ipv4', 'diagnostic_vm_latency', 'full_check_latency']
-    keys.map(key => metricsResult[key].push(factory(key)))
+    // Fixes a bug if a node has no metrics for the given timeframe
+    if(thisNode){
+        const factory = keyName => ({ time: thisNode.measured_at, value: thisNode[keyName] * 100 })
+        const keys = ['base_latency', 'base_latency_ipv4', 'diagnostic_vm_latency', 'full_check_latency']
+        keys.map(key => metricsResult[key].push(factory(key)))
+    }
 }
 
 async function* fetchLatestMetrics (hostname, fromDate) {


### PR DESCRIPTION
Fixes an error when loading the metrics graph due to missing metrics message. 

This fix, however may add incomplete data sets to the metrics graph (see below)
![image](https://github.com/aleph-im/aleph-vm/assets/26065817/46c13a50-9de6-4634-9a5b-8b1d9159f55a)
