### PR TITLE
Solve network issues on Ubuntu hosts

### DIFF
--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -134,7 +134,8 @@ def run():
     engine = setup_engine()
     asyncio.run(create_tables(engine))
 
-    pool = VmPool()
+    loop = asyncio.new_event_loop()
+    pool = VmPool(loop)
     pool.setup()
 
     hostname = settings.DOMAIN_NAME

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -57,7 +57,7 @@ from packaging.version import InvalidVersion, Version
 logger = logging.getLogger(__name__)
 
 
-def run_code_from_path(request: web.Request) -> Awaitable[web.Response]:
+async def run_code_from_path(request: web.Request) -> web.Response:
     """Allow running an Aleph VM function from a URL path
 
     The path is expected to follow the scheme defined in `app.add_routes` below,
@@ -68,7 +68,7 @@ def run_code_from_path(request: web.Request) -> Awaitable[web.Response]:
 
     message_ref = ItemHash(request.match_info["ref"])
     pool: VmPool = request.app["vm_pool"]
-    return run_code_on_request(message_ref, path, pool, request)
+    return await run_code_on_request(message_ref, path, pool, request)
 
 
 async def run_code_from_hostname(request: web.Request) -> web.Response:


### PR DESCRIPTION
Problem: After the change of the new interface library to handle network interfaces, when you call 2 VMs at the same time, it assigns to you the same VM_ID and the network setup fails.

Solution: Implement semaphores on the execution creation to avoid creating VMs at the same time.
* Avoid raising exceptions on network issues and just log it as error.
* Added missing await async on VM request handling