### PR TITLE
Solve Websocket error handling

### DIFF
--- a/tests/supervisor/views/test_operator.py
+++ b/tests/supervisor/views/test_operator.py
@@ -349,6 +349,9 @@ async def test_websocket_logs_invalid_auth(aiohttp_client, mocker):
     await websocket.send_json({"auth": "invalid auth package"})
     response = await websocket.receive()
     # Subject to change in the future, for now the connexion si broken and closed
+    assert response.type == aiohttp.WSMsgType.TEXT
+    assert response.data == '{"status": "failed", "reason": "string indices must be integers"}'
+    response = await websocket.receive()
     assert response.type == aiohttp.WSMsgType.CLOSE
     assert websocket.closed
 


### PR DESCRIPTION
Problem: If the frontend or a user send and incorrect auth payload, the endpoint just stop sharing data without return anything or close the connection.

Solution: Handle error issues on the endpoint to always return status field and the reason why it's failing, and closing the connection.