### PR TITLE
Fix: Log level could not be configured from settings

### DIFF
--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -144,6 +144,7 @@ class Settings(BaseSettings):
     # System logs make boot ~2x slower
     PRINT_SYSTEM_LOGS = False
     IGNORE_TRACEBACK_FROM_DIAGNOSTICS = True
+    LOG_LEVEL = "WARNING"
     DEBUG_ASYNCIO = False
 
     # Networking does not work inside Docker/Podman

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -307,7 +307,7 @@ def main():
     )
 
     logging.basicConfig(
-        level=settings.loglevel,
+        level=settings.LOG_LEVEL,
         format=log_format,
     )
 

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -294,10 +294,6 @@ def main():
         if args.profile
         else "%(asctime)s | %(levelname)s | %(message)s"
     )
-    logging.basicConfig(
-        level=args.loglevel,
-        format=log_format,
-    )
 
     settings.update(
         USE_JAILER=args.use_jailer,
@@ -307,6 +303,12 @@ def main():
         FAKE_DATA_PROGRAM=args.fake_data_program,
         DEBUG_ASYNCIO=args.debug_asyncio,
         FAKE_INSTANCE_BASE=args.fake_instance_base,
+        LOG_LEVEL=logging.getLevelName(args.loglevel),
+    )
+
+    logging.basicConfig(
+        level=settings.loglevel,
+        format=log_format,
     )
 
     if args.run_fake_instance:


### PR DESCRIPTION
Solution: Add a `LOG_LEVEL` setting defaulting to "WARNING".
