### PR TITLE
Fix 199 ruff errors

### DIFF
--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -117,7 +117,8 @@ def obtain_dns_ips(dns_resolver: DnsResolver, network_interface: str) -> list[st
         return list(resolvectl_dns_servers_ipv4(interface=network_interface))
 
     else:
-        assert False, "No DNS resolve defined, this should never happen."
+        msg = "No DNS resolve defined, this should never happen."
+        raise AssertionError(msg)
 
 
 class Settings(BaseSettings):

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -9,7 +9,7 @@ from enum import Enum
 from os.path import abspath, exists, isdir, isfile, join
 from pathlib import Path
 from subprocess import CalledProcessError, check_output
-from typing import Any, Literal, NewType, Optional, Union
+from typing import Any, Literal, NewType
 
 from aleph_message.models import Chain
 from aleph_message.models.execution.environment import HypervisorType
@@ -17,7 +17,7 @@ from pydantic import BaseSettings, Field, HttpUrl
 from pydantic.env_settings import DotenvType, env_file_sentinel
 from pydantic.typing import StrPath
 
-from aleph.vm.orchestrator.chain import STREAM_CHAINS, ChainInfo
+from aleph.vm.orchestrator.chain import STREAM_CHAINS
 from aleph.vm.utils import (
     check_amd_sev_es_supported,
     check_amd_sev_supported,
@@ -85,7 +85,7 @@ def resolvectl_dns_servers_ipv4(interface: str) -> Iterable[str]:
             yield server
 
 
-def get_default_interface() -> Optional[str]:
+def get_default_interface() -> str | None:
     """Returns the default network interface"""
     with open("/proc/net/route") as f:
         for line in f.readlines():
@@ -150,7 +150,7 @@ class Settings(BaseSettings):
 
     # Networking does not work inside Docker/Podman
     ALLOW_VM_NETWORKING = True
-    NETWORK_INTERFACE: Optional[str] = None
+    NETWORK_INTERFACE: str | None = None
     IPV4_ADDRESS_POOL = Field(
         default="172.16.0.0/12",
         description="IPv4 address range used to provide networks to VMs.",
@@ -179,8 +179,8 @@ class Settings(BaseSettings):
         description="Use the Neighbor Discovery Protocol Proxy to respond to Router Solicitation for instances on IPv6",
     )
 
-    DNS_RESOLUTION: Optional[DnsResolver] = DnsResolver.detect
-    DNS_NAMESERVERS: Optional[list[str]] = None
+    DNS_RESOLUTION: DnsResolver | None = DnsResolver.detect
+    DNS_NAMESERVERS: list[str] | None = None
 
     FIRECRACKER_PATH = Path("/opt/firecracker/firecracker")
     JAILER_PATH = Path("/opt/firecracker/jailer")
@@ -259,7 +259,7 @@ class Settings(BaseSettings):
     ALLOCATION_TOKEN_HASH = "151ba92f2eb90bce67e912af2f7a5c17d8654b3d29895b042107ea312a7eebda"
 
     ENABLE_QEMU_SUPPORT: bool = Field(default=True)
-    INSTANCE_DEFAULT_HYPERVISOR: Optional[HypervisorType] = Field(
+    INSTANCE_DEFAULT_HYPERVISOR: HypervisorType | None = Field(
         default=HypervisorType.firecracker,  # User Firecracker
         description="Default hypervisor to use on running instances, can be Firecracker or QEmu",
     )
@@ -279,19 +279,17 @@ class Settings(BaseSettings):
 
     # Tests on programs
 
-    FAKE_DATA_PROGRAM: Optional[Path] = None
+    FAKE_DATA_PROGRAM: Path | None = None
     BENCHMARK_FAKE_DATA_PROGRAM = Path(abspath(join(__file__, "../../../../examples/example_fastapi")))
 
     FAKE_DATA_MESSAGE = Path(abspath(join(__file__, "../../../../examples/program_message_from_aleph.json")))
-    FAKE_DATA_DATA: Optional[Path] = Path(abspath(join(__file__, "../../../../examples/data/")))
+    FAKE_DATA_DATA: Path | None = Path(abspath(join(__file__, "../../../../examples/data/")))
     FAKE_DATA_RUNTIME = Path(abspath(join(__file__, "../../../../runtimes/aleph-debian-12-python/rootfs.squashfs")))
-    FAKE_DATA_VOLUME: Optional[Path] = Path(
-        abspath(join(__file__, "../../../../examples/volumes/volume-venv.squashfs"))
-    )
+    FAKE_DATA_VOLUME: Path | None = Path(abspath(join(__file__, "../../../../examples/volumes/volume-venv.squashfs")))
 
     # Tests on instances
 
-    TEST_INSTANCE_ID: Optional[str] = Field(
+    TEST_INSTANCE_ID: str | None = Field(
         default=None,  # TODO: Use a valid item_hash here
         description="Identifier of the instance message used when testing the launch of an instance from the network",
     )
@@ -312,11 +310,11 @@ class Settings(BaseSettings):
 
     # Developer options
 
-    SENTRY_DSN: Optional[str] = None
+    SENTRY_DSN: str | None = None
     SENTRY_TRACES_SAMPLE_RATE: float = Field(ge=0, le=1.0, default=0.1)
-    DEVELOPER_SSH_KEYS: Optional[list[str]] = []
+    DEVELOPER_SSH_KEYS: list[str] | None = []
     # Using an object here forces the value to come from Python code and not from an environment variable.
-    USE_DEVELOPER_SSH_KEYS: Union[Literal[False], object] = False
+    USE_DEVELOPER_SSH_KEYS: Literal[False] | object = False
 
     # Fields
     SENSITIVE_FIELDS: list[str] = Field(
@@ -461,10 +459,10 @@ class Settings(BaseSettings):
 
     def __init__(
         self,
-        _env_file: Optional[DotenvType] = env_file_sentinel,
-        _env_file_encoding: Optional[str] = None,
-        _env_nested_delimiter: Optional[str] = None,
-        _secrets_dir: Optional[StrPath] = None,
+        _env_file: DotenvType | None = env_file_sentinel,
+        _env_file_encoding: str | None = None,
+        _env_nested_delimiter: str | None = None,
+        _secrets_dir: StrPath | None = None,
         **values: Any,
     ) -> None:
         super().__init__(_env_file, _env_file_encoding, _env_nested_delimiter, _secrets_dir, **values)

--- a/src/aleph/vm/controllers/__main__.py
+++ b/src/aleph/vm/controllers/__main__.py
@@ -6,7 +6,6 @@ import signal
 import sys
 from asyncio.subprocess import Process
 from pathlib import Path
-from typing import Union
 
 from aleph.vm.hypervisors.firecracker.microvm import MicroVM
 from aleph.vm.hypervisors.qemu.qemuvm import QemuVM
@@ -85,7 +84,7 @@ async def execute_persistent_vm(config: Configuration):
     return execution, process
 
 
-async def handle_persistent_vm(config: Configuration, execution: Union[MicroVM, QemuVM], process: Process):
+async def handle_persistent_vm(config: Configuration, execution: MicroVM | QemuVM, process: Process):
     # Catch the terminating signal and send a proper message to the vm to stop it so it close files properly
     loop = asyncio.get_event_loop()
 

--- a/src/aleph/vm/controllers/configuration.py
+++ b/src/aleph/vm/controllers/configuration.py
@@ -1,7 +1,6 @@
 import logging
 from enum import Enum
 from pathlib import Path
-from typing import List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -26,26 +25,26 @@ class QemuVMHostVolume(BaseModel):
 
 class QemuVMConfiguration(BaseModel):
     qemu_bin_path: str
-    cloud_init_drive_path: Optional[str]
+    cloud_init_drive_path: str | None
     image_path: str
     monitor_socket_path: Path
     qmp_socket_path: Path
     vcpu_count: int
     mem_size_mb: int
-    interface_name: Optional[str]
-    host_volumes: List[QemuVMHostVolume]
+    interface_name: str | None
+    host_volumes: list[QemuVMHostVolume]
 
 
 class QemuConfidentialVMConfiguration(BaseModel):
     qemu_bin_path: str
-    cloud_init_drive_path: Optional[str]
+    cloud_init_drive_path: str | None
     image_path: str
     monitor_socket_path: Path
     qmp_socket_path: Path
     vcpu_count: int
     mem_size_mb: int
-    interface_name: Optional[str]
-    host_volumes: List[QemuVMHostVolume]
+    interface_name: str | None
+    host_volumes: list[QemuVMHostVolume]
     ovmf_path: Path
     sev_session_file: Path
     sev_dh_cert_file: Path
@@ -61,7 +60,7 @@ class Configuration(BaseModel):
     vm_id: int
     vm_hash: str
     settings: Settings
-    vm_configuration: Union[QemuConfidentialVMConfiguration, QemuVMConfiguration, VMConfiguration]
+    vm_configuration: QemuConfidentialVMConfiguration | QemuVMConfiguration | VMConfiguration
     hypervisor: HypervisorType = HypervisorType.firecracker
 
 

--- a/src/aleph/vm/controllers/firecracker/executable.py
+++ b/src/aleph/vm/controllers/firecracker/executable.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from multiprocessing import Process, set_start_method
 from os.path import exists, isfile
 from pathlib import Path
-from typing import Generic, Optional, TypeVar
+from typing import Generic, TypeVar
 
 from aiohttp import ClientResponseError
 from aleph_message.models import ExecutableContent, ItemHash
@@ -75,18 +75,18 @@ class HostVolume:
 @dataclass
 class BaseConfiguration:
     vm_hash: ItemHash
-    ip: Optional[str] = None
-    route: Optional[str] = None
+    ip: str | None = None
+    route: str | None = None
     dns_servers: list[str] = field(default_factory=list)
     volumes: list[Volume] = field(default_factory=list)
-    variables: Optional[dict[str, str]] = None
+    variables: dict[str, str] | None = None
 
 
 @dataclass
 class ConfigurationResponse:
     success: bool
-    error: Optional[str] = None
-    traceback: Optional[str] = None
+    error: str | None = None
+    traceback: str | None = None
 
 
 class AlephFirecrackerResources:
@@ -149,14 +149,14 @@ class AlephFirecrackerExecutable(Generic[ConfigurationType], AlephVmControllerIn
     enable_console: bool
     enable_networking: bool
     hardware_resources: MachineResources
-    tap_interface: Optional[TapInterface] = None
+    tap_interface: TapInterface | None = None
     fvm: MicroVM
-    vm_configuration: Optional[ConfigurationType]
-    guest_api_process: Optional[Process] = None
+    vm_configuration: ConfigurationType | None
+    guest_api_process: Process | None = None
     is_instance: bool
     persistent: bool
-    _firecracker_config: Optional[FirecrackerConfig] = None
-    controller_configuration: Optional[Configuration] = None
+    _firecracker_config: FirecrackerConfig | None = None
+    controller_configuration: Configuration | None = None
     support_snapshot: bool
 
     @property
@@ -169,9 +169,9 @@ class AlephFirecrackerExecutable(Generic[ConfigurationType], AlephVmControllerIn
         vm_hash: ItemHash,
         resources: AlephFirecrackerResources,
         enable_networking: bool = False,
-        enable_console: Optional[bool] = None,
-        hardware_resources: Optional[MachineResources] = None,
-        tap_interface: Optional[TapInterface] = None,
+        enable_console: bool | None = None,
+        hardware_resources: MachineResources | None = None,
+        tap_interface: TapInterface | None = None,
         persistent: bool = False,
         prepare_jailer: bool = True,
     ):

--- a/src/aleph/vm/controllers/firecracker/instance.py
+++ b/src/aleph/vm/controllers/firecracker/instance.py
@@ -4,7 +4,6 @@ import json
 import logging
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Optional, Union
 
 import yaml
 from aleph_message.models import ItemHash
@@ -56,7 +55,7 @@ class AlephInstanceResources(AlephFirecrackerResources):
 class AlephFirecrackerInstance(AlephFirecrackerExecutable):
     vm_configuration: BaseConfiguration
     resources: AlephInstanceResources
-    latest_snapshot: Optional[DiskVolumeSnapshot]
+    latest_snapshot: DiskVolumeSnapshot | None
     is_instance = True
     support_snapshot = False
 
@@ -66,9 +65,9 @@ class AlephFirecrackerInstance(AlephFirecrackerExecutable):
         vm_hash: ItemHash,
         resources: AlephInstanceResources,
         enable_networking: bool = False,
-        enable_console: Optional[bool] = None,
-        hardware_resources: Optional[MachineResources] = None,
-        tap_interface: Optional[TapInterface] = None,
+        enable_console: bool | None = None,
+        hardware_resources: MachineResources | None = None,
+        tap_interface: TapInterface | None = None,
         prepare_jailer: bool = True,
     ):
         self.latest_snapshot = None
@@ -169,13 +168,13 @@ class AlephFirecrackerInstance(AlephFirecrackerExecutable):
     def _encode_user_data(self) -> bytes:
         """Creates user data configuration file for cloud-init tool"""
 
-        ssh_authorized_keys: Optional[list[str]]
+        ssh_authorized_keys: list[str] | None
         if settings.USE_DEVELOPER_SSH_KEYS:
             ssh_authorized_keys = settings.DEVELOPER_SSH_KEYS or []
         else:
             ssh_authorized_keys = self.resources.message_content.authorized_keys or []
 
-        config: dict[str, Union[str, bool, list[str]]] = {
+        config: dict[str, str | bool | list[str]] = {
             "hostname": self._get_hostname(),
             "disable_root": False,
             "ssh_pwauth": False,

--- a/src/aleph/vm/controllers/firecracker/snapshot_manager.py
+++ b/src/aleph/vm/controllers/firecracker/snapshot_manager.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import threading
 from time import sleep
-from typing import Optional
 
 from aleph_message.models import ItemHash
 from schedule import Job, Scheduler
@@ -95,7 +94,7 @@ class SnapshotManager:
         )
         job_thread.start()
 
-    async def start_for(self, vm: AlephFirecrackerExecutable, frequency: Optional[int] = None) -> None:
+    async def start_for(self, vm: AlephFirecrackerExecutable, frequency: int | None = None) -> None:
         if not vm.support_snapshot:
             msg = "Snapshots are not implemented for programs."
             raise NotImplementedError(msg)

--- a/src/aleph/vm/controllers/firecracker/snapshots.py
+++ b/src/aleph/vm/controllers/firecracker/snapshots.py
@@ -1,6 +1,5 @@
 import logging
 from pathlib import Path
-from typing import Optional
 
 from aleph_message.models import ItemHash
 
@@ -35,7 +34,7 @@ class CompressedDiskVolumeSnapshot(DiskVolumeFile):
 
 
 class DiskVolumeSnapshot(DiskVolumeFile):
-    compressed: Optional[CompressedDiskVolumeSnapshot]
+    compressed: CompressedDiskVolumeSnapshot | None
 
     def delete(self) -> None:
         if self.compressed:

--- a/src/aleph/vm/controllers/interface.py
+++ b/src/aleph/vm/controllers/interface.py
@@ -2,8 +2,8 @@ import asyncio
 import logging
 from abc import ABC
 from asyncio.subprocess import Process
-from collections.abc import Coroutine
-from typing import Any, Callable, Optional
+from collections.abc import Callable, Coroutine
+from typing import Any
 
 from aleph_message.models import ItemHash
 from aleph_message.models.execution.environment import MachineResources
@@ -31,26 +31,26 @@ class AlephVmControllerInterface(ABC):
     hardware_resources: MachineResources
     support_snapshot: bool
     """Does this controller support snapshotting"""
-    guest_api_process: Optional[Process] = None
-    tap_interface: Optional[TapInterface] = None
+    guest_api_process: Process | None = None
+    tap_interface: TapInterface | None = None
     """Network interface used for this VM"""
 
-    def get_ip(self) -> Optional[str]:
+    def get_ip(self) -> str | None:
         if self.tap_interface:
             return self.tap_interface.guest_ip.with_prefixlen
         return None
 
-    def get_ip_route(self) -> Optional[str]:
+    def get_ip_route(self) -> str | None:
         if self.tap_interface:
             return str(self.tap_interface.host_ip).split("/", 1)[0]
         return None
 
-    def get_ipv6(self) -> Optional[str]:
+    def get_ipv6(self) -> str | None:
         if self.tap_interface:
             return self.tap_interface.guest_ipv6.with_prefixlen
         return None
 
-    def get_ipv6_gateway(self) -> Optional[str]:
+    def get_ipv6_gateway(self) -> str | None:
         if self.tap_interface:
             return str(self.tap_interface.host_ipv6.ip)
         return None

--- a/src/aleph/vm/controllers/qemu/client.py
+++ b/src/aleph/vm/controllers/qemu/client.py
@@ -16,7 +16,8 @@ class QemuVmClient:
     def __init__(self, vm):
         self.vm = vm
         if not (vm.qmp_socket_path and vm.qmp_socket_path.exists()):
-            raise Exception("VM is not running")
+            msg = "VM is not running"
+            raise Exception(msg)
         client = qmp.QEMUMonitorProtocol(str(vm.qmp_socket_path))
         client.connect()
 

--- a/src/aleph/vm/controllers/qemu/cloudinit.py
+++ b/src/aleph/vm/controllers/qemu/cloudinit.py
@@ -17,7 +17,6 @@ import base64
 import json
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Union
 
 import yaml
 from aleph_message.models import ItemHash
@@ -35,7 +34,7 @@ def get_hostname_from_hash(vm_hash: ItemHash) -> str:
 
 def encode_user_data(hostname, ssh_authorized_keys) -> bytes:
     """Creates user data configuration file for cloud-init tool"""
-    config: dict[str, Union[str, bool, list[str]]] = {
+    config: dict[str, str | bool | list[str]] = {
         "hostname": hostname,
         "disable_root": False,
         "ssh_pwauth": False,

--- a/src/aleph/vm/controllers/qemu/instance.py
+++ b/src/aleph/vm/controllers/qemu/instance.py
@@ -5,7 +5,7 @@ import shutil
 from asyncio import Task
 from asyncio.subprocess import Process
 from pathlib import Path
-from typing import Generic, Optional, TypeVar, Union
+from typing import Generic, TypeVar
 
 import psutil
 from aleph_message.models import ItemHash
@@ -47,9 +47,9 @@ class AlephQemuResources(AlephFirecrackerResources):
             self.download_volumes(),
         )
 
-    async def make_writable_volume(self, parent_image_path, volume: Union[PersistentVolume, RootfsVolume]):
+    async def make_writable_volume(self, parent_image_path, volume: PersistentVolume | RootfsVolume):
         """Create a new qcow2 image file based on the passed one, that we give to the VM to write onto"""
-        qemu_img_path: Optional[str] = shutil.which("qemu-img")
+        qemu_img_path: str | None = shutil.which("qemu-img")
         if not qemu_img_path:
             raise VmSetupError("qemu-img not found in PATH")
 
@@ -98,10 +98,10 @@ class AlephQemuInstance(Generic[ConfigurationType], CloudInitMixin, AlephVmContr
     resources: AlephQemuResources
     enable_networking: bool
     hardware_resources: MachineResources
-    tap_interface: Optional[TapInterface] = None
-    vm_configuration: Optional[ConfigurationType]
+    tap_interface: TapInterface | None = None
+    vm_configuration: ConfigurationType | None
     is_instance: bool
-    qemu_process: Optional[Process]
+    qemu_process: Process | None
     support_snapshot = False
     persistent = True
     controller_configuration: Configuration
@@ -119,7 +119,7 @@ class AlephQemuInstance(Generic[ConfigurationType], CloudInitMixin, AlephVmContr
         resources: AlephQemuResources,
         enable_networking: bool = False,
         hardware_resources: MachineResources = MachineResources(),
-        tap_interface: Optional[TapInterface] = None,
+        tap_interface: TapInterface | None = None,
     ):
         self.vm_id = vm_id
         self.vm_hash = vm_hash
@@ -253,7 +253,7 @@ class AlephQemuInstance(Generic[ConfigurationType], CloudInitMixin, AlephVmContr
     async def stop_guest_api(self):
         pass
 
-    print_task: Optional[Task] = None
+    print_task: Task | None = None
 
     async def teardown(self):
         if self.print_task:

--- a/src/aleph/vm/controllers/qemu/instance.py
+++ b/src/aleph/vm/controllers/qemu/instance.py
@@ -51,7 +51,8 @@ class AlephQemuResources(AlephFirecrackerResources):
         """Create a new qcow2 image file based on the passed one, that we give to the VM to write onto"""
         qemu_img_path: str | None = shutil.which("qemu-img")
         if not qemu_img_path:
-            raise VmSetupError("qemu-img not found in PATH")
+            msg = "qemu-img not found in PATH"
+            raise VmSetupError(msg)
 
         volume_name = volume.name if isinstance(volume, PersistentVolume) else "rootfs"
 
@@ -60,9 +61,11 @@ class AlephQemuResources(AlephFirecrackerResources):
         out = json.loads(out_json)
         parent_format = out.get("format", None)
         if parent_format is None:
-            raise VmSetupError(f"Failed to detect format for {volume}: {out_json}")
+            msg = f"Failed to detect format for {volume}: {out_json}"
+            raise VmSetupError(msg)
         if parent_format not in ("qcow2", "raw"):
-            raise VmSetupError(f"Format {parent_format} for {volume} unhandled by QEMU hypervisor")
+            msg = f"Format {parent_format} for {volume} unhandled by QEMU hypervisor"
+            raise VmSetupError(msg)
 
         dest_path = settings.PERSISTENT_VOLUMES_DIR / self.namespace / f"{volume_name}.qcow2"
         # Do not override if user asked for host persistance.

--- a/src/aleph/vm/controllers/qemu_confidential/instance.py
+++ b/src/aleph/vm/controllers/qemu_confidential/instance.py
@@ -2,8 +2,8 @@ import asyncio
 import logging
 import shutil
 from asyncio.subprocess import Process
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Optional
 
 from aleph_message.models import ItemHash
 from aleph_message.models.execution.environment import AMDSEVPolicy, MachineResources
@@ -50,10 +50,10 @@ class AlephQemuConfidentialInstance(AlephQemuInstance):
     enable_console: bool
     enable_networking: bool
     hardware_resources: MachineResources
-    tap_interface: Optional[TapInterface] = None
-    vm_configuration: Optional[ConfigurationType]
+    tap_interface: TapInterface | None = None
+    vm_configuration: ConfigurationType | None
     is_instance: bool
-    qemu_process: Optional[Process]
+    qemu_process: Process | None
     support_snapshot = False
     persistent = True
     _queue_cancellers: dict[asyncio.Queue, Callable] = {}
@@ -74,7 +74,7 @@ class AlephQemuConfidentialInstance(AlephQemuInstance):
         enable_networking: bool = False,
         confidential_policy: int = AMDSEVPolicy.NO_DBG,
         hardware_resources: MachineResources = MachineResources(),
-        tap_interface: Optional[TapInterface] = None,
+        tap_interface: TapInterface | None = None,
     ):
         super().__init__(vm_id, vm_hash, resources, enable_networking, hardware_resources, tap_interface)
         self.confidential_policy = confidential_policy

--- a/src/aleph/vm/guest_api/__main__.py
+++ b/src/aleph/vm/guest_api/__main__.py
@@ -2,7 +2,6 @@ import json
 import logging
 import re
 from pathlib import Path
-from typing import Optional
 
 import aiohttp
 import aioredis
@@ -20,7 +19,7 @@ ALEPH_VM_CONNECTOR = "http://localhost:4021"
 CACHE_EXPIRES_AFTER = 7 * 24 * 3600  # Seconds
 REDIS_ADDRESS = "redis://localhost"
 
-_redis: Optional[aioredis.Redis] = None
+_redis: aioredis.Redis | None = None
 
 
 async def get_redis(address: str = REDIS_ADDRESS) -> aioredis.Redis:
@@ -105,7 +104,7 @@ async def sign(request: web.Request):
 
 async def get_from_cache(request: web.Request):
     prefix: str = request.app["meta_vm_hash"]
-    key: Optional[str] = request.match_info.get("key")
+    key: str | None = request.match_info.get("key")
     if not (key and re.match(r"^\w+$", key)):
         return web.HTTPBadRequest(text="Invalid key")
 
@@ -119,7 +118,7 @@ async def get_from_cache(request: web.Request):
 
 async def put_in_cache(request: web.Request):
     prefix: str = request.app["meta_vm_hash"]
-    key: Optional[str] = request.match_info.get("key")
+    key: str | None = request.match_info.get("key")
     if not (key and re.match(r"^\w+$", key)):
         return web.HTTPBadRequest(text="Invalid key")
 
@@ -131,7 +130,7 @@ async def put_in_cache(request: web.Request):
 
 async def delete_from_cache(request: web.Request):
     prefix: str = request.app["meta_vm_hash"]
-    key: Optional[str] = request.match_info.get("key")
+    key: str | None = request.match_info.get("key")
     if not (key and re.match(r"^\w+$", key)):
         return web.HTTPBadRequest(text="Invalid key")
 
@@ -154,9 +153,9 @@ async def list_keys_from_cache(request: web.Request):
 
 def run_guest_api(
     unix_socket_path: Path,
-    vm_hash: Optional[str] = None,
-    sentry_dsn: Optional[str] = None,
-    server_name: Optional[str] = None,
+    vm_hash: str | None = None,
+    sentry_dsn: str | None = None,
+    server_name: str | None = None,
 ):
     # This function runs in a separate process, requiring to reinitialize the Sentry SDK
     if sentry_sdk and sentry_dsn:

--- a/src/aleph/vm/hypervisors/firecracker/config.py
+++ b/src/aleph/vm/hypervisors/firecracker/config.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Optional
 
 from pydantic import BaseModel, PositiveInt
 
@@ -52,8 +51,8 @@ class FirecrackerConfig(BaseModel):
     boot_source: BootSource
     drives: list[Drive]
     machine_config: MachineConfig
-    vsock: Optional[Vsock]
-    network_interfaces: Optional[list[NetworkInterface]]
+    vsock: Vsock | None
+    network_interfaces: list[NetworkInterface] | None
 
     class Config:
         allow_population_by_field_name = True

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -5,7 +5,6 @@ import logging
 import os.path
 import shutil
 import string
-import sys
 import traceback
 from asyncio import Task
 from asyncio.base_events import Server

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -296,10 +296,7 @@ class MicroVM:
             jailer_kernel_image_path = f"/opt/{kernel_filename}"
 
             try:
-                if sys.version_info >= (3, 10):
-                    Path(f"{self.jailer_path}{jailer_kernel_image_path}").hardlink_to(kernel_image_path)
-                else:
-                    kernel_image_path.link_to(f"{self.jailer_path}{jailer_kernel_image_path}")
+                Path(f"{self.jailer_path}{jailer_kernel_image_path}").hardlink_to(kernel_image_path)
             except FileExistsError:
                 logger.debug(f"File {jailer_kernel_image_path} already exists")
 
@@ -379,10 +376,7 @@ class MicroVM:
             jailer_path_on_host = f"/opt/{drive_filename}"
 
             try:
-                if sys.version_info >= (3, 10):
-                    Path(f"{self.jailer_path}/{jailer_path_on_host}").hardlink_to(drive_path)
-                else:
-                    drive_path.link_to(f"{self.jailer_path}/{jailer_path_on_host}")
+                Path(f"{self.jailer_path}/{jailer_path_on_host}").hardlink_to(drive_path)
             except FileExistsError:
                 logger.debug(f"File {jailer_path_on_host} already exists")
             drive_path = Path(jailer_path_on_host)

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -14,7 +14,7 @@ from os import getuid
 from pathlib import Path
 from pwd import getpwnam
 from tempfile import NamedTemporaryFile
-from typing import Any, Optional, TextIO
+from typing import Any
 
 import msgpack
 from aleph_message.models import ItemHash
@@ -83,16 +83,16 @@ class MicroVM:
     vm_id: int
     use_jailer: bool
     firecracker_bin_path: Path
-    jailer_bin_path: Optional[Path]
-    proc: Optional[asyncio.subprocess.Process] = None
-    stdout_task: Optional[Task] = None
-    stderr_task: Optional[Task] = None
-    config_file_path: Optional[Path] = None
+    jailer_bin_path: Path | None
+    proc: asyncio.subprocess.Process | None = None
+    stdout_task: Task | None = None
+    stderr_task: Task | None = None
+    config_file_path: Path | None = None
     drives: list[Drive]
     init_timeout: float
-    runtime_config: Optional[RuntimeConfiguration]
-    mounted_rootfs: Optional[Path] = None
-    _unix_socket: Optional[Server] = None
+    runtime_config: RuntimeConfiguration | None
+    mounted_rootfs: Path | None = None
+    _unix_socket: Server | None = None
     enable_log: bool
 
     def __repr__(self):
@@ -131,7 +131,7 @@ class MicroVM:
         firecracker_bin_path: Path,
         jailer_base_directory: Path,
         use_jailer: bool = True,
-        jailer_bin_path: Optional[Path] = None,
+        jailer_bin_path: Path | None = None,
         init_timeout: float = 5.0,
         enable_log: bool = True,
     ):

--- a/src/aleph/vm/hypervisors/qemu/qemuvm.py
+++ b/src/aleph/vm/hypervisors/qemu/qemuvm.py
@@ -2,7 +2,7 @@ import asyncio
 from asyncio.subprocess import Process
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, TextIO
+from typing import TextIO
 
 import qmp
 from systemd import journal
@@ -19,14 +19,14 @@ class HostVolume:
 
 class QemuVM:
     qemu_bin_path: str
-    cloud_init_drive_path: Optional[str]
+    cloud_init_drive_path: str | None
     image_path: str
     monitor_socket_path: Path
     qmp_socket_path: Path
     vcpu_count: int
     mem_size_mb: int
     interface_name: str
-    qemu_process: Optional[Process] = None
+    qemu_process: Process | None = None
     host_volumes: list[HostVolume]
 
     def __repr__(self) -> str:
@@ -129,7 +129,7 @@ class QemuVM:
         )
         return proc
 
-    def _get_qmpclient(self) -> Optional[qmp.QEMUMonitorProtocol]:
+    def _get_qmpclient(self) -> qmp.QEMUMonitorProtocol | None:
         if not (self.qmp_socket_path and self.qmp_socket_path.exists()):
             return None
         client = qmp.QEMUMonitorProtocol(str(self.qmp_socket_path))

--- a/src/aleph/vm/hypervisors/qemu_confidential/qemuvm.py
+++ b/src/aleph/vm/hypervisors/qemu_confidential/qemuvm.py
@@ -56,12 +56,14 @@ class QemuConfidentialVM(QemuVM):
         # TODO : ensure this is ok at launch
         sev_info = secure_encryption_info()
         if sev_info is None:
-            raise ValueError("Not running on an AMD SEV platform?")
+            msg = "Not running on an AMD SEV platform?"
+            raise ValueError(msg)
         godh = self.sev_dh_cert_file
         launch_blob = self.sev_session_file
 
         if not (godh.is_file() and launch_blob.is_file()):
-            raise FileNotFoundError("Missing guest owner certificates, cannot start the VM.`")
+            msg = "Missing guest owner certificates, cannot start the VM.`"
+            raise FileNotFoundError(msg)
         args = [
             self.qemu_bin_path,
             "-enable-kvm",

--- a/src/aleph/vm/hypervisors/qemu_confidential/qemuvm.py
+++ b/src/aleph/vm/hypervisors/qemu_confidential/qemuvm.py
@@ -8,7 +8,6 @@ from cpuid.features import secure_encryption_info
 from systemd import journal
 
 from aleph.vm.controllers.configuration import QemuConfidentialVMConfiguration
-from aleph.vm.controllers.qemu.instance import logger
 from aleph.vm.hypervisors.qemu.qemuvm import QemuVM
 
 

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -200,9 +200,11 @@ class VmExecution:
                     else:
                         resources = AlephQemuResources(self.message, namespace=self.vm_hash)
                 else:
-                    raise ValueError(f"Unknown hypervisor type {self.hypervisor}")
+                    msg = f"Unknown hypervisor type {self.hypervisor}"
+                    raise ValueError(msg)
             else:
-                raise ValueError("Unknown executable message type")
+                msg = "Unknown executable message type"
+                raise ValueError(msg)
 
             if not resources:
                 msg = "Unknown executable message type"
@@ -265,9 +267,11 @@ class VmExecution:
                         tap_interface=tap_interface,
                     )
             else:
-                raise Exception("Unknown VM")
+                msg = "Unknown VM"
+                raise Exception(msg)
         else:
-            raise Exception("Unknown VM")
+            msg = "Unknown VM"
+            raise Exception(msg)
 
         return vm
 

--- a/src/aleph/vm/network/hostnetwork.py
+++ b/src/aleph/vm/network/hostnetwork.py
@@ -1,7 +1,7 @@
 import logging
 from ipaddress import IPv6Network
 from pathlib import Path
-from typing import Optional, Protocol
+from typing import Protocol
 
 import pyroute2
 from aleph_message.models import ItemHash
@@ -105,8 +105,8 @@ def make_ipv6_allocator(
 
 
 class Network:
-    ipv4_forward_state_before_setup: Optional[int] = None
-    ipv6_forward_state_before_setup: Optional[int] = None
+    ipv4_forward_state_before_setup: int | None = None
+    ipv6_forward_state_before_setup: int | None = None
     external_interface: str
     ipv4_forwarding_enabled: bool
     ipv6_forwarding_enabled: bool
@@ -114,7 +114,7 @@ class Network:
     ipv4_address_pool: IPv4NetworkWithInterfaces = IPv4NetworkWithInterfaces("172.16.0.0/12")
     ipv6_address_pool: IPv6Network
     network_size: int
-    ndp_proxy: Optional[NdpProxy] = None
+    ndp_proxy: NdpProxy | None = None
 
     IPV6_SUBNET_PREFIX: int = 124
 

--- a/src/aleph/vm/network/interfaces.py
+++ b/src/aleph/vm/network/interfaces.py
@@ -3,7 +3,6 @@ import errno
 import logging
 import shutil
 from ipaddress import IPv4Interface, IPv6Interface, IPv6Network
-from typing import Optional, Union
 
 from pyroute2 import IPRoute, NetlinkError
 
@@ -44,7 +43,7 @@ def create_tap_interface(ipr: IPRoute, device_name: str):
             logger.error(f"Unknown exception while creating interface {device_name}: {error}")
 
 
-def add_ip_address(ipr: IPRoute, device_name: str, ip: Union[IPv4Interface, IPv6Interface]):
+def add_ip_address(ipr: IPRoute, device_name: str, ip: IPv4Interface | IPv6Interface):
     """Add an IP address to the given interface. If the address already exists, a warning is logged and the function
     returns without error."""
     interface_index: list[int] = ipr.link_lookup(ifname=device_name)
@@ -61,7 +60,7 @@ def add_ip_address(ipr: IPRoute, device_name: str, ip: Union[IPv4Interface, IPv6
         logger.error(f"Unknown exception while adding address {ip} to interface {device_name}: {e}")
 
 
-def delete_ip_address(ipr: IPRoute, device_name: str, ip: Union[IPv4Interface, IPv6Interface]):
+def delete_ip_address(ipr: IPRoute, device_name: str, ip: IPv4Interface | IPv6Interface):
     """Delete an IP address to the given interface."""
     interface_index: list[int] = ipr.link_lookup(ifname=device_name)
     if not interface_index:
@@ -110,7 +109,7 @@ class TapInterface:
         device_name: str,
         ip_network: IPv4NetworkWithInterfaces,
         ipv6_network: IPv6Network,
-        ndp_proxy: Optional[NdpProxy],
+        ndp_proxy: NdpProxy | None,
     ):
         self.device_name: str = device_name
         self.ip_network: IPv4NetworkWithInterfaces = ip_network

--- a/src/aleph/vm/network/interfaces.py
+++ b/src/aleph/vm/network/interfaces.py
@@ -48,7 +48,8 @@ def add_ip_address(ipr: IPRoute, device_name: str, ip: IPv4Interface | IPv6Inter
     returns without error."""
     interface_index: list[int] = ipr.link_lookup(ifname=device_name)
     if not interface_index:
-        raise MissingInterfaceError(f"Interface {device_name} does not exist, can't add address {ip} to it.")
+        msg = f"Interface {device_name} does not exist, can't add address {ip} to it."
+        raise MissingInterfaceError(msg)
     try:
         ipr.addr("add", index=interface_index[0], address=str(ip.ip), mask=ip.network.prefixlen)
     except NetlinkError as e:
@@ -64,7 +65,8 @@ def delete_ip_address(ipr: IPRoute, device_name: str, ip: IPv4Interface | IPv6In
     """Delete an IP address to the given interface."""
     interface_index: list[int] = ipr.link_lookup(ifname=device_name)
     if not interface_index:
-        raise MissingInterfaceError(f"Interface {device_name} does not exist, can't delete address {ip} to it.")
+        msg = f"Interface {device_name} does not exist, can't delete address {ip} to it."
+        raise MissingInterfaceError(msg)
     try:
         ipr.addr("del", index=interface_index[0], address=str(ip.ip), mask=ip.network.prefixlen)
     except NetlinkError as e:
@@ -77,7 +79,8 @@ def set_link_up(ipr: IPRoute, device_name: str):
     """Set the given interface up."""
     interface_index: list[int] = ipr.link_lookup(ifname=device_name)
     if not interface_index:
-        raise MissingInterfaceError(f"Interface {device_name} does not exist, can't set it up.")
+        msg = f"Interface {device_name} does not exist, can't set it up."
+        raise MissingInterfaceError(msg)
     try:
         ipr.link("set", index=interface_index[0], state="up")
     except NetlinkError as e:
@@ -144,7 +147,8 @@ class TapInterface:
 
         ip_command = shutil.which("ip")
         if not ip_command:
-            raise FileNotFoundError("ip command not found")
+            msg = "ip command not found"
+            raise FileNotFoundError(msg)
 
         ipv6_gateway = self.host_ipv6
 

--- a/src/aleph/vm/orchestrator/chain.py
+++ b/src/aleph/vm/orchestrator/chain.py
@@ -23,9 +23,10 @@ class ChainInfo(BaseModel):
         return self.super_token or self.standard_token
 
     @root_validator(pre=True)
-    def check_tokens(cls, values):
+    def check_tokens(self, values):
         if not values.get("standard_token") and not values.get("super_token"):
-            raise ValueError("At least one of standard_token or super_token must be provided.")
+            msg = "At least one of standard_token or super_token must be provided."
+            raise ValueError(msg)
         return values
 
 
@@ -63,4 +64,5 @@ def get_chain(chain: str) -> ChainInfo:
     try:
         return STREAM_CHAINS[chain]
     except KeyError:
-        raise ValueError(f"Unknown chain id for chain {chain}")
+        msg = f"Unknown chain id for chain {chain}"
+        raise ValueError(msg)

--- a/src/aleph/vm/orchestrator/chain.py
+++ b/src/aleph/vm/orchestrator/chain.py
@@ -23,7 +23,7 @@ class ChainInfo(BaseModel):
         return self.super_token or self.standard_token
 
     @root_validator(pre=True)
-    def check_tokens(self, values):
+    def check_tokens(cls, values):
         if not values.get("standard_token") and not values.get("super_token"):
             msg = "At least one of standard_token or super_token must be provided."
             raise ValueError(msg)

--- a/src/aleph/vm/orchestrator/chain.py
+++ b/src/aleph/vm/orchestrator/chain.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Dict, Optional, Union
 
 from aleph_message.models import Chain
 from pydantic import BaseModel, root_validator
@@ -14,13 +13,13 @@ class ChainInfo(BaseModel):
 
     chain_id: int
     rpc: str
-    standard_token: Optional[str] = None
-    super_token: Optional[str] = None
+    standard_token: str | None = None
+    super_token: str | None = None
     testnet: bool = False
     active: bool = True
 
     @property
-    def token(self) -> Optional[str]:
+    def token(self) -> str | None:
         return self.super_token or self.standard_token
 
     @root_validator(pre=True)
@@ -30,7 +29,7 @@ class ChainInfo(BaseModel):
         return values
 
 
-STREAM_CHAINS: Dict[Union[Chain, str], ChainInfo] = {
+STREAM_CHAINS: dict[Chain | str, ChainInfo] = {
     # TESTNETS
     "SEPOLIA": ChainInfo(
         chain_id=11155111,
@@ -63,5 +62,5 @@ STREAM_CHAINS: Dict[Union[Chain, str], ChainInfo] = {
 def get_chain(chain: str) -> ChainInfo:
     try:
         return STREAM_CHAINS[chain]
-    except KeyError as error:
+    except KeyError:
         raise ValueError(f"Unknown chain id for chain {chain}")

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -5,9 +5,10 @@ import logging
 import os
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
 from statistics import mean
-from typing import Callable, Optional, cast
+from typing import cast
 
 import alembic.command
 import alembic.config
@@ -238,7 +239,7 @@ async def benchmark(runs: int):
     print("Event result", result)
 
 
-async def start_instance(item_hash: ItemHash, pubsub: Optional[PubSub], pool) -> VmExecution:
+async def start_instance(item_hash: ItemHash, pubsub: PubSub | None, pool) -> VmExecution:
     """Run an instance from an InstanceMessage."""
     return await start_persistent_vm(item_hash, pubsub, pool)
 
@@ -251,7 +252,7 @@ async def run_instances(instances: list[ItemHash]) -> None:
     # The main program uses a singleton pubsub instance in order to watch for updates.
     # We create another instance here since that singleton is not initialized yet.
     # Watching for updates on this instance will therefore not work.
-    pubsub: Optional[PubSub] = None
+    pubsub: PubSub | None = None
 
     await asyncio.gather(*[start_instance(instance_id, pubsub, pool) for instance_id in instances])
 

--- a/src/aleph/vm/orchestrator/payment.py
+++ b/src/aleph/vm/orchestrator/payment.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 from collections.abc import Iterable
 from decimal import Decimal
-from typing import Optional
 
 import aiohttp
 from aleph_message.models import ItemHash, PaymentType
@@ -55,7 +54,7 @@ async def fetch_execution_flow_price(item_hash: ItemHash) -> Decimal:
 
         resp_data = await resp.json()
         required_flow: float = resp_data["required_tokens"]
-        payment_type: Optional[str] = resp_data["payment_type"]
+        payment_type: str | None = resp_data["payment_type"]
 
         if payment_type is None:
             raise ValueError("Payment type must be specified in the message")
@@ -75,7 +74,7 @@ async def fetch_execution_hold_price(item_hash: ItemHash) -> Decimal:
 
         resp_data = await resp.json()
         required_hold: float = resp_data["required_tokens"]
-        payment_type: Optional[str] = resp_data["payment_type"]
+        payment_type: str | None = resp_data["payment_type"]
 
         if payment_type not in (None, PaymentType.hold):
             raise ValueError(f"Payment type {payment_type} is not supported")

--- a/src/aleph/vm/orchestrator/payment.py
+++ b/src/aleph/vm/orchestrator/payment.py
@@ -57,9 +57,11 @@ async def fetch_execution_flow_price(item_hash: ItemHash) -> Decimal:
         payment_type: str | None = resp_data["payment_type"]
 
         if payment_type is None:
-            raise ValueError("Payment type must be specified in the message")
+            msg = "Payment type must be specified in the message"
+            raise ValueError(msg)
         elif payment_type != PaymentType.superfluid:
-            raise ValueError(f"Payment type {payment_type} is not supported")
+            msg = f"Payment type {payment_type} is not supported"
+            raise ValueError(msg)
 
         return Decimal(required_flow)
 
@@ -77,7 +79,8 @@ async def fetch_execution_hold_price(item_hash: ItemHash) -> Decimal:
         payment_type: str | None = resp_data["payment_type"]
 
         if payment_type not in (None, PaymentType.hold):
-            raise ValueError(f"Payment type {payment_type} is not supported")
+            msg = f"Payment type {payment_type} is not supported"
+            raise ValueError(msg)
 
         return Decimal(required_hold)
 
@@ -99,24 +102,28 @@ async def get_stream(sender: str, receiver: str, chain: str) -> Decimal:
     """
     chain_info: ChainInfo = get_chain(chain=chain)
     if not chain_info.active:
-        raise InvalidChainError(f"Chain : {chain} is not active for superfluid")
+        msg = f"Chain : {chain} is not active for superfluid"
+        raise InvalidChainError(msg)
 
     superfluid_instance = CFA_V1(chain_info.rpc, chain_info.chain_id)
 
     try:
         super_token: HexAddress = to_normalized_address(chain_info.super_token)
     except ValueError as error:
-        raise InvalidAddressError(f"Invalid token address '{chain_info.super_token}' - {error.args}") from error
+        msg = f"Invalid token address '{chain_info.super_token}' - {error.args}"
+        raise InvalidAddressError(msg) from error
 
     try:
         sender_address: HexAddress = to_normalized_address(sender)
     except ValueError as error:
-        raise InvalidAddressError(f"Invalid sender address '{sender}' - {error.args}") from error
+        msg = f"Invalid sender address '{sender}' - {error.args}"
+        raise InvalidAddressError(msg) from error
 
     try:
         receiver_address: HexAddress = to_normalized_address(receiver)
     except ValueError as error:
-        raise InvalidAddressError(f"Invalid receiver address '{receiver}' - {error.args}") from error
+        msg = f"Invalid receiver address '{receiver}' - {error.args}"
+        raise InvalidAddressError(msg) from error
 
     # Run the network request in a background thread and wait for it to complete.
     loop = asyncio.get_event_loop()

--- a/src/aleph/vm/orchestrator/pubsub.py
+++ b/src/aleph/vm/orchestrator/pubsub.py
@@ -5,7 +5,6 @@ Used to trigger VM shutdown on updates.
 
 import asyncio
 import logging
-import sys
 from collections.abc import Hashable
 
 from aleph_message.models import AlephMessage, ChainRef, ItemHash

--- a/src/aleph/vm/orchestrator/pubsub.py
+++ b/src/aleph/vm/orchestrator/pubsub.py
@@ -7,7 +7,6 @@ import asyncio
 import logging
 import sys
 from collections.abc import Hashable
-from typing import Union
 
 from aleph_message.models import AlephMessage, ChainRef, ItemHash
 
@@ -59,6 +58,6 @@ class PubSub:
                 if self.subscribers.get(key) == set():
                     self.subscribers.pop(key)
 
-    async def publish(self, key: Union[ItemHash, str, ChainRef], value: AlephMessage):
+    async def publish(self, key: ItemHash | str | ChainRef, value: AlephMessage):
         for queue in self.subscribers.get(key, ()):
             await queue.put(value)

--- a/src/aleph/vm/orchestrator/pubsub.py
+++ b/src/aleph/vm/orchestrator/pubsub.py
@@ -14,11 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class PubSub:
-    if sys.version_info >= (3, 9):
-        subscribers: dict[Hashable, set[asyncio.Queue[set]]]
-    else:
-        # Support for Python 3.8 (Ubuntu 20.04)
-        subscribers: dict[Hashable, set[asyncio.Queue]]
+    subscribers: dict[Hashable, set[asyncio.Queue[set]]]
 
     def __init__(self):
         self.subscribers = {}

--- a/src/aleph/vm/orchestrator/resources.py
+++ b/src/aleph/vm/orchestrator/resources.py
@@ -1,7 +1,6 @@
 import math
 from datetime import datetime, timezone
 from functools import lru_cache
-from typing import Optional
 
 import cpuinfo
 import psutil
@@ -157,8 +156,8 @@ class Allocation(BaseModel):
 
     persistent_vms: set[ItemHash] = Field(default_factory=set)
     instances: set[ItemHash] = Field(default_factory=set)
-    on_demand_vms: Optional[set[ItemHash]] = None
-    jobs: Optional[set[ItemHash]] = None
+    on_demand_vms: set[ItemHash] | None = None
+    jobs: set[ItemHash] | None = None
 
 
 class VMNotification(BaseModel):

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any, Optional
+from typing import Any
 
 import msgpack
 from aiohttp import web
@@ -99,7 +99,7 @@ async def run_code_on_request(vm_hash: ItemHash, path: str, pool: VmPool, reques
     Execute the code corresponding to the 'code id' in the path.
     """
 
-    execution: Optional[VmExecution] = pool.get_running_vm(vm_hash=vm_hash)
+    execution: VmExecution | None = pool.get_running_vm(vm_hash=vm_hash)
 
     # Prevent execution issues if the execution resources are empty
     # TODO: Improve expiration process to avoid that kind of issues.
@@ -203,7 +203,7 @@ async def run_code_on_event(vm_hash: ItemHash, event, pubsub: PubSub, pool: VmPo
     Execute code in response to an event.
     """
 
-    execution: Optional[VmExecution] = pool.get_running_vm(vm_hash=vm_hash)
+    execution: VmExecution | None = pool.get_running_vm(vm_hash=vm_hash)
 
     if not execution:
         execution = await create_vm_execution_or_raise_http_error(vm_hash=vm_hash, pool=pool)
@@ -248,8 +248,8 @@ async def run_code_on_event(vm_hash: ItemHash, event, pubsub: PubSub, pool: VmPo
             await execution.stop()
 
 
-async def start_persistent_vm(vm_hash: ItemHash, pubsub: Optional[PubSub], pool: VmPool) -> VmExecution:
-    execution: Optional[VmExecution] = pool.get_running_vm(vm_hash=vm_hash)
+async def start_persistent_vm(vm_hash: ItemHash, pubsub: PubSub | None, pool: VmPool) -> VmExecution:
+    execution: VmExecution | None = pool.get_running_vm(vm_hash=vm_hash)
 
     if not execution:
         logger.info(f"Starting persistent virtual machine with id: {vm_hash}")
@@ -269,7 +269,7 @@ async def start_persistent_vm(vm_hash: ItemHash, pubsub: Optional[PubSub], pool:
     return execution
 
 
-async def stop_persistent_vm(vm_hash: ItemHash, pool: VmPool) -> Optional[VmExecution]:
+async def stop_persistent_vm(vm_hash: ItemHash, pool: VmPool) -> VmExecution | None:
     logger.info(f"Stopping persistent VM {vm_hash}")
     execution = pool.get_running_vm(vm_hash)
 

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -8,10 +8,9 @@ evolve in the future.
 
 import asyncio
 import logging
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from secrets import token_urlsafe
-from typing import Callable
 
 from aiohttp import web
 from aiohttp_cors import ResourceOptions, setup

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -192,7 +192,7 @@ async def index(request: web.Request):
 
 
 @cors_allow_all
-async def status_check_fastapi(request: web.Request, vm_id: Optional[ItemHash] = None):
+async def status_check_fastapi(request: web.Request, vm_id: ItemHash | None = None):
     """Check that the FastAPI diagnostic VM runs correctly"""
 
     # Retro-compatibility mode ignores some of the newer checks. It is used to check the status of legacy VMs.
@@ -276,7 +276,7 @@ async def status_check_ipv6(request: web.Request):
 @cors_allow_all
 async def status_check_version(request: web.Request):
     """Check if the software is running a version equal or newer than the given one"""
-    reference_str: Optional[str] = request.query.get("reference")
+    reference_str: str | None = request.query.get("reference")
     if not reference_str:
         raise web.HTTPBadRequest(text="Query field '?reference=` must be specified")
     try:

--- a/src/aleph/vm/orchestrator/views/authentication.py
+++ b/src/aleph/vm/orchestrator/views/authentication.py
@@ -3,15 +3,15 @@ import datetime
 import functools
 import json
 import logging
-from collections.abc import Awaitable, Coroutine
-from typing import Any, Callable, Literal, Union
+from collections.abc import Awaitable, Callable, Coroutine
+from typing import Any, Literal
 
 import cryptography.exceptions
 import pydantic
 from aiohttp import web
 from eth_account import Account
 from eth_account.messages import encode_defunct
-from jwcrypto import jwk, jws
+from jwcrypto import jwk
 from jwcrypto.jwa import JWA
 from pydantic import BaseModel, ValidationError, root_validator, validator
 
@@ -98,7 +98,7 @@ class SignedPubKeyHeader(BaseModel):
 
 class SignedOperationPayload(BaseModel):
     time: datetime.datetime
-    method: Union[Literal["POST"], Literal["GET"]]
+    method: Literal["POST"] | Literal["GET"]
     domain: str
     path: str
     # body_sha256: str  # disabled since there is no body
@@ -166,8 +166,7 @@ def get_signed_pubkey(request: web.Request) -> SignedPubKeyHeader:
                 raise web.HTTPUnauthorized(reason="Token expired") from errors
             if str(err.exc) == "Invalid signature":
                 raise web.HTTPUnauthorized(reason="Invalid signature") from errors
-        else:
-            raise errors
+        raise errors
 
 
 def get_signed_operation(request: web.Request) -> SignedOperation:

--- a/src/aleph/vm/orchestrator/views/authentication.py
+++ b/src/aleph/vm/orchestrator/views/authentication.py
@@ -109,9 +109,11 @@ class SignedOperationPayload(BaseModel):
         max_past = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(minutes=2)
         max_future = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(minutes=2)
         if v < max_past:
-            raise ValueError("Time is too far in the past")
+            msg = "Time is too far in the past"
+            raise ValueError(msg)
         if v > max_future:
-            raise ValueError("Time is too far in the future")
+            msg = "Time is too far in the future"
+            raise ValueError(msg)
         return v
 
 

--- a/src/aleph/vm/orchestrator/views/host_status.py
+++ b/src/aleph/vm/orchestrator/views/host_status.py
@@ -1,7 +1,7 @@
 import logging
 import socket
-from collections.abc import Awaitable
-from typing import Any, Callable, Optional
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 import aiohttp
 
@@ -46,10 +46,10 @@ async def check_host_egress_ipv6() -> bool:
     return await check_ip_connectivity(settings.CONNECTIVITY_IPV6_URL)
 
 
-async def resolve_dns(hostname: str) -> tuple[Optional[str], Optional[str]]:
+async def resolve_dns(hostname: str) -> tuple[str | None, str | None]:
     """Resolve a hostname to an IPv4 and IPv6 address."""
-    ipv4: Optional[str] = None
-    ipv6: Optional[str] = None
+    ipv4: str | None = None
+    ipv6: str | None = None
 
     info = socket.getaddrinfo(hostname, 80, proto=socket.IPPROTO_TCP)
     if not info:

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -5,7 +5,6 @@ import json
 import logging
 from collections.abc import Iterable
 from datetime import datetime, timezone
-from typing import Optional
 
 from aleph_message.models import (
     Chain,
@@ -40,8 +39,8 @@ class VmPool:
     counter: int  # Used to provide distinct ids to network interfaces
     executions: dict[ItemHash, VmExecution]
     message_cache: dict[str, ExecutableMessage]
-    network: Optional[Network]
-    snapshot_manager: Optional[SnapshotManager] = None
+    network: Network | None
+    snapshot_manager: SnapshotManager | None = None
     systemd_manager: SystemDManager
     creation_lock: asyncio.Lock
 
@@ -168,11 +167,10 @@ class VmPool:
             for i in range(settings.START_ID_INDEX, 255**2):
                 if i not in currently_used_vm_ids:
                     return i
-            else:
-                msg = "No available value for vm_id."
-                raise ValueError(msg)
+            msg = "No available value for vm_id."
+            raise ValueError(msg)
 
-    def get_running_vm(self, vm_hash: ItemHash) -> Optional[VmExecution]:
+    def get_running_vm(self, vm_hash: ItemHash) -> VmExecution | None:
         """Return a running VM or None. Disables the VM expiration task."""
         execution = self.executions.get(vm_hash)
         if execution and execution.is_running and not execution.is_stopping:
@@ -181,7 +179,7 @@ class VmPool:
         else:
             return None
 
-    async def stop_vm(self, vm_hash: ItemHash) -> Optional[VmExecution]:
+    async def stop_vm(self, vm_hash: ItemHash) -> VmExecution | None:
         """Stop a VM."""
         execution = self.executions.get(vm_hash)
         if execution:

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -14,7 +14,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from shutil import copy2, make_archive
 from subprocess import CalledProcessError
-from typing import Union
 
 import aiohttp
 from aleph_message.models import (
@@ -142,7 +141,7 @@ async def get_latest_amend(item_hash: str) -> str:
             return result or item_hash
 
 
-async def get_message(ref: str) -> Union[ProgramMessage, InstanceMessage]:
+async def get_message(ref: str) -> ProgramMessage | InstanceMessage:
     if ref == settings.FAKE_INSTANCE_ID:
         logger.debug("Using the fake instance message since the ref matches")
         cache_path = settings.FAKE_INSTANCE_MESSAGE
@@ -256,7 +255,7 @@ async def create_ext4(path: Path, size_mib: int) -> bool:
     return True
 
 
-async def create_volume_file(volume: Union[PersistentVolume, RootfsVolume], namespace: str) -> Path:
+async def create_volume_file(volume: PersistentVolume | RootfsVolume, namespace: str) -> Path:
     volume_name = volume.name if isinstance(volume, PersistentVolume) else "rootfs"
     # Assume that the main filesystem format is BTRFS
     path = settings.PERSISTENT_VOLUMES_DIR / namespace / f"{volume_name}.btrfs"
@@ -300,7 +299,7 @@ async def resize_and_tune_file_system(device_path: Path, mount_path: Path) -> No
     await run_in_subprocess(["umount", str(mount_path)])
 
 
-async def create_devmapper(volume: Union[PersistentVolume, RootfsVolume], namespace: str) -> Path:
+async def create_devmapper(volume: PersistentVolume | RootfsVolume, namespace: str) -> Path:
     """It creates a /dev/mapper/DEVICE inside the VM, that is an extended mapped device of the volume specified.
     We follow the steps described here: https://community.aleph.im/t/deploying-mutable-vm-instances-on-aleph/56/2
     """

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -161,7 +161,7 @@ async def get_message(ref: str) -> ProgramMessage | InstanceMessage:
             msg = fix_message_validation(msg)
 
         result = parse_message(message_dict=msg)
-        assert isinstance(result, (InstanceMessage, ProgramMessage)), "Parsed message is not executable"
+        assert isinstance(result, InstanceMessage | ProgramMessage), "Parsed message is not executable"
         return result
 
 
@@ -369,7 +369,7 @@ async def get_volume_path(volume: MachineVolume, namespace: str) -> Path:
     if isinstance(volume, ImmutableVolume):
         ref = volume.ref
         return await get_existing_file(ref)
-    elif isinstance(volume, (PersistentVolume, RootfsVolume)):
+    elif isinstance(volume, PersistentVolume | RootfsVolume):
         volume_name = volume.name if isinstance(volume, PersistentVolume) else "rootfs"
         if volume.persistence != VolumePersistence.host:
             msg = "Only 'host' persistence is supported"

--- a/src/aleph/vm/utils/__init__.py
+++ b/src/aleph/vm/utils/__init__.py
@@ -5,12 +5,12 @@ import json
 import logging
 import subprocess
 from base64 import b16encode, b32decode
-from collections.abc import Coroutine
+from collections.abc import Callable, Coroutine
 from dataclasses import asdict as dataclass_as_dict
 from dataclasses import is_dataclass
 from pathlib import Path
 from shutil import disk_usage
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 import aiodns
 import msgpack
@@ -80,7 +80,7 @@ def to_json(o: Any):
         return str(o)
 
 
-def dumps_for_json(o: Any, indent: Optional[int] = None):
+def dumps_for_json(o: Any, indent: int | None = None):
     return json.dumps(o, default=to_json, indent=indent)
 
 
@@ -98,7 +98,7 @@ def create_task_log_exceptions(coro: Coroutine, *, name=None):
     return asyncio.create_task(run_and_log_exception(coro), name=name)
 
 
-async def run_in_subprocess(command: list[str], check: bool = True, stdin_input: Optional[bytes] = None) -> bytes:
+async def run_in_subprocess(command: list[str], check: bool = True, stdin_input: bytes | None = None) -> bytes:
     """Run the specified command in a subprocess, returns the stdout of the process."""
     command = [str(arg) for arg in command]
     logger.debug(f"command: {' '.join(command)}")
@@ -131,7 +131,7 @@ def is_command_available(command):
         return False
 
 
-def check_system_module(module_path: str) -> Optional[str]:
+def check_system_module(module_path: str) -> str | None:
     p = Path("/sys/module") / module_path
     if not p.exists():
         return None

--- a/src/aleph/vm/utils/__init__.py
+++ b/src/aleph/vm/utils/__init__.py
@@ -206,7 +206,8 @@ async def get_path_size(path: Path) -> int:
     elif path.is_file():
         return path.stat().st_size
     else:
-        raise ValueError(f"Unknown path type for {path}")
+        msg = f"Unknown path type for {path}"
+        raise ValueError(msg)
 
 
 async def get_block_device_size(device: str) -> int:
@@ -226,11 +227,13 @@ def to_normalized_address(value: str) -> HexAddress:
     try:
         hex_address = hexstr_if_str(to_hex, value).lower()
     except AttributeError:
-        raise TypeError(f"Value must be any string, instead got type {type(value)}")
+        msg = f"Value must be any string, instead got type {type(value)}"
+        raise TypeError(msg)
     if is_address(hex_address):
         return HexAddress(HexStr(hex_address))
     else:
-        raise ValueError(f"Unknown format {value}, attempted to normalize to {hex_address}")
+        msg = f"Unknown format {value}, attempted to normalize to {hex_address}"
+        raise ValueError(msg)
 
 
 def md5sum(file_path: Path) -> str:
@@ -241,7 +244,8 @@ def md5sum(file_path: Path) -> str:
 def file_hashes_differ(source: Path, destination: Path, checksum: Callable[[Path], str] = md5sum) -> bool:
     """Check if the MD5 hash of two files differ."""
     if not source.exists():
-        raise FileNotFoundError(f"Source file does not exist: {source}")
+        msg = f"Source file does not exist: {source}"
+        raise FileNotFoundError(msg)
 
     if not destination.exists():
         return True

--- a/src/aleph/vm/utils/logs.py
+++ b/src/aleph/vm/utils/logs.py
@@ -79,5 +79,4 @@ def get_past_vm_logs(stdout_identifier, stderr_identifier) -> Generator[EntryDic
     r.add_match(SYSLOG_IDENTIFIER=stderr_identifier)
 
     r.seek_head()
-    for entry in r:
-        yield entry
+    yield from r

--- a/src/aleph/vm/utils/logs.py
+++ b/src/aleph/vm/utils/logs.py
@@ -1,7 +1,8 @@
 import asyncio
 import logging
+from collections.abc import Callable, Generator
 from datetime import datetime
-from typing import Callable, Generator, TypedDict
+from typing import TypedDict
 
 from systemd import journal
 

--- a/src/aleph/vm/version.py
+++ b/src/aleph/vm/version.py
@@ -1,11 +1,10 @@
 import logging
 from subprocess import CalledProcessError, check_output
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 
-def get_version_from_git() -> Optional[str]:
+def get_version_from_git() -> str | None:
     try:
         return check_output(("git", "describe", "--tags")).strip().decode()
     except FileNotFoundError:
@@ -16,7 +15,7 @@ def get_version_from_git() -> Optional[str]:
         return None
 
 
-def get_version_from_apt() -> Optional[str]:
+def get_version_from_apt() -> str | None:
     try:
         import apt
 
@@ -26,7 +25,7 @@ def get_version_from_apt() -> Optional[str]:
         return None
 
 
-def get_version() -> Optional[str]:
+def get_version() -> str | None:
     return get_version_from_git() or get_version_from_apt()
 
 

--- a/tests/supervisor/views/test_run_code.py
+++ b/tests/supervisor/views/test_run_code.py
@@ -21,7 +21,7 @@ async def test_run_code_from_invalid_path(aiohttp_client):
 
     app = web.Application()
 
-    app.router.add_route("*", "/vm/{ref}{suffix:.*}", run_code_from_path),
+    app.router.add_route("*", "/vm/{ref}{suffix:.*}", run_code_from_path)
     client = await aiohttp_client(app)
 
     invalid_hash_request: web.Request = make_mocked_request(


### PR DESCRIPTION
Explain what problem this PR is resolving

The python linter [ruff](https://github.com/astral-sh/ruff) is not enable on this project because it raises too many errors to fix at once. At the time of writing, `ruff check src` raises 375 errors.

## Self proofreading checklist

Not relevant for these changes.

- [ ] The new code clear, easy to read and well commented.
- [ ] New code does not duplicate the functions of builtin or popular libraries.
- [ ] An LLM was used to review the new code and look for simplifications.
- [ ] New classes and functions contain docstrings explaining what they provide.
- [ ] All new code is covered by relevant tests.
- [ ] Documentation has been updated regarding these changes.

## Changes

The first commit contains the result of `ruff check src --fix`, which contains safe automatic fixes to the codebase.

I then ran `ruff check src --fix --unsafe-fixes` and added the following commits with the changes that I reviewed manually and deem ready to commit:
- Fix: Generator loop -> 'yield from'
- Fix: Type annotations could be improved
- Fix: Python < 3.10 is no supported anymore
- Fix: Ruff errored on exception raising

## How to test

Run `ruff check src` or `hatch run testing:ruff`.

`ruff check src` on the code found 176 errors after the changes.