### PR TITLE
Add script to build OVMF file for confidential VMs

### DIFF
--- a/runtimes/ovmf/README.md
+++ b/runtimes/ovmf/README.md
@@ -1,0 +1,24 @@
+# OVMF build for Confidential VMs
+
+The files in this directory build a version of OVMF able to store SEV secrets
+in a physical memory region that will then be accessible by Grub. The final OVMF image
+also include Grub in order to measure OVMF+Grub before loading secrets inside
+the VM.
+
+This process relies on the patch sets produced by James Bottomley:
+https://listman.redhat.com/archives/edk2-devel-archive/2020-November/msg01247.html
+
+## Build instructions
+
+As this requires a patched version of Grub, it is advised to build both tools inside a container.
+
+
+e.g using podman
+```
+# Clone grub and edk2, and apply the patches
+bash ./download_dependencies.sh
+podman run -v ./build_ovmf.sh:/opt/build_ovmf.sh  -v ./downloads:/opt/downloads\
+ ubuntu:22.04  bash /opt/download_dependencies.sh
+# The OVMF.fd file will be in `downloads/edk2/Build/AmdSev/RELEASE_GCC5/FV/OVMF.fd
+cp downloads/edk2/Build/AmdSev/RELEASE_GCC5/FV/OVMF.fd confidential-OVMF.fd
+```

--- a/runtimes/ovmf/build_ovmf.sh
+++ b/runtimes/ovmf/build_ovmf.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+# Script to build OVMF + Grub for confidential computing. The resulting image will be
+# a single firmware image containing OVMF and Grub so that the entirety of the unencrypted
+# boot code can be measured before feeding secrets to the VM.
+
+set -eo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+GRUB_DIR="${SCRIPT_DIR}/downloads/grub"
+EDK2_DIR="${SCRIPT_DIR}/downloads/edk2"
+
+if [ ! -d "${GRUB_DIR}" ]; then
+  echo "Grub directory not found: ${GRUB_DIR}" >&2
+fi
+
+if [ ! -d "${EDK2_DIR}" ]; then
+  echo "EDK2 directory not found: ${EDK2_DIR}" >&2
+fi
+
+apt-get update
+# Packages for Grub
+apt-get install -y autoconf autopoint binutils bison flex gcc gettext git make pkg-config python3 python-is-python3
+# Packages for OVMF (there are some duplicates with Grub, kept for documentation)
+apt-get install -y bison build-essential dosfstools flex iasl libgmp3-dev libmpfr-dev mtools nasm subversion texinfo uuid-dev
+
+cd $GRUB_DIR
+./bootstrap
+./configure --prefix /usr/ --with-platform=efi --target=x86_64
+make
+make install
+
+# Build OVMF
+cd $EDK2_DIR
+OvmfPkg/build.sh -b RELEASE -p OvmfPkg/AmdSev/AmdSevX64.dsc

--- a/runtimes/ovmf/download_dependencies.sh
+++ b/runtimes/ovmf/download_dependencies.sh
@@ -1,0 +1,39 @@
+#! /bin/bash
+
+set -eo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DOWNLOAD_DIR="${SCRIPT_DIR}/downloads"
+PATCH_DIR="${SCRIPT_DIR}/patches"
+
+GRUB_GIT_REPOSITORY="https://github.com/aleph-im/grub.git"
+GRUB_COMMIT="aleph/efi-secrets"
+GRUB_DIR="${DOWNLOAD_DIR}/grub"
+
+EDK2_GIT_REPOSITORY="https://github.com/tianocore/edk2.git"
+EDK2_COMMIT="edk2-stable202205"
+EDK2_DIR="${DOWNLOAD_DIR}/edk2"
+
+# Download Grub
+git clone  --depth 1 --branch "${GRUB_COMMIT}" ${GRUB_GIT_REPOSITORY} "${GRUB_DIR}"
+
+# Download EDK2 (=OVMF)
+git clone --recurse-submodules "${EDK2_GIT_REPOSITORY}" "${EDK2_DIR}"
+
+
+
+
+# Apply patches to EDK2
+EDK2_PATCH_DIR="${PATCH_DIR}/edk2"
+pushd "${EDK2_DIR}" > /dev/null
+git checkout "${EDK2_COMMIT}"
+git submodule update
+# Default user is needed by git am. only set it for the repo if not set already
+if ! git config user.name > /dev/null; then
+    git config --local user.name "Your Name"
+fi
+if ! git config user.email > /dev/null; then
+    git config  --local user.email "you@example.com"
+fi
+git am --ignore-space-change --ignore-whitespace "${EDK2_PATCH_DIR}/0001-Fix-invokation-of-cryptomount-s-for-AMD-SEV.patch"
+popd > /dev/null

--- a/runtimes/ovmf/patches/edk2/0001-Fix-invokation-of-cryptomount-s-for-AMD-SEV.patch
+++ b/runtimes/ovmf/patches/edk2/0001-Fix-invokation-of-cryptomount-s-for-AMD-SEV.patch
@@ -1,0 +1,58 @@
+From b3f1d358cc4098fb59a778d5340018a4e73ff87f Mon Sep 17 00:00:00 2001
+From: Olivier Desenfans <desenfans.olivier@gmail.com>
+Date: Thu, 30 Jun 2022 10:38:18 +0200
+Subject: [PATCH] Fix invokation of cryptomount -s for AMD SEV
+
+The current implementation targeted the first version of James
+Bottomley's Grub patches. These patches have since been updated
+to move the secret loading part from a dedicated command to
+a secret-finding module that must be invoked with
+
+cryptomount -s MOD
+
+Fixed the name of the Grub module which was renamed from sevsecret
+to efisecret.
+---
+ OvmfPkg/AmdSev/Grub/grub.cfg | 10 ++--------
+ OvmfPkg/AmdSev/Grub/grub.sh  |  2 +-
+ 2 files changed, 3 insertions(+), 9 deletions(-)
+
+diff --git a/OvmfPkg/AmdSev/Grub/grub.cfg b/OvmfPkg/AmdSev/Grub/grub.cfg
+index 17be94277a..331baf798c 100644
+--- a/OvmfPkg/AmdSev/Grub/grub.cfg
++++ b/OvmfPkg/AmdSev/Grub/grub.cfg
+@@ -10,16 +10,10 @@
+ ##
+ 
+ echo "Entering grub config"
+-sevsecret
++cryptomount -s efisecret
+ if [ $? -ne 0 ]; then
+-    echo "Failed to locate anything in the SEV secret area, prompting for password"
++    echo "Failed to mount root securely, retrying with password prompt"
+     cryptomount -a
+-else
+-    cryptomount -s
+-    if [ $? -ne 0 ]; then
+-        echo "Failed to mount root securely, retrying with password prompt"
+-        cryptomount -a
+-    fi
+ fi
+ set root=
+ for f in (crypto*); do
+diff --git a/OvmfPkg/AmdSev/Grub/grub.sh b/OvmfPkg/AmdSev/Grub/grub.sh
+index 99807d7291..abec80d7da 100644
+--- a/OvmfPkg/AmdSev/Grub/grub.sh
++++ b/OvmfPkg/AmdSev/Grub/grub.sh
+@@ -44,7 +44,7 @@ GRUB_MODULES="
+             linux
+             linuxefi
+             reboot
+-            sevsecret
++            efisecret
+             "
+ basedir=$(dirname -- "$0")
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
I put this in the runtimes directory as for me it's kind of like a runtimes: We provide a default one that the user can use as is or as a base to build a customised version. But I'm open to suggestion.