### PR TITLE
Validation of ItemHash on allocations raised wrong error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ dependencies = [
   "pytest-cov==4.1.0",
   "pytest-mock==3.12.0",
   "pytest-asyncio==0.23.5",
+  "pytest-aiohttp==1.0.5",
 ]
 [tool.hatch.envs.testing.scripts]
 test = "pytest {args:tests}"

--- a/src/aleph/vm/orchestrator/resources.py
+++ b/src/aleph/vm/orchestrator/resources.py
@@ -124,10 +124,10 @@ class Allocation(BaseModel):
     It contains the item_hashes of all persistent VMs, instances, on-demand VMs and jobs.
     """
 
-    persistent_vms: set[str] = Field(default_factory=set)
-    instances: set[str] = Field(default_factory=set)
-    on_demand_vms: Optional[set[str]] = None
-    jobs: Optional[set[str]] = None
+    persistent_vms: set[ItemHash] = Field(default_factory=set)
+    instances: set[ItemHash] = Field(default_factory=set)
+    on_demand_vms: Optional[set[ItemHash]] = None
+    jobs: Optional[set[ItemHash]] = None
 
 
 class VMNotification(BaseModel):

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -350,7 +350,7 @@ async def update_allocations(request: web.Request):
         data = await request.json()
         allocation = Allocation.parse_obj(data)
     except ValidationError as error:
-        return web.json_response(data=error.json(), status=web.HTTPBadRequest.status_code)
+        return web.json_response(text=error.json(), status=web.HTTPBadRequest.status_code)
 
     pubsub: PubSub = request.app["pubsub"]
     pool: VmPool = request.app["vm_pool"]

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -1,0 +1,26 @@
+import pytest
+from aiohttp import web
+
+from aleph.vm.conf import settings
+from aleph.vm.orchestrator.supervisor import app
+
+
+@pytest.mark.asyncio
+async def test_allocation_fails_on_invalid_item_hash(aiohttp_client):
+    """Test that the allocation endpoint fails when an invalid item_hash is provided."""
+    client = await aiohttp_client(app)
+    settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
+    response: web.Response = await client.post(
+        "/control/allocations", json={"persistent_vms": ["not-an-ItemHash"]}, headers={"X-Auth-Signature": "test"}
+    )
+    assert response.status == 400
+    assert await response.json() == [
+        {
+            "loc": [
+                "persistent_vms",
+                0,
+            ],
+            "msg": "Could not determine hash type: 'not-an-ItemHash'",
+            "type": "value_error.unknownhash",
+        },
+    ]


### PR DESCRIPTION
- Fix: Error data was JSON encoded twice
- Fix: Invalid ItemHash did not raise a ValidationError

Do not squash.
See the details of each commit for more information.

In particular:

    Fix: Invalid ItemHash did not raise a ValidationError
    
    Problem: Posting invalid item hashes to the `update_allocations` API failed far after the initial validation, with:
    
     ```   File "/opt/aleph-vm/aleph_message/models/item_hash.py", line 25, in from_hash
         raise UnknownHashError(f"Could not determine hash type: '{item_hash}'")
    aleph_message.exceptions.UnknownHashError: Could not determine hash type: '${{ matrix.check_vm.item_hash }}'
    ```
    
    Solution: Require ItemHash as part of the `Allocation` schema, in order to fail validation earlier, in the section dedicated to the validation of the uploaded data.

