### PR TITLE
chore: rename hatch lint env to linting

### DIFF
--- a/.github/workflows/test-using-pytest.yml
+++ b/.github/workflows/test-using-pytest.yml
@@ -33,11 +33,11 @@ jobs:
 
       - name: Test style wth ruff, black and isort
         run: |
-          hatch run lint:style
+          hatch run linting:style
 
       - name: Test typing with Mypy
         run: |
-          hatch run lint:typing
+          hatch run linting:typing
 
       - name: Install required system packages for installing and running tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ cov = [
 [[tool.hatch.envs.all.matrix]]
 python = ["3.10", "3.11", "3.12"]
 
-[tool.hatch.envs.lint]
+[tool.hatch.envs.linting]
 detached = true
 dependencies = [
   "black==24.3.0",
@@ -117,7 +117,7 @@ dependencies = [
   "ruff==0.4.6",
   "isort==5.13.2",
 ]
-[tool.hatch.envs.lint.scripts]
+[tool.hatch.envs.linting.scripts]
 typing = "mypy {args:src/aleph/vm/ tests/ examples/example_fastapi runtimes/aleph-debian-12-python}"
 style = [
 #  "ruff {args:.}",


### PR DESCRIPTION
This is to uniformise its name with other projects env names where "linting" is used everywhere.
