### PR TITLE
Use ruff for formatting and document code quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,35 @@ Unless your focus is developing the VM-Connector, using the Docker image is easi
 ## Testing
 See [Testinc doc](./TESTING.md)
 
+## Code Formatting and Linting
+
+To help maintain a clean and consistent codebase, we provide automated tools for formatting and style checks.
+To ensure your code is properly **formatted** according to project standards, you can use:
+
+```bash
+hatch linting:fmt
+```
+
+**Typing** helps ensure your code adheres to expected type annotations, improving reliability and clarity. To validate
+typing in your code, use:
+```bash
+hatch linting:typing
+```
+
+These checks are also validated in Continuous Integration (CI) alongside unit tests. To ensure a smooth workflow, we 
+recommend running these commands before committing changes.
+
+**Linting** checks for potential errors, coding style violations, and patterns that may lead to bugs or reduce code
+quality (e.g., unused variables, incorrect imports, or inconsistent naming). While linting is not currently enforced in
+Continuous Integration (CI), it is considered a best practice to check linting manually to maintain high-quality code.
+You can manually lint your code by running:
+
+```bash
+hatch fmt
+```
+
+Following these best practices can help streamline code reviews and improve overall project quality.
+
 # Architecture
 
 ![Aleph im VM - Details](https://user-images.githubusercontent.com/404665/127126908-3225a633-2c36-4129-8766-9810f2fcd7d6.png)

--- a/examples/example_django/manage.py
+++ b/examples/example_django/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,7 @@ line-length = 120
 [tool.ruff]
 target-version = "py310"
 line-length = 120
+src = [ "src" ]
 lint.select = [
   "A",
   "ARG",
@@ -197,9 +198,6 @@ lint.ignore = [
   # Allow the use of assert statements
   "S101",
 ]
-src = ["src"]
-
-
 #[tool.ruff.flake8-tidy-imports]
 #ban-relative-imports = "all"
 #unfixable = [
@@ -212,6 +210,7 @@ lint.per-file-ignores."tests/**/*" = [ "PLR2004", "S101", "TID252" ]
 
 [tool.isort]
 profile = "black"
+extra_standard_library = [ "packaging" ]
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,16 +126,18 @@ dependencies = [
 ]
 [tool.hatch.envs.linting.scripts]
 typing = "mypy {args:src/aleph/vm/ tests/ examples/example_fastapi runtimes/aleph-debian-12-python}"
+# Check
 style = [
-  #  "ruff {args:.}",
+  "ruff format --diff {args:.}",
   "black --check --diff {args:.}",
   "isort --check-only --profile black {args:.}",
   "yamlfix --check .",
   "pyproject-fmt --check pyproject.toml",
 ]
+# Do modification
 fmt = [
+  "ruff format {args:.}",
   "black {args:.}",
-  #  "ruff --fix {args:.}",
   "isort --profile black {args:.}",
   "yamlfix .",
   "pyproject-fmt pyproject.toml",
@@ -182,6 +184,8 @@ lint.select = [
   "YTT",
 ]
 lint.ignore = [
+  "ISC001",
+  # https://docs.astral.sh/ruff/rules/single-line-implicit-string-concatenation/#single-line-implicit-string-concatenation-isc001
   #  # Allow non-abstract empty methods in abstract base classes
   #  "B027",
   #  # Allow boolean positional values in function calls, like `dict.get(... True)`
@@ -193,16 +197,21 @@ lint.ignore = [
   # Allow the use of assert statements
   "S101",
 ]
+src = ["src"]
+
+
 #[tool.ruff.flake8-tidy-imports]
 #ban-relative-imports = "all"
 #unfixable = [
 #  # Don't touch unused imports
 #  "F401",
 #]
-#lint.isort = [ "aleph.vm" ]
 
 # Tests can use magic values, assertions, and relative imports
 lint.per-file-ignores."tests/**/*" = [ "PLR2004", "S101", "TID252" ]
+
+[tool.isort]
+profile = "black"
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,6 @@ python = [ "3.10", "3.11", "3.12" ]
 [tool.hatch.envs.linting]
 detached = true
 dependencies = [
-  "black==24.3.0",
   "mypy==1.8.0",
   "ruff==0.4.6",
   "isort==5.13.2",
@@ -129,7 +128,6 @@ typing = "mypy {args:src/aleph/vm/ tests/ examples/example_fastapi runtimes/alep
 # Check
 style = [
   "ruff format --diff {args:.}",
-  "black --check --diff {args:.}",
   "isort --check-only --profile black {args:.}",
   "yamlfix --check .",
   "pyproject-fmt --check pyproject.toml",
@@ -137,7 +135,6 @@ style = [
 # Do modification
 fmt = [
   "ruff format {args:.}",
-  "black {args:.}",
   "isort --profile black {args:.}",
   "yamlfix .",
   "pyproject-fmt pyproject.toml",

--- a/runtimes/aleph-debian-12-python/init1.py
+++ b/runtimes/aleph-debian-12-python/init1.py
@@ -558,6 +558,7 @@ async def main() -> None:
 
     class ServerReference:
         "Reference used to close the server from within `handle_instruction"
+
         server: asyncio.AbstractServer
 
     server_reference = ServerReference()

--- a/src/aleph/vm/hypervisors/qemu_confidential/qemuvm.py
+++ b/src/aleph/vm/hypervisors/qemu_confidential/qemuvm.py
@@ -12,7 +12,6 @@ from aleph.vm.hypervisors.qemu.qemuvm import QemuVM
 
 
 class QemuConfidentialVM(QemuVM):
-
     sev_policy: str = hex(AMDSEVPolicy.NO_DBG)
     sev_dh_cert_file: Path  # "vm_godh.b64"
     sev_session_file: Path  # "vm_session.b64"

--- a/src/aleph/vm/orchestrator/custom_logs.py
+++ b/src/aleph/vm/orchestrator/custom_logs.py
@@ -25,7 +25,6 @@ class InjectingFilter(logging.Filter):
     """
 
     def filter(self, record):
-
         vm_hash = ctx_current_execution_hash.get(None)
         if not vm_hash:
             vm_execution: VmExecution | None = ctx_current_execution.get(None)

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -4,6 +4,7 @@ import logging
 from decimal import Decimal
 from hashlib import sha256
 from json import JSONDecodeError
+from packaging.version import InvalidVersion, Version
 from pathlib import Path
 from secrets import compare_digest
 from string import Template
@@ -55,7 +56,6 @@ from aleph.vm.utils import (
     get_ref_from_dns,
 )
 from aleph.vm.version import __version__
-from packaging.version import InvalidVersion, Version
 
 logger = logging.getLogger(__name__)
 

--- a/src/aleph/vm/orchestrator/views/authentication.py
+++ b/src/aleph/vm/orchestrator/views/authentication.py
@@ -257,7 +257,7 @@ async def authenticate_websocket_message(message) -> str:
 
 
 def require_jwk_authentication(
-    handler: Callable[[web.Request, str], Coroutine[Any, Any, web.StreamResponse]]
+    handler: Callable[[web.Request, str], Coroutine[Any, Any, web.StreamResponse]],
 ) -> Callable[[web.Request], Awaitable[web.StreamResponse]]:
     """A decorator to enforce JWK-based authentication for HTTP requests.
 

--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -216,7 +216,6 @@ async def operate_confidential_initialize(request: web.Request, authenticated_se
     """Start the confidential virtual machine if possible."""
     vm_hash = get_itemhash_or_400(request.match_info)
     with set_vm_for_logging(vm_hash=vm_hash):
-
         pool: VmPool = request.app["vm_pool"]
         logger.debug(f"Iterating through running executions... {pool.executions}")
         execution = get_execution_or_404(vm_hash, pool=pool)

--- a/tests/supervisor/test_authentication.py
+++ b/tests/supervisor/test_authentication.py
@@ -16,7 +16,6 @@ from aleph.vm.orchestrator.views.authentication import (
 )
 from aleph.vm.utils.test_helpers import (
     generate_signer_and_signed_headers_for_operation,
-    patch_datetime_now,
     to_0x_hex,
 )
 

--- a/tests/supervisor/test_authentication.py
+++ b/tests/supervisor/test_authentication.py
@@ -16,8 +16,12 @@ from aleph.vm.orchestrator.views.authentication import (
 )
 from aleph.vm.utils.test_helpers import (
     generate_signer_and_signed_headers_for_operation,
+    patch_datetime_now,
     to_0x_hex,
 )
+
+# Ensure this is not removed by ruff
+assert patch_datetime_now
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_instance.py
+++ b/tests/supervisor/test_instance.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 from asyncio.subprocess import Process
 from pathlib import Path
-from typing import Optional
 
 import pytest
 from aleph_message.models import ItemHash
@@ -21,8 +20,8 @@ from aleph.vm.vm_type import VmType
 
 @pytest.mark.asyncio
 class MockSystemDManager(SystemDManager):
-    execution: Optional[MicroVM] = None
-    process: Optional[Process] = None
+    execution: MicroVM | None = None
+    process: Process | None = None
 
     async def enable_and_start(self, vm_hash: str):
         config_path = Path(f"{settings.EXECUTION_ROOT}/{vm_hash}-controller.json")

--- a/tests/supervisor/test_qemu_instance.py
+++ b/tests/supervisor/test_qemu_instance.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 from asyncio.subprocess import Process
 from pathlib import Path
-from typing import Optional
 
 import pytest
 from aleph_message.models import ItemHash
@@ -21,8 +20,8 @@ from aleph.vm.vm_type import VmType
 
 @pytest.mark.asyncio
 class MockSystemDManager(SystemDManager):
-    execution: Optional[QemuVM] = None
-    process: Optional[Process] = None
+    execution: QemuVM | None = None
+    process: Process | None = None
 
     async def enable_and_start(self, vm_hash: str):
         config_path = Path(f"{settings.EXECUTION_ROOT}/{vm_hash}-controller.json")

--- a/tests/supervisor/test_utils.py
+++ b/tests/supervisor/test_utils.py
@@ -9,7 +9,6 @@ from aleph.vm.utils import (
 
 
 def test_check_system_module_enabled():
-
     with mock.patch(
         "pathlib.Path.exists",
         return_value=True,
@@ -19,7 +18,6 @@ def test_check_system_module_enabled():
             "aleph.vm.utils.Path.open",
             mock.mock_open(read_data=expected_value),
         ):
-
             output = check_system_module("kvm_amd/parameters/sev_enp")
             assert output == expected_value
 

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -1,5 +1,5 @@
 import tempfile
-from pathlib import Path, PosixPath
+from pathlib import Path
 from unittest import mock
 from unittest.mock import call
 

--- a/tests/supervisor/views/test_operator.py
+++ b/tests/supervisor/views/test_operator.py
@@ -9,18 +9,14 @@ from unittest.mock import MagicMock
 import aiohttp
 import pytest
 from aiohttp.test_utils import TestClient
-from aleph_message.models import ItemHash, ProgramMessage
+from aleph_message.models import ItemHash
 
 from aleph.vm.conf import settings
 from aleph.vm.orchestrator.metrics import ExecutionRecord
 from aleph.vm.orchestrator.supervisor import setup_webapp
-from aleph.vm.pool import VmPool
 from aleph.vm.storage import get_message
 from aleph.vm.utils.logs import EntryDict
-from aleph.vm.utils.test_helpers import (
-    generate_signer_and_signed_headers_for_operation,
-    patch_datetime_now,
-)
+from aleph.vm.utils.test_helpers import generate_signer_and_signed_headers_for_operation
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/views/test_operator.py
+++ b/tests/supervisor/views/test_operator.py
@@ -16,7 +16,13 @@ from aleph.vm.orchestrator.metrics import ExecutionRecord
 from aleph.vm.orchestrator.supervisor import setup_webapp
 from aleph.vm.storage import get_message
 from aleph.vm.utils.logs import EntryDict
-from aleph.vm.utils.test_helpers import generate_signer_and_signed_headers_for_operation
+from aleph.vm.utils.test_helpers import (
+    generate_signer_and_signed_headers_for_operation,
+    patch_datetime_now,
+)
+
+# Ensure this is not removed by ruff
+assert patch_datetime_now
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Switch to ruff for formatting (not linting) instead of black.

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.
- [x] Documentation has been updated regarding these changes.
- [x] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

## Changes

To clarify, ruff has two mode:
*  formatting, launched with `ruff format` or `hatch fmt --formatter`,  which is more or less equivalent to `black`
* linting, lauched with `ruff --fix` or `ruff check fix` or `hatch fmt --linter`, which check the code style more comprehensively  and which fixes can't always be automated.

The builtin command `hatch fmt` launch both. But in aleph-vm we use `hatch linting:fmt` (or `linting:style` ) that do a whole bunch additional checks (yaml, pyproject.toml, etc..)

This PR remove `black` execution from the fmt/style scripts in hatch but keep it configured and installed for now (so we can double check and to ease transition)

The ruff  configuration is also modified so it match what isort  do. We still use isort as `ruff format` doesn't match that capability (but ruff lint does)

Did a ruff check on tests (lint)



## How to test
No expected behaviural chnage in the program run. 

## Notes


