### PR TITLE
Fix: Test launch a VM without building it locally

### DIFF
--- a/.github/workflows/test-build-examples.yml
+++ b/.github/workflows/test-build-examples.yml
@@ -34,7 +34,6 @@ jobs:
           ls
           pwd
           pip3 install -t /opt/packages -r ./examples/example_pip/requirements.txt
-          mksquashfs /opt/packages packages.squashfs
 
 #      - run: |
 #          ipfs add packages.squashfs


### PR DESCRIPTION
Deleting the line with mksquashfs which was building the runtimes locally.