### PR TITLE
Added `USE_CONFIDENTIAL_COMPUTING` check

### DIFF
--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -16,7 +16,7 @@ from pydantic import BaseSettings, Field, HttpUrl
 from pydantic.env_settings import DotenvType, env_file_sentinel
 from pydantic.typing import StrPath
 
-from aleph.vm.utils import file_hashes_differ, is_command_available
+from aleph.vm.utils import check_system_module, file_hashes_differ, is_command_available
 
 logger = logging.getLogger(__name__)
 
@@ -261,6 +261,12 @@ class Settings(BaseSettings):
         description="Default hypervisor to use on running instances, can be Firecracker or QEmu",
     )
 
+    USE_CONFIDENTIAL_COMPUTING: bool = Field(
+        default=False,
+        description="Enable Confidential Computing using AMD-SEV. It will test if the host is compatible "
+        "with SEV and SEV-ES",
+    )
+
     # Tests on programs
 
     FAKE_DATA_PROGRAM: Optional[Path] = None
@@ -335,6 +341,12 @@ class Settings(BaseSettings):
             assert (
                 int(ipv4_pool_length) <= settings.IPV4_NETWORK_PREFIX_LENGTH
             ), "The IPv4 address pool prefix must be shorter than an individual VM network prefix"
+
+        if self.USE_CONFIDENTIAL_COMPUTING:
+            assert check_system_module("kvm_amd/parameters/sev") == "Y", "SEV feature isn't enabled, enable it in BIOS."
+            assert (
+                check_system_module("kvm_amd/parameters/sev_es") == "Y"
+            ), "SEV-ES feature isn't enabled, enable it in BIOS."
 
         if self.FAKE_DATA_PROGRAM:
             assert self.FAKE_DATA_PROGRAM, "Local fake program directory not specified"

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -331,6 +331,12 @@ async def status_public_config(request: web.Request):
                 "PAYMENT_RECEIVER_ADDRESS": settings.PAYMENT_RECEIVER_ADDRESS,
                 "PAYMENT_SUPER_TOKEN": settings.PAYMENT_SUPER_TOKEN,
                 "PAYMENT_CHAIN_ID": settings.PAYMENT_CHAIN_ID,
+                "PAYMENT_MONITOR_INTERVAL": settings.PAYMENT_MONITOR_INTERVAL,
+            },
+            "computing": {
+                "ENABLE_QEMU_SUPPORT": settings.ENABLE_QEMU_SUPPORT,
+                "INSTANCE_DEFAULT_HYPERVISOR": settings.INSTANCE_DEFAULT_HYPERVISOR,
+                "USE_CONFIDENTIAL_COMPUTING": settings.USE_CONFIDENTIAL_COMPUTING,
             },
         },
         dumps=dumps_for_json,

--- a/src/aleph/vm/utils.py
+++ b/src/aleph/vm/utils.py
@@ -130,6 +130,14 @@ def is_command_available(command):
         return False
 
 
+def check_system_module(module_path) -> str:
+    try:
+        output = subprocess.check_output(["cat", "/sys/module", module_path], stderr=subprocess.STDOUT)
+        return str(output)
+    except subprocess.CalledProcessError:
+        return ""
+
+
 def fix_message_validation(message: dict) -> dict:
     """Patch a fake message program to pass validation."""
     message["item_content"] = json.dumps(message["content"])

--- a/tests/supervisor/test_utils.py
+++ b/tests/supervisor/test_utils.py
@@ -1,0 +1,13 @@
+from unittest import mock
+
+from aleph.vm.utils import check_system_module
+
+
+def test_check_system_module_enabled():
+    with mock.patch(
+        "aleph.vm.utils.subprocess.check_output",
+        return_value="Y",
+    ):
+        expected_value = "Y"
+        output = check_system_module("kvm_amd/parameters/sev_enp")
+        assert output == expected_value


### PR DESCRIPTION
Problem: A node operator cannot check or add support for confidential computing.

Solution: Implemented a setting to allow node operator to enable confidential computing. A check ensure that the system is well configured, and it shows that configuration on the /public/config endpoint.

Implementations:
- Added `USE_CONFIDENTIAL_COMPUTING` setting with a `False` default value. If the user enables it, it checks the module availability on the system.
- Added a new computing section on `/public/config` endpoint with relevant information about computing.
- Added `PAYMENT_MONITOR_INTERVAL` field on payment section on `/public/config` endpoint to show the payment interval check.