### PR TITLE
Problem: Crash when trying to auth via websocket

### DIFF
--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -337,11 +337,11 @@ async def status_public_config(request: web.Request):
     )
 
 
-def authenticate_api_request(request: web.Request) -> bool:
+def authenticate_api_request(request: web.Request, raises_on_missing_header=True) -> bool:
     """Authenticate an API request to update the VM allocations."""
     signature: bytes = request.headers.get("X-Auth-Signature", "").encode()
 
-    if not signature:
+    if not signature and raises_on_missing_header:
         raise web.HTTPUnauthorized(text="Authentication token is missing")
 
     # Use a simple authentication method: the hash of the signature should match the value in the settings

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -337,11 +337,11 @@ async def status_public_config(request: web.Request):
     )
 
 
-def authenticate_api_request(request: web.Request, raises_on_missing_header=True) -> bool:
+def authenticate_api_request(request: web.Request) -> bool:
     """Authenticate an API request to update the VM allocations."""
     signature: bytes = request.headers.get("X-Auth-Signature", "").encode()
 
-    if not signature and raises_on_missing_header:
+    if not signature:
         raise web.HTTPUnauthorized(text="Authentication token is missing")
 
     # Use a simple authentication method: the hash of the signature should match the value in the settings

--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -90,8 +90,8 @@ async def stream_logs(request: web.Request) -> web.StreamResponse:
 
 async def authenticate_for_vm_or_403(execution, request, vm_hash, ws):
     """Allow authentication via HEADER or via websocket"""
-    if authenticate_api_request(request):
-        logger.debug(f"Accepted request to access logs via the allocatioan api key on {vm_hash}")
+    if authenticate_api_request(request, raises_on_missing_header=False):
+        logger.debug(f"Accepted request to access logs via the allocation api key on {vm_hash}")
         return True
 
     first_message = await ws.receive_json()


### PR DESCRIPTION
The auth function in websocket was crashing when the header  "X-Auth-Signature" wasn't passed, even  that authentification method wasn't used.

Make it an option in the method so we can still have error raised in normal header auth