### PR TITLE
Fix: dictionary changed size during iteration

### DIFF
--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -150,7 +150,7 @@ async def monitor_payments(app: web.Application):
         await asyncio.sleep(settings.PAYMENT_MONITOR_INTERVAL)
 
         # Check if the executions continues existing or are forgotten before checking the payment
-        for vm_hash in pool.executions.keys():
+        for vm_hash in list(pool.executions.keys()):
             message_status = await get_message_status(vm_hash)
             if message_status != MessageStatus.PROCESSED:
                 logger.debug(f"Stopping {vm_hash} execution due to {message_status} message status")


### PR DESCRIPTION
Iterating over the keys of a dictionary is a lazy operation that uses a generator under the hood.

An error was reported on Sentry due to "RuntimeError: dictionary changed size during iteration".
[Error on Sentry](https://alephim.sentry.io/share/issue/9327621b4aa44d7b80bb53ae7696590c/)

This error was introduced by @nesitor on PR https://github.com/aleph-im/aleph-vm/pull/679

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [ ] New classes and functions contain docstrings explaining what they provide.
- [ ] All new code is covered by relevant tests.
- [ ] Documentation has been updated regarding these changes.

## Changes

This fixes the issue by transforming the generator into a list, which is the standard way to approach this issue in Python.