### PR TITLE
Check message status before checking the payment

### DIFF
--- a/src/aleph/vm/orchestrator/messages.py
+++ b/src/aleph/vm/orchestrator/messages.py
@@ -1,7 +1,7 @@
 import asyncio
 import copy
 
-from aiohttp import ClientSession, ClientConnectorError, ClientResponseError
+from aiohttp import ClientConnectorError, ClientResponseError, ClientSession
 from aiohttp.web_exceptions import HTTPNotFound, HTTPServiceUnavailable
 from aleph_message.models import ExecutableMessage, ItemHash, MessageType
 from aleph_message.status import MessageStatus

--- a/src/aleph/vm/orchestrator/messages.py
+++ b/src/aleph/vm/orchestrator/messages.py
@@ -74,7 +74,11 @@ async def load_updated_message(
 
 
 async def get_message_status(item_hash: ItemHash) -> MessageStatus:
-    """Fetch the status of an execution from the reference API server."""
+    """
+    Fetch the status of an execution from the reference API server.
+    We use a normal API call to the CCN instead to use the connector because we want to get the updated status of the
+    message and bypass the messages cache.
+    """
     async with ClientSession() as session:
         url = f"{settings.API_SERVER}/api/v0/messages/{item_hash}"
         resp = await session.get(url)

--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -23,7 +23,7 @@ from aleph.vm.conf import settings
 from aleph.vm.pool import VmPool
 from aleph.vm.utils import create_task_log_exceptions
 
-from .messages import load_updated_message, get_message_status
+from .messages import get_message_status, load_updated_message
 from .payment import (
     compute_required_balance,
     compute_required_flow,

--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -16,13 +16,14 @@ from aleph_message.models import (
     ProgramMessage,
     parse_message,
 )
+from aleph_message.status import MessageStatus
 from yarl import URL
 
 from aleph.vm.conf import settings
 from aleph.vm.pool import VmPool
 from aleph.vm.utils import create_task_log_exceptions
 
-from .messages import load_updated_message
+from .messages import load_updated_message, get_message_status
 from .payment import (
     compute_required_balance,
     compute_required_flow,
@@ -148,6 +149,14 @@ async def monitor_payments(app: web.Application):
     while True:
         await asyncio.sleep(settings.PAYMENT_MONITOR_INTERVAL)
 
+        # Check if the executions continues existing or are forgotten before checking the payment
+        for vm_hash in pool.executions.keys():
+            message_status = await get_message_status(vm_hash)
+            if message_status != MessageStatus.PROCESSED:
+                logger.debug(f"Stopping {vm_hash} execution due to {message_status} message status")
+                await pool.stop_vm(vm_hash)
+                pool.forget_vm(vm_hash)
+
         # Check if the balance held in the wallet is sufficient holder tier resources (Not do it yet)
         for sender, chains in pool.get_executions_by_sender(payment_type=PaymentType.hold).items():
             for chain, executions in chains.items():
@@ -171,6 +180,7 @@ async def monitor_payments(app: web.Application):
                 logger.debug(
                     f"Get stream flow from Sender {sender} to Receiver {settings.PAYMENT_RECEIVER_ADDRESS} of {stream}"
                 )
+
                 required_stream = await compute_required_flow(executions)
                 logger.debug(f"Required stream for Sender {sender} executions: {required_stream}")
                 # Stop executions until the required stream is reached

--- a/tests/supervisor/test_status.py
+++ b/tests/supervisor/test_status.py
@@ -7,21 +7,6 @@ from aleph.vm.orchestrator.status import check_internet
 
 
 @pytest.mark.asyncio
-async def test_check_internet_no_server_header():
-    vm_id = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
-
-    mock_session = Mock()
-    mock_session.get = MagicMock()
-    mock_session.get.__aenter__.return_value.json = AsyncMock(return_value={"result": 200})
-
-    # A "Server" header is always expected in the result from the VM.
-    # If it is not present, the diagnostic VM is not working correctly
-    # and an error must be raised.
-    with pytest.raises(ValueError):
-        await check_internet(mock_session, vm_id)
-
-
-@pytest.mark.asyncio
 async def test_check_internet_wrong_result_code():
     vm_id = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
 


### PR DESCRIPTION
Problem: If a user allocates a VM and later forgets the VM, the payment task fails because cannot get the price for that execution.

Solution: Check the message status before checking the price and remove the execution if it is forgotten or on a different status than `processed`.