### PR TITLE
Provide confidential example image

### DIFF
--- a/examples/example_confidential_image/README.md
+++ b/examples/example_confidential_image/README.md
@@ -42,7 +42,7 @@ as the owner of the directory.
 ```shell
 export ROOT_DIR=./extracted
 mkdir ${ROOT_DIR}
-sudo cp -R /mnt/debian/* ${ROOT_DIR}
+sudo cp --archive /mnt/debian/* ${ROOT_DIR}
 sudo chown -R ${USER}:${USER} ${ROOT_DIR}
 ```
 

--- a/examples/example_confidential_image/README.md
+++ b/examples/example_confidential_image/README.md
@@ -1,0 +1,77 @@
+# Create an encrypted VM image
+Theses samples scripts create an encrypted VM image suitable be used for confidential computing.
+
+They will create an encrypted partition, a boot partition and the necessary initramfs to decrypt the partition. The created image is designed to work in tandem with the custom OVMF found in `runtimes/ovmf` which can receive the decryption key in a secure channel via QMP and pass it to grub to decrypt the disk.  
+
+You can customise your VM by modifying the `setup_debian_rootfs.sh` script and  adding your instructions at the end. This script is run "inside" the VM chroot. For examples: add your user, ssh key or install additional software. 
+
+
+## Procedure to create the image
+### Requirements
+* guestmount
+* parted
+* cryptsetup
+
+On debian they can be installed via their respective packages :
+`apt install guestmount parted cryptsetup`
+
+### Procure a debian image
+Your image need to have cloud-init installed in it for the network setup. It is recommended to start from the genericcloud image. Experiment with using the nocloud image then installing cloud-init have failed to work.
+
+```shell
+wget https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2
+```
+
+### Extract the root filesystem
+To do so, we simply need to mount the raw image with `guestmount`.
+
+> Make sure that you stop the VM before exporting the root filesystem.
+
+```shell
+sudo mkdir -p /mnt/debian
+sudo guestmount \
+  --format=qcow2 \
+  -a ./debian-12-genericcloud-amd64.qcow2 \
+  -o allow_other \
+  -i /mnt/debian
+```
+
+Then, you can simply copy the root file system to any directory, set your own user
+as the owner of the directory.
+
+```shell
+export ROOT_DIR=./extracted
+mkdir ${ROOT_DIR}
+sudo cp -R /mnt/debian/* ${ROOT_DIR}
+sudo chown -R ${USER}:${USER} ${ROOT_DIR}
+```
+
+Clean up the mount
+```shell
+sudo guestunmount /mnt/debian
+sudo rm -r /mnt/debian
+```
+
+
+Run the build_debian_image.sh that will create the image with the encrypted disk 
+> This script will require sudo for certain commands
+```shell
+bash ./build_debian_image.sh -o ~/destination-image.img --password your-password -r $ROOT_DIR
+```
+
+
+## To test and further customise you image you can also boot it inside qemu
+```shell
+sudo qemu-system-x86_64 \
+  -drive format=raw,file=</path/to/your/image.img> \
+  -enable-kvm \
+  -m 2048 \
+  -nic user,model=virtio \
+  -nographic \
+  -serial mon:stdio \
+  -drive if=pflash,format=raw,unit=0,file=/usr/share/ovmf/OVMF.fd,readonly=on
+  ```
+
+> Once you have entered your password you might have to wait a minute or so for the disk to decrypt and boot.
+
+To exit qemu : press Ctrl a, x and then [Enter]

--- a/examples/example_confidential_image/README.md
+++ b/examples/example_confidential_image/README.md
@@ -36,14 +36,12 @@ sudo guestmount \
   -i /mnt/debian
 ```
 
-Then, you can simply copy the root file system to any directory, set your own user
-as the owner of the directory.
+Then, you can simply copy the root file system to any directory, take caution to preserve the proper permission like the setuid bit with the --archive option.
 
 ```shell
 export ROOT_DIR=./extracted
 mkdir ${ROOT_DIR}
 sudo cp --archive /mnt/debian/* ${ROOT_DIR}
-sudo chown -R ${USER}:${USER} ${ROOT_DIR}
 ```
 
 Clean up the mount

--- a/examples/example_confidential_image/README.md
+++ b/examples/example_confidential_image/README.md
@@ -57,6 +57,7 @@ Run the build_debian_image.sh that will create the image with the encrypted disk
 bash ./build_debian_image.sh -o ~/destination-image.img --password your-password -r $ROOT_DIR
 ```
 
+> If you need debuging you can pass the -x option to bash before the script name
 
 ## To test and further customise you image you can also boot it inside qemu
 ```shell

--- a/examples/example_confidential_image/build_debian_image.sh
+++ b/examples/example_confidential_image/build_debian_image.sh
@@ -11,8 +11,13 @@ MAPPER_NAME="cr_root"
 LOOP_DEVICE_ID=""
 MAPPED_DEVICE_ID=""
 MOUNT_POINT=""
+CLEANUP_DONE=false
 
 cleanup() {
+  if [ "$CLEANUP_DONE" = true ]; then
+    return
+  fi
+  CLEANUP_DONE=true
   echo "Cleaning up..."
   if mountpoint -q "${MOUNT_POINT}"; then
     sudo umount --recursive "${MOUNT_POINT}" || echo "Failed to unmount ${MOUNT_POINT}"
@@ -36,7 +41,7 @@ cleanup() {
 # - QUIT (SIGQUIT): Signal 3, sent when the user requests the process to quit and perform a core dump (e.g., pressing Ctrl+\).
 # - PIPE (SIGPIPE): Signal 13, sent when attempting to write to a pipe without a reader (e.g., in scripts using pipelines if a command in the pipeline exits prematurely).
 # - TERM (SIGTERM): Signal 15, sent by the kill command to request the process to terminate gracefully.
-trap cleanup HUP INT QUIT PIPE TERM
+trap cleanup EXIT HUP INT QUIT PIPE TERM
 
 usage() {
   cat <<USAGE >&2

--- a/examples/example_confidential_image/build_debian_image.sh
+++ b/examples/example_confidential_image/build_debian_image.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+ROOTFS_DIR=""
+IMAGE_SIZE="4GB"
+IMAGE_FILE=""
+MAPPER_NAME="cr_root"
+LOOP_DEVICE_ID=""
+MAPPED_DEVICE_ID=""
+MOUNT_POINT=""
+
+cleanup() {
+  echo "Cleaning up..."
+  if mountpoint -q "${MOUNT_POINT}"; then
+    sudo umount --recursive "${MOUNT_POINT}" || echo "Failed to unmount ${MOUNT_POINT}"
+  fi
+  if [ -n "${MAPPED_DEVICE_ID}" ]; then
+    sudo cryptsetup close "${MAPPED_DEVICE_ID}" || echo "Failed to close encrypted device ${MAPPED_DEVICE_ID}"
+  fi
+  if [ -n "${LOOP_DEVICE_ID}" ]; then
+    sudo losetup -d "${LOOP_DEVICE_ID}" || echo "Failed to detach loop device ${LOOP_DEVICE_ID}"
+  fi
+  if [ -f "${KEY_FILE}" ]; then
+    rm -f "${KEY_FILE}" || echo "Failed to remove key file ${KEY_FILE}"
+  fi
+}
+
+
+# Trap command to catch and handle various signals:
+# - EXIT: Triggered when the script exits (normal completion or an error).
+# - HUP (SIGHUP): Signal 1, sent when the controlling terminal is closed (e.g., terminal window closed or SSH session logout).
+# - INT (SIGINT): Signal 2, sent when the user interrupts the process (e.g., pressing Ctrl+C).
+# - QUIT (SIGQUIT): Signal 3, sent when the user requests the process to quit and perform a core dump (e.g., pressing Ctrl+\).
+# - PIPE (SIGPIPE): Signal 13, sent when attempting to write to a pipe without a reader (e.g., in scripts using pipelines if a command in the pipeline exits prematurely).
+# - TERM (SIGTERM): Signal 15, sent by the kill command to request the process to terminate gracefully.
+trap cleanup HUP INT QUIT PIPE TERM
+
+usage() {
+  cat <<USAGE >&2
+Usage:
+    $0 --rootfs-dir ROOTFS_DIR [--image-size IMAGE_SIZE] [--password DISK_PASSWORD] [--mapper-name MAPPER_NAME]
+    -o IMAGE_FILE | --output IMAGE_FILE       Image file to use. Defaults to "<ROOTFS_DIR>.img."
+    -p DISK_PASSWORD | --password=DISK_PASSWORD   Password to use for the encrypted disk. Automatically generated if not specified.
+    -r ROOTFS_DIR | --rootfs-dir=ROOTFS_DIR   Directory containing the original rootfs.
+    -s IMAGE_SIZE | --image-size IMAGE_SIZE   Size of the target image, ex: 20GB. Defaults to 4GB.
+    -m MAPPER_NAME | --mapper-name=MAPPER_NAME   Device mapped name for encrypted disk. Default to "cr_root" if not specified.
+USAGE
+}
+
+while true; do
+  case "$1" in
+  -o | --output)
+    IMAGE_FILE=$2
+    shift 2
+    ;;
+  -p | --password)
+    DISK_PASSWORD=$2
+    shift 2
+    ;;
+  -r | --rootfs-dir)
+    ROOTFS_DIR=$2
+    shift 2
+    ;;
+  -s | --image-size)
+    IMAGE_SIZE=$2
+    shift 2
+    ;;
+  -m | --mapper-name)
+      MAPPER_NAME=$2
+      shift 2
+      ;;
+  *)
+    break
+    ;;
+  esac
+done
+
+if [ -z "${ROOTFS_DIR}" ]; then
+  usage
+  exit 1
+fi
+
+if [ -z "${DISK_PASSWORD}" ]; then
+  echo "No disk password provided. Generating one..."
+  DISK_PASSWORD=$(
+    tr </dev/urandom -dc _A-Z-a-z-0-9 | head -c${1:-16}
+    echo
+  )
+fi
+
+if [ -z "${IMAGE_FILE}" ]; then
+  IMAGE_FILE="$(basename ${ROOTFS_DIR}).img"
+fi
+
+BOOT_PARTITION_SIZE=100MiB
+KEY_FILE="${SCRIPT_DIR}/os_partition.key"
+
+truncate -s "${IMAGE_SIZE}" "${IMAGE_FILE}"
+
+# Create two partitions: a FAT32 boot partition for Grub and an ext4 partition for Debian
+# TODO: is there a way to do all this without sudo?
+echo "Creating partitions..."
+sudo parted "${IMAGE_FILE}" mklabel gpt
+sudo parted "${IMAGE_FILE}" mkpart primary 1Mib "${BOOT_PARTITION_SIZE}"
+sudo parted "${IMAGE_FILE}" mkpart primary "${BOOT_PARTITION_SIZE}" 100%
+
+# Mark partition 1 as boot+ESP
+sudo parted "${IMAGE_FILE}" set 1 esp on
+sudo parted "${IMAGE_FILE}" set 1 boot on
+
+# Mount the disk as a loop device and get the device ID
+LOOP_DEVICE_ID=$(sudo losetup --partscan --find --show "${IMAGE_FILE}")
+BOOT_PARTITION_DEVICE_ID="${LOOP_DEVICE_ID}p1"
+OS_PARTITION_DEVICE_ID="${LOOP_DEVICE_ID}p2"
+
+# Format the boot partition
+echo "Formatting the boot partition..."
+sudo mkfs.vfat "${BOOT_PARTITION_DEVICE_ID}"
+
+echo "Encrypting and formatting the OS partition..."
+MAPPED_DEVICE_ID="/dev/mapper/${MAPPER_NAME}"
+MOUNT_POINT="/mnt/${MAPPER_NAME}"
+echo -n "${DISK_PASSWORD}" >"${KEY_FILE}"
+
+sudo cryptsetup --batch-mode --type luks1 --key-file "${KEY_FILE}" luksFormat "${OS_PARTITION_DEVICE_ID}"
+sudo cryptsetup open --key-file "${KEY_FILE}" "${OS_PARTITION_DEVICE_ID}" "${MAPPER_NAME}"
+sudo mkfs.ext4 "${MAPPED_DEVICE_ID}"
+
+echo "Copying root file system to the new OS partition..."
+sudo mkdir -p "${MOUNT_POINT}"
+sudo mount "${MAPPED_DEVICE_ID}" "${MOUNT_POINT}"
+sudo cp -R "${ROOTFS_DIR}"/* "${MOUNT_POINT}"
+
+echo "Configuring root file system..."
+for m in run sys proc dev; do sudo mount --bind /$m ${MOUNT_POINT}/$m; done
+sudo cp "${SCRIPT_DIR}/setup_debian_rootfs.sh" "${KEY_FILE}" "${MOUNT_POINT}"
+sudo chroot "${MOUNT_POINT}" bash setup_debian_rootfs.sh --loop-device-id "${LOOP_DEVICE_ID}" --mapper-name "${MAPPER_NAME}"
+sudo rm "${MOUNT_POINT}/setup_debian_rootfs.sh" "${KEY_FILE}"
+
+cleanup
+
+echo "Done! The new image is available as ${IMAGE_FILE}."
+echo "Disk password: ${DISK_PASSWORD}"

--- a/examples/example_confidential_image/build_debian_image.sh
+++ b/examples/example_confidential_image/build_debian_image.sh
@@ -137,7 +137,7 @@ sudo mkfs.ext4 "${MAPPED_DEVICE_ID}"
 echo "Copying root file system to the new OS partition..."
 sudo mkdir -p "${MOUNT_POINT}"
 sudo mount "${MAPPED_DEVICE_ID}" "${MOUNT_POINT}"
-sudo cp -R "${ROOTFS_DIR}"/* "${MOUNT_POINT}"
+sudo cp --archive "${ROOTFS_DIR}"/* "${MOUNT_POINT}"
 
 echo "Configuring root file system..."
 for m in run sys proc dev; do sudo mount --bind /$m ${MOUNT_POINT}/$m; done

--- a/examples/example_confidential_image/setup_debian_rootfs.sh
+++ b/examples/example_confidential_image/setup_debian_rootfs.sh
@@ -106,4 +106,9 @@ update-initramfs -u
 # Generate system SSH keys
 ssh-keygen -A
 
+# Example to add a sudo user
+useradd -m -s /bin/bash username
+echo 'username:password' | chpasswd
+usermod -aG sudo username
+
 umount /tmp

--- a/examples/example_confidential_image/setup_debian_rootfs.sh
+++ b/examples/example_confidential_image/setup_debian_rootfs.sh
@@ -1,0 +1,109 @@
+#! /bin/bash
+# This script sets up the Debian root file system to boot from an encrypted OS partition.
+# In details:
+# * Configure crypttab to add a second key to the OS partition to make the kernel unlock
+#   the partition by itself without requiring user input
+# * Configure /etc/fstab to point to the correct devices
+# * Regenerate Grub in removable so that the only unencrypted script just points to
+#   the Grub scripts inside the encrypted partition
+# * Update the initramfs to take the modifications to the config files into account.
+
+set -eo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+LOOP_DEVICE_ID=""
+MAPPER_NAME=""
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $0 --loop-device LOOP_DEVICE_ID [--mapper-name MAPPER_NAME]
+    -d LOOP_DEVICE_ID | --loop-device-id=LOOP_DEVICE_ID   Device ID of the disk image.
+    -m MAPPER_NAME | --mapper-name=MAPPER_NAME   Device mapped name for encrypted disk. Automatically set to "cr_root" if not specified.
+USAGE
+}
+
+while test -n "$1"; do
+  case "$1" in
+  -d | --loop-device-id)
+    LOOP_DEVICE_ID=$2
+    shift 2
+    ;;
+  -p | --mapper-name)
+      MAPPER_NAME=$2
+      shift 2
+      ;;
+  esac
+done
+
+if [ -z "${LOOP_DEVICE_ID}" ]; then
+  usage
+  exit 1
+fi
+
+if [ -z "${MAPPER_NAME}" ]; then
+  MAPPER_NAME=cr_root
+fi
+
+# Temporary tmp is needed for apt
+mount -t tmpfs  -o size=100M tmpfs /tmp
+#  Install crypsetup and openssh
+DEBIAN_FRONTEND=noninteractive apt update
+DEBIAN_FRONTEND=noninteractive apt install -y -f openssh-server openssh-client cryptsetup cryptsetup-initramfs
+
+# The original password of the OS partition. Must be provided by the caller of the script.
+BOOT_KEY_FILE="${SCRIPT_DIR}/os_partition.key"
+
+BOOT_PARTITION_DEVICE_ID="${LOOP_DEVICE_ID}p1"
+OS_PARTITION_DEVICE_ID="${LOOP_DEVICE_ID}p2"
+
+BOOT_PARTITION_UUID=$(blkid --match-tag=UUID --output=value "${BOOT_PARTITION_DEVICE_ID}" )
+OS_PARTITION_UUID=$(blkid --match-tag=UUID --output=value "${OS_PARTITION_DEVICE_ID}" )
+
+MAPPED_DEVICE_ID="/dev/mapper/${MAPPER_NAME}"
+
+# Create key file to unlock the disk at boot
+mkdir -p /etc/cryptsetup-keys.d
+KEY_FILE="/etc/cryptsetup-keys.d/luks-${OS_PARTITION_UUID}.key"
+dd if=/dev/urandom bs=1 count=33|base64 -w 0 > "${KEY_FILE}"
+chmod 0600 "${KEY_FILE}"
+cryptsetup \
+  --key-slot 1 \
+  --iter-time 1 \
+  --key-file "${BOOT_KEY_FILE}" \
+  luksAddKey "${OS_PARTITION_DEVICE_ID}" \
+  "${KEY_FILE}"
+
+# Tell the kernel to look for keys in /etc/cryptsetup-keys.d
+echo "KEYFILE_PATTERN=\"/etc/cryptsetup-keys.d/*\"" >>/etc/cryptsetup-initramfs/conf-hook
+
+# Reduce the accessibility of the initramfs
+echo "UMASK=0077" >> /etc/initramfs-tools/initramfs.conf
+
+# Configure Grub and crypttab
+echo "GRUB_ENABLE_CRYPTODISK=y" >> /etc/default/grub
+echo 'GRUB_PRELOAD_MODULES="luks cryptodisk lvm ext2"' >> /etc/default/grub
+echo "${MAPPER_NAME} UUID=${OS_PARTITION_UUID} ${KEY_FILE} luks" >> /etc/crypttab
+cat << EOF > /etc/fstab
+${MAPPED_DEVICE_ID} / ext4 rw,discard,errors=remount-ro 0 1
+UUID=${BOOT_PARTITION_UUID} /boot/efi vfat defaults 0 0
+EOF
+
+# Install Grub and regenerate grub.cfg
+mount /boot/efi
+grub-install --target=x86_64-efi --removable
+grub-install --target=x86_64-efi --recheck
+grub-mkconfig -o /boot/grub/grub.cfg
+umount /boot/efi
+
+# Force Grub config to use a crypt device
+sed -i "s+root=PARTUUID= +cryptdevice=UUID=${OS_PARTITION_UUID}:${MAPPER_NAME} root=${MAPPED_DEVICE_ID} +g" /boot/grub/grub.cfg
+
+# Update initramfs after changes to fstab and crypttab
+update-initramfs -u
+
+# Generate system SSH keys
+ssh-keygen -A
+
+umount /tmp


### PR DESCRIPTION
I have moved the creation scripts from Olivier Desenfans , and improved them
They now  clean up ressources  the loop device and mount on crash.
Compared to the original method it is not necessary anymore to log into the original image to upgrade the kernel and install cryptsetup before launching the scripts.
The whole procedure is also now documented

I have also fixed a bug with the permission that broke `sudo` and other suid executable inside the VM.