### PR TITLE
Problem: FirecrackerVM not working if /var/lib and /var/cache on two …

### DIFF
--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -324,7 +324,7 @@ class MicroVM:
             rootfs_filename = Path(path_on_host).name
             jailer_path_on_host = f"/opt/{rootfs_filename}"
             try:
-                os.link(path_on_host, f"{self.jailer_path}/{jailer_path_on_host}")
+                os.symlink(path_on_host, f"{self.jailer_path}/{jailer_path_on_host}")
             except FileExistsError:
                 logger.debug(f"File {jailer_path_on_host} already exists")
             return Path(jailer_path_on_host)

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -326,7 +326,7 @@ class MicroVM:
             rootfs_filename = Path(path_on_host).name
             jailer_path_on_host = f"/opt/{rootfs_filename}"
             try:
-                os.symlink(path_on_host, f"{self.jailer_path}/{jailer_path_on_host}")
+                os.link(path_on_host, f"{self.jailer_path}/{jailer_path_on_host}")
             except FileExistsError:
                 logger.debug(f"File {jailer_path_on_host} already exists")
             except OSError as err:


### PR DESCRIPTION
…separate partion

The prepare step for jailer was failing because it couldn't create a link to rootfs file when the CACHE and EXECUTION were not on the same partition

This was due do trying to make a hardlink instead of as soft symlink (contrary to what the docstring indicated)

Solution: Make a symlink