### PR TITLE
ci/fix(test-using-pytest): ensure hatch is always installed when needed

### DIFF
--- a/.github/workflows/test-using-pytest.yml
+++ b/.github/workflows/test-using-pytest.yml
@@ -72,16 +72,19 @@ jobs:
       - name: "Build example volume"
         run: |
           cd examples/volumes && bash build_squashfs.sh
-        
+
       # Unit tests create and delete network interfaces, and therefore require to run as root
       - name: Run unit tests
         run: |
           sudo python3 -m pip install hatch hatch-vcs coverage
           sudo hatch run testing:cov
+
       - name: Output modules used and their version
         if:  always()
         run: |
-           sudo hatch -e testing run pip freeze
+          # re-install hatch in case previous job failed and hatch didn't get installed
+          sudo python3 -m pip install hatch hatch-vcs coverage
+          sudo hatch -e testing run pip freeze
 
 
       - name: Upload coverage reports to Codecov
@@ -107,4 +110,4 @@ jobs:
       - name: Run Shellcheck on all shell scripts
         run: |
           find ./ -type f -name "*.sh" -exec shellcheck {} \;
-  
+


### PR DESCRIPTION
Sometime in test-using-pytest CI workflow the previous job failed, for example
[here](https://github.com/aleph-im/aleph-vm/actions/runs/10687238972/job/29624379941?pr=689),
and this line with `if: always()` won't be able to run because hatch is
installed in the previous step but this step might get skipped.

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] All new code is covered by relevant tests.

## Changes

Always install hatch in this `always` step of the job.

## How to test

Make a PR that will fail this job, for example by not respecting black or use
[act](https://github.com/nektos/act) to test that locally.
