### PR TITLE
Fix strict typing errors

### DIFF
--- a/examples/example_django/example_django/asgi.py
+++ b/examples/example_django/example_django/asgi.py
@@ -17,4 +17,4 @@ application = get_asgi_application()
 
 os.system("/usr/bin/python3 /opt/code/manage.py migrate")
 
-os.system("/usr/bin/python3 /opt/code/manage.py " "loaddata /opt/code/blog/fixtures/default_articles.json")
+os.system("/usr/bin/python3 /opt/code/manage.py loaddata /opt/code/blog/fixtures/default_articles.json")

--- a/examples/example_fastapi/main.py
+++ b/examples/example_fastapi/main.py
@@ -7,7 +7,7 @@ import sys
 from datetime import datetime
 from os import listdir
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 import aiohttp
 from fastapi import FastAPI
@@ -84,7 +84,7 @@ async def check_lifespan():
 
 
 @app.get("/environ")
-async def environ() -> Dict[str, str]:
+async def environ() -> dict[str, str]:
     """List environment variables"""
     return dict(os.environ)
 

--- a/packaging/version_from_git.py
+++ b/packaging/version_from_git.py
@@ -30,7 +30,7 @@ for arg in args:
         sys.exit(1)
 
 if not os.path.isfile(target_file_path):
-    print("No such file: '{}'".format(target_file_path))
+    print(f"No such file: '{target_file_path}'")
     sys.exit(2)
 
 
@@ -41,17 +41,17 @@ def get_git_version():
 
 version = get_git_version()
 
-with open(target_file_path, "r") as target_file:
+with open(target_file_path) as target_file:
     target_content = target_file.read()
 
 if format_ == "deb":
-    updated_content = re.sub(r"(Version:)\w*(.*)", "\\1 {}".format(version), target_content)
+    updated_content = re.sub(r"(Version:)\w*(.*)", f"\\1 {version}", target_content)
 elif format_ == "setup.py":
-    updated_content = re.sub(r"(version)\w*=(.*)'", "\\1='{}'".format(version), target_content)
+    updated_content = re.sub(r"(version)\w*=(.*)'", f"\\1='{version}'", target_content)
 elif format_ == "__version__":
-    updated_content = re.sub(r"(__version__)\w*(.*)", "\\1 = '{}'".format(version), target_content)
+    updated_content = re.sub(r"(__version__)\w*(.*)", f"\\1 = '{version}'", target_content)
 else:
-    print("Format must be 'deb', 'setup.py' or '__version__', not '{}'".format(format_))
+    print(f"Format must be 'deb', 'setup.py' or '__version__', not '{format_}'")
 
 if "--inplace" in args:
     with open(target_file_path, "w") as target_file:

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -118,7 +118,7 @@ class Settings(BaseSettings):
     SUPERVISOR_PORT: int = 4020
 
     # Public domain name
