### PR TITLE
Problem: Vm execution failed due to network interface

### DIFF
--- a/src/aleph/vm/network/hostnetwork.py
+++ b/src/aleph/vm/network/hostnetwork.py
@@ -3,6 +3,8 @@ from ipaddress import IPv6Network
 from pathlib import Path
 from typing import Optional, Protocol
 
+import pyroute2
+
 from aleph_message.models import ItemHash
 
 from aleph.vm.conf import IPv6AllocationPolicy
@@ -136,6 +138,7 @@ class Network:
         self.ipv4_forwarding_enabled = ipv4_forwarding_enabled
         self.ipv6_forwarding_enabled = ipv6_forwarding_enabled
         self.use_ndp_proxy = use_ndp_proxy
+        self.ndb = pyroute2.NDB()
 
         if not self.ipv4_address_pool.is_private:
             logger.warning(f"Using a network range that is not private: {self.ipv4_address_pool}")
@@ -220,3 +223,7 @@ class Network:
         """Create TAP interface to be used by VM"""
         await interface.create()
         setup_nftables_for_vm(vm_id, interface)
+
+    def interface_exists(self, vm_id: int):
+        interface_name = f"vmtap{vm_id}"
+        return self.ndb.interfaces.exists(interface_name)

--- a/src/aleph/vm/network/hostnetwork.py
+++ b/src/aleph/vm/network/hostnetwork.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Optional, Protocol
 
 import pyroute2
-
 from aleph_message.models import ItemHash
 
 from aleph.vm.conf import IPv6AllocationPolicy

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -161,6 +161,12 @@ class VmPool:
             # anymore.
             currently_used_vm_ids = {execution.vm_id for execution in self.executions.values() if execution.is_running}
             for i in range(settings.START_ID_INDEX, 255**2):
+
+                if self.network:
+                    # Check the network interface don't already exists, otherwise it will cause a crash
+                    if self.network.interface_exists(i):
+                        continue
+
                 if i not in currently_used_vm_ids:
                     return i
             else:


### PR DESCRIPTION
occasionaly vm creation vm because the assigned tap network inteface was already existing. Probably not properly teared down from a previous execution or from a concurrency issue

Displayed Error was :
 OSError: [Errno 16] Device or resource busy

it was then looped as a retry and blocked the whole thing

Solution:
When assigning a vm_id, check that the network interface for that vm doesn't already exists This act as a double check for a variety of issues