### PR TITLE
Fix: Tests were run twice

### DIFF
--- a/.github/workflows/test-on-droplets-matrix.yml
+++ b/.github/workflows/test-on-droplets-matrix.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Run unit tests
         run: |
           sudo python3 -m pip install hatch hatch-vcs coverage
-          sudo hatch run testing:test-cov
           sudo hatch run testing:cov
 
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
The command `hatch run testing:cov` includes running `hatch run testing:test-cov`.

This removes the duplication