-    DOMAIN_NAME: Optional[str] = Field(
+    DOMAIN_NAME: str = Field(
         default="localhost",
         description="Default public domain name",
     )

--- a/src/aleph/vm/controllers/__main__.py
+++ b/src/aleph/vm/controllers/__main__.py
@@ -6,15 +6,9 @@ import signal
 import sys
 from pathlib import Path
 
+from aleph.vm.hypervisors.firecracker.microvm import MicroVM
 from aleph.vm.hypervisors.qemu.qemuvm import QemuVM
 from aleph.vm.network.hostnetwork import Network, make_ipv6_allocator
-
-try:
-    import sentry_sdk
-except ImportError:
-    sentry_sdk = None
-
-from aleph.vm.hypervisors.firecracker.microvm import MicroVM
 
 from .configuration import (
     Configuration,

--- a/src/aleph/vm/controllers/firecracker/program.py
+++ b/src/aleph/vm/controllers/firecracker/program.py
@@ -284,7 +284,7 @@ class AlephFirecrackerProgram(AlephFirecrackerExecutable[ProgramVmConfiguration]
             prepare_jailer,
         )
 
-    async def setup(self):
+    async def setup(self) -> None:
         logger.debug(f"Setup started for VM={self.vm_id}")
         await setfacl()
 
@@ -326,7 +326,7 @@ class AlephFirecrackerProgram(AlephFirecrackerExecutable[ProgramVmConfiguration]
         """Wait for the custom init inside the virtual machine to signal it is ready."""
         await self.fvm.wait_for_init()
 
-    async def load_configuration(self):
+    async def load_configuration(self) -> None:
         code: bytes | None
         volumes: list[Volume]
 
@@ -342,7 +342,7 @@ class AlephFirecrackerProgram(AlephFirecrackerExecutable[ProgramVmConfiguration]
         input_data: bytes | None,
         interface: Interface,
         volumes: list[Volume],
-    ):
+    ) -> None:
         """Set up the VM configuration. The program mode uses a VSOCK connection to the custom init of the virtual
         machine to send this configuration. Other modes may use Cloud-init, ..."""
         logger.debug("Sending configuration")

--- a/src/aleph/vm/controllers/firecracker/program.py
+++ b/src/aleph/vm/controllers/firecracker/program.py
@@ -84,7 +84,8 @@ class ProgramVmConfiguration(MsgpackSerializable):
 
 
 @dataclass
-class ConfigurationPayload(MsgpackSerializable): ...
+class ConfigurationPayload(MsgpackSerializable):
+    pass
 
 
 @dataclass

--- a/src/aleph/vm/controllers/qemu/instance.py
+++ b/src/aleph/vm/controllers/qemu/instance.py
@@ -111,7 +111,7 @@ def make_logs_queue(stdout_identifier, stderr_identifier, skip_past=True) -> tup
     r.add_match(SYSLOG_IDENTIFIER=stderr_identifier)
     queue: asyncio.Queue = asyncio.Queue(maxsize=1000)
 
-    def _ready_for_read():
+    def _ready_for_read() -> None:
         change_type = r.process()  # reset fd status
         if change_type != journal.APPEND:
             return

--- a/src/aleph/vm/controllers/qemu/instance.py
+++ b/src/aleph/vm/controllers/qemu/instance.py
@@ -44,7 +44,10 @@ class AlephQemuResources(AlephFirecrackerResources):
 
     async def make_writable_volume(self, parent_image_path, volume: Union[PersistentVolume, RootfsVolume]):
         """Create a new qcow2 image file based on the passed one, that we give to the VM to write onto"""
-        qemu_img_path = shutil.which("qemu-img")
+        qemu_img_path: Optional[str] = shutil.which("qemu-img")
+        if not qemu_img_path:
+            raise VmSetupError("qemu-img not found in PATH")
+
         volume_name = volume.name if isinstance(volume, PersistentVolume) else "rootfs"
 
         # detect the image format

--- a/src/aleph/vm/guest_api/__main__.py
+++ b/src/aleph/vm/guest_api/__main__.py
@@ -5,16 +5,12 @@ from typing import Optional
 
 import aiohttp
 import aioredis
+import sentry_sdk
 from aiohttp import web
 from setproctitle import setproctitle
 
 from aleph.vm.conf import settings
 from aleph.vm.version import get_version_from_apt, get_version_from_git
-
-try:
-    import sentry_sdk
-except ImportError:
-    sentry_sdk = None
 
 logger = logging.getLogger(__name__)
 

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -104,18 +104,18 @@ class MicroVM:
         return str(self.jailer_base_directory / firecracker_bin_name / str(self.vm_id))
 
     @property
-    def jailer_path(self):
+    def jailer_path(self) -> str:
         return os.path.join(self.namespace_path, "root")
 
     @property
-    def socket_path(self):
+    def socket_path(self) -> str:
         if self.use_jailer:
             return f"{self.jailer_path}/run/firecracker.socket"
         else:
             return f"/tmp/firecracker-{self.vm_id}.socket"
 
     @property
-    def vsock_path(self):
+    def vsock_path(self) -> str:
         if self.use_jailer:
             return f"{self.jailer_path}{VSOCK_PATH}"
         else:
@@ -140,7 +140,7 @@ class MicroVM:
         self.runtime_config = None
         self.log_queues: list[asyncio.Queue] = []
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         return {
             "jailer_path": self.jailer_path,
             "socket_path": self.socket_path,
@@ -148,9 +148,9 @@ class MicroVM:
             **self.__dict__,
         }
 
-    def prepare_jailer(self):
+    def prepare_jailer(self) -> None:
         if not self.use_jailer:
-            return False
+            return
         system(f"rm -fr {self.jailer_path}")
 
         # system(f"rm -fr {self.jailer_path}/run/")

--- a/src/aleph/vm/hypervisors/qemu/qemuvm.py
+++ b/src/aleph/vm/hypervisors/qemu/qemuvm.py
@@ -21,6 +21,7 @@ class QemuVM:
     mem_size_mb: int
     interface_name: str
     qemu_process = None
+    log_queues: list[asyncio.Queue]
 
     def __repr__(self) -> str:
         if self.qemu_process:
@@ -37,6 +38,7 @@ class QemuVM:
         self.vcpu_count = config.vcpu_count
         self.mem_size_mb = config.mem_size_mb
         self.interface_name = config.interface_name
+        self.log_queues = []
 
     def prepare_start(self):
         pass
@@ -93,8 +95,6 @@ class QemuVM:
 
         logger.debug(f"started qemu vm {self}, {proc}")
         return proc
-
-    log_queues: list[asyncio.Queue] = []
 
     # TODO : convert when merging with log fixing branch
     async def _process_stderr(self):

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -9,22 +9,16 @@ from pathlib import Path
 from statistics import mean
 from typing import Callable, Optional, cast
 
-from aiohttp.web import Request, Response
-from sqlalchemy.ext.asyncio import create_async_engine
-
-from aleph.vm.version import get_version_from_apt, get_version_from_git
-
-try:
-    import sentry_sdk
-except ImportError:
-    sentry_sdk = None
-
 import alembic.command
 import alembic.config
+import sentry_sdk
+from aiohttp.web import Request, Response
 from aleph_message.models import ItemHash
+from sqlalchemy.ext.asyncio import create_async_engine
 
 from aleph.vm.conf import ALLOW_DEVELOPER_SSH_KEYS, make_db_url, settings
 from aleph.vm.pool import VmPool
+from aleph.vm.version import get_version_from_apt, get_version_from_git
 
 from . import metrics, supervisor
 from .pubsub import PubSub

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -7,7 +7,6 @@ import sys
 import time
 from pathlib import Path
 from statistics import mean
-from typing import Callable
 from typing import Callable, Optional, cast
 
 from aiohttp.web import Request, Response
@@ -239,8 +238,7 @@ async def benchmark(runs: int):
     logger.info(f"BENCHMARK: n={len(bench)} avg={mean(bench):03f} min={min(bench):03f} max={max(bench):03f}")
     logger.info(bench)
 
-    event = None
-    result = await run_code_on_event(vm_hash=ref, event=event, pubsub=PubSub(), pool=pool)
+    result = await run_code_on_event(vm_hash=ref, event=None, pubsub=PubSub(), pool=pool)
     print("Event result", result)
 
 
@@ -251,7 +249,7 @@ async def start_instance(item_hash: ItemHash) -> None:
     # The main program uses a singleton pubsub instance in order to watch for updates.
     # We create another instance here since that singleton is not initialized yet.
     # Watching for updates on this instance will therefore not work.
-    pubsub = None
+    pubsub: Optional[PubSub] = None
 
     await start_persistent_vm(item_hash, pubsub, pool)
 

--- a/src/aleph/vm/orchestrator/metrics.py
+++ b/src/aleph/vm/orchestrator/metrics.py
@@ -15,9 +15,12 @@ from sqlalchemy import (
     delete,
     select,
 )
-from sqlalchemy.engine import Engine
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 try:
     from sqlalchemy.orm import declarative_base
@@ -26,7 +29,7 @@ except ImportError:
 
 from aleph.vm.conf import make_db_url, settings
 
-AsyncSessionMaker: sessionmaker
+AsyncSessionMaker: async_sessionmaker[AsyncSession]
 
 logger = logging.getLogger(__name__)
 
@@ -36,11 +39,11 @@ Base: Any = declarative_base()
 def setup_engine():
     global AsyncSessionMaker
     engine = create_async_engine(make_db_url(), echo=True)
-    AsyncSessionMaker = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    AsyncSessionMaker = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
     return engine
 
 
-async def create_tables(engine: Engine):
+async def create_tables(engine: AsyncEngine):
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -82,6 +82,11 @@ async def allow_cors_on_endpoint(request: web.Request):
     )
 
 
+async def http_not_found(request: web.Request):
+    """Return a 404 error for unknown URLs."""
+    return web.HTTPNotFound()
+
+
 app = web.Application(middlewares=[server_version_middleware])
 cors = aiohttp_cors.setup(app)
 
@@ -110,9 +115,9 @@ app.add_routes(
         web.get("/status/check/ipv6", status_check_ipv6),
         web.get("/status/config", status_public_config),
         # Raise an HTTP Error 404 if attempting to access an unknown URL within these paths.
-        web.get("/about/{suffix:.*}", lambda _: web.HTTPNotFound()),
-        web.get("/control/{suffix:.*}", lambda _: web.HTTPNotFound()),
-        web.get("/status/{suffix:.*}", lambda _: web.HTTPNotFound()),
+        web.get("/about/{suffix:.*}", http_not_found),
+        web.get("/control/{suffix:.*}", http_not_found),
+        web.get("/status/{suffix:.*}", http_not_found),
         # /static is used to serve static files
         web.static("/static", Path(__file__).parent / "views/static"),
         # /vm is used to launch VMs on-demand

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -1,6 +1,5 @@
 import binascii
 import logging
-from collections.abc import Awaitable
 from decimal import Decimal
 from hashlib import sha256
 from json import JSONDecodeError

--- a/src/aleph/vm/orchestrator/views/authentication.py
+++ b/src/aleph/vm/orchestrator/views/authentication.py
@@ -218,7 +218,7 @@ async def authenticate_websocket_message(message) -> str:
 
 def require_jwk_authentication(
     handler: Callable[[web.Request, str], Coroutine[Any, Any, web.StreamResponse]]
-) -> Callable[[web.Response], Awaitable[web.StreamResponse]]:
+) -> Callable[[web.Request], Awaitable[web.StreamResponse]]:
     @functools.wraps(handler)
     async def wrapper(request):
         try:

--- a/src/aleph/vm/orchestrator/views/authentication.py
+++ b/src/aleph/vm/orchestrator/views/authentication.py
@@ -68,7 +68,7 @@ class SignedPubKeyHeader(BaseModel):
         return bytes.fromhex(v.decode())
 
     @root_validator(pre=False, skip_on_failure=True)
-    def check_expiry(cls, values):
+    def check_expiry(cls, values) -> dict[str, bytes]:
         """Check that the token has not expired"""
         payload: bytes = values["payload"]
         content = SignedPubKeyPayload.parse_raw(payload)
@@ -78,7 +78,7 @@ class SignedPubKeyHeader(BaseModel):
         return values
 
     @root_validator(pre=False, skip_on_failure=True)
-    def check_signature(cls, values):
+    def check_signature(cls, values) -> dict[str, bytes]:
         """Check that the signature is valid"""
         signature: bytes = values["signature"]
         payload: bytes = values["payload"]

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -39,7 +39,7 @@ class VmPool:
 
     counter: int  # Used to provide distinct ids to network interfaces
     executions: dict[ItemHash, VmExecution]
-    message_cache: dict[str, ExecutableMessage] = {}
+    message_cache: dict[str, ExecutableMessage]
     network: Optional[Network]
     snapshot_manager: Optional[SnapshotManager] = None
     systemd_manager: SystemDManager
@@ -48,6 +48,7 @@ class VmPool:
     def __init__(self, loop: asyncio.AbstractEventLoop):
         self.counter = settings.START_ID_INDEX
         self.executions = {}
+        self.message_cache = {}
 
         asyncio.set_event_loop(loop)
         self.creation_lock = asyncio.Lock()

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -121,7 +121,7 @@ async def download_file(url: str, local_path: Path) -> None:
         ) as error:
             if attempt < (download_attempts - 1):
                 logger.warning(f"Download failed, retrying attempt {attempt + 1}/{download_attempts}...")
