### PR TITLE
Problem: error org.freedesktop.systemd1.NoSuchUnit: Unit aleph-vm-con…

### DIFF
--- a/src/aleph/vm/systemd.py
+++ b/src/aleph/vm/systemd.py
@@ -60,7 +60,10 @@ class SystemDManager:
 
     def is_service_active(self, service: str) -> bool:
         try:
-            systemd_service = self.bus.get_object("org.freedesktop.systemd1", object_path=self.manager.GetUnit(service))
+            if not self.is_service_enabled(service):
+                return False
+            unit_path = self.manager.GetUnit(service)
+            systemd_service = self.bus.get_object("org.freedesktop.systemd1", object_path=unit_path)
             unit = dbus.Interface(systemd_service, "org.freedesktop.systemd1.Unit")
             unit_properties = dbus.Interface(unit, "org.freedesktop.DBus.Properties")
             active_state = unit_properties.Get("org.freedesktop.systemd1.Unit", "ActiveState")


### PR DESCRIPTION
Problem: error org.freedesktop.systemd1.NoSuchUnit: Unit aleph-vm-controller@...

Jira issue: ALEPH-113

This happened because we tried to check if the service was running before checking if it was enabled. It resulted in no proper error but was creating an error message in the logs

Solution: Check if service is enabled before checking if it is active

How to test:
Launch instances. Restart the aleph-vm process, stop them. That error message should not display

