### PR TITLE
Implement get platform certificates endpoint

### DIFF
--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -267,6 +267,11 @@ class Settings(BaseSettings):
         "with SEV and SEV-ES",
     )
 
+    CONFIDENTIAL_DIRECTORY: Path = Field(
+        None,
+        description="Confidential Computing default directory. Default to EXECUTION_ROOT/confidential",
+    )
+
     # Tests on programs
 
     FAKE_DATA_PROGRAM: Optional[Path] = None
@@ -409,6 +414,7 @@ class Settings(BaseSettings):
 
         os.makedirs(self.EXECUTION_LOG_DIRECTORY, exist_ok=True)
         os.makedirs(self.PERSISTENT_VOLUMES_DIR, exist_ok=True)
+        os.makedirs(self.CONFIDENTIAL_DIRECTORY, exist_ok=True)
 
         self.API_SERVER = self.API_SERVER.rstrip("/")
 
@@ -467,6 +473,8 @@ class Settings(BaseSettings):
             self.EXECUTION_LOG_DIRECTORY = self.EXECUTION_ROOT / "executions"
         if not self.JAILER_BASE_DIR:
             self.JAILER_BASE_DIR = self.EXECUTION_ROOT / "jailer"
+        if not self.CONFIDENTIAL_DIRECTORY:
+            self.CONFIDENTIAL_DIRECTORY = self.EXECUTION_ROOT / "confidential"
 
     class Config:
         env_prefix = "ALEPH_VM_"

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -387,6 +387,7 @@ class Settings(BaseSettings):
             assert (
                 check_system_module("kvm_amd/parameters/sev_es") == "Y"
             ), "SEV-ES feature isn't enabled, enable it in BIOS"
+            assert is_command_available("sevctl"), "Command `sevctl` not found, run `cargo install sevctl`"
 
             assert self.ENABLE_QEMU_SUPPORT, "Qemu Support is needed for confidential computing and it's disabled, "
             "enable it setting the env variable `ENABLE_QEMU_SUPPORT=True` in configuration"

--- a/src/aleph/vm/orchestrator/resources.py
+++ b/src/aleph/vm/orchestrator/resources.py
@@ -11,6 +11,7 @@ from aleph_message.models.execution.environment import CpuProperties
 from pydantic import BaseModel, Field
 
 from aleph.vm.conf import settings
+from aleph.vm.sevclient import SevClient
 from aleph.vm.utils import cors_allow_all
 
 
@@ -129,10 +130,10 @@ async def about_certificates(request: web.Request):
     if not settings.ENABLE_CONFIDENTIAL_COMPUTING:
         return web.HTTPBadRequest(reason="Confidential computing setting not enabled on that server")
 
-    sev_client = request.app["sev_client"]
+    sev_client: SevClient = request.app["sev_client"]
 
     if not sev_client.certificates_archive.is_file():
-        sev_client.export_certificates()
+        await sev_client.export_certificates()
 
     return web.FileResponse(sev_client.certificates_archive)
 

--- a/src/aleph/vm/orchestrator/resources.py
+++ b/src/aleph/vm/orchestrator/resources.py
@@ -122,6 +122,21 @@ async def about_system_usage(_: web.Request):
     return web.json_response(text=usage.json(exclude_none=True))
 
 
+@cors_allow_all
+async def about_certificates(request: web.Request):
+    """Public endpoint to expose platform certificates for confidential computing."""
+
+    if not settings.ENABLE_CONFIDENTIAL_COMPUTING:
+        return web.HTTPBadRequest(reason="Confidential computing setting not enabled on that server")
+
+    sev_client = request.app["sev_client"]
+
+    if not sev_client.certificates_archive.is_file():
+        sev_client.export_certificates()
+
+    return web.FileResponse(sev_client.certificates_archive)
+
+
 class Allocation(BaseModel):
     """An allocation is the set of resources that are currently allocated on this orchestrator.
     It contains the item_hashes of all persistent VMs, instances, on-demand VMs and jobs.

--- a/src/aleph/vm/orchestrator/resources.py
+++ b/src/aleph/vm/orchestrator/resources.py
@@ -132,10 +132,7 @@ async def about_certificates(request: web.Request):
 
     sev_client: SevClient = request.app["sev_client"]
 
-    if not sev_client.certificates_archive.is_file():
-        await sev_client.export_certificates()
-
-    return web.FileResponse(sev_client.certificates_archive)
+    return web.FileResponse(await sev_client.get_certificates())
 
 
 class Allocation(BaseModel):

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -20,8 +20,9 @@ from aleph.vm.conf import settings
 from aleph.vm.pool import VmPool
 from aleph.vm.version import __version__
 
+from ..sevclient import SevClient
 from .metrics import create_tables, setup_engine
-from .resources import about_system_usage, about_certificates
+from .resources import about_certificates, about_system_usage
 from .tasks import (
     start_payment_monitoring_task,
     start_watch_for_messages_task,
@@ -52,7 +53,6 @@ from .views.operator import (
     operate_stop,
     stream_logs,
 )
-from ..sevclient import SevClient
 
 logger = logging.getLogger(__name__)
 

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -21,7 +21,7 @@ from aleph.vm.pool import VmPool
 from aleph.vm.version import __version__
 
 from .metrics import create_tables, setup_engine
-from .resources import about_system_usage
+from .resources import about_system_usage, about_certificates
 from .tasks import (
     start_payment_monitoring_task,
     start_watch_for_messages_task,
@@ -52,6 +52,7 @@ from .views.operator import (
     operate_stop,
     stream_logs,
 )
+from ..sevclient import SevClient
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +96,7 @@ def setup_webapp():
         web.get("/about/executions/details", about_executions),
         web.get("/about/executions/records", about_execution_records),
         web.get("/about/usage/system", about_system_usage),
+        web.get("/about/certificates", about_certificates),
         web.get("/about/config", about_config),
         # /control APIs are used to control the VMs and access their logs
         web.post("/control/allocation/notify", notify_allocation),
@@ -158,6 +160,12 @@ def run():
     # Store app singletons. Note that app["pubsub"] will also be created.
     app["secret_token"] = secret_token
     app["vm_pool"] = pool
+
+    # Store sevctl app singleton only if confidential feature is enabled
+    if settings.ENABLE_CONFIDENTIAL_COMPUTING:
+        sev_client = SevClient(settings.CONFIDENTIAL_DIRECTORY)
+        app["sev_client"] = sev_client
+        # TODO: Review and check sevctl first initialization steps, like (sevctl generate and sevctl provision)
 
     logger.debug(f"Login to /about pages {protocol}://{hostname}/about/login?token={secret_token}")
 

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -18,9 +18,9 @@ from aiohttp_cors import ResourceOptions, setup
 
 from aleph.vm.conf import settings
 from aleph.vm.pool import VmPool
+from aleph.vm.sevclient import SevClient
 from aleph.vm.version import __version__
 
-from ..sevclient import SevClient
 from .metrics import create_tables, setup_engine
 from .resources import about_certificates, about_system_usage
 from .tasks import (

--- a/src/aleph/vm/sevclient.py
+++ b/src/aleph/vm/sevclient.py
@@ -1,5 +1,6 @@
-import subprocess
 from pathlib import Path
+
+from aleph.vm.utils import run_in_subprocess
 
 
 class SevClient:
@@ -9,14 +10,13 @@ class SevClient:
         self.certificates_dir.mkdir(exist_ok=True, parents=True)
         self.certificates_archive = self.certificates_dir / "certs_export.cert"
 
-    def sevctl_cmd(self, *args) -> subprocess.CompletedProcess:
-        result = subprocess.run(
+    async def sevctl_cmd(self, *args) -> bytes:
+        result = await run_in_subprocess(
             ["sevctl", *args],
-            capture_output=True,
-            text=True,
+            check=True,
         )
 
         return result
 
-    def export_certificates(self):
-        _ = self.sevctl_cmd("export", self.certificates_archive)
+    async def export_certificates(self):
+        _ = await self.sevctl_cmd("export", self.certificates_archive)

--- a/src/aleph/vm/sevclient.py
+++ b/src/aleph/vm/sevclient.py
@@ -19,4 +19,4 @@ class SevClient:
         return result
 
     async def export_certificates(self):
-        _ = await self.sevctl_cmd("export", self.certificates_archive)
+        _ = await self.sevctl_cmd("export", str(self.certificates_archive))

--- a/src/aleph/vm/sevclient.py
+++ b/src/aleph/vm/sevclient.py
@@ -11,12 +11,13 @@ class SevClient:
         self.certificates_archive = self.certificates_dir / "certs_export.cert"
 
     async def sevctl_cmd(self, *args) -> bytes:
-        result = await run_in_subprocess(
+        return await run_in_subprocess(
             ["sevctl", *args],
             check=True,
         )
 
-        return result
+    async def get_certificates(self) -> Path:
+        if not self.certificates_archive.is_file():
+            _ = await self.sevctl_cmd("export", str(self.certificates_archive))
 
-    async def export_certificates(self):
-        _ = await self.sevctl_cmd("export", str(self.certificates_archive))
+        return self.certificates_archive

--- a/src/aleph/vm/sevclient.py
+++ b/src/aleph/vm/sevclient.py
@@ -1,0 +1,22 @@
+import subprocess
+from pathlib import Path
+
+
+class SevClient:
+    def __init__(self, sev_dir: Path):
+        self.sev_dir = sev_dir
+        self.certificates_dir = sev_dir / "platform"
+        self.certificates_dir.mkdir(exist_ok=True, parents=True)
+        self.certificates_archive = self.certificates_dir / "certs_export.cert"
+
+    def sevctl_cmd(self, *args) -> subprocess.CompletedProcess:
+        result = subprocess.run(
+            ["sevctl", *args],
+            capture_output=True,
+            text=True,
+        )
+
+        return result
+
+    def export_certificates(self):
+        _ = self.sevctl_cmd("export", self.certificates_archive)

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -169,9 +169,7 @@ async def test_about_certificates(aiohttp_client):
             assert response.status == 200
             is_file_mock.assert_has_calls([call(), call()])
             certificates_expected_dir = sev_client.certificates_archive
-            export_mock.assert_called_once_with(
-                ["sevctl", "export", str(certificates_expected_dir)], check=True
-            )
+            export_mock.assert_called_once_with(["sevctl", "export", str(certificates_expected_dir)], check=True)
 
             # Remove file mock
             Path(sev_client.certificates_archive).unlink()

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -155,7 +155,7 @@ async def test_about_certificates(aiohttp_client):
         return_value=False,
     ) as is_file_mock:
         with mock.patch(
-            "aleph.vm.utils.run_in_subprocess",
+            "aleph.vm.sevclient.run_in_subprocess",
             return_value=True,
         ) as export_mock:
             app = setup_webapp()
@@ -170,7 +170,7 @@ async def test_about_certificates(aiohttp_client):
             is_file_mock.assert_has_calls([call(), call()])
             certificates_expected_dir = sev_client.certificates_archive
             export_mock.assert_called_once_with(
-                ["sevctl", "export", certificates_expected_dir], capture_output=True, text=True
+                ["sevctl", "export", str(certificates_expected_dir)], check=True
             )
 
             # Remove file mock

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -155,7 +155,7 @@ async def test_about_certificates(aiohttp_client):
         return_value=False,
     ) as is_file_mock:
         with mock.patch(
-            "subprocess.run",
+            "aleph.vm.utils.run_in_subprocess",
             return_value=True,
         ) as export_mock:
             app = setup_webapp()

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -1,8 +1,13 @@
+from pathlib import Path
+from unittest import mock
+from unittest.mock import call
+
 import pytest
 from aiohttp import web
 
 from aleph.vm.conf import settings
 from aleph.vm.orchestrator.supervisor import setup_webapp
+from aleph.vm.sevclient import SevClient
 
 
 @pytest.mark.asyncio
@@ -121,3 +126,52 @@ async def test_allocation_valid_token(aiohttp_client):
     )
     assert response.status == 200
     assert await response.json() == {"success": True, "successful": [], "failing": [], "errors": {}}
+
+
+@pytest.mark.asyncio
+async def test_about_certificates_missing_setting(aiohttp_client):
+    """Test that the certificates system endpoint returns an error if the setting isn't enabled"""
+    settings.ENABLE_CONFIDENTIAL_COMPUTING = False
+
+    app = setup_webapp()
+    app["sev_client"] = SevClient(Path().resolve())
+    client = await aiohttp_client(app)
+    response: web.Response = await client.get("/about/certificates")
+    assert response.status == 400
+    assert await response.text() == "400: Confidential computing setting not enabled on that server"
+
+
+@pytest.mark.asyncio
+async def test_about_certificates(aiohttp_client):
+    """Test that the certificates system endpoint responds. No auth needed"""
+
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.ENABLE_CONFIDENTIAL_COMPUTING = True
+    settings.CONFIDENTIAL_DIRECTORY = Path().resolve()
+    settings.setup()
+
+    with mock.patch(
+        "pathlib.Path.is_file",
+        return_value=False,
+    ) as is_file_mock:
+        with mock.patch(
+            "subprocess.run",
+            return_value=True,
+        ) as export_mock:
+            app = setup_webapp()
+            sev_client = SevClient(settings.CONFIDENTIAL_DIRECTORY)
+            app["sev_client"] = sev_client
+            # Create mock file to return it
+            Path(sev_client.certificates_archive).touch(exist_ok=True)
+
+            client = await aiohttp_client(app)
+            response: web.Response = await client.get("/about/certificates")
+            assert response.status == 200
+            is_file_mock.assert_has_calls([call(), call()])
+            certificates_expected_dir = sev_client.certificates_archive
+            export_mock.assert_called_once_with(
+                ["sevctl", "export", certificates_expected_dir], capture_output=True, text=True
+            )
+
+            # Remove file mock
+            Path(sev_client.certificates_archive).unlink()


### PR DESCRIPTION
Problem: There isn't an endpoint to be able to get the confidential platform certificates to start the VM key exchange.

Solution: Create that endpoint and return the platform certificates generated by the `sevctl` command.