### PR TITLE
add pyproject-fmt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ dependencies = [
   "mypy==1.8.0",
   "ruff==0.4.6",
   "isort==5.13.2",
+  "pyproject-fmt==2.2.1",
 ]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy {args:src/aleph/vm/ tests/ examples/example_fastapi runtimes/aleph-debian-12-python}"
@@ -123,11 +124,13 @@ style = [
 #  "ruff {args:.}",
   "black --check --diff {args:.}",
   "isort --check-only --profile black {args:.}",
+  "pyproject-fmt --check pyproject.toml",
 ]
 fmt = [
   "black {args:.}",
 #  "ruff --fix {args:.}",
   "isort --profile black {args:.}",
+  "pyproject-fmt pyproject.toml",
   "style",
 ]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,18 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+requires = [ "hatch-vcs", "hatchling" ]
 
 [project]
 name = "aleph-vm"
-dynamic = ["version"]
 description = "Aleph.im VM execution engine"
 readme = "README.md"
-requires-python = ">=3.10"
-license = {file = "LICENSE"}
-keywords = []
+keywords = [  ]
+license = { file = "LICENSE" }
 authors = [
-  { name="Hugo Herter", email="git@hugoherter.com" },
+  { name = "Hugo Herter", email = "git@hugoherter.com" },
 ]
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Environment :: Console",
@@ -20,62 +20,62 @@ classifiers = [
   "Intended Audience :: Information Technology",
   "License :: OSI Approved :: MIT License",
   "Operating System :: POSIX :: Linux",
-  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: System :: Distributed Computing",
 ]
+dynamic = [ "version" ]
 dependencies = [
-  "pydantic[dotenv]~=1.10.13",
+  "aiodns==3.1",
   "aiohttp==3.9.5",
-  "aiodns==3.1.0",
-  "setproctitle==1.3.3",
-  "pyyaml==6.0.1",
-  "aleph-message==0.4.9",
-  "eth-account~=0.10",
-  "sentry-sdk==1.31.0",
+  "aiohttp-cors~=0.7.0",
   "aioredis==1.3.1",
-  "psutil==5.9.5",
-  "py-cpuinfo==9.0.0",
-  "schedule==1.2.1",
-  "nftables @ git+https://salsa.debian.org/pkg-netfilter-team/pkg-nftables#egg=nftables&subdirectory=py",
-  "msgpack==1.0.7",
-  "packaging==23.2",
-  "jsonschema==4.19.1",
-  "qmp==1.1.0",
-  "dbus-python==1.3.2",
-  "systemd-python==235",
-  "systemd-python==235",
-  "aleph-superfluid~=0.2.1",
-  "sqlalchemy[asyncio]>=2.0",
-  "aiosqlite==0.19.0",
+  "aiosqlite==0.19",
   "alembic==1.13.1",
-  "aiohttp_cors~=0.7.0",
-  "pyroute2==0.7.12",
+  "aleph-message==0.4.9",
+  "aleph-superfluid~=0.2.1",
+  "dbus-python==1.3.2",
+  "eth-account~=0.10",
+  "jsonschema==4.19.1",
   "jwcrypto==1.5.6",
-  "python-cpuid==0.1.0"
+  "msgpack==1.0.7",
+  "nftables @ git+https://salsa.debian.org/pkg-netfilter-team/pkg-nftables#egg=nftables&subdirectory=py",
+  "packaging==23.2",
+  "psutil==5.9.5",
+  "py-cpuinfo==9",
+  "pydantic[dotenv]~=1.10.13",
+  "pyroute2==0.7.12",
+  "python-cpuid==0.1",
+  "pyyaml==6.0.1",
+  "qmp==1.1",
+  "schedule==1.2.1",
+  "sentry-sdk==1.31",
+  "setproctitle==1.3.3",
+  "sqlalchemy[asyncio]>=2",
+  "systemd-python==235",
 ]
 
-[project.urls]
-Documentation = "https://docs.aleph.im/nodes/compute/"
-Issues = "https://github.com/aleph-im/aleph-vm/issues"
-Source = "https://github.com/aleph-im/aleph-vm"
-Discussions = "https://community.aleph.im/"
-
-[project.scripts]
-aleph-vm = "aleph.vm.orchestrator.cli:main"
+urls.Discussions = "https://community.aleph.im/"
+urls.Documentation = "https://docs.aleph.im/nodes/compute/"
+urls.Issues = "https://github.com/aleph-im/aleph-vm/issues"
+urls.Source = "https://github.com/aleph-im/aleph-vm"
+scripts.aleph-vm = "aleph.vm.orchestrator.cli:main"
 
 [tool.hatch.version]
 source = "vcs"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/aleph"]
+packages = [ "src/aleph" ]
 
 [tool.hatch.metadata]
 allow-direct-references = true
 
 [tool.hatch.envs.default]
-platforms = ["linux"]
+platforms = [ "linux" ]
 dependencies = [
-#  "git+https://salsa.debian.org/pkg-netfilter-team/pkg-nftables#egg=nftables&subdirectory=py",
+  #  "git+https://salsa.debian.org/pkg-netfilter-team/pkg-nftables#egg=nftables&subdirectory=py",
 ]
 
 [tool.hatch.envs.default.scripts]
@@ -87,7 +87,7 @@ check = "aleph-vm controller run {args:--help}"
 type = "virtual"
 system-packages = true
 dependencies = [
-  "eth_typing==4.3.1", # Temp fix for bug in CI with 5.0.0
+  "eth_typing==4.3.1",      # Temp fix for bug in CI with 5.0.0
   "pytest==8.2.1",
   "pytest-cov==5.0.0",
   "pytest-mock==3.14.0",
@@ -107,7 +107,7 @@ cov = [
 ]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.10", "3.11", "3.12"]
+python = [ "3.10", "3.11", "3.12" ]
 
 [tool.hatch.envs.lint]
 detached = true
@@ -121,14 +121,14 @@ dependencies = [
 [tool.hatch.envs.lint.scripts]
 typing = "mypy {args:src/aleph/vm/ tests/ examples/example_fastapi runtimes/aleph-debian-12-python}"
 style = [
-#  "ruff {args:.}",
+  #  "ruff {args:.}",
   "black --check --diff {args:.}",
   "isort --check-only --profile black {args:.}",
   "pyproject-fmt --check pyproject.toml",
 ]
 fmt = [
   "black {args:.}",
-#  "ruff --fix {args:.}",
+  #  "ruff --fix {args:.}",
   "isort --profile black {args:.}",
   "pyproject-fmt pyproject.toml",
   "style",
@@ -138,36 +138,15 @@ all = [
   "typing",
 ]
 
-[tool.pytest.ini_options]
-pythonpath = [
-  "src"
-]
-testpaths = [
-  "tests"
-]
-norecursedirs = [
-  "runtimes/aleph-debian-11-python/rootfs/",
-  "runtimes/aleph-debian-12-python/rootfs/",
-]
-
 [tool.black]
-target-version = ["py310"]
+target-version = [ "py310" ]
 line-length = 120
 #skip-string-normalization = true
-
-[tool.mypy]
-python_version = "3.10"
-install_types = true
-non_interactive = true
-ignore_missing_imports = true
-explicit_package_bases = true
-check_untyped_defs = true
 
 [tool.ruff]
 target-version = "py310"
 line-length = 120
-[tool.ruff.lint]
-select = [
+lint.select = [
   "A",
   "ARG",
   "B",
@@ -194,34 +173,42 @@ select = [
   "W",
   "YTT",
 ]
-ignore = [
-#  # Allow non-abstract empty methods in abstract base classes
-#  "B027",
-#  # Allow boolean positional values in function calls, like `dict.get(... True)`
-#  "FBT003",
-#  # Ignore checks for possible passwords
-#  "S105", "S106", "S107",
-#  # Ignore complexity
-#  "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
+lint.ignore = [
+  #  # Allow non-abstract empty methods in abstract base classes
+  #  "B027",
+  #  # Allow boolean positional values in function calls, like `dict.get(... True)`
+  #  "FBT003",
+  #  # Ignore checks for possible passwords
+  #  "S105", "S106", "S107",
+  #  # Ignore complexity
+  #  "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
   # Allow the use of assert statements
-  "S101"
+  "S101",
 ]
+# Tests can use magic values, assertions, and relative imports
+lint.per-file-ignores."tests/**/*" = [ "PLR2004", "S101", "TID252" ]
+#[tool.ruff.flake8-tidy-imports]
+#ban-relative-imports = "all"
 #unfixable = [
 #  # Don't touch unused imports
 #  "F401",
 #]
+lint.isort = [ "aleph.vm" ]
 
-isort.known-first-party = ["aleph.vm"]
-
-#[tool.ruff.flake8-tidy-imports]
-#ban-relative-imports = "all"
-
-[tool.ruff.lint.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+[tool.pytest.ini_options]
+pythonpath = [
+  "src",
+]
+testpaths = [
+  "tests",
+]
+norecursedirs = [
+  "runtimes/aleph-debian-11-python/rootfs/",
+  "runtimes/aleph-debian-12-python/rootfs/",
+]
 
 [tool.coverage.run]
-source_pkgs = ["aleph.vm", "tests"]
+source_pkgs = [ "aleph.vm", "tests" ]
 branch = true
 parallel = true
 omit = [
@@ -229,8 +216,8 @@ omit = [
 ]
 
 [tool.coverage.paths]
-aleph_vm = ["src/aleph/vm", "*/aleph-vm/src/aleph/vm"]
-tests = ["tests", "*/aleph-vm/tests"]
+aleph_vm = [ "src/aleph/vm", "*/aleph-vm/src/aleph/vm" ]
+tests = [ "tests", "*/aleph-vm/tests" ]
 
 [tool.coverage.report]
 exclude_lines = [
@@ -238,3 +225,11 @@ exclude_lines = [
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:",
 ]
+
+[tool.mypy]
+python_version = "3.10"
+install_types = true
+non_interactive = true
+ignore_missing_imports = true
+explicit_package_bases = true
+check_untyped_defs = true


### PR DESCRIPTION
Enable pyproject-fmt to uniformise pyproject.toml formatting accross all projects.

Related ClickUp, GitHub or Jira tickets : ALEPH-181

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.

## How to test

Just run:

```
hatch run lint:style
hatch run lint:fmt
```
