### PR TITLE
Chore(deps): Bump aiohttp from 3.9.5 to 3.10.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dynamic = [ "version" ]
 # Upon adding or updating dependencies, update `packaging/Makefile` for the Debian package
 dependencies = [
   "aiodns==3.1",
-  "aiohttp==3.9.5",
+  "aiohttp==3.10.11",
   "aiohttp-cors~=0.7.0",
   "aioredis==1.3.1",
   "aiosqlite==0.19",


### PR DESCRIPTION
Reopening #732 since dependabots can't execute CI

---
updated-dependencies:
- dependency-name: aiohttp
  dependency-type: direct:production
...