### PR TITLE
Solve holding tier issue for instances

### DIFF
--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -147,20 +147,20 @@ async def monitor_payments(app: web.Application):
     while True:
         await asyncio.sleep(settings.PAYMENT_MONITOR_INTERVAL)
 
-        # Check if the balance held in the wallet is sufficient holder tier resources
-        for sender, chains in pool.get_executions_by_sender(payment_type=PaymentType.hold).items():
-            for chain, executions in chains.items():
-                balance = await fetch_balance_of_address(sender)
-
-                # Stop executions until the required balance is reached
-                required_balance = await compute_required_balance(executions)
-                logger.debug(f"Required balance for Sender {sender} executions: {required_balance}")
-                # Stop executions until the required balance is reached
-                while balance < (required_balance + settings.PAYMENT_BUFFER):
-                    last_execution = executions.pop(-1)
-                    logger.debug(f"Stopping {last_execution} due to insufficient stream")
-                    await pool.stop_vm(last_execution.vm_hash)
-                    required_balance = await compute_required_balance(executions)
+        # Check if the balance held in the wallet is sufficient holder tier resources (Not do it yet)
+        # for sender, chains in pool.get_executions_by_sender(payment_type=PaymentType.hold).items():
+        #     for chain, executions in chains.items():
+        #         balance = await fetch_balance_of_address(sender)
+        #
+        #         # Stop executions until the required balance is reached
+        #         required_balance = await compute_required_balance(executions)
+        #         logger.debug(f"Required balance for Sender {sender} executions: {required_balance}")
+        #         # Stop executions until the required balance is reached
+        #         while balance < (required_balance + settings.PAYMENT_BUFFER):
+        #             last_execution = executions.pop(-1)
+        #             logger.debug(f"Stopping {last_execution} due to insufficient balance")
+        #             await pool.stop_vm(last_execution.vm_hash)
+        #             required_balance = await compute_required_balance(executions)
 
         # Check if the balance held in the wallet is sufficient stream tier resources
         for sender, chains in pool.get_executions_by_sender(payment_type=PaymentType.superfluid).items():


### PR DESCRIPTION
Fix: We are not managing well the holding tier on instances, so will be better to disable that control.