### PR TITLE
Small fixes noticed on new installations.

### DIFF
--- a/src/aleph/vm/orchestrator/status.py
+++ b/src/aleph/vm/orchestrator/status.py
@@ -120,7 +120,7 @@ async def check_internet(session: ClientSession, vm_id: ItemHash) -> bool:
     try:
         response: dict = await get_json_from_vm(session, vm_id, "/internet")
 
-        if not hasattr(response, "headers"):
+        if "headers" not in response:
             logger.error("The server cannot connect to Internet")
             return False
 

--- a/src/aleph/vm/orchestrator/status.py
+++ b/src/aleph/vm/orchestrator/status.py
@@ -120,6 +120,10 @@ async def check_internet(session: ClientSession, vm_id: ItemHash) -> bool:
     try:
         response: dict = await get_json_from_vm(session, vm_id, "/internet")
 
+        if not hasattr(response, "headers"):
+            logger.error("The server cannot connect to Internet")
+            return False
+
         # The HTTP Header "Server" must always be present in the result.
         if "Server" not in response["headers"]:
             raise ValueError("Server header not found in the result.")

--- a/src/aleph/vm/orchestrator/status.py
+++ b/src/aleph/vm/orchestrator/status.py
@@ -121,8 +121,7 @@ async def check_internet(session: ClientSession, vm_id: ItemHash) -> bool:
         response: dict = await get_json_from_vm(session, vm_id, "/internet")
 
         if "headers" not in response:
-            logger.error("The server cannot connect to Internet")
-            return False
+            raise ValueError("The server cannot connect to Internet")
 
         # The HTTP Header "Server" must always be present in the result.
         if "Server" not in response["headers"]:


### PR DESCRIPTION
Problem: If the server doesn't have access to Internet, it just crashes. Also, if an instance is removed, it fails removing the base block device.

Solution: Handle the crash and log as an error about the Internet connection. Check if the mounted block devices exist before removing it.