### PR TITLE
Fix: Backquote in shell script executed command

### DIFF
--- a/runtimes/aleph-debian-11-python/create_disk_image.sh
+++ b/runtimes/aleph-debian-11-python/create_disk_image.sh
@@ -39,7 +39,7 @@ echo "Pip installing aleph-client"
 pip3 install 'aleph-sdk-python==0.7.0'
 
 # Compile Python code to bytecode for faster execution
-# -o2 is needed to compile with optimization level 2 which is what we launch init1.py (`python -OO`)
+# -o2 is needed to compile with optimization level 2 which is what we launch init1.py ("python -OO")
 # otherwise they are not used
 python3 -m compileall -o 2 -f /usr/local/lib/python3.9
 

--- a/runtimes/aleph-debian-12-python/create_disk_image.sh
+++ b/runtimes/aleph-debian-12-python/create_disk_image.sh
@@ -39,7 +39,7 @@ mkdir -p /opt/aleph/libs
 pip3 install --target /opt/aleph/libs 'aleph-sdk-python==0.9.0' 'aleph-message==0.4.4' 'fastapi~=0.109.2'
 
 # Compile Python code to bytecode for faster execution
-# -o2 is needed to compile with optimization level 2 which is what we launch init1.py (`python -OO`)
+# -o2 is needed to compile with optimization level 2 which is what we launch init1.py ("python -OO")
 # otherwise they are not used
 python3 -m compileall -o 2 -f /usr/local/lib/python3.11
 python3 -m compileall -o 2 -f /opt/aleph/libs


### PR DESCRIPTION
When executed using `bash`, the `create_disk_image` was interrupted by a Python REPL due to the `python -OO` command being surrounded by backquotes.
