### PR TITLE
CI: docker: Error response from daemon: toomanyrequests

### DIFF
--- a/.github/workflows/test-on-droplets-matrix.yml
+++ b/.github/workflows/test-on-droplets-matrix.yml
@@ -134,7 +134,8 @@ jobs:
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o DPkg::Lock::Timeout=60 update"
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o DPkg::Lock::Timeout=60 upgrade -y"
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o DPkg::Lock::Timeout=60 install -y docker.io apparmor-profiles"
-          ssh root@${DROPLET_IPV4} "docker run -d -p 127.0.0.1:4021:4021/tcp --restart=always --name vm-connector alephim/vm-connector:alpha"
+          ssh root@${DROPLET_IPV4} "docker pull ghcr.io/aleph-im/vm-connector:alpha"
+          ssh root@${DROPLET_IPV4} "docker run -d -p 127.0.0.1:4021:4021/tcp --restart=always --name vm-connector ghcr.io/aleph-im/vm-connector:alpha"
 
           scp packaging/target/${{ matrix.os_config.package_name }} root@${DROPLET_IPV4}:/opt
           # "--force-confold" keeps existing config files during package install/upgrade, avoiding prompts.


### PR DESCRIPTION
CI returned error:
docker: Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit. DAMN

Solution: :Use GitHub container repository instead of hub.docker.io (default one for docker)

olethanh pushed the image using:
```bash
podman pull docker.io/alephim/vm-connector:alpha
podman tag alephim/vm-connector:alpha ghcr.io/aleph-im/vm-connector:alpha
podman push ghcr.io/aleph-im/vm-connector:alpha
```

Auth to github firt https://docs.github.com/fr/packages/working-with-a-github-packages-registry/working-with-the-container-registry

Explain what problem this PR is resolving

Related ClickUp, GitHub or Jira tickets : ALEPH-315
