### PR TITLE
Fix: Linux kernel from package could not be on a different device

### DIFF
--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -16,7 +16,7 @@ from pydantic import BaseSettings, Field, HttpUrl
 from pydantic.env_settings import DotenvType, env_file_sentinel
 from pydantic.typing import StrPath
 
-from aleph.vm.utils import is_command_available
+from aleph.vm.utils import file_hashes_differ, is_command_available
 
 logger = logging.getLogger(__name__)
 
@@ -362,7 +362,11 @@ class Settings(BaseSettings):
         if os.stat(self.LINUX_PATH).st_dev != os.stat(self.EXECUTION_ROOT).st_dev:
             logger.info("The Linux kernel is on another device than the execution root. Creating a copy.")
             linux_path_on_device = self.EXECUTION_ROOT / "vmlinux.bin"
-            shutil.copy(self.LINUX_PATH, linux_path_on_device)
+
+            # Only copy if the hash of the file differ.
+            if file_hashes_differ(self.LINUX_PATH, linux_path_on_device):
+                shutil.copy(self.LINUX_PATH, linux_path_on_device)
+
             self.LINUX_PATH = linux_path_on_device
 
         os.makedirs(self.EXECUTION_LOG_DIRECTORY, exist_ok=True)

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -2,6 +2,7 @@ import ipaddress
 import logging
 import os
 import re
+import shutil
 from collections.abc import Iterable
 from decimal import Decimal
 from enum import Enum
@@ -355,6 +356,14 @@ class Settings(BaseSettings):
         os.makedirs(self.DATA_CACHE, exist_ok=True)
 
         os.makedirs(self.EXECUTION_ROOT, exist_ok=True)
+
+        # If the Linux kernel provided is on another device than the execution root,
+        # copy it to the execution root to allow hardlink creation within jailer directories.
+        if os.stat(self.LINUX_PATH).st_dev != os.stat(self.EXECUTION_ROOT).st_dev:
+            logger.info("The Linux kernel is on another device than the execution root. Creating a copy.")
+            linux_path_on_device = self.EXECUTION_ROOT / "vmlinux.bin"
+            shutil.copy(self.LINUX_PATH, linux_path_on_device)
+            self.LINUX_PATH = linux_path_on_device
 
         os.makedirs(self.EXECUTION_LOG_DIRECTORY, exist_ok=True)
         os.makedirs(self.PERSISTENT_VOLUMES_DIR, exist_ok=True)

--- a/src/aleph/vm/utils.py
+++ b/src/aleph/vm/utils.py
@@ -10,7 +10,7 @@ from dataclasses import asdict as dataclass_as_dict
 from dataclasses import is_dataclass
 from pathlib import Path
 from shutil import disk_usage
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 import aiodns
 import msgpack
@@ -186,3 +186,19 @@ def to_normalized_address(value: str) -> HexAddress:
         return HexAddress(HexStr(hex_address))
     else:
         raise ValueError("Unknown format {}, attempted to normalize to {}".format(value, hex_address))
+
+
+def md5sum(file_path: Path) -> str:
+    """Calculate the MD5 hash of a file. Externalize to the `md5sum` command for better performance."""
+    return subprocess.check_output(["md5sum", file_path], text=True).split()[0]
+
+
+def file_hashes_differ(source: Path, destination: Path, checksum: Callable[[Path], str] = md5sum) -> bool:
+    """Check if the MD5 hash of two files differ."""
+    if not source.exists():
+        raise FileNotFoundError("Source file does not exist: {}".format(source))
+
+    if not destination.exists():
+        return True
+
+    return checksum(source) != checksum(destination)


### PR DESCRIPTION
If the Linux kernel provided is was another device than the execution root, creating a hardlink within the jailer directory would fail.

Solution: Copy the kernel to the execution root during setup.
