### PR TITLE
Fix: asyncio.run was sometimes used within a coroutine

### DIFF
--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -242,7 +242,8 @@ class Settings(BaseSettings):
 
     SNAPSHOT_FREQUENCY: int = Field(
         default=60,
-        description="Snapshot frequency interval in minutes. It will create a VM snapshot every X minutes.",
+        description="Snapshot frequency interval in minutes. It will create a VM snapshot every X minutes. "
+        "If set to zero, snapshots are disabled.",
     )
 
     SNAPSHOT_COMPRESSION_ALGORITHM: SnapshotCompressionAlgorithm = Field(

--- a/src/aleph/vm/controllers/firecracker/snapshot_manager.py
+++ b/src/aleph/vm/controllers/firecracker/snapshot_manager.py
@@ -86,7 +86,7 @@ class SnapshotManager:
         self.executions = {}
         self._scheduler = Scheduler()
 
-    def run_snapshots(self) -> None:
+    def run_in_thread(self) -> None:
         job_thread = threading.Thread(
             target=infinite_run_scheduler_jobs,
             args=[self._scheduler],

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -156,6 +156,10 @@ def run():
             app.on_cleanup.append(stop_balances_monitoring_task)
             app.on_cleanup.append(stop_all_vms)
 
+        logger.info("Loading existing executions ...")
+        asyncio.run(pool.load_persistent_executions())
+
+        logger.info(f"Starting the web server on http://{settings.SUPERVISOR_HOST}:{settings.SUPERVISOR_PORT}")
         web.run_app(app, host=settings.SUPERVISOR_HOST, port=settings.SUPERVISOR_PORT)
     except OSError as e:
         if e.errno == 98:

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -251,7 +251,8 @@ class VmPool:
                 self._schedule_forget_on_stop(execution)
 
                 # Start the snapshot manager for the VM
-                await self.snapshot_manager.start_for(vm=execution.vm)
+                if execution.vm.support_snapshot and self.snapshot_manager:
+                    await self.snapshot_manager.start_for(vm=execution.vm)
 
                 self.executions[vm_hash] = execution
             else:

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -251,7 +251,7 @@ class VmPool:
                 self._schedule_forget_on_stop(execution)
 
                 # Start the snapshot manager for the VM
-                if execution.vm.support_snapshot and self.snapshot_manager:
+                if vm.support_snapshot and self.snapshot_manager:
                     await self.snapshot_manager.start_for(vm=execution.vm)
 
                 self.executions[vm_hash] = execution

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -250,6 +250,9 @@ class VmPool:
 
                 self._schedule_forget_on_stop(execution)
 
+                # Start the snapshot manager for the VM
+                await self.snapshot_manager.start_for(vm=execution.vm)
+
                 self.executions[vm_hash] = execution
             else:
                 execution.uuid = saved_execution.uuid


### PR DESCRIPTION
`asyncio.run` was called when initializing a pool object using `VmPool.__init__(...)`.

This caused two issues:
  1. The pool was sometimes created from within a coroutine in the context of tests, and this would raise an error.
  2. Having side effects inside the `__init__` method makes objects more difficult to manipulate and test.
  3. Tests should not load persistent executions automatically.
  4. The network was configured after loading persistent executions, which could cause networking issues.

A related issue is the snapshot manager being started when initializing the `VmPool`, while this is not always desirable.

Solution proposed:
  1. Explicitly load the persistent executions using `pool.load_persistent_executions()` from the `supervisor.run()` function. This is now called after `VmPool.setup()` and therefore after the networking of the host has been configured.
  2. The snapshot manager is now started by `VmPool.setup()` instead of `VmPool.__init__`. This function is almost always called just after initializing the pool.
  3. Configuring `settings.SNAPSHOT_FREQUENCY` to zero now disables the snapshot manager.
  4. `SnapshotManager.run_snapshots` is renamed `SnapshotManager.run_in_thread` to make its behaviour more explicit.

```python
RuntimeError: asyncio.run() cannot be called from a running event loop
(5 additional frame(s) were not displayed)
...
  File "<frozen runpy>", line 88, in _run_code
  File "__main__.py", line 4, in <module>
    main()
  File "aleph/vm/orchestrator/cli.py", line 353, in main
    asyncio.run(benchmark(runs=args.benchmark), debug=args.debug_asyncio)
  File "aleph/vm/orchestrator/cli.py", line 197, in benchmark
    pool = VmPool()
  File "aleph/vm/pool.py", line 73, in __init__
    asyncio.run(self._load_persistent_executions())
```