### PR TITLE
Fix: Error fetching message from vm-connector for start_watch_for_messages_task

### DIFF
--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -123,12 +123,12 @@ async def start_watch_for_messages_task(app: web.Application):
 
     # Register an hardcoded initial program
     # TODO: Register all programs with subscriptions
-    sample_message, _ = await load_updated_message(
-        ref=ItemHash("cad11970efe9b7478300fd04d7cc91c646ca0a792b9cc718650f86e1ccfac73e")
-    )
-    if isinstance(sample_message, ProgramMessage):
-        assert sample_message.content.on.message, sample_message
-        reactor.register(sample_message)
+    # sample_message, _ = await load_updated_message(
+    #     ref=ItemHash("cad11970efe9b7478300fd04d7cc91c646ca0a792b9cc718650f86e1ccfac73e")
+    # )
+    # if isinstance(sample_message, ProgramMessage):
+    #     assert sample_message.content.on.message, sample_message
+    #     reactor.register(sample_message)
 
     app["pubsub"] = pubsub
     app["reactor"] = reactor


### PR DESCRIPTION

Problem:
When aleph-vm was starting if the vm-connector couldn't connect to the pyaleph API , the startup crashed and systemd restarted it in a loop.

Solution:
Stop registering the sample program at startup, so the  pyaleph api don't need to be reached at startup. This code was left as a demo but it didn't really do anything  at the moment.

We have just commented the code if we want to reuse it in the future.

Jira ticket : ALEPH-111

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.
- [x] Documentation has been updated regarding these changes.

## Changes

## How to test

stop your pyaleph and restart aleph-vm

## Print screen / video


## Notes

A more complete and long analysis of the problem, along with different proposed solution is in the comment of the  JIRA ticket

https://aleph-im.atlassian.net/browse/ALEPH-111?focusedCommentId=10008
