### PR TITLE
Solve Firecracker reboot issues

### DIFF
--- a/src/aleph/vm/controllers/__main__.py
+++ b/src/aleph/vm/controllers/__main__.py
@@ -91,7 +91,7 @@ async def handle_persistent_vm(config: Configuration, execution: Union[MicroVM, 
 
     def callback():
         """Callback for the signal handler to stop the VM and cleanup properly on SIGTERM."""
-        loop.create_task(execution.teardown())
+        loop.create_task(execution.stop())
 
     loop.add_signal_handler(signal.SIGTERM, callback)
 

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -181,6 +181,7 @@ class MicroVM:
         system(f"rm -fr {self.jailer_path}/dev/net/")
         system(f"rm -fr {self.jailer_path}/dev/kvm")
         system(f"rm -fr {self.jailer_path}/dev/urandom")
+        system(f"rm -fr {self.jailer_path}/dev/userfaultfd")
         system(f"rm -fr {self.jailer_path}/run/")
 
         if os.path.exists(path=self.vsock_path):

--- a/src/aleph/vm/hypervisors/qemu/qemuvm.py
+++ b/src/aleph/vm/hypervisors/qemu/qemuvm.py
@@ -146,6 +146,6 @@ class QemuVM:
             print("shutdown message sent")
             client.close()
 
-    async def teardown(self):
+    async def stop(self):
         """Stop the VM."""
         self.send_shutdown_message()


### PR DESCRIPTION
Problem: If the frontend or a user send the request to reboot a Firecracker instance, it stops but doesn't start again.

Solution: Change method to restart it just stopping the process, cleaning the firecracker run files and starting it again.