### PR TITLE
Runtimes: Update locale settings to en_US UTF-8

### DIFF
--- a/runtimes/aleph-debian-11-python/create_disk_image.sh
+++ b/runtimes/aleph-debian-11-python/create_disk_image.sh
@@ -26,7 +26,12 @@ apt-get install -y --no-install-recommends --no-install-suggests \
   docker.io \
   cgroupfs-mount \
   nftables \
-  iputils-ping curl
+  iputils-ping curl \
+  locales
+
+# Update locale settings to en_US UTF-8
+echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
+locale-gen en_US.UTF-8
 
 pip3 install 'fastapi~=0.103.1'
 

--- a/runtimes/aleph-debian-12-python/create_disk_image.sh
+++ b/runtimes/aleph-debian-12-python/create_disk_image.sh
@@ -27,7 +27,12 @@ apt-get install -y --no-install-recommends --no-install-suggests \
   docker.io \
   cgroupfs-mount \
   nftables \
-  iputils-ping curl
+  iputils-ping curl \
+  locales
+
+# Update locale settings to en_US UTF-8
+echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
+locale-gen en_US.UTF-8
 
 echo "Pip installing aleph-sdk-python"
 mkdir -p /opt/aleph/libs


### PR DESCRIPTION
Some packages cannot run using the current runtime with its default locale settings:
```shell
C
C.UTF-8
POSIX
```
This pull request enhances package stability by adding support for the en_US.UTF-8 locale.

