### PR TITLE
Problem: sevctl installation broken on Ubuntu

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -47,8 +47,7 @@ download-ipfs-kubo: target-dir build-dir
 	curl -fsSL https://github.com/ipfs/kubo/releases/download/v0.23.0/kubo_v0.23.0_linux-amd64.tar.gz | tar -xz --directory ./target/kubo
 
 target/bin/sevctl:
-	# Release 0.4.3 matches revision c41c9172be013d6f10b9e1d7286fcb021805d5a5
-	cargo install --git https://github.com/virtee/sevctl.git --rev c41c9172be013d6f10b9e1d7286fcb021805d5a5 --target x86_64-unknown-linux-gnu --root ./target
+	cargo install --git https://github.com/virtee/sevctl.git --rev v0.6.0 --target x86_64-unknown-linux-gnu --root ./target
 	./target/bin/sevctl -V
 
 version:

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -15,7 +15,7 @@ debian-package-code:
 	cp ../examples/instance_message_from_aleph.json ./aleph-vm/opt/aleph-vm/examples/instance_message_from_aleph.json
 	cp -r ../examples/data ./aleph-vm/opt/aleph-vm/examples/data
 	mkdir -p ./aleph-vm/opt/aleph-vm/examples/volumes
-	pip3 install --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.4.9' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2'
+	pip3 install --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.4.9' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2'
 	python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux download-ipfs-kubo  target/bin/sevctl


### PR DESCRIPTION
sevctl 0.4.3 was refusing to compile on Ubuntu 22.04 and 24.02
because of some deps. This happened in the Github CI

This prevented the build of package and the testing inside the CI

Solution: Update sevctl to 0.6.0

Error logs
```
Compiling structopt-derive v0.4.18
error[E0658]: `c".."` literals are experimental
--> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/kvm-ioctls-0.19.0/src/ioctls/system.rs:99:24
|
99 |         let kvm_path = c"/dev/kvm";
|                        ^^^^^^^^^^^
|
= note: see issue #105723 <https://github.com/rust-lang/rust/issues/105723> for more information

error[E0658]: `c".."` literals are experimental
--> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/kvm-ioctls-0.19.0/src/ioctls/system.rs:744:24
|
744 |         let kvm_path = c"/dev/kvm";
|                        ^^^^^^^^^^^
|
= note: see issue #105723 <https://github.com/rust-lang/rust/issues/105723> for more information

For more information about this error, try `rustc --explain E0658`.
The following warnings were emitted during compilation:

warning: kvm-ioctls@0.19.0: cargo:rustc-check-cfg requires -Zcheck-cfg flag

error: could not compile `kvm-ioctls` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: failed to compile `sevctl v0.4.3 (https://github.com/virtee/sevctl.git?rev=c41c9172be013d6f10b9e1d7286fcb021805d5a5#c41c9172)`, intermediate artifacts can be found at `/tmp/cargo-installXhERbT`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
make: *** [Makefile:51: target/bin/sevctl] Error 101
make: *** [Makefile:89: all-podman-ubuntu-2204] Error 2
```