### PR TITLE
Fix: Deleting a missing interface crashed

### DIFF
--- a/src/aleph/vm/network/interfaces.py
+++ b/src/aleph/vm/network/interfaces.py
@@ -64,7 +64,7 @@ def set_link_up(ipr: IPRoute, device_name: str):
     interface_index: list[int] = ipr.link_lookup(ifname=device_name)
     if not interface_index:
         raise MissingInterfaceError(f"Interface {device_name} does not exist, can't set it up.")
-    ipr.link("set", index=ipr.link_lookup(ifname=device_name)[0], state="up")
+    ipr.link("set", index=interface_index[0], state="up")
 
 
 def delete_tap_interface(ipr: IPRoute, device_name: str):

--- a/tests/supervisor/test_interfaces.py
+++ b/tests/supervisor/test_interfaces.py
@@ -5,6 +5,7 @@ import pytest
 from pyroute2 import IPRoute
 
 from aleph.vm.network.interfaces import (
+    MissingInterfaceError,
     add_ip_address,
     create_tap_interface,
     delete_tap_interface,
@@ -45,7 +46,7 @@ def test_add_ip_address():
         run(["ip", "tuntap", "del", test_device_name, "mode", "tap"], check=False)
 
     # Without an interface, the function should raise an error
-    with pytest.raises(IndexError):
+    with pytest.raises(MissingInterfaceError):
         add_ip_address(IPRoute(), test_device_name, test_ipv4)
 
 


### PR DESCRIPTION
Calling `delete_tap_interface` on an interface that is not present raised an error. This logs a debug message instead.

When the interface is not found for adding an IP address or setting a link up, a more explicit error is raised.