-                continue
+                # continue  #  continue inside try/finally block is unimplemented in `mypyc`
             else:
                 raise error
         finally:

--- a/tests/supervisor/test_jwk.py
+++ b/tests/supervisor/test_jwk.py
@@ -7,7 +7,7 @@ from aleph.vm.orchestrator.views.authentication import authenticate_jwk
 # Avoid failures linked to settings when initializing the global VmPool object
 os.environ["ALEPH_VM_ALLOW_VM_NETWORKING"] = "False"
 
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -23,7 +23,7 @@ def valid_jwk_headers(mocker):
 
 @pytest.mark.skip(reason="TODO: Fix this test")
 @pytest.mark.asyncio
-async def test_valid_signature(valid_jwk_headers: Dict[str, Any], mocker):
+async def test_valid_signature(valid_jwk_headers: dict[str, Any], mocker):
     request = mocker.AsyncMock()
     request.headers = valid_jwk_headers
     await authenticate_jwk(request)
@@ -31,7 +31,7 @@ async def test_valid_signature(valid_jwk_headers: Dict[str, Any], mocker):
 
 @pytest.mark.skip(reason="TODO: Fix this test")
 @pytest.mark.asyncio
-async def test_invalid_signature(valid_jwk_headers: Dict[str, Any], mocker):
+async def test_invalid_signature(valid_jwk_headers: dict[str, Any], mocker):
     valid_jwk_headers["X-SignedOperation"] = (
         '{"time":"2023-07-14T22:14:14.132Z","signature":"96ffdbbd1704d5f6bfe4698235a0de0d2f58668deaa4371422bee26664f313f51fd483c78c34c6b317fc209779f9ddd9c45accf558e3bf881b49ad970ebf0ade"}'
     )
@@ -44,7 +44,7 @@ async def test_invalid_signature(valid_jwk_headers: Dict[str, Any], mocker):
 
 @pytest.mark.skip(reason="TODO: Fix this test")
 @pytest.mark.asyncio
-async def test_expired_token(valid_jwk_headers: Dict[str, Any], mocker):
+async def test_expired_token(valid_jwk_headers: dict[str, Any], mocker):
     mocker.patch("aleph.vm.orchestrator.views.authentication.is_token_still_valid", lambda timestamp: False)
     request = mocker.AsyncMock()
     request.headers = valid_jwk_headers
@@ -55,7 +55,7 @@ async def test_expired_token(valid_jwk_headers: Dict[str, Any], mocker):
 
 @pytest.mark.parametrize("missing_header", ["X-SignedPubKey", "X-SignedOperation"])
 @pytest.mark.asyncio
-async def test_missing_headers(valid_jwk_headers: Dict[str, Any], mocker, missing_header: str):
+async def test_missing_headers(valid_jwk_headers: dict[str, Any], mocker, missing_header: str):
     del valid_jwk_headers[missing_header]
 
     request = mocker.AsyncMock()

--- a/vm_connector/main.py
+++ b/vm_connector/main.py
@@ -26,9 +26,7 @@ def read_root():
 
 async def get_latest_message_amend(ref: str, sender: str) -> Optional[dict]:
     async with aiohttp.ClientSession() as session:
