### PR TITLE
Fix: Network errors were hard to inspect

### DIFF
--- a/.github/workflows/test-on-droplets-matrix.yml
+++ b/.github/workflows/test-on-droplets-matrix.yml
@@ -37,10 +37,12 @@ jobs:
         run: |
           sudo apt-get install libsystemd-dev cmake libdbus-1-dev libglib2.0-dev
 
+        # Unit tests create and delete network interfaces, and therefore require to run as root
       - name: Run unit tests
         run: |
-          hatch run testing:test-cov
-          hatch run testing:cov
+          sudo python3 -m pip install hatch hatch-vcs coverage
+          sudo hatch run testing:test-cov
+          sudo hatch run testing:cov
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -15,7 +15,7 @@ debian-package-code:
 	cp ../examples/instance_message_from_aleph.json ./aleph-vm/opt/aleph-vm/examples/instance_message_from_aleph.json
 	cp -r ../examples/data ./aleph-vm/opt/aleph-vm/examples/data
 	mkdir -p ./aleph-vm/opt/aleph-vm/examples/volumes
-	pip3 install --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.4.4' 'jwskate==0.8.0' 'eth-account==0.9.0' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'superfluid==0.2.1' 'sqlalchemy[asyncio]' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0'
+	pip3 install --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.4.4' 'jwskate==0.8.0' 'eth-account==0.9.0' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'superfluid==0.2.1' 'sqlalchemy[asyncio]' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12'
 	python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux download-ipfs-kubo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
   "aiosqlite==0.19.0",
   "alembic==1.13.1",
   "aiohttp_cors~=0.7.0",
+  "pyroute2==0.7.12",
 ]
 
 [project.urls]

--- a/src/aleph/vm/network/interfaces.py
+++ b/src/aleph/vm/network/interfaces.py
@@ -1,14 +1,62 @@
 import asyncio
+import errno
 import logging
 import shutil
 from ipaddress import IPv4Interface, IPv6Interface, IPv6Network
-from subprocess import run
-from typing import Optional
+from typing import Optional, Union
+
+from pyroute2 import IPRoute, NetlinkError
 
 from .ipaddresses import IPv4NetworkWithInterfaces
 from .ndp_proxy import NdpProxy
 
 logger = logging.getLogger(__name__)
+
+
+class InterfaceBusyError(Exception):
+    """The interface is busy."""
+
+    pass
+
+
+def create_tap_interface(ipr: IPRoute, device_name: str):
+    """Create a TAP interface with the given name. If the interface already exists, which should not happen, a warning
+    is logged and the function returns without error."""
+    try:
+        ipr.link("add", ifname=device_name, kind="tuntap", mode="tap")
+    except NetlinkError as error:
+        if error.code == 17:
+            logger.warning(f"Interface {device_name} already exists")
+        elif error.code == 16:
+            raise InterfaceBusyError(
+                f"Interface {device_name} is busy - is there another process using it ?"
+            ) from error
+        else:
+            raise
+    except OSError as error:
+        if error.errno == errno.EBUSY:
+            raise InterfaceBusyError(f"Interface {device_name} is busy. Is another process using it ?") from error
+
+
+def add_ip_address(ipr: IPRoute, device_name: str, ip: Union[IPv4Interface, IPv6Interface]):
+    """Add an IP address to the given interface. If the address already exists, a warning is logged and the function
+    returns without error."""
+    try:
+        ipr.addr("add", index=ipr.link_lookup(ifname=device_name)[0], address=str(ip.ip), mask=ip.network.prefixlen)
+    except NetlinkError as e:
+        if e.code == 17:
+            logger.warning(f"Address {ip} already exists")
+        else:
+            raise
+
+
+def set_link_up(ipr: IPRoute, device_name: str):
+    """Set the given interface up."""
+    ipr.link("set", index=ipr.link_lookup(ifname=device_name)[0], state="up")
+
+
+def delete_tap_interface(ipr: IPRoute, device_name: str):
+    ipr.link("del", index=ipr.link_lookup(ifname=device_name)[0])
 
 
 class TapInterface:
@@ -58,31 +106,14 @@ class TapInterface:
         if not ip_command:
             raise FileNotFoundError("ip command not found")
 
-        run([ip_command, "tuntap", "add", self.device_name, "mode", "tap"], check=True)
-        run(
-            [
-                ip_command,
-                "addr",
-                "add",
-                str(self.host_ip.with_prefixlen),
-                "dev",
-                self.device_name,
-            ],
-            check=True,
-        )
         ipv6_gateway = self.host_ipv6
-        run(
-            [
-                ip_command,
-                "addr",
-                "add",
-                str(ipv6_gateway),
-                "dev",
-                self.device_name,
-            ],
-            check=True,
-        )
-        run([ip_command, "link", "set", self.device_name, "up"], check=True)
+
+        with IPRoute() as ipr:
+            create_tap_interface(ipr, self.device_name)
+            add_ip_address(ipr, self.device_name, self.host_ip)
+            add_ip_address(ipr, self.device_name, self.host_ipv6)
+            set_link_up(ipr, self.device_name)
+
         if self.ndp_proxy:
             await self.ndp_proxy.add_range(self.device_name, ipv6_gateway.network)
         logger.debug(f"Network interface created: {self.device_name}")
@@ -94,4 +125,5 @@ class TapInterface:
         await asyncio.sleep(0.1)  # Avoids Device/Resource busy bug
         if self.ndp_proxy:
             await self.ndp_proxy.delete_range(self.device_name)
-        run(["ip", "tuntap", "del", self.device_name, "mode", "tap"], check=True)
+        with IPRoute() as ipr:
+            delete_tap_interface(ipr, self.device_name)

--- a/tests/supervisor/test_interfaces.py
+++ b/tests/supervisor/test_interfaces.py
@@ -1,0 +1,69 @@
+from ipaddress import IPv4Interface
+from subprocess import run
+
+import pytest
+from pyroute2 import IPRoute
+
+from aleph.vm.network.interfaces import (
+    add_ip_address,
+    create_tap_interface,
+    delete_tap_interface,
+    set_link_up,
+)
+
+
+def test_create_tap_interface():
+    """Test the creation of a TAP interface and related error handling."""
+    test_device_name = "test_tap"
+    try:
+        with IPRoute() as ipr:
+            create_tap_interface(ipr, test_device_name)
+            # Check that the interface was created
+            assert run(["ip", "link", "show", test_device_name], check=False).returncode == 0
+            # Create the interface a second time, which should be ignored
+            create_tap_interface(ipr, test_device_name)
+    finally:
+        run(["ip", "tuntap", "del", test_device_name, "mode", "tap"], check=False)
+
+
+def test_add_ip_address():
+    """Test the addition of an IP address to an interface."""
+    test_device_name = "test_tap"
+    test_ipv4 = IPv4Interface(("10.10.10.10", 24))
+    try:
+        with IPRoute() as ipr:
+            # We need an interface to add an address to
+            create_tap_interface(ipr, test_device_name)
+            # Add an IP address to the interface
+            add_ip_address(ipr, test_device_name, test_ipv4)
+            # Check that the address was added
+            assert run(["ip", "address", "show", test_device_name], check=False).returncode == 0
+            # Add the same address again, which should be ignored
+            add_ip_address(ipr, test_device_name, test_ipv4)
+    finally:
+        # Delete the interface, ignoring any errors
+        run(["ip", "tuntap", "del", test_device_name, "mode", "tap"], check=False)
+
+    # Without an interface, the function should raise an error
+    with pytest.raises(IndexError):
+        add_ip_address(IPRoute(), test_device_name, test_ipv4)
+
+
+def test_link_up_down():
+    """Test the addition of an IP address to an interface."""
+    test_device_name = "test_tap"
+    try:
+        with IPRoute() as ipr:
+            # We need an interface to set the link up
+            create_tap_interface(ipr, test_device_name)
+
+            set_link_up(ipr, test_device_name)
+            # Check that the interface is up
+            assert run(["ip", "link", "show", test_device_name], check=False).returncode == 0
+            # Delete the interface
+            delete_tap_interface(ipr, test_device_name)
+            # Check that the interface is down
+            assert run(["ip", "link", "show", test_device_name], check=False).returncode != 0
+    finally:
+        # Delete the interface, ignoring any errors
+        run(["ip", "tuntap", "del", test_device_name, "mode", "tap"], check=False)


### PR DESCRIPTION
Context: We recently added the argument `check=True` to `subprocess.run(command)` to ensure we do not ignore errors in the setup or teardown of network interfaces.

Problem: Analyzing the errors that may happen during the setup or teardown of network interfaces is difficult due to the little amount of information provided by the `ip` command. It is therefore difficult to react accordingly.

Solution: Switch to use `pyroute2`, a pure Python netlink library that provides the required functions with more fined grained error reports.

The library `Pyroute2` is available in Debian 12 [1], however that version (0.7.2-2) is not documented anymore. It is absent from Debian 11. We therefore use the latest stable version from PyPI.

[1] https://packages.debian.org/bookworm/python3-pyroute2
