### PR TITLE
Solve auto-deployment network issues

### DIFF
--- a/.github/workflows/deploy-main-on-staging.yml
+++ b/.github/workflows/deploy-main-on-staging.yml
@@ -57,6 +57,10 @@ jobs:
           # Wait for /var/lib/apt/lists/lock to be unlocked on the remote host via SSH.
           while ssh root@${{ matrix.staging_servers.hostname }} lsof /var/lib/apt/lists/lock; do sleep 1; done
 
+          # Copy the artifact package to opt folder.
           scp packaging/target/${{ matrix.staging_servers.artifact_name }} root@${{ matrix.staging_servers.hostname }}:/opt
+          
+          # Stop Aleph VM supervisor service before install the new package again.
+          ssh root@${{ matrix.staging_servers.hostname }} DEBIAN_FRONTEND=noninteractive "systemctl stop aleph-vm-supervisor"
           ssh root@${{ matrix.staging_servers.hostname }} DEBIAN_FRONTEND=noninteractive "apt-get -o DPkg::Lock::Timeout=60 install -y --allow-downgrades /opt/${{ matrix.staging_servers.artifact_name }}"
 

--- a/src/aleph/vm/orchestrator/status.py
+++ b/src/aleph/vm/orchestrator/status.py
@@ -120,13 +120,6 @@ async def check_internet(session: ClientSession, vm_id: ItemHash) -> bool:
     try:
         response: dict = await get_json_from_vm(session, vm_id, "/internet")
 
-        if "headers" not in response:
-            raise ValueError("The server cannot connect to Internet")
-
-        # The HTTP Header "Server" must always be present in the result.
-        if "Server" not in response["headers"]:
-            raise ValueError("Server header not found in the result.")
-
         # The diagnostic VM returns HTTP 200 with {"result": False} when cannot connect to the internet.
         # else it forwards the return code if its own test endpoint.
         return response.get("result") == HTTPOk.status_code


### PR DESCRIPTION
Every time that a new PR is merged on the `main` branch, the auto-deployment on the staging servers makes the server fail cause issues on the network.

Solution: Stop `aleph-vm-supervisor` servicer before installing the new package.