### PR TITLE
Minor code cleanup in check_system_module

### DIFF
--- a/src/aleph/vm/utils.py
+++ b/src/aleph/vm/utils.py
@@ -130,11 +130,11 @@ def is_command_available(command):
         return False
 
 
-def check_system_module(module_path: str) -> str:
+def check_system_module(module_path: str) -> Optional[str]:
     p = Path("/sys/module") / module_path
     if not p.exists():
-        return ""
-    return p.open().read().strip()
+        return None
+    return p.read_text().strip()
 
 
 def fix_message_validation(message: dict) -> dict:


### PR DESCRIPTION
Problem: Reading a file using `f.open().read()` keeps the file open until the garbage collector deletes the variable.

Since this uses Pathlib already, using `Path(...).read_text()` is cleaner and does not depend on the opening mode being `r`.

A file with no content could not be distinguished from a missing file. Instead, this changes the behaviour to return None when the file is missing instead of an empty string.
