### PR TITLE
Problem: Non deterministic teardown

### DIFF
--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -503,13 +503,3 @@ class MicroVM:
             self.config_file_path.unlink(missing_ok=True)
         if Path(self.namespace_path).exists():
             system(f"rm -fr {self.namespace_path}")
-
-    def __del__(self):
-        try:
-            loop = asyncio.get_running_loop()
-            loop.create_task(self.teardown())
-        except RuntimeError as error:
-            if error.args == ("no running event loop",):
-                return
-            else:
-                raise


### PR DESCRIPTION
There was a teardown() inside a __del__
which was triggered by the garbage collection
This resulted in an unclear lifecycle and strange log error since the teardown was already triggered before and made for strange error when running tests

Solution: remove it
