### PR TITLE
Fix: TypeError: catching classes that do not inherit from BaseException is not allowed

### DIFF
--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -245,7 +245,7 @@ async def status_check_ipv6(request: web.Request):
     async with aiohttp.ClientSession(timeout=timeout) as session:
         try:
             vm_ipv6 = await status.check_ipv6(session, vm_id=ItemHash(settings.CHECK_FASTAPI_VM_ID))
-        except aiohttp.ClientTimeout:
+        except TimeoutError:
             vm_ipv6 = False
 
     result = {"host": await check_host_egress_ipv6(), "vm": vm_ipv6}


### PR DESCRIPTION
This code used the wrong class for the timeout exception.
