### PR TITLE
Fix: CRN API did not expose CPU features for trusted computing

### DIFF
--- a/docker/vm_supervisor-dev.dockerfile
+++ b/docker/vm_supervisor-dev.dockerfile
@@ -19,7 +19,7 @@ RUN curl -fsSL -o /opt/firecracker/vmlinux.bin https://s3.amazonaws.com/spec.ccf
 RUN ln /opt/firecracker/release-*/firecracker-v* /opt/firecracker/firecracker
 RUN ln /opt/firecracker/release-*/jailer-v* /opt/firecracker/jailer
 
-RUN pip3 install typing-extensions 'aleph-message==0.4.4'
+RUN pip3 install typing-extensions 'aleph-message==0.4.7'
 
 RUN mkdir -p /var/lib/aleph/vm/jailer
 

--- a/examples/volumes/Dockerfile
+++ b/examples/volumes/Dockerfile
@@ -6,6 +6,6 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m venv /opt/venv
-RUN /opt/venv/bin/pip install 'aleph-message==0.4.4'
+RUN /opt/venv/bin/pip install 'aleph-message==0.4.7'
 
 CMD mksquashfs /opt/venv /mnt/volume-venv.squashfs

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -15,7 +15,7 @@ debian-package-code:
 	cp ../examples/instance_message_from_aleph.json ./aleph-vm/opt/aleph-vm/examples/instance_message_from_aleph.json
 	cp -r ../examples/data ./aleph-vm/opt/aleph-vm/examples/data
 	mkdir -p ./aleph-vm/opt/aleph-vm/examples/volumes
-	pip3 install --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.4.4' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'superfluid==0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12'
+	pip3 install --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.4.7' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'superfluid==0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12'
 	python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux download-ipfs-kubo  target/bin/sevctl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "aiodns==3.1.0",
   "setproctitle==1.3.3",
   "pyyaml==6.0.1",
-  "aleph-message==0.4.4",
+  "aleph-message==0.4.7",
   "eth-account~=0.10",
   "sentry-sdk==1.31.0",
   "aioredis==1.3.1",

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -16,7 +16,12 @@ from pydantic import BaseSettings, Field, HttpUrl
 from pydantic.env_settings import DotenvType, env_file_sentinel
 from pydantic.typing import StrPath
 
-from aleph.vm.utils import check_system_module, file_hashes_differ, is_command_available
+from aleph.vm.utils import (
+    check_amd_sev_es_supported,
+    check_amd_sev_supported,
+    file_hashes_differ,
+    is_command_available,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -384,11 +389,11 @@ class Settings(BaseSettings):
             ), "Command `qemu-system-x86_64` not found, run `apt install qemu-system-x86`"
 
         if self.ENABLE_CONFIDENTIAL_COMPUTING:
-            assert check_system_module("kvm_amd/parameters/sev") == "Y", "SEV feature isn't enabled, enable it in BIOS"
-            assert (
-                check_system_module("kvm_amd/parameters/sev_es") == "Y"
-            ), "SEV-ES feature isn't enabled, enable it in BIOS"
             assert self.SEV_CTL_PATH.is_file(), f"File not found {self.SEV_CTL_PATH}"
+            assert check_amd_sev_supported(), "SEV feature isn't enabled, enable it in BIOS"
+            assert check_amd_sev_es_supported(), "SEV-ES feature isn't enabled, enable it in BIOS"
+            # Not available on the test machine yet
+            # assert check_amd_sev_snp_supported(), "SEV-SNP feature isn't enabled, enable it in BIOS"
             assert self.ENABLE_QEMU_SUPPORT, "Qemu Support is needed for confidential computing and it's disabled, "
             "enable it setting the env variable `ENABLE_QEMU_SUPPORT=True` in configuration"
 

--- a/src/aleph/vm/orchestrator/README.md
+++ b/src/aleph/vm/orchestrator/README.md
@@ -86,7 +86,7 @@ is used to parse and validate Aleph messages.
 ```shell
 apt install -y --no-install-recommends --no-install-suggests python3-pip
 pip3 install pydantic[dotenv]
-pip3 install 'aleph-message==0.4.4'
+pip3 install 'aleph-message==0.4.7'
 ```
 
 ### 2.f. Create the jailer working directory:

--- a/src/aleph/vm/orchestrator/resources.py
+++ b/src/aleph/vm/orchestrator/resources.py
@@ -12,7 +12,12 @@ from pydantic import BaseModel, Field
 
 from aleph.vm.conf import settings
 from aleph.vm.sevclient import SevClient
-from aleph.vm.utils import cors_allow_all
+from aleph.vm.utils import (
+    check_amd_sev_es_supported,
+    check_amd_sev_snp_supported,
+    check_amd_sev_supported,
+    cors_allow_all,
+)
 
 
 class Period(BaseModel):
@@ -90,6 +95,16 @@ def get_machine_properties() -> MachineProperties:
         cpu=CpuProperties(
             architecture=cpu_info.get("raw_arch_string", cpu_info.get("arch_string_raw")),
             vendor=cpu_info.get("vendor_id", cpu_info.get("vendor_id_raw")),
+            features=list(
+                filter(
+                    None,
+                    (
+                        "sev" if check_amd_sev_supported() else None,
+                        "sev_es" if check_amd_sev_es_supported() else None,
+                        "sev_snp" if check_amd_sev_snp_supported() else None,
+                    ),
+                )
+            ),
         ),
     )
 

--- a/src/aleph/vm/utils/__init__.py
+++ b/src/aleph/vm/utils/__init__.py
@@ -143,7 +143,7 @@ def check_amd_sev_supported() -> bool:
     AMD Secure Encrypted Virtualization (SEV)
     Uses one key per virtual machine to isolate guests and the hypervisor from one another.
     """
-    return check_system_module("kvm_amd/parameters/sev") == "Y"
+    return (check_system_module("kvm_amd/parameters/sev") == "Y") and Path("/dev/sev").exists()
 
 
 def check_amd_sev_es_supported() -> bool:
@@ -152,7 +152,7 @@ def check_amd_sev_es_supported() -> bool:
     AMD Secure Encrypted Virtualization-Encrypted State (SEV-ES)
     Encrypts all CPU register contents when a VM stops running.
     """
-    return check_system_module("kvm_amd/parameters/sev_es") == "Y"
+    return (check_system_module("kvm_amd/parameters/sev_es") == "Y") and Path("/dev/sev").exists()
 
 
 def check_amd_sev_snp_supported() -> bool:

--- a/src/aleph/vm/utils/__init__.py
+++ b/src/aleph/vm/utils/__init__.py
@@ -137,6 +137,34 @@ def check_system_module(module_path: str) -> Optional[str]:
     return p.read_text().strip()
 
 
+def check_amd_sev_supported() -> bool:
+    """Check if AMD SEV is supported on the system.
+
+    AMD Secure Encrypted Virtualization (SEV)
+    Uses one key per virtual machine to isolate guests and the hypervisor from one another.
+    """
+    return check_system_module("kvm_amd/parameters/sev") == "Y"
+
+
+def check_amd_sev_es_supported() -> bool:
+    """Check if AMD SEV-ES is supported on the system.
+
+    AMD Secure Encrypted Virtualization-Encrypted State (SEV-ES)
+    Encrypts all CPU register contents when a VM stops running.
+    """
+    return check_system_module("kvm_amd/parameters/sev_es") == "Y"
+
+
+def check_amd_sev_snp_supported() -> bool:
+    """Check if AMD SEV-SNP is supported on the system.
+
+    AMD Secure Encrypted Virtualization-Secure Nested Paging (SEV-SNP)
+    Adds strong memory integrity protection to help prevent malicious hypervisor-based attacks like data replay,
+    memory re-mapping, and more in order to create an isolated execution environment.
+    """
+    return check_system_module("kvm_amd/parameters/sev_snp") == "Y"
+
+
 def fix_message_validation(message: dict) -> dict:
     """Patch a fake message program to pass validation."""
     message["item_content"] = json.dumps(message["content"])

--- a/tests/supervisor/test_utils.py
+++ b/tests/supervisor/test_utils.py
@@ -1,6 +1,11 @@
 from unittest import mock
 
-from aleph.vm.utils import check_system_module
+from aleph.vm.utils import (
+    check_amd_sev_es_supported,
+    check_amd_sev_snp_supported,
+    check_amd_sev_supported,
+    check_system_module,
+)
 
 
 def test_check_system_module_enabled():
@@ -11,9 +16,24 @@ def test_check_system_module_enabled():
     ):
         expected_value = "Y"
         with mock.patch(
-            "pathlib.Path.open",
+            "aleph.vm.utils.Path.open",
             mock.mock_open(read_data=expected_value),
         ):
 
             output = check_system_module("kvm_amd/parameters/sev_enp")
             assert output == expected_value
+
+            assert check_amd_sev_supported() is True
+            assert check_amd_sev_es_supported() is True
+            assert check_amd_sev_snp_supported() is True
+
+        with mock.patch(
+            "aleph.vm.utils.Path.open",
+            mock.mock_open(read_data="N"),
+        ):
+            output = check_system_module("kvm_amd/parameters/sev_enp")
+            assert output == "N"
+
+            assert check_amd_sev_supported() is False
+            assert check_amd_sev_es_supported() is False
+            assert check_amd_sev_snp_supported() is False


### PR DESCRIPTION
Trusted computing requires CPU features such as `sev`, `sev_es` and `sev_snp`.

This adds the field `properties.cpu.features` `/about/usage/system` as a list of CPU features.

Currently, only SEV related features are present, but more can be added, for example `avx2`, `fma` and `f16c`. Adding them will require ensuring that they are actually active and not just present on the CPU via `/proc/cpuinfo`.

This work is based on a proposal to add the relevant field on aleph-message: https://github.com/aleph-im/aleph-message/pull/100

Example JSON output:
```json
{
  "cpu": {
    "count": 12,
    "load_average": {
      "load1": 0.31494140625,
      "load5": 0.1806640625,
      "load15": 0.17138671875
    },
    "core_frequencies": {
      "min": 2200,
      "max": 3600
    }
  },
  "mem": {
    "total_kB": 16663798,
    "available_kB": 13188161
  },
  "disk": {
    "total_kB": 981630836,
    "available_kB": 879101616
  },
  "period": {
    "start_timestamp": "2024-05-29T18:16:00+00:00",
    "duration_seconds": 60
  },
  "properties": {
    "cpu": {
      "architecture": "x86_64",
      "vendor": "AuthenticAMD"
    },
    "features": [
      "sev"
    ]
  },
  "active": true
}
```