### PR TITLE
Fix: AttributeError when `self.vm` == None

### DIFF
--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -330,7 +330,7 @@ class VmExecution:
             await self.runs_done_event.wait()
 
     async def save(self):
-        pid_info = self.vm.to_dict()
+        pid_info = self.vm.to_dict() if self.vm else None
         # Handle cases when the process cannot be accessed
         if not self.persistent and pid_info and pid_info.get("process"):
             await save_record(


### PR DESCRIPTION
Fixes the following error, reported by node operators.

```
task: <Task finished name='Task-1' coro=<_run_app() done, defined at /usr/lib/python3/dist-packages/aiohttp/web.py:287> exception=AttributeError("'NoneType' object has no attribute 'to_dict'")>
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/aiohttp/web.py", line 431, in _run_app
    await asyncio.sleep(delay)
  File "/usr/lib/python3.10/asyncio/tasks.py", line 605, in sleep
    return await future
asyncio.exceptions.CancelledError
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/aiohttp/web.py", line 433, in _run_app
    await runner.cleanup()
  File "/opt/aleph-vm/aleph/vm/models.py", line 234, in stop
    await self.record_usage()
  File "/opt/aleph-vm/aleph/vm/models.py", line 275, in record_usage
    pid_info = self.vm.to_dict()
AttributeError: 'NoneType' object has no attribute 'to_dict'
```