-        url = (
-            f"{settings.API_SERVER}/api/v0/messages.json?msgType=STORE&sort_order=-1" f"&refs={ref}&addresses={sender}"
-        )
+        url = f"{settings.API_SERVER}/api/v0/messages.json?msgType=STORE&sort_order=-1&refs={ref}&addresses={sender}"
         resp = await session.get(url)
         resp.raise_for_status()
         resp_data = await resp.json()

--- a/vm_connector/main.py
+++ b/vm_connector/main.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Dict, Optional, Union
+from typing import Optional
 
 import aiohttp
 from aleph_client.asynchronous import create_post
@@ -24,7 +24,7 @@ def read_root():
     return {"Server": "Aleph.im VM Connector"}
 
 
-async def get_latest_message_amend(ref: str, sender: str) -> Optional[Dict]:
+async def get_latest_message_amend(ref: str, sender: str) -> Optional[dict]:
     async with aiohttp.ClientSession() as session:
         url = (
             f"{settings.API_SERVER}/api/v0/messages.json?msgType=STORE&sort_order=-1" f"&refs={ref}&addresses={sender}"
@@ -38,7 +38,7 @@ async def get_latest_message_amend(ref: str, sender: str) -> Optional[Dict]:
             return None
 
 
-async def get_message(hash_: str) -> Optional[Dict]:
+async def get_message(hash_: str) -> Optional[dict]:
     async with aiohttp.ClientSession() as session:
         url = f"{settings.API_SERVER}/api/v0/messages.json?hashes={hash_}"
         resp = await session.get(url)
@@ -63,7 +63,7 @@ async def stream_url_chunks(url):
 
 
 @app.get("/download/message/{ref}")
-async def download_message(ref: str) -> Dict:
+async def download_message(ref: str) -> dict:
     """
     Fetch on Aleph and return a VM function message, after checking its validity.
     Used by the VM Supervisor run the code.


### PR DESCRIPTION
This branch fixes a series of errors reported when using strict typing checks with the tool `mypyc`

I recommend reviewing these changes one commit at a time.
Not not squash.

- Fix typing: web.HTTPBadRequest may not be raised
- Fix typing: Wrong type in annotation
- Fix typing: FakeRequest class was not of type Request
- Fix typing: Invalid type annotations
- Fix typing: Replace Dict->dict, List->list
- Fix typing: SQLAlchemy annotations were incorrect
- Fix typing: Missing return types on methods
- Fix typing: Strict type checks raised issues
- Fix: Properties were initialized with a global object
- fixup! Fix typing: Replace Dict->dict, List->list
- Fix typing: `...` in class is not allowed
- Fix typing: `continue` inside try/finally block is unimplemented in `mypyc`
- Fix typing: Use of lambda caused typing errors
- Fix: Automated code cleanup
- Fix typing: Missing annotation on methods
- Fix typing: Missing path was not considered
- Fix: Domain name must always be specified
