### PR TITLE
Fix: Errors in network interface manipulation were invisible

### DIFF
--- a/src/aleph/vm/network/interfaces.py
+++ b/src/aleph/vm/network/interfaces.py
@@ -58,7 +58,7 @@ class TapInterface:
         if not ip_command:
             raise FileNotFoundError("ip command not found")
 
-        run([ip_command, "tuntap", "add", self.device_name, "mode", "tap"])
+        run([ip_command, "tuntap", "add", self.device_name, "mode", "tap"], check=True)
         run(
             [
                 ip_command,
@@ -67,7 +67,8 @@ class TapInterface:
                 str(self.host_ip.with_prefixlen),
                 "dev",
                 self.device_name,
-            ]
+            ],
+            check=True,
         )
         ipv6_gateway = self.host_ipv6
         run(
@@ -78,9 +79,10 @@ class TapInterface:
                 str(ipv6_gateway),
                 "dev",
                 self.device_name,
-            ]
+            ],
+            check=True,
         )
-        run([ip_command, "link", "set", self.device_name, "up"])
+        run([ip_command, "link", "set", self.device_name, "up"], check=True)
         if self.ndp_proxy:
             await self.ndp_proxy.add_range(self.device_name, ipv6_gateway.network)
         logger.debug(f"Network interface created: {self.device_name}")
@@ -92,4 +94,4 @@ class TapInterface:
         await asyncio.sleep(0.1)  # Avoids Device/Resource busy bug
         if self.ndp_proxy:
             await self.ndp_proxy.delete_range(self.device_name)
-        run(["ip", "tuntap", "del", self.device_name, "mode", "tap"])
+        run(["ip", "tuntap", "del", self.device_name, "mode", "tap"], check=True)


### PR DESCRIPTION
Solution: Always use `check=True` to force errors in `subprocess.run` to raise an error.
