### PR TITLE
Problem: Solana wallet  couln't be used to control the VM

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -15,7 +15,7 @@ debian-package-code:
 	cp ../examples/instance_message_from_aleph.json ./aleph-vm/opt/aleph-vm/examples/instance_message_from_aleph.json
 	cp -r ../examples/data ./aleph-vm/opt/aleph-vm/examples/data
 	mkdir -p ./aleph-vm/opt/aleph-vm/examples/volumes
-	pip3 install --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.4.9' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12' 'python-cpuid==0.1.0'
+	pip3 install --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.4.9' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2'
 	python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux download-ipfs-kubo  target/bin/sevctl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ classifiers = [
   "Topic :: System :: Distributed Computing",
 ]
 dynamic = [ "version" ]
+
+# Upon adding or updating dependencies, update `packaging/Makefile` for the Debian package
 dependencies = [
   "aiodns==3.1",
   "aiohttp==3.9.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
   "schedule==1.2.1",
   "sentry-sdk==1.31",
   "setproctitle==1.3.3",
+  "solathon==1.0.2",
   "sqlalchemy[asyncio]>=2",
   "systemd-python==235",
 ]

--- a/src/aleph/vm/orchestrator/views/authentication.py
+++ b/src/aleph/vm/orchestrator/views/authentication.py
@@ -1,6 +1,6 @@
 """Functions for authentications
 
-See /doc/operator_auth.md for the explaination of how the operator authentication works.
+See /doc/operator_auth.md for the explanation of how the operator authentication works.
 
 Can be enabled on an endpoint using the @require_jwk_authentication decorator
 """
@@ -236,6 +236,26 @@ async def authenticate_websocket_message(message) -> str:
 def require_jwk_authentication(
     handler: Callable[[web.Request, str], Coroutine[Any, Any, web.StreamResponse]]
 ) -> Callable[[web.Request], Awaitable[web.StreamResponse]]:
+    """A decorator to enforce JWK-based authentication for HTTP requests.
+
+    The decorator ensures that the incoming request includes valid authentication headers
+    (as per the VM owner authentication protocol) and provides the authenticated wallet address (`authenticated_sender`)
+    to the handler. The handler can then use this address to verify access to the requested resource.
+
+    Args:
+        handler (Callable[[web.Request, str], Coroutine[Any, Any, web.StreamResponse]]):
+            The request handler function that will receive the `authenticated_sender` (the authenticated wallet address)
+            as an additional argument.
+
+    Returns:
+        Callable[[web.Request], Awaitable[web.StreamResponse]]:
+            A wrapped handler that verifies the authentication and passes the wallet address to the handler.
+
+    Note:
+        Refer to the "Authentication protocol for VM owner" documentation for detailed information on the authentication
+        headers and validation process.
+    """
+
     @functools.wraps(handler)
     async def wrapper(request):
         try:
@@ -247,7 +267,7 @@ def require_jwk_authentication(
             logging.exception(e)
             raise
 
-        # authenticated_sender is the authenticted wallet address of the requester (as a string)
+        # authenticated_sender is the authenticate wallet address of the requester (as a string)
         response = await handler(request, authenticated_sender)
         return response
 

--- a/src/aleph/vm/utils/__init__.py
+++ b/src/aleph/vm/utils/__init__.py
@@ -75,7 +75,7 @@ def to_json(o: Any) -> dict | str:
     elif hasattr(o, "dict"):  # Pydantic
         return o.dict()
     elif is_dataclass(o):
-        return dataclass_as_dict(o)
+        return dataclass_as_dict(o)  # type: ignore
     else:
         return str(o)
 


### PR DESCRIPTION
Add Solana authentication method for the VM operator endpoint.

First version on how to implement this. It is the same method as with Ethereum using an ephemeral key, but that key is signed with Solana private key instead of Ethereum.

On the  SignedPubKeyPayload a  `chain` argument that can be either `ETH` or `SOL` so we know which chain signing method to validate against. It default to ETH as to remain backward compatible with current client implementations.

Also added a docstring on the `require_jwk_authentication` decorator. 

Related Jira tickets : ALEPH-50

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.
- [x] Documentation has been updated regarding these changes.


## How to test

Not really much to test as the client part (Python/ web) is not developed yet. So you will have to rely on the tests.

## Print screen / video

N/A

## Notes

This add the new dependency Solathon to sign and validate the signature via a Solana wallet, it itself use the nacl.sign module (which is a binding on top of libsodium). An alternative would be to use the Solders lib which is running in rust. The API we use is quite small. So it shouldn't be much trouble to port from one to the other.
