### PR TITLE
Problem: status_check_fastapi endpoint raising eror

### DIFF
--- a/src/aleph/vm/orchestrator/status.py
+++ b/src/aleph/vm/orchestrator/status.py
@@ -120,13 +120,6 @@ async def check_internet(session: ClientSession, vm_id: ItemHash) -> bool:
     try:
         response: dict = await get_json_from_vm(session, vm_id, "/internet")
 
-        if "headers" not in response:
-            raise ValueError("The server cannot connect to Internet")
-
-        # The HTTP Header "Server" must always be present in the result.
-        if "Server" not in response["headers"]:
-            raise ValueError("Server header not found in the result.")
-
         # The diagnostic VM returns HTTP 200 with {"result": False} when cannot connect to the internet.
         # else it forwards the return code if its own test endpoint.
         return response.get("result") == HTTPOk.status_code


### PR DESCRIPTION
Endpoint `/status/check/fastapi` was raising error when there was no internet inside vm

This was caused by `check_internet` raising an error instead of just returning False

Note: Contrarely to what was previously understood the diagnostic vm don't return a headers when the result is False.

Previous stacktrace
```
ValueError: The server cannot connect to Internet
  File "aiohttp/web_app.py", line 537, in _handle
    resp = await handler(request)
  File "aiohttp/web_middlewares.py", line 114, in impl
    return await handler(request)
  File "aleph/vm/orchestrator/supervisor.py", line 70, in server_version_middleware
    resp: web.StreamResponse = await handler(request)
  File "aleph/vm/orchestrator/views/__init__.py", line 215, in status_check_fastapi
    "internet": await status.check_internet(session, fastapi_vm_id),
  File "aleph/vm/orchestrator/status.py", line 124, in check_internet
    raise ValueError("The server cannot connect to Internet")
```

Sentry issue : https://alephim.sentry.io/issues/5654330290/