### PR TITLE
Don't require DBus for development

### DIFF
--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -81,7 +81,8 @@ class VmExecution:
     expire_task: Optional[asyncio.Task] = None
     update_task: Optional[asyncio.Task] = None
 
-    persistent: bool = False
+    snapshot_manager: Optional[SnapshotManager]
+    systemd_manager: Optional["SystemDManager"]
 
     @property
     def is_running(self) -> bool:
@@ -102,6 +103,10 @@ class VmExecution:
     @property
     def is_instance(self) -> bool:
         return isinstance(self.message, InstanceContent)
+
+    @property
+    def persistent(self) -> bool:
+        return self.systemd_manager is not None
 
     @property
     def hypervisor(self) -> HypervisorType:
@@ -134,9 +139,8 @@ class VmExecution:
         vm_hash: ItemHash,
         message: ExecutableContent,
         original: ExecutableContent,
-        snapshot_manager: "SnapshotManager",
-        systemd_manager: "SystemDManager",
-        persistent: bool,
+        snapshot_manager: Optional[SnapshotManager],
+        systemd_manager: Optional[SystemDManager],
     ):
         self.uuid = uuid.uuid1()  # uuid1() includes the hardware address and timestamp
         self.vm_hash = vm_hash
@@ -151,7 +155,6 @@ class VmExecution:
         self.stop_pending_lock = asyncio.Lock()
         self.snapshot_manager = snapshot_manager
         self.systemd_manager = systemd_manager
-        self.persistent = persistent
 
     def to_dict(self) -> dict:
         return {

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import uuid

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -185,7 +185,8 @@ class VmPool:
     async def stop_persistent_execution(self, execution: VmExecution):
         """Stop persistent VMs in the pool."""
         assert execution.persistent, "Execution isn't persistent"
-        self.systemd_manager.stop_and_disable(execution.controller_service)
+        assert execution.systemd_manager, "SystemDManager isn't defined on a persistent execution"
+        execution.systemd_manager.stop_and_disable(execution.controller_service)
         await execution.stop()
 
     def forget_vm(self, vm_hash: ItemHash) -> None:

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -98,8 +98,7 @@ class VmPool:
                 message=message,
                 original=original,
                 snapshot_manager=self.snapshot_manager,
-                systemd_manager=self.systemd_manager,
-                persistent=persistent,
+                systemd_manager=self.systemd_manager if persistent else None,
             )
             self.executions[vm_hash] = execution
 
@@ -118,8 +117,8 @@ class VmPool:
             await execution.start()
 
             # Start VM and snapshots automatically
-            if execution.persistent:
-                self.systemd_manager.enable_and_start(execution.controller_service)
+            if execution.systemd_manager:
+                execution.systemd_manager.enable_and_start(execution.controller_service)
                 await execution.wait_for_init()
                 if execution.is_program and execution.vm:
                     await execution.vm.load_configuration()
@@ -230,8 +229,7 @@ class VmPool:
                 message=get_message_executable_content(message_dict),
                 original=get_message_executable_content(original_dict),
                 snapshot_manager=self.snapshot_manager,
-                systemd_manager=self.systemd_manager,
-                persistent=saved_execution.persistent,
+                systemd_manager=self.systemd_manager if saved_execution.persistent else None,
             )
 
             if execution.is_running:

--- a/src/aleph/vm/systemd.py
+++ b/src/aleph/vm/systemd.py
@@ -3,12 +3,20 @@ async SystemD Manager implementation.
 """
 
 import logging
-
-import dbus
-from dbus import DBusException, SystemBus
-from dbus.proxies import Interface
+from typing import Any
 
 logger = logging.getLogger(__name__)
+
+try:
+    import dbus
+    from dbus import DBusException, SystemBus
+    from dbus.proxies import Interface
+except ImportError:
+    logger.error("dbus-python not installed. SystemDManager will not work.")
+    # Mock the dbus module to avoid errors in type annotations
+    DBusException = Any
+    SystemBus = Any
+    Interface = Any
 
 
 class SystemDManager:
@@ -24,6 +32,10 @@ class SystemDManager:
         self.bus = dbus.SystemBus()
         systemd = self.bus.get_object("org.freedesktop.systemd1", "/org/freedesktop/systemd1")
         self.manager = dbus.Interface(systemd, "org.freedesktop.systemd1.Manager")
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return SystemBus is not Any
 
     def stop_and_disable(self, service: str) -> None:
         if self.is_service_active(service):


### PR DESCRIPTION
- Fix: Execution field `persistent` was redundant
- Fix: Fix typing errors
- Fix: Could not run without DBus in development
