### PR TITLE
Problem: ping: invalid value (`2.0' near `.0')

### DIFF
--- a/src/aleph/vm/controllers/firecracker/instance.py
+++ b/src/aleph/vm/controllers/firecracker/instance.py
@@ -133,7 +133,7 @@ class AlephFirecrackerInstance(AlephFirecrackerExecutable):
         ip = ip.split("/", 1)[0]
 
         attempts = 30
-        timeout_seconds = 2.0
+        timeout_seconds = 2
 
         for attempt in range(attempts):
             try:

--- a/src/aleph/vm/controllers/qemu/instance.py
+++ b/src/aleph/vm/controllers/qemu/instance.py
@@ -235,7 +235,7 @@ class AlephQemuInstance(Generic[ConfigurationType], CloudInitMixin, AlephVmContr
         ip = ip.split("/", 1)[0]
 
         attempts = 30
-        timeout_seconds = 2.0
+        timeout_seconds = 2
 
         for attempt in range(attempts):
             try:

--- a/src/aleph/vm/utils/__init__.py
+++ b/src/aleph/vm/utils/__init__.py
@@ -177,7 +177,7 @@ class HostNotFoundError(Exception):
     pass
 
 
-async def ping(host: str, packets: int, timeout: float):
+async def ping(host: str, packets: int, timeout: int):
     """
     Waits for a host to respond to a ping request.
     """


### PR DESCRIPTION
Symptoms:
Could not allocate a VM on some ubuntu server because the wait_for_init/ping
was failing

```
2024-09-03 12:18:47,259 | DEBUG | command: ping -c 1 -W 2.0 172.16.4.2
2024-09-03 12:18:47,259 | ERROR | Command failed with error code 1:
    stdin = None
    command = ['ping', '-c', '1', '-W', '2.0', '172.16.4.2']
    stdout = b"ping: invalid value (`2.0' near `.0')\n"
2024-09-03 12:18:47,260 | ERROR |
Traceback (most recent call last):
  File "/home/olivier/pycharm/aleph-vm/src/aleph/vm/utils/__init__.py", line 186, in ping
    await run_in_subprocess(["ping", "-c", str(packets), "-W", str(timeout), host], check=True)
  File "/home/olivier/pycharm/aleph-vm/src/aleph/vm/utils/__init__.py", line 121, in run_in_subprocess
    raise subprocess.CalledProcessError(process.returncode, str(command), stderr.decode())
subprocess.CalledProcessError: Command '['ping', '-c', '1', '-W', '2.0', '172.16.4.2']' returned non-zero exit status 1.
```

Causes:
The root cause seems to be that the ping command from the  deb package inetutils-ping 2.5-3ubuntu4 doesn't accept a float for it's -W argument

While the ping command  from the package 'iputils-ping' which we use on other server accept it.

Solution:
Convert the argument to a int since we didn't use the float part This allow compatibility with both version of the binary

Explain what problem this PR is resolving

Related ClickUp, GitHub or Jira tickets : ALEPH-XXX

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [na] An LLM was used to review the new code and look for simplifications.
- [na] New classes and functions contain docstrings explaining what they provide.
- [na] All new code is covered by relevant tests.
- [na] Documentation has been updated regarding these changes.

## Changes

See above

## How to test

use the `inetutils-ping` package (`apt install inetutils-ping`) and allocate a new VM, you can do so using the aleph instance create command
