### PR TITLE
Improve logging, Add logging per VM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,15 +191,16 @@ lint.ignore = [
   # Allow the use of assert statements
   "S101",
 ]
-# Tests can use magic values, assertions, and relative imports
-lint.per-file-ignores."tests/**/*" = [ "PLR2004", "S101", "TID252" ]
 #[tool.ruff.flake8-tidy-imports]
 #ban-relative-imports = "all"
 #unfixable = [
 #  # Don't touch unused imports
 #  "F401",
 #]
-lint.isort = [ "aleph.vm" ]
+#lint.isort = [ "aleph.vm" ]
+
+# Tests can use magic values, assertions, and relative imports
+lint.per-file-ignores."tests/**/*" = [ "PLR2004", "S101", "TID252" ]
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -396,8 +396,6 @@ class Settings(BaseSettings):
         STREAM_CHAINS[Chain.AVAX].rpc = str(self.RPC_AVAX)
         STREAM_CHAINS[Chain.BASE].rpc = str(self.RPC_BASE)
 
-        logger.info(STREAM_CHAINS)
-
         os.makedirs(self.MESSAGE_CACHE, exist_ok=True)
         os.makedirs(self.CODE_CACHE, exist_ok=True)
         os.makedirs(self.RUNTIME_CACHE, exist_ok=True)

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -136,6 +136,7 @@ class Settings(BaseSettings):
     # System logs make boot ~2x slower
     PRINT_SYSTEM_LOGS = False
     IGNORE_TRACEBACK_FROM_DIAGNOSTICS = True
+    LOG_LEVEL = "WARNING"
     DEBUG_ASYNCIO = False
 
     # Networking does not work inside Docker/Podman

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -66,7 +66,7 @@ def parse_args(args):
         help="set loglevel to INFO",
         action="store_const",
         const=logging.INFO,
-        default=logging.WARNING,
+        default=settings.LOG_LEVEL,
     )
     parser.add_argument(
         "-vv",
@@ -298,7 +298,12 @@ def main():
     )
     # log_format = "[%(asctime)s] p%(process)s {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s"
 
-    setup_handlers(args, log_format)
+    handlers = setup_handlers(args, log_format)
+    logging.basicConfig(
+        level=args.loglevel,
+        format=log_format,
+        handlers=handlers,
+    )
 
     logging.getLogger("aiosqlite").setLevel(logging.WARNING)
     logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -305,8 +305,8 @@ def main():
         handlers=handlers,
     )
 
-    logging.getLogger("aiosqlite").setLevel(logging.WARNING)
-    logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
+    logging.getLogger("aiosqlite").setLevel(settings.LOG_LEVEL)
+    logging.getLogger("sqlalchemy.engine").setLevel(settings.LOG_LEVEL)
 
     settings.update(
         USE_JAILER=args.use_jailer,

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -300,6 +300,9 @@ def main():
         format=log_format,
     )
 
+    logging.getLogger("aiosqlite").setLevel(logging.WARNING)
+    logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
+
     settings.update(
         USE_JAILER=args.use_jailer,
         PRINT_SYSTEM_LOGS=args.system_logs,

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -282,7 +282,7 @@ def run_db_migrations(connection):
 
 
 async def run_async_db_migrations():
-    async_engine = create_async_engine(make_db_url(), echo=True)
+    async_engine = create_async_engine(make_db_url(), echo=False)
     async with async_engine.begin() as conn:
         await conn.run_sync(run_db_migrations)
 

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -293,8 +293,10 @@ def main():
     log_format = (
         "%(relativeCreated)4f | %(levelname)s | %(message)s"
         if args.profile
-        else "%(asctime)s | %(levelname)s | %(message)s"
+        else "%(asctime)s | %(levelname)s %(name)s:%(lineno)s | %(message)s"
     )
+    # log_format = "[%(asctime)s] p%(process)s {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s"
+
     logging.basicConfig(
         level=args.loglevel,
         format=log_format,

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -23,6 +23,7 @@ from aleph.vm.pool import VmPool
 from aleph.vm.version import __version__, get_version_from_apt, get_version_from_git
 
 from . import metrics, supervisor
+from .custom_logs import setup_handlers
 from .pubsub import PubSub
 from .run import run_code_on_event, run_code_on_request, start_persistent_vm
 
@@ -297,10 +298,7 @@ def main():
     )
     # log_format = "[%(asctime)s] p%(process)s {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s"
 
-    logging.basicConfig(
-        level=args.loglevel,
-        format=log_format,
-    )
+    setup_handlers(args, log_format)
 
     logging.getLogger("aiosqlite").setLevel(logging.WARNING)
     logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)

--- a/src/aleph/vm/orchestrator/custom_logs.py
+++ b/src/aleph/vm/orchestrator/custom_logs.py
@@ -51,8 +51,4 @@ def setup_handlers(args, log_format):
     non_execution_handler.setFormatter(
         logging.Formatter("%(asctime)s | %(levelname)s %(name)s:%(lineno)s | %(message)s ")
     )
-    logging.basicConfig(
-        level=args.loglevel,
-        format=log_format,
-        handlers=[non_execution_handler, execution_handler],
-    )
+    return [non_execution_handler, execution_handler]

--- a/src/aleph/vm/orchestrator/custom_logs.py
+++ b/src/aleph/vm/orchestrator/custom_logs.py
@@ -1,0 +1,58 @@
+import contextlib
+import logging
+from contextvars import ContextVar
+
+from aleph_message.models import ItemHash
+
+from aleph.vm.models import VmExecution
+
+ctx_current_execution: ContextVar[VmExecution | None] = ContextVar("current_execution")
+ctx_current_execution_hash: ContextVar[ItemHash | None] = ContextVar("current_execution_hash")
+
+
+@contextlib.contextmanager
+def set_vm_for_logging(vm_hash):
+    token = ctx_current_execution_hash.set(vm_hash)
+    try:
+        yield
+    finally:
+        ctx_current_execution_hash.reset(token)
+
+
+class InjectingFilter(logging.Filter):
+    """
+    A filter which injects context-specific information into logs
+    """
+
+    def filter(self, record):
+
+        vm_hash = ctx_current_execution_hash.get(None)
+        if not vm_hash:
+            vm_execution: VmExecution | None = ctx_current_execution.get(None)
+            if vm_execution:
+                vm_hash = vm_execution.vm_hash
+
+        if not vm_hash:
+            return False
+
+        record.vm_hash = vm_hash
+        return True
+
+
+def setup_handlers(args, log_format):
+    # Set up two custom handler, one that will add the VM information if present and the other print if not
+    execution_handler = logging.StreamHandler()
+    execution_handler.addFilter(InjectingFilter())
+    execution_handler.setFormatter(
+        logging.Formatter("%(asctime)s | %(levelname)s %(name)s:%(lineno)s | {%(vm_hash)s} %(message)s ")
+    )
+    non_execution_handler = logging.StreamHandler()
+    non_execution_handler.addFilter(lambda x: ctx_current_execution_hash.get(None) is None)
+    non_execution_handler.setFormatter(
+        logging.Formatter("%(asctime)s | %(levelname)s %(name)s:%(lineno)s | %(message)s ")
+    )
+    logging.basicConfig(
+        level=args.loglevel,
+        format=log_format,
+        handlers=[non_execution_handler, execution_handler],
+    )

--- a/src/aleph/vm/orchestrator/metrics.py
+++ b/src/aleph/vm/orchestrator/metrics.py
@@ -38,7 +38,7 @@ Base: Any = declarative_base()
 
 def setup_engine():
     global AsyncSessionMaker
-    engine = create_async_engine(make_db_url(), echo=True)
+    engine = create_async_engine(make_db_url(), echo=False)
     AsyncSessionMaker = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
     return engine
 

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -115,7 +115,8 @@ async def run_code_from_hostname(request: web.Request) -> web.Response:
                 return HTTPNotFound(reason="Invalid message reference")
 
     pool = request.app["vm_pool"]
-    return await run_code_on_request(message_ref, path, pool, request)
+    with set_vm_for_logging(vm_hash=message_ref):
+        return await run_code_on_request(message_ref, path, pool, request)
 
 
 def authenticate_request(request: web.Request) -> None:

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -1,4 +1,5 @@
 import binascii
+import contextlib
 import logging
 from decimal import Decimal
 from hashlib import sha256
@@ -25,6 +26,7 @@ from aleph.vm.controllers.firecracker.program import FileTooLargeError
 from aleph.vm.hypervisors.firecracker.microvm import MicroVMFailedInitError
 from aleph.vm.orchestrator import payment, status
 from aleph.vm.orchestrator.chain import STREAM_CHAINS, ChainInfo
+from aleph.vm.orchestrator.custom_logs import set_vm_for_logging
 from aleph.vm.orchestrator.messages import try_get_message
 from aleph.vm.orchestrator.metrics import get_execution_records
 from aleph.vm.orchestrator.payment import (
@@ -75,7 +77,8 @@ async def run_code_from_path(request: web.Request) -> web.Response:
         ) from e
 
     pool: VmPool = request.app["vm_pool"]
-    return await run_code_on_request(message_ref, path, pool, request)
+    with set_vm_for_logging(vm_hash=message_ref):
+        return await run_code_on_request(message_ref, path, pool, request)
 
 
 async def run_code_from_hostname(request: web.Request) -> web.Response:

--- a/src/aleph/vm/version.py
+++ b/src/aleph/vm/version.py
@@ -1,17 +1,17 @@
 import logging
-from subprocess import CalledProcessError, check_output
+from subprocess import STDOUT, CalledProcessError, check_output
 
 logger = logging.getLogger(__name__)
 
 
 def get_version_from_git() -> str | None:
     try:
-        return check_output(("git", "describe", "--tags")).strip().decode()
+        return check_output(("git", "describe", "--tags"), stderr=STDOUT).strip().decode()
     except FileNotFoundError:
-        logger.warning("git not found")
+        logger.warning("version: git not found")
         return None
-    except CalledProcessError:
-        logger.warning("git description not available")
+    except CalledProcessError as err:
+        logger.info("version: git description not available: %s", err.output.decode().strip())
         return None
 
 


### PR DESCRIPTION
Split of from #719 , better reviewability.

Improve the logging for ALEPH-VM
This is a lot of small improvement to make aleph-vm more usable. I'm putting them all under the banner of the  Jira tickets : ALEPH-166


* Include the VM hash in logs were relevant (might have missed some place yet) to help debug endpoint
* Remove the duplicate output of the  db  logs (sqlalchemy)
* Ensure logs for http request are printed
* Set default level for logging to INFO (so node owner have useful info by default for debugging problem)
* Fix `hatch fmt` command (and `ruff fmt` )
* Less crap in the program output in general
* Don't check payment for fake debug instances.
* Ability to set the LOG level via an environment variable  (replace https://github.com/aleph-im/aleph-vm/pull/581 )



Related ClickUp, GitHub or Jira tickets :Part of  ALEPH-166 Epic

## Self proofreading checklist

- [ ] The new code clear, easy to read and well commented.
- [ ] New code does not duplicate the functions of builtin or popular libraries.
- [ ] An LLM was used to review the new code and look for simplifications.
- [ ] New classes and functions contain docstrings explaining what they provide.
- [ ] All new code is covered by relevant tests.
- [ ] Documentation has been updated regarding these changes.
- [ ] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

## Changes

Explain the changes that were made. The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:
- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints

## How to test

Use is as usual.

