### PR TITLE
Fix: CI Droplet cleanup failed when same name was used

### DIFF
--- a/.github/workflows/test-on-droplets-matrix.yml
+++ b/.github/workflows/test-on-droplets-matrix.yml
@@ -176,4 +176,9 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          doctl compute droplet delete -f aleph-vm-ci-${{ matrix.os_config.alias }}-${{ matrix.check_vm.alias }}
+          DROPLET_IDS=$(doctl compute droplet list --format "ID,Name" --no-header | grep "aleph-vm-ci-${{ matrix.os_config.alias }}-${{ matrix.check_vm.alias }}" | awk '{print $1}')
+
+          for DROPLET_ID in $DROPLET_IDS; do
+            echo "Deleting droplet with ID: $DROPLET_ID"
+            doctl compute droplet delete --force $DROPLET_ID
+          done


### PR DESCRIPTION
When there were multiple Droplets with the same name, cleanup using doctl compute droplet delete -f $NAME would not work.

Error: There are 3 Droplets with the name "aleph-vm-ci-XXX"; please provide a specific Droplet ID. [425559566, 425702949, 425703724]
