### PR TITLE
Fix: Binary `sevctl` was absent from debian packages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,4 @@
 **/data.tgz
 /pydantic/
 **/target
+/packaging/sevctl/target

--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -7,6 +7,7 @@ jobs:
     name: "Build ${{ matrix.os }} Package"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         os: ["debian-11", "debian-12", "ubuntu-22.04"]
         include:

--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -38,6 +38,14 @@ jobs:
           cd packaging && make ${{ matrix.make_target }} && cd ..
           ls packaging/target
 
+      - name: Ensure that the relevant files are present in the package
+        run: |
+          dpkg --contents packaging/target/${{ matrix.artifact_name }} | grep /opt/kubo/ipfs
+          dpkg --contents packaging/target/${{ matrix.artifact_name }} | grep /opt/firecracker/firecracker
+          dpkg --contents packaging/target/${{ matrix.artifact_name }} | grep /opt/firecracker/jailer
+          dpkg --contents packaging/target/${{ matrix.artifact_name }} | grep /opt/firecracker/vmlinux.bin
+          dpkg --contents packaging/target/${{ matrix.artifact_name }} | grep /opt/sevctl
+
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}

--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -26,8 +26,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          submodules: true
           # Fetch the whole history for all tags and branches (required for aleph.__version__)
           fetch-depth: 0
+
+      - name: Initialize git submodules
+        run: git submodule init
 
       - run: |
           cd packaging && make ${{ matrix.make_target }} && cd ..

--- a/.github/workflows/test-on-droplets-matrix.yml
+++ b/.github/workflows/test-on-droplets-matrix.yml
@@ -26,6 +26,7 @@ jobs:
     timeout-minutes: 10
 
     strategy:
+      fail-fast: false
       matrix:
 
         # Check compatibility with all supported OSes.

--- a/.github/workflows/test-on-droplets-matrix.yml
+++ b/.github/workflows/test-on-droplets-matrix.yml
@@ -68,6 +68,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: true
 
       - name: Install doctl
         uses: digitalocean/action-doctl@v2

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ node_modules
 /runtimes/aleph-debian-11-python/rootfs/
 /packaging/aleph-vm/opt/
 /packaging/target/
+/packaging/sevctl/target/
 /packaging/repositories/*/db/
 /packaging/repositories/*/dists/
 /packaging/repositories/*/pool/

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -18,13 +18,14 @@ debian-package-code:
 	pip3 install --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.4.4' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'superfluid==0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12'
 	python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
-debian-package-resources: firecracker-bins vmlinux download-ipfs-kubo
+debian-package-resources: firecracker-bins vmlinux download-ipfs-kubo  target/bin/sevctl
 	rm -fr ./aleph-vm/opt/firecracker
 	mkdir -p ./aleph-vm/opt/firecracker
 	cp -pr ./target/vmlinux.bin ./aleph-vm/opt/firecracker/
 	cp -pr ./target/firecracker ./aleph-vm/opt/firecracker/
 	cp -pr ./target/jailer ./aleph-vm/opt/firecracker/
 	cp -pr ./target/kubo/kubo ./aleph-vm/opt/kubo
+	cp -pr ./target/bin/sevctl ./aleph-vm/opt/sevctl
 
 firecracker-bins: target-dir build-dir
 	mkdir -p ./build/firecracker-release
@@ -45,6 +46,11 @@ download-ipfs-kubo: target-dir build-dir
 	mkdir -p ./target/kubo
 	curl -fsSL https://github.com/ipfs/kubo/releases/download/v0.23.0/kubo_v0.23.0_linux-amd64.tar.gz | tar -xz --directory ./target/kubo
 
+target/bin/sevctl:
+	# Release 0.4.3 matches revision c41c9172be013d6f10b9e1d7286fcb021805d5a5
+	cargo install --git https://github.com/virtee/sevctl.git --rev c41c9172be013d6f10b9e1d7286fcb021805d5a5 --target x86_64-unknown-linux-gnu --root ./target
+	./target/bin/sevctl -V
+
 version:
 	python3 ./version_from_git.py --inplace deb aleph-vm/DEBIAN/control
 	python3 ./version_from_git.py --inplace __version__ ../src/aleph/vm/version.py
@@ -62,6 +68,7 @@ clean:
 	rm -fr ./aleph-vm/opt/firecracker/
 	rm -fr ./aleph-vm/opt/kubo/
 	rm -fr ./aleph-vm/opt/aleph-vm/
+	rm -fr ./sevctl/target/
 
 all-podman-debian-11: version
 	cd .. && podman build -t localhost/aleph-vm-packaging-debian-11:latest -f ./packaging/debian-11.dockerfile .
@@ -86,6 +93,8 @@ all-podman-debian-12: version
 	mv target/aleph-vm.deb target/aleph-vm.debian-12.deb
 
 all-podman-ubuntu-2204: version
+	# Ensure the sevctl submodule is checked out first.
+	git submodule init
 	cd .. && podman build -t localhost/aleph-vm-packaging-ubuntu-2204:latest -f ./packaging/ubuntu-22.04.dockerfile .
 	mkdir -p ./target
 	podman run --rm -ti \

--- a/packaging/debian-11.dockerfile
+++ b/packaging/debian-11.dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM rust:1.79.0-bullseye
 
 RUN apt-get update && apt-get -y upgrade && apt-get install -y \
     make \

--- a/packaging/debian-12.dockerfile
+++ b/packaging/debian-12.dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM rust:1.79.0-bookworm
 
 RUN apt-get update && apt-get -y upgrade && apt-get install -y \
     make \

--- a/packaging/ubuntu-22.04.dockerfile
+++ b/packaging/ubuntu-22.04.dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y \
     curl \
     sudo \
     python3-pip \
+    cargo \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt

--- a/packaging/ubuntu-24.04.dockerfile
+++ b/packaging/ubuntu-24.04.dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y \
     curl \
     sudo \
     python3-pip \
+    cargo \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -177,6 +177,7 @@ class Settings(BaseSettings):
 
     FIRECRACKER_PATH = Path("/opt/firecracker/firecracker")
     JAILER_PATH = Path("/opt/firecracker/jailer")
+    SEV_CTL_PATH = Path("/opt/sevctl")
     LINUX_PATH = Path("/opt/firecracker/vmlinux.bin")
     INIT_TIMEOUT: float = 20.0
 


### PR DESCRIPTION
Solution: Build `sevctl` using an upstream version of Rust (the version in Debian is not supported), and bundle it in the Debian packages.

Add a setting in aleph-vm with the path of the bundled binary.
