### PR TITLE
Fix `FAKE_DATA_PROGRAM` issue on instances.

### DIFF
--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -258,7 +258,7 @@ class Settings(BaseSettings):
 
     # Tests on programs
 
-    FAKE_DATA_PROGRAM: Optional[Path] = Path(abspath(join(__file__, "../../../../examples/example_fastapi")))
+    FAKE_DATA_PROGRAM: Optional[Path] = None
     BENCHMARK_FAKE_DATA_PROGRAM = Path(abspath(join(__file__, "../../../../examples/example_fastapi")))
 
     FAKE_DATA_MESSAGE = Path(abspath(join(__file__, "../../../../examples/program_message_from_aleph.json")))


### PR DESCRIPTION
Fix: If the `FAKE_DATA_PROGRAM` variable have a default value, when we start the controllers, it takes that default value instead to avoid it, and it fails on the checks.

Solution: Put `FAKE_DATA_PROGRAM` variable to None by default.