### PR TITLE
Problem: IGNORE_TRACEBACK_FROM_DIAGNOSTICS broken

### DIFF
--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -150,9 +150,11 @@ async def run_code_on_request(vm_hash: ItemHash, path: str, pool: VmPool, reques
 
             # The Diagnostics VM checks for the proper handling of exceptions.
             # This fills the logs with noisy stack traces, so we ignore this specific error.
-            ignored_error = 'raise CustomError("Whoops")'
+            ignored_errors = ['raise CustomError("Whoops")', "main.CustomError: Whoops"]
 
-            if settings.IGNORE_TRACEBACK_FROM_DIAGNOSTICS and ignored_error in result["traceback"]:
+            if settings.IGNORE_TRACEBACK_FROM_DIAGNOSTICS and any(
+                ignored_error in result["traceback"] for ignored_error in ignored_errors
+            ):
                 logger.debug('Ignored traceback from CustomError("Whoops")')
             else:
                 logger.warning(result["traceback"])


### PR DESCRIPTION
Symptom:
The CustomError from the diagnostics VM was printed even if if IGNORE_TRACEBACK_FROM_DIAGNOSTICS was set to True (the default)

Analysis:
This was caused by the refactoring of the fastapi_example/main.py file done in fe9235ac658915eea20d5371ae45cedabe1f7b17
Which changed the output used to detect the error to catch

Solution:
Fix detection string
