### PR TITLE
Solve random 500 errors on ephemeral VMs

### DIFF
--- a/src/aleph/vm/controllers/firecracker/executable.py
+++ b/src/aleph/vm/controllers/firecracker/executable.py
@@ -159,6 +159,10 @@ class AlephFirecrackerExecutable(Generic[ConfigurationType], AlephVmControllerIn
     controller_configuration: Optional[Configuration] = None
     support_snapshot: bool
 
+    @property
+    def resources_path(self) -> Path:
+        return Path(self.fvm.namespace_path)
+
     def __init__(
         self,
         vm_id: int,

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -121,11 +121,7 @@ class VmExecution:
 
     @property
     def has_resources(self):
-        return (
-            self.vm.resources_path.exists()
-            if self.hypervisor == HypervisorType.firecracker
-            else True
-        )
+        return self.vm.resources_path.exists() if self.hypervisor == HypervisorType.firecracker else True
 
     def __init__(
         self,

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -119,6 +119,14 @@ class VmExecution:
     def uses_payment_stream(self) -> bool:
         return self.message.payment and self.message.payment.is_stream
 
+    @property
+    def has_resources(self):
+        return (
+            self.vm.resources_path.exists()
+            if self.hypervisor == HypervisorType.firecracker
+            else True
+        )
+
     def __init__(
         self,
         vm_hash: ItemHash,

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -121,7 +121,7 @@ async def run_code_on_request(vm_hash: ItemHash, path: str, pool: VmPool, reques
 
     # Prevent execution issues if the execution resources are empty
     # TODO: Improve expiration process to avoid that kind of issues.
-    if not execution.has_resources:
+    if execution and not execution.has_resources:
         pool.forget_vm(execution.vm_hash)
         execution = None
 


### PR DESCRIPTION
Problem: Sometimes, when a VM expires, the execution is not removed.

Solution: Check if the namespace stills there and if not just remove the execution.