### PR TITLE
Implement default hypervisor options on settings

### DIFF
--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -361,9 +361,6 @@ class Settings(BaseSettings):
             assert is_command_available(
                 "qemu-system-x86_64"
             ), "Command `qemu-system-x86_64` not found, run `apt install qemu-system-x86`"
-        else:
-            # If QEmu is not supported, ignore the setting and use Firecracker by default
-            settings.INSTANCE_DEFAULT_HYPERVISOR = HypervisorType.firecracker
 
     def setup(self):
         os.makedirs(self.MESSAGE_CACHE, exist_ok=True)
@@ -398,6 +395,10 @@ class Settings(BaseSettings):
                 dns_resolver=self.DNS_RESOLUTION,
                 network_interface=self.NETWORK_INTERFACE,
             )
+
+        if not settings.ENABLE_QEMU_SUPPORT:
+            # If QEmu is not supported, ignore the setting and use Firecracker by default
+            settings.INSTANCE_DEFAULT_HYPERVISOR = HypervisorType.firecracker
 
     def display(self) -> str:
         attributes: dict[str, Any] = {}

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -11,11 +11,11 @@ from pathlib import Path
 from subprocess import CalledProcessError, check_output
 from typing import Any, Literal, NewType, Optional, Union
 
+from aleph_message.models.execution.environment import HypervisorType
 from pydantic import BaseSettings, Field, HttpUrl
 from pydantic.env_settings import DotenvType, env_file_sentinel
 from pydantic.typing import StrPath
 
-from aleph_message.models.execution.environment import HypervisorType
 from aleph.vm.utils import file_hashes_differ, is_command_available
 
 logger = logging.getLogger(__name__)

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -105,8 +105,11 @@ class VmExecution:
 
     @property
     def hypervisor(self) -> HypervisorType:
-        # default to firecracker for retro compat
-        return self.message.environment.hypervisor or HypervisorType.firecracker
+        if self.is_program:
+            return HypervisorType.firecracker
+
+        # Hypervisor setting is only used for instances
+        return self.message.environment.hypervisor or settings.INSTANCE_DEFAULT_HYPERVISOR
 
     @property
     def becomes_ready(self) -> Callable[[], Coroutine]:


### PR DESCRIPTION
Problem: The unique way to set the default hypervisor to use is hard-coded on the `models.py` class, so we can't select another one by default.

Solution: Implement `INSTANCE_DEFAULT_HYPERVISOR` field on the orchestrator configuration variables.