### PR TITLE
Load already running persistent VMs

### DIFF
--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -364,6 +364,8 @@ class Settings(BaseSettings):
             self.JAILER_BASE_DIRECTORY = self.EXECUTION_ROOT / "jailer"
         if not self.PERSISTENT_VOLUMES_DIR:
             self.PERSISTENT_VOLUMES_DIR = self.EXECUTION_ROOT / "volumes" / "persistent"
+        if not self.EXECUTION_DATABASE:
+            self.EXECUTION_DATABASE = self.EXECUTION_ROOT / "executions.sqlite3"
         if not self.EXECUTION_LOG_DIRECTORY:
             self.EXECUTION_LOG_DIRECTORY = self.EXECUTION_ROOT / "executions"
         if not self.JAILER_BASE_DIR:

--- a/src/aleph/vm/controllers/firecracker/executable.py
+++ b/src/aleph/vm/controllers/firecracker/executable.py
@@ -169,6 +169,7 @@ class AlephFirecrackerExecutable(Generic[ConfigurationType], AlephVmControllerIn
         hardware_resources: Optional[MachineResources] = None,
         tap_interface: Optional[TapInterface] = None,
         persistent: bool = False,
+        prepare_jailer: bool = True,
     ):
         self.vm_id = vm_id
         self.vm_hash = vm_hash
@@ -189,7 +190,8 @@ class AlephFirecrackerExecutable(Generic[ConfigurationType], AlephVmControllerIn
             jailer_bin_path=settings.JAILER_PATH,
             init_timeout=settings.INIT_TIMEOUT,
         )
-        self.fvm.prepare_jailer()
+        if prepare_jailer:
+            self.fvm.prepare_jailer()
 
         # These properties are set later in the setup and configuration.
         self.vm_configuration = None

--- a/src/aleph/vm/controllers/firecracker/instance.py
+++ b/src/aleph/vm/controllers/firecracker/instance.py
@@ -69,8 +69,10 @@ class AlephFirecrackerInstance(AlephFirecrackerExecutable):
         enable_console: Optional[bool] = None,
         hardware_resources: Optional[MachineResources] = None,
         tap_interface: Optional[TapInterface] = None,
+        prepare_jailer: bool = True,
     ):
         self.latest_snapshot = None
+        persistent = True
         super().__init__(
             vm_id,
             vm_hash,
@@ -79,7 +81,8 @@ class AlephFirecrackerInstance(AlephFirecrackerExecutable):
             enable_console,
             hardware_resources or MachineResources(),
             tap_interface,
-            persistent=True,
+            persistent,
+            prepare_jailer,
         )
 
     async def setup(self):

--- a/src/aleph/vm/controllers/firecracker/program.py
+++ b/src/aleph/vm/controllers/firecracker/program.py
@@ -270,6 +270,7 @@ class AlephFirecrackerProgram(AlephFirecrackerExecutable[ProgramVmConfiguration]
         hardware_resources: MachineResources = MachineResources(),
         tap_interface: TapInterface | None = None,
         persistent: bool = False,
+        prepare_jailer: bool = True,
     ):
         super().__init__(
             vm_id,
@@ -280,6 +281,7 @@ class AlephFirecrackerProgram(AlephFirecrackerExecutable[ProgramVmConfiguration]
             hardware_resources,
             tap_interface,
             persistent,
+            prepare_jailer,
         )
 
     async def setup(self):

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -148,7 +148,7 @@ class VmExecution:
     def to_json(self, indent: Optional[int] = None) -> str:
         return dumps_for_json(self.to_dict(), indent=indent)
 
-    async def prepare(self, download: bool = True):
+    async def prepare(self):
         """Download VM required files"""
         async with self.preparation_pending_lock:
             if self.resources:
@@ -168,8 +168,7 @@ class VmExecution:
             if not resources:
                 msg = "Unknown executable message type"
                 raise ValueError(msg, repr(self.message))
-            if download:
-                await resources.download_all()
+            await resources.download_all()
             self.times.prepared_at = datetime.now(tz=timezone.utc)
             self.resources = resources
 

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -348,8 +348,8 @@ class VmExecution:
                     vcpus=self.vm.hardware_resources.vcpus,
                     memory=self.vm.hardware_resources.memory,
                     network_tap=self.vm.tap_interface.device_name if self.vm.tap_interface else "",
-                    message=self.message,
-                    original_message=self.original,
+                    message=self.message.json(),
+                    original_message=self.original.json(),
                     persistent=self.persistent,
                 )
             )

--- a/src/aleph/vm/network/hostnetwork.py
+++ b/src/aleph/vm/network/hostnetwork.py
@@ -203,8 +203,8 @@ class Network:
         self.reset_ipv4_forwarding_state()
         self.reset_ipv6_forwarding_state()
 
-    async def create_tap(self, vm_id: int, vm_hash: ItemHash, vm_type: VmType) -> TapInterface:
-        """Create TAP interface to be used by VM"""
+    async def prepare_tap(self, vm_id: int, vm_hash: ItemHash, vm_type: VmType) -> TapInterface:
+        """Prepare TAP interface to be used by VM"""
         interface = TapInterface(
             f"vmtap{vm_id}",
             ip_network=self.get_network_for_tap(vm_id),
@@ -215,6 +215,9 @@ class Network:
             ),
             ndp_proxy=self.ndp_proxy,
         )
+        return interface
+
+    async def create_tap(self, vm_id: int, interface: TapInterface):
+        """Create TAP interface to be used by VM"""
         await interface.create()
         setup_nftables_for_vm(vm_id, interface)
