### PR TITLE
Fix: Correct string formatting in VM startup response

### DIFF
--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -182,7 +182,7 @@ async def operate_reboot(request: web.Request, authenticated_sender: str) -> web
             await create_vm_execution(vm_hash=vm_hash, pool=pool)
         return web.Response(status=200, body=f"Rebooted VM with ref {vm_hash}")
     else:
-        return web.Response(status=200, body="Starting VM (was not running) with ref {vm_hash}")
+        return web.Response(status=200, body=f"Starting VM (was not running) with ref {vm_hash}")
 
 
 @cors_allow_all


### PR DESCRIPTION
Problem:
{vm_hash} was not being replaced with the actual value.

![image](https://github.com/aleph-im/aleph-vm/assets/40899431/371c3140-6686-4ab3-b70c-9c4f3aa83661)
