### PR TITLE
Fix error Deleting network interface

### DIFF
--- a/src/aleph/vm/network/interfaces.py
+++ b/src/aleph/vm/network/interfaces.py
@@ -170,6 +170,4 @@ class TapInterface:
         if self.ndp_proxy:
             await self.ndp_proxy.delete_range(self.device_name)
         with IPRoute() as ipr:
-            delete_ip_address(ipr, self.device_name, self.host_ip)
-            delete_ip_address(ipr, self.device_name, self.host_ipv6)
             delete_tap_interface(ipr, self.device_name)

--- a/src/aleph/vm/network/interfaces.py
+++ b/src/aleph/vm/network/interfaces.py
@@ -61,20 +61,6 @@ def add_ip_address(ipr: IPRoute, device_name: str, ip: IPv4Interface | IPv6Inter
         logger.error(f"Unknown exception while adding address {ip} to interface {device_name}: {e}")
 
 
-def delete_ip_address(ipr: IPRoute, device_name: str, ip: IPv4Interface | IPv6Interface):
-    """Delete an IP address to the given interface."""
-    interface_index: list[int] = ipr.link_lookup(ifname=device_name)
-    if not interface_index:
-        msg = f"Interface {device_name} does not exist, can't delete address {ip} to it."
-        raise MissingInterfaceError(msg)
-    try:
-        ipr.addr("del", index=interface_index[0], address=str(ip.ip), mask=ip.network.prefixlen)
-    except NetlinkError as e:
-        logger.exception(f"Unknown exception while deleting address {ip} to interface {device_name}: {e}")
-    except OSError as e:
-        logger.exception(f"Unknown exception while deleting address {ip} to interface {device_name}: {e}")
-
-
 def set_link_up(ipr: IPRoute, device_name: str):
     """Set the given interface up."""
     interface_index: list[int] = ipr.link_lookup(ifname=device_name)


### PR DESCRIPTION
JIRA: ALEPH-115

**Problem**:
When reusing an existing stale network interface, the following error would occasionally occur:

```
Unknown exception while deleting address 2a01:4f8:171:787:1:63fa:f8b5:db10/124 to interface vmtap...
```

See details in Sentry: [https://alephim.sentry.io/issues/5993120643/?project=4506303231819776](https://alephim.sentry.io/issues/5993120643/?project=4506303231819776)

**Analysis**:
This error occurred during the process of cleaning up an old interface (that was not deleted after usage for various possible reasons). The code was attempting to delete the IP addresses associated with this interface (as calculated in the code). However, when these IP addresses did not exist, an error was raised.

**Solution**:
Our initial approach was to use the `IPRoute` module to list the IP addresses associated with the network interface and then delete them instead of calculating their names in the Python code as is done presently.

After experimentation, we determined that deleting the interface directly also removes the associated IP addresses. Therefore, it is unnecessary to delete them manually, which simplifies the code.

**To test**:
Create and stop Program
Create network interface
```bash
sudo ip tuntap add dev vmtap4 mode tap
```
and attach ip to them
```bash
sudo ip addr add 1.1.1.1/30 dev  vmtap4
```

Try different combinaison and validate that everything still work correctly

To check the networks interfaces use the following command to list them
```bash
sudo ip link
```

and to list the ip address use:
```
sudo ip addr
```