-        return interface

--- a/src/aleph/vm/orchestrator/metrics.py
+++ b/src/aleph/vm/orchestrator/metrics.py
@@ -104,16 +104,6 @@ async def delete_record(execution_uuid: str):
         session.close()
 
 
-async def delete_all_records():
-    """Delete all the resource usage in database"""
-    session = Session()  # undefined name 'Session'
-    try:
-        session.query(ExecutionRecord).delete()
-        session.commit()
-    finally:
-        session.close()
-
-
 async def get_execution_records() -> Iterable[ExecutionRecord]:
     """Get the execution records from the database."""
     session = Session()  # undefined name 'Session'

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -107,6 +107,10 @@ async def stop_all_vms(app: web.Application):
 def run():
     """Run the VM Supervisor."""
     settings.check()
+
+    engine = setup_engine()
+    create_tables(engine)
+
     pool = VmPool()
     pool.setup()
 
@@ -119,10 +123,7 @@ def run():
     app["secret_token"] = secret_token
     app["vm_pool"] = pool
 
-    print(f"Login to /about pages {protocol}://{hostname}/about/login?token={secret_token}")
-
-    engine = setup_engine()
-    create_tables(engine)
+    logger.debug(f"Login to /about pages {protocol}://{hostname}/about/login?token={secret_token}")
 
     try:
         if settings.WATCH_FOR_MESSAGES:

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -252,11 +252,12 @@ async def update_allocations(request: web.Request):
     # First free resources from persistent programs and instances that are not scheduled anymore.
     allocations = allocation.persistent_vms | allocation.instances
     # Make a copy since the pool is modified
-    for execution in list(pool.executions.values()):
+    for execution in list(pool.get_persistent_executions()):
         if execution.vm_hash not in allocations and execution.is_running:
             vm_type = "instance" if execution.is_instance else "persistent program"
             logger.info("Stopping %s %s", vm_type, execution.vm_hash)
             await pool.stop_vm(execution.vm_hash)
+            pool.forget_vm(execution.vm_hash)
 
     # Second start persistent VMs and instances sequentially to limit resource usage.
 

--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -171,6 +171,7 @@ async def operate_reboot(request: web.Request, authenticated_sender: str) -> web
     if execution.is_running:
         logger.info(f"Rebooting {execution.vm_hash}")
         await pool.stop_vm(vm_hash)
+        await pool.forget_vm(vm_hash)
 
         await create_vm_execution(vm_hash=vm_hash, pool=pool)
         return web.Response(status=200, body=f"Rebooted VM with ref {vm_hash}")
@@ -194,7 +195,7 @@ async def operate_erase(request: web.Request, authenticated_sender: str) -> web.
 
     # Stop the VM
     await execution.stop()
-    execution.persistent = False
+    await pool.forget_vm(execution.vm_hash)
 
     # Delete all data
     if execution.resources is not None:

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -11,7 +11,7 @@ from aleph_message.models.execution.instance import InstanceContent
 from aleph.vm.conf import settings
 from aleph.vm.controllers.firecracker.snapshot_manager import SnapshotManager
 from aleph.vm.network.hostnetwork import Network, make_ipv6_allocator
-from aleph.vm.orchestrator.metrics import delete_all_records, get_execution_records
+from aleph.vm.orchestrator.metrics import get_execution_records
 from aleph.vm.systemd import SystemDManager
 from aleph.vm.utils import get_message_executable_content
 from aleph.vm.vm_type import VmType
@@ -61,9 +61,10 @@ class VmPool:
         self.snapshot_manager = SnapshotManager()
         logger.debug("Initializing SnapshotManager ...")
         self.snapshot_manager.run_snapshots()
+
         logger.debug("Loading existing executions ...")
-        # asyncio.run(delete_all_records())
-        asyncio.run(self._load_persistent_executions())
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self._load_persistent_executions())
 
     def setup(self) -> None:
         """Set up the VM pool and the network."""

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -220,7 +220,7 @@ class VmPool:
             )
             if execution.is_running:
                 # TODO: Improve the way that we re-create running execution
-                await execution.prepare(download=False)
+                await execution.prepare()
                 if self.network:
                     vm_type = VmType.from_message_content(execution.message)
                     tap_interface = await self.network.prepare_tap(vm_id, execution.vm_hash, vm_type)

--- a/src/aleph/vm/utils.py
+++ b/src/aleph/vm/utils.py
@@ -9,12 +9,23 @@ from collections.abc import Coroutine
 from dataclasses import asdict as dataclass_as_dict
 from dataclasses import is_dataclass
 from shutil import disk_usage
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import aiodns
 import msgpack
+from aleph_message.models import ExecutableContent, InstanceContent, ProgramContent
+from aleph_message.models.execution.base import MachineType
 
 logger = logging.getLogger(__name__)
+
+
+def get_message_executable_content(message_dict: Dict) -> ExecutableContent:
+    if message_dict["type"] == MachineType.vm_function:
+        return ProgramContent.parse_obj(message_dict)
+    elif message_dict["type"] == MachineType.vm_instance:
+        return InstanceContent.parse_obj(message_dict)
+    else:
+        raise ValueError(f"Unknown message type {message_dict['type']}")
 
 
 class MsgpackSerializable:


### PR DESCRIPTION
Problem: When the node operator restarts the orchestrator with already running persistent VMs, at the start, it doesn't get already running persistent VMs.

Solution: Use the SQLite database to save all the executions and re-create it from the start.