### PR TITLE
Fix: No .deb was built for Ubuntu 24.04

### DIFF
--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -19,6 +19,9 @@ jobs:
           - os: "ubuntu-22.04"
             make_target: "all-podman-ubuntu-2204"
             artifact_name: "aleph-vm.ubuntu-22.04.deb"
+          - os: "ubuntu-24.04"
+            make_target: "all-podman-ubuntu-2404"
+            artifact_name: "aleph-vm.ubuntu-24.04.deb"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -93,6 +93,17 @@ all-podman-ubuntu-2204: version
 	file target/aleph-vm.deb
 	mv target/aleph-vm.deb target/aleph-vm.ubuntu-22.04.deb
 
+all-podman-ubuntu-2404: version
+	cd .. && podman build -t localhost/aleph-vm-packaging-ubuntu-2404:latest -f ./packaging/ubuntu-24.04.dockerfile .
+	mkdir -p ./target
+	podman run --rm -ti \
+		-w /opt/packaging \
+		-v ./target:/opt/packaging/target \
+		localhost/aleph-vm-packaging-ubuntu-2404:latest \
+		make
+	file target/aleph-vm.deb
+	mv target/aleph-vm.deb target/aleph-vm.ubuntu-24.04.deb
+
 # extract Python requirements from Debian 11 container
 requirements-debian-11: all-podman-debian-11
 	podman run --rm -ti \
@@ -119,6 +130,15 @@ requirements-ubuntu-22.04: all-podman-ubuntu-2204
 		-v ./requirements-ubuntu-22.04.txt:/mnt/requirements-ubuntu-22.04.txt \
 		ubuntu:jammy \
 		bash -c "/opt/extract_requirements.sh /mnt/requirements-ubuntu-22.04.txt"
+
+# extract Python requirements from Ubuntu 24.04 container
+requirements-ubuntu-24.04: all-podman-ubuntu-2404
+	podman run --rm -ti \
+		-v ./target/aleph-vm.ubuntu-24.04.deb:/opt/packaging/target/aleph-vm.deb:ro \
+		-v ./extract_requirements.sh:/opt/extract_requirements.sh:ro \
+		-v ./requirements-ubuntu-24.04.txt:/mnt/requirements-ubuntu-24.04.txt \
+		ubuntu:noble \
+		bash -c "/opt/extract_requirements.sh /mnt/requirements-ubuntu-24.04.txt"
 
 # run on host in order to sign with GPG
 repository-bullseye:

--- a/packaging/ubuntu-24.04.dockerfile
+++ b/packaging/ubuntu-24.04.dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get -y upgrade && apt-get install -y \
+    make \
+    git \
+    curl \
+    sudo \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+COPY ../src/aleph ./src/aleph
+COPY ../packaging ./packaging
+COPY ../kernels ./kernels
+
+COPY ../examples/ ./examples


### PR DESCRIPTION
This adds support in the packaging/Makefile and in the CI to build packages for Ubuntu 24.04
