### PR TITLE
Fix: Logs of invalid messages were too verbose

### DIFF
--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -74,9 +74,10 @@ async def subscribe_via_ws(url) -> AsyncIterable[AlephMessage]:
                     try:
                         yield parse_message(data)
                     except pydantic.error_wrappers.ValidationError as error:
-                        logger.error(
-                            f"Invalid Aleph message: \n  {error.json()}\n  {error.raw_errors}",
-                            exc_info=True,
+                        item_hash = data.get("item_hash", "ITEM_HASH_NOT_FOUND")
+                        logger.warning(
+                            f"Invalid Aleph message: {item_hash} \n  {error.json()}\n  {error.raw_errors}",
+                            exc_info=False,
                         )
                         continue
                     except KeyError:


### PR DESCRIPTION
This reduces the log level to warning and does not print the stacktrace.

We also add the `item_hash` in the logs for diagnostic as it was missing.

Previously, logs looked like:
```
2024-02-02 10:16:59,290 | ERROR | Invalid Aleph message:
  [
  {
    "loc": [
      "content",
      "payment"
    ],
    "msg": "extra fields not permitted",
    "type": "value_error.extra"
  }
]
  [ErrorWrapper(exc=ValidationError(model='InstanceContent', errors=[{'loc': ('payment',), 'msg': 'extra fields not permitted', 'type': 'value_error.extra'}]), loc=('content',))]
Traceback (most recent call last):
  File "/opt/aleph-vm/aleph/vm/orchestrator/tasks.py", line 63, in subscribe_via_ws
    yield parse_message(data)
  File "/opt/aleph-vm/aleph_message/models/__init__.py", line 366, in parse_message
    return message_class.parse_obj(message_dict)
  File "pydantic/main.py", line 526, in pydantic.main.BaseModel.parse_obj
    return cls(**obj)
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
    raise validation_error
pydantic.error_wrappers.ValidationError: 1 validation error for InstanceMessage
content -> payment
  extra fields not permitted (type=value_error.extra)
```
