### PR TITLE
update allocation halted on missing hash ALEPH-337

### DIFF
--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -403,6 +403,7 @@ async def update_allocations(request: web.Request):
         VmSetupError,
         MicroVMFailedInitError,
         HostNotFoundError,
+        HTTPNotFound,
     )
 
     scheduling_errors: dict[ItemHash, Exception] = {}

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -110,9 +110,12 @@ async def download_file(url: str, local_path: Path) -> None:
                 await asyncio.wait_for(file_downloaded_by_another_task(local_path), timeout=30)
             except TimeoutError as error:
                 if attempt < (download_attempts - 1):
-                    logger.warning(f"Download failed, retrying attempt {attempt + 1}/{download_attempts}...")
+                    logger.warning(
+                        f"Download failed (waiting for another taks), retrying attempt {attempt + 1}/{download_attempts}..."
+                    )
                     continue
                 else:
+                    logger.warning(f"Download of {url} failed  (waiting for another task), aborting...")
                     raise error from file_exists_error
         except (
             aiohttp.ClientConnectionError,
@@ -123,6 +126,7 @@ async def download_file(url: str, local_path: Path) -> None:
                 logger.warning(f"Download failed, retrying attempt {attempt + 1}/{download_attempts}...")
                 # continue  #  continue inside try/finally block is unimplemented in `mypyc`
             else:
+                logger.warning(f"Download of {url} failed  (aborting...")
                 raise error
         finally:
             # Ensure no partial file is left behind


### PR DESCRIPTION
If a message was inexisting, fake or rejected, for example in the ref for an instance, update_allocation halted at the VM it was processing,  stopping the processing of the rest of the list of VM. This mean that any bad item hash from the scheduler would block bringing any new VM ups.

This situation is now improved more generally so as to catch any error that might happen during VM creation.


Related ClickUp, GitHub or Jira tickets : Jira Ticket: ALEH-337

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [no] All new code is covered by relevant tests.
- [n/a] Documentation has been updated regarding these changes.
- [ x] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

## Changes

Explain the changes that were made. The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:
- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints

## How to test

Call update allocation with invalid hash mixed in

e.g.
```
POST http://localhost:4020/control/allocations
Content-Type: application/json
X-Auth-Signature: test
Accept: application/json
Content-Length: 191
User-Agent: IntelliJ HTTP Client/PyCharm 2024.3.1
Accept-Encoding: br, deflate, gzip, x-gzip

{
  "persistent_vms": [],
  "instances": [
    "2f473bb4662888edf852b5dda6662328cca000cdf4d64c8a4576bea355d3d723",
    "f473bb4662888edf852b5dda6662328cca000cdf4d64c8a4576bea355d3d7232"
  ]
}
```

it should return a something like


```
{
  "success": false,
  "successful": [],
  "failing": [
    "f473bb4662888edf852b5dda6662328cca000cdf4d64c8a4576bea355d3d7232",
    "2f473bb4662888edf852b5dda6662328cca000cdf4d64c8a4576bea355d3d723"
  ],
  "errors": {
    "f473bb4662888edf852b5dda6662328cca000cdf4d64c8a4576bea355d3d7232": "HostNotFoundError()",
    "2f473bb4662888edf852b5dda6662328cca000cdf4d64c8a4576bea355d3d723": "<HTTPNotFound Hash not found not prepared>"
  }
}
```

