### PR TITLE
Fix: Orchestrator failed with `assert result["result"] == HTTPOk.status_code`

### DIFF
--- a/tests/supervisor/test_status.py
+++ b/tests/supervisor/test_status.py
@@ -1,0 +1,39 @@
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+from aleph_message.models import ItemHash
+
+from aleph.vm.orchestrator.status import check_internet
+
+
+@pytest.mark.asyncio
+async def test_check_internet_no_server_header():
+    vm_id = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
+
+    mock_session = Mock()
+    mock_session.get = MagicMock()
+    mock_session.get.__aenter__.return_value.json = AsyncMock(return_value={"result": 200})
+
+    # A "Server" header is always expected in the result from the VM.
+    # If it is not present, the diagnostic VM is not working correctly
+    # and an error must be raised.
+    with pytest.raises(ValueError):
+        await check_internet(mock_session, vm_id)
+
+
+@pytest.mark.asyncio
+async def test_check_internet_wrong_result_code():
+    vm_id = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
+
+    mock_session = Mock()
+    mock_session.get = MagicMock()
+
+    mock_session.get.return_value.__aenter__.return_value.json = AsyncMock(
+        return_value={"result": 200, "headers": {"Server": "nginx"}}
+    )
+    assert await check_internet(mock_session, vm_id) is True
+
+    mock_session.get.return_value.__aenter__.return_value.json = AsyncMock(
+        return_value={"result": 400, "headers": {"Server": "nginx"}}
+    )
+    assert await check_internet(mock_session, vm_id) is False


### PR DESCRIPTION
Problem:

The diagnostic VM returned HTTP 200 with {"result": False} when it could not connect to the internet.

Since this is an OK return code, `raise_for_status` did not raise an error and an assertion error was raised.

Solution:

Test that the returned status code also corresponds to HTTP OK.

Stacktrace:

```
Jun 05 10:39:20 testing-hetzner python3[1400146]: vm-5 1851967.687130 |V DEBUG | <<<
Jun 05 10:39:20 testing-hetzner python3[1400146]: vm-5
Jun 05 10:39:25 testing-hetzner python3[1400146]: vm-5 2024-06-05 10:39:25,688 | ERROR | Error handling request
Jun 05 10:39:25 testing-hetzner python3[1400146]: Traceback (most recent call last):
Jun 05 10:39:25 testing-hetzner python3[1400146]:   File "/opt/aleph-vm/aiohttp/web_protocol.py", line 452, in _handle_request
Jun 05 10:39:25 testing-hetzner python3[1400146]:     resp = await request_handler(request)
Jun 05 10:39:25 testing-hetzner python3[1400146]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 05 10:39:25 testing-hetzner python3[1400146]:   File "/opt/aleph-vm/sentry_sdk/integrations/aiohttp.py", line 139, in sentry_app_handle
Jun 05 10:39:25 testing-hetzner python3[1400146]:     reraise(*_capture_exception(hub))
Jun 05 10:39:25 testing-hetzner python3[1400146]:   File "/opt/aleph-vm/sentry_sdk/_compat.py", line 99, in reraise
Jun 05 10:39:25 testing-hetzner python3[1400146]:     raise value
Jun 05 10:39:25 testing-hetzner python3[1400146]:   File "/opt/aleph-vm/sentry_sdk/integrations/aiohttp.py", line 129, in sentry_app_handle
Jun 05 10:39:25 testing-hetzner python3[1400146]:     response = await old_handle(self, request)
Jun 05 10:39:25 testing-hetzner python3[1400146]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 05 10:39:25 testing-hetzner python3[1400146]:   File "/opt/aleph-vm/aiohttp/web_app.py", line 543, in _handle
Jun 05 10:39:25 testing-hetzner python3[1400146]:     resp = await handler(request)
Jun 05 10:39:25 testing-hetzner python3[1400146]:            ^^^^^^^^^^^^^^^^^^^^^^
Jun 05 10:39:25 testing-hetzner python3[1400146]:   File "/opt/aleph-vm/aiohttp/web_middlewares.py", line 114, in impl
Jun 05 10:39:25 testing-hetzner python3[1400146]:     return await handler(request)
Jun 05 10:39:25 testing-hetzner python3[1400146]:            ^^^^^^^^^^^^^^^^^^^^^^
Jun 05 10:39:25 testing-hetzner python3[1400146]:   File "/opt/aleph-vm/aleph/vm/orchestrator/supervisor.py", line 65, in server_version_middleware
Jun 05 10:39:25 testing-hetzner python3[1400146]:     resp: web.StreamResponse = await handler(request)
Jun 05 10:39:25 testing-hetzner python3[1400146]:                                ^^^^^^^^^^^^^^^^^^^^^^
Jun 05 10:39:25 testing-hetzner python3[1400146]:   File "/opt/aleph-vm/aleph/vm/orchestrator/views/__init__.py", line 215, in status_check_fastapi
Jun 05 10:39:25 testing-hetzner python3[1400146]:     "internet": await status.check_internet(session, fastapi_vm_id),
Jun 05 10:39:25 testing-hetzner python3[1400146]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 05 10:39:25 testing-hetzner python3[1400146]:   File "/opt/aleph-vm/aleph/vm/orchestrator/status.py", line 122, in check_internet
Jun 05 10:39:25 testing-hetzner python3[1400146]:     assert result["result"] == HTTPOk.status_code
Jun 05 10:39:25 testing-hetzner python3[1400146]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 05 10:39:25 testing-hetzner python3[1400146]: AssertionError
```

