### PR TITLE
Fix: Solved issue when a user stops a Qemu VM that show a `QMPCapabil…

### DIFF
--- a/src/aleph/vm/hypervisors/qemu/qemuvm.py
+++ b/src/aleph/vm/hypervisors/qemu/qemuvm.py
@@ -132,9 +132,15 @@ class QemuVM:
     def _get_qmpclient(self) -> qmp.QEMUMonitorProtocol | None:
         if not (self.qmp_socket_path and self.qmp_socket_path.exists()):
             return None
-        client = qmp.QEMUMonitorProtocol(str(self.qmp_socket_path))
-        client.connect()
-        return client
+        try:
+            client = qmp.QEMUMonitorProtocol(str(self.qmp_socket_path))
+            # Class only used to STOP the VM, so checking the capabilities are not needed and prevent to show and error.
+            # TODO: Use the already existing QEmuClient class.
+            client.connect(negotiate=False)
+            return client
+        except Exception as e:
+            logger.error(e)
+            return None
 
     def send_shutdown_message(self):
         print("sending shutdown message to vm")


### PR DESCRIPTION
Symptom:

Every time that a Qemu VM is stopped, this error is raised on the logs:

```
Sep 05 12:24:03 testing-hetzner python3[2468548]: 2024-09-05 12:24:03,187 | ERROR | Task exception was never retrieved
Sep 05 12:24:03 testing-hetzner python3[2468548]: future: <Task finished name='Task-3' coro=<QemuVM.stop() done, defined at /opt/aleph-vm/aleph/vm/hypervisors/qemu/qemuvm.py:149> exception=QMPCapabilitiesError()>
Sep 05 12:24:03 testing-hetzner python3[2468548]: Traceback (most recent call last):
Sep 05 12:24:03 testing-hetzner python3[2468548]:   File "/opt/aleph-vm/aleph/vm/hypervisors/qemu/qemuvm.py", line 151, in stop
Sep 05 12:24:03 testing-hetzner python3[2468548]:     self.send_shutdown_message()
Sep 05 12:24:03 testing-hetzner python3[2468548]:   File "/opt/aleph-vm/aleph/vm/hypervisors/qemu/qemuvm.py", line 141, in send_shutdown_message
Sep 05 12:24:03 testing-hetzner python3[2468548]:     client = self._get_qmpclient()
Sep 05 12:24:03 testing-hetzner python3[2468548]:              ^^^^^^^^^^^^^^^^^^^^^
Sep 05 12:24:03 testing-hetzner python3[2468548]:   File "/opt/aleph-vm/aleph/vm/hypervisors/qemu/qemuvm.py", line 136, in _get_qmpclient
Sep 05 12:24:03 testing-hetzner python3[2468548]:     client.connect()
Sep 05 12:24:03 testing-hetzner python3[2468548]:   File "/opt/aleph-vm/qmp.py", line 162, in connect
Sep 05 12:24:03 testing-hetzner python3[2468548]:     return self.__negotiate_capabilities()
Sep 05 12:24:03 testing-hetzner python3[2468548]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Sep 05 12:24:03 testing-hetzner python3[2468548]:   File "/opt/aleph-vm/qmp.py", line 88, in __negotiate_capabilities
Sep 05 12:24:03 testing-hetzner python3[2468548]:     raise QMPCapabilitiesError
Sep 05 12:24:03 testing-hetzner python3[2468548]: qmp.QMPCapabilitiesError
Sep 05 12:24:03 testing-hetzner python3[2468548]: 2024-09-05 12:24:03,285 | WARNING | Process terminated with 0
```


Causes:
This issue is caused by the default QMP client, that tries to negotiate the QMP capabilities but the client returns an error because the capabilities are already negotiated:

```
{"error": {"class": "CommandNotFound", "desc": "Capabilities negotiation is already complete, command ignored"}}
```


Solution:
Avoid to negotiate capabilities when the QMP client only wants to stop the VM and handle the client connection error if it occurs again.

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [ ] All new code is covered by relevant tests.

## Changes

See above

## How to test

Create a Qemu instance and try to stop it checking the logs, if an error appears it seems that the fix didn't work, but if any error is seen seems that the issue is fixed.
