### PR TITLE
Fix CI slowness and correct  execution tests

### DIFF
--- a/.github/workflows/test-using-pytest.yml
+++ b/.github/workflows/test-using-pytest.yml
@@ -7,6 +7,12 @@ jobs:
   tests-python:
     name: "Test Python code"
     runs-on: ubuntu-22.04
+    services:
+      # Run vm connector for the execution tests
+      vm-connector:
+        image: alephim/vm-connector:alpha
+        ports:
+          - 4021:4021
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-using-pytest.yml
+++ b/.github/workflows/test-using-pytest.yml
@@ -1,4 +1,4 @@
-name: "Test on DigitalOcean Droplets"
+name: "py.test and linting"
 
 on:
   push

--- a/examples/example_fastapi/main.py
+++ b/examples/example_fastapi/main.py
@@ -25,7 +25,6 @@ from pip._internal.operations.freeze import freeze
 from pydantic import BaseModel, HttpUrl
 from starlette.responses import JSONResponse
 
-from aleph.sdk.chains.ethereum import get_fallback_account
 from aleph.sdk.chains.remote import RemoteAccount
 from aleph.sdk.client import AlephHttpClient, AuthenticatedAlephHttpClient
 from aleph.sdk.query.filters import MessageFilter
@@ -292,6 +291,7 @@ async def post_with_remote_account():
 @app.post("/post_a_message_local_account")
 async def post_with_local_account():
     """Post a message on the Aleph.im network using a local private key."""
+    from aleph.sdk.chains.ethereum import get_fallback_account
 
     account = get_fallback_account()
 
@@ -326,6 +326,8 @@ async def post_with_local_account():
 
 @app.post("/post_a_file")
 async def post_a_file():
+    from aleph.sdk.chains.ethereum import get_fallback_account
+
     account = get_fallback_account()
     file_path = Path(__file__).absolute()
     async with AuthenticatedAlephHttpClient(
@@ -351,6 +353,8 @@ async def post_a_file():
 async def sign_a_message():
     """Sign a message using a locally managed account within the virtual machine."""
     # FIXME: Broken, fixing this depends on https://github.com/aleph-im/aleph-sdk-python/pull/120
+    from aleph.sdk.chains.ethereum import get_fallback_account
+
     account = get_fallback_account()
     message = {"hello": "world", "chain": "ETH"}
     signed_message = await account.sign_message(message)

--- a/runtimes/aleph-debian-11-python/init1.py
+++ b/runtimes/aleph-debian-11-python/init1.py
@@ -247,6 +247,7 @@ async def setup_code_asgi(code: bytes, encoding: Encoding, entrypoint: str) -> A
         module = __import__(module_name)
         for level in module_name.split(".")[1:]:
             module = getattr(module, level)
+        logger.debug("import done")
         app = getattr(module, app_name)
     elif encoding == Encoding.plain:
         # Execute the code and extract the entrypoint

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -331,8 +331,8 @@ class MicroVM:
                 logger.debug(f"File {jailer_path_on_host} already exists")
             except OSError as err:
                 if err.errno == errno.EXDEV:
-                    #  Invalid cross-device link:
-                    # cannot make hard link between partition. Make a copy instead
+                    # Invalid cross-device link: cannot make hard link between partition.
+                    # In this case, copy the file instead:
                     shutil.copyfile(path_on_host, f"{self.jailer_path}/{jailer_path_on_host}")
                 else:
                     raise

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -1,4 +1,5 @@
 import asyncio
+import errno
 import json
 import logging
 import os.path
@@ -318,7 +319,8 @@ class MicroVM:
     def enable_file_rootfs(self, path_on_host: Path) -> Path:
         """Make a rootfs available to the VM.
 
-        Creates a symlink to the rootfs file if jailer is in use.
+        If jailer is in use, try to create a hardlink
+        If it is not possible to create a link because the dir are in separate device made a copy.
         """
         if self.use_jailer:
             rootfs_filename = Path(path_on_host).name
@@ -327,6 +329,13 @@ class MicroVM:
                 os.link(path_on_host, f"{self.jailer_path}/{jailer_path_on_host}")
             except FileExistsError:
                 logger.debug(f"File {jailer_path_on_host} already exists")
+            except OSError as err:
+                if err.errno == errno.EXDEV:
+                    #  Invalid cross-device link:
+                    # cannot make hard link between partition. Make a copy instead
+                    shutil.copyfile(path_on_host, f"{self.jailer_path}/{jailer_path_on_host}")
+                else:
+                    raise
             return Path(jailer_path_on_host)
         else:
             return path_on_host

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -148,6 +148,7 @@ async def get_message(ref: str) -> Union[ProgramMessage, InstanceMessage]:
         cache_path = settings.FAKE_INSTANCE_MESSAGE
     elif settings.FAKE_DATA_PROGRAM:
         cache_path = settings.FAKE_DATA_MESSAGE
+        logger.debug("Using the fake data message")
     else:
         cache_path = (Path(settings.MESSAGE_CACHE) / ref).with_suffix(".json")
         url = f"{settings.CONNECTOR_URL}/download/message/{ref}"

--- a/tests/supervisor/test_execution.py
+++ b/tests/supervisor/test_execution.py
@@ -91,8 +91,9 @@ async def test_create_execution_online(vm_hash: ItemHash = None):
         persistent=False,
     )
 
-    # Downloading the resources required may take some time, limit it to 10 seconds
-    await asyncio.wait_for(execution.prepare(), timeout=30)
+    # Downloading the resources required may take some time, limit it to 120 seconds
+    # since it is a bit slow in GitHub Actions
+    await asyncio.wait_for(execution.prepare(), timeout=120)
 
     vm = execution.create(vm_id=3, tap_interface=None)
 

--- a/tests/supervisor/test_execution.py
+++ b/tests/supervisor/test_execution.py
@@ -4,29 +4,35 @@ import logging
 import pytest
 from aleph_message.models import ItemHash
 
-from aleph.vm.conf import settings
+from aleph.vm.conf import Settings, settings
 from aleph.vm.controllers.firecracker import AlephFirecrackerProgram
 from aleph.vm.models import VmExecution
 from aleph.vm.orchestrator import metrics
+from aleph.vm.orchestrator.messages import load_updated_message
 from aleph.vm.storage import get_message
 
 
 @pytest.mark.asyncio
-async def test_create_execution():
+async def test_create_execution(mocker):
     """
     Create a new VM execution and check that it starts properly.
     """
+    mock_settings = Settings()
+    mocker.patch("aleph.vm.conf.settings", new=mock_settings)
+    mocker.patch("aleph.vm.storage.settings", new=mock_settings)
+    mocker.patch("aleph.vm.controllers.firecracker.executable.settings", new=mock_settings)
+    mocker.patch("aleph.vm.controllers.firecracker.program.settings", new=mock_settings)
 
-    settings.FAKE_DATA_PROGRAM = settings.BENCHMARK_FAKE_DATA_PROGRAM
-    settings.ALLOW_VM_NETWORKING = False
-    settings.USE_JAILER = False
+    mock_settings.FAKE_DATA_PROGRAM = mock_settings.BENCHMARK_FAKE_DATA_PROGRAM
+    mock_settings.ALLOW_VM_NETWORKING = False
+    mock_settings.USE_JAILER = False
 
     logging.basicConfig(level=logging.DEBUG)
-    settings.PRINT_SYSTEM_LOGS = True
+    mock_settings.PRINT_SYSTEM_LOGS = True
 
     # Ensure that the settings are correct and required files present.
-    settings.setup()
-    settings.check()
+    mock_settings.setup()
+    mock_settings.check()
 
     # The database is required for the metrics and is currently not optional.
     engine = metrics.setup_engine()
@@ -73,12 +79,12 @@ async def test_create_execution_online(vm_hash: ItemHash = None):
     engine = metrics.setup_engine()
     await metrics.create_tables(engine)
 
-    message = await get_message(ref=vm_hash)
+    message, original_message = await load_updated_message(vm_hash)
 
     execution = VmExecution(
         vm_hash=vm_hash,
         message=message.content,
-        original=message.content,
+        original=original_message.content,
         snapshot_manager=None,
         systemd_manager=None,
         persistent=False,
@@ -88,8 +94,11 @@ async def test_create_execution_online(vm_hash: ItemHash = None):
     await asyncio.wait_for(execution.prepare(), timeout=30)
 
     vm = execution.create(vm_id=3, tap_interface=None)
+
     # Test that the VM is created correctly. It is not started yet.
     assert isinstance(vm, AlephFirecrackerProgram)
+    vm.enable_console = True
+    vm.fvm.enable_log = True
     assert vm.vm_id == 3
 
     await execution.start()

--- a/tests/supervisor/test_execution.py
+++ b/tests/supervisor/test_execution.py
@@ -63,6 +63,7 @@ async def test_create_execution(mocker):
     await execution.stop()
 
 
+# This test depends on having a vm-connector running on port 4021
 @pytest.mark.asyncio
 async def test_create_execution_online(vm_hash: ItemHash = None):
     """
@@ -105,6 +106,7 @@ async def test_create_execution_online(vm_hash: ItemHash = None):
     await execution.stop()
 
 
+# This test depends on having a vm-connector running on port 4021
 @pytest.mark.asyncio
 async def test_create_execution_legacy():
     """


### PR DESCRIPTION
This PR solve a few issue with the tests:

- test_create_execution Was VERY VERY slow, more than 10 minutes to run. -> Now it run in less than 1 minutes
- test_create_execution_online  and test_create_execution_legacy were actually running the same test as test_create_execution. (because of a settings contamination) Which compelled the problem and made the whole test suite take 3/4h to run
- Additionally the code path of running a real program wasn't tested
- The Workflow name was not correct
- Execution test  of a program were failing on python 3.12

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.
- [x] Documentation has been updated regarding these changes.

## Changes
see above

## How to test
Everything is in CI

