### PR TITLE
Improve instances code

### DIFF
--- a/runtimes/instance-rootfs/create-debian-11-qemu-disk.sh
+++ b/runtimes/instance-rootfs/create-debian-11-qemu-disk.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euf
+
+# Variables
+ROOTFS_FILENAME="./rootfs.img"
+IMAGE_URL="https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-genericcloud-amd64.qcow2"
+IMAGE_NAME="debian-11-genericcloud-amd64.qcow2"
+
+# Cleanup previous run
+rm -f "$ROOTFS_FILENAME"
+
+# Download Ubuntu image
+echo "Downloading Debian 11 image"
+curl -L "$IMAGE_URL" -o "$IMAGE_NAME"
+
+# Rename final file
+mv "$IMAGE_NAME" "$ROOTFS_FILENAME"

--- a/runtimes/instance-rootfs/create-debian-12-qemu-disk.sh
+++ b/runtimes/instance-rootfs/create-debian-12-qemu-disk.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euf
+
+# Variables
+ROOTFS_FILENAME="./rootfs.img"
+IMAGE_URL="https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
+IMAGE_NAME="debian-12-genericcloud-amd64.qcow2"
+
+# Cleanup previous run
+rm -f "$ROOTFS_FILENAME"
+
+# Download Ubuntu image
+echo "Downloading Debian 12 image"
+curl -L "$IMAGE_URL" -o "$IMAGE_NAME"
+
+# Rename final file
+mv "$IMAGE_NAME" "$ROOTFS_FILENAME"

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -477,6 +477,7 @@ class MicroVM:
             await asyncio.sleep(1)
             root_fs = self.mounted_rootfs.name
             system(f"dmsetup remove {root_fs}")
+            system(f"dmsetup remove {root_fs}_base")
             if self.use_jailer and Path(self.jailer_path).is_dir():
                 shutil.rmtree(self.jailer_path)
 


### PR DESCRIPTION
Problem: If an instance is created and removed, one of the base mounted devices remains on the system. Also, a user cannot create a `Qemu` disk from Debian image.

Solution: Remove the useless device from the system and create the two needed script to create `Qemu` Debian runtimes.