### PR TITLE
Problem: Test failing not clearly

### DIFF
--- a/tests/supervisor/test_execution.py
+++ b/tests/supervisor/test_execution.py
@@ -23,6 +23,9 @@ async def test_create_execution(mocker):
     mocker.patch("aleph.vm.controllers.firecracker.executable.settings", new=mock_settings)
     mocker.patch("aleph.vm.controllers.firecracker.program.settings", new=mock_settings)
 
+    if not mock_settings.FAKE_DATA_RUNTIME.exists():
+        pytest.xfail("Test Runtime not setup. run `cd runtimes/aleph-debian-12-python && sudo ./create_disk_image.sh`")
+
     mock_settings.FAKE_DATA_PROGRAM = mock_settings.BENCHMARK_FAKE_DATA_PROGRAM
     mock_settings.ALLOW_VM_NETWORKING = False
     mock_settings.USE_JAILER = False

--- a/tests/supervisor/test_instance.py
+++ b/tests/supervisor/test_instance.py
@@ -63,6 +63,8 @@ async def test_create_instance():
     # Ensure that the settings are correct and required files present.
     settings.setup()
     settings.check()
+    if not settings.FAKE_DATA_RUNTIME.exists():
+        pytest.xfail("Test Runtime not setup. run `cd runtimes/aleph-debian-12-python && sudo ./create_disk_image.sh`")
 
     # The database is required for the metrics and is currently not optional.
     engine = metrics.setup_engine()

--- a/tests/supervisor/test_qemu_instance.py
+++ b/tests/supervisor/test_qemu_instance.py
@@ -56,6 +56,8 @@ async def test_create_qemu_instance():
     settings.ENABLE_CONFIDENTIAL_COMPUTING = False
     settings.ALLOW_VM_NETWORKING = False
     settings.USE_JAILER = False
+    if not settings.FAKE_INSTANCE_BASE.exists():
+        pytest.xfail("Test Runtime not setup. run `cd runtimes/instance-rootfs && sudo ./create-debian-12-disk.sh`")
 
     logging.basicConfig(level=logging.DEBUG)
 
@@ -117,6 +119,8 @@ async def test_create_qemu_instance_online():
     # Ensure that the settings are correct and required files present.
     settings.setup()
     settings.check()
+    if not settings.FAKE_INSTANCE_BASE.exists():
+        pytest.xfail("Test Runtime not setup. run `cd runtimes/instance-rootfs && sudo ./create-debian-12-disk.sh`")
 
     # The database is required for the metrics and is currently not optional.
     engine = metrics.setup_engine()


### PR DESCRIPTION
The execution and instances tests were failing if the runtime or dis image were not properly set up but it was not clear to the user why

Solution: 
Use xfail to display an user to the message on how to set up properly

> tests/supervisor/test_execution.py::test_create_execution XFAIL (Test
Runtime not setup. run `cd runtimes/aleph-debian-12-python && sudo ./create_disk_image.sh`)

