### PR TITLE
Display proper error for message not found

### DIFF
--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -3,7 +3,7 @@ import logging
 from typing import Any
 
 import msgpack
-from aiohttp import web
+from aiohttp import ClientResponseError, web
 from aiohttp.web_exceptions import (
     HTTPBadGateway,
     HTTPBadRequest,
@@ -88,6 +88,12 @@ async def create_vm_execution_or_raise_http_error(vm_hash: ItemHash, pool: VmPoo
         logger.exception(error)
         pool.forget_vm(vm_hash=vm_hash)
         raise HTTPInternalServerError(reason="Host did not respond to ping") from error
+    except ClientResponseError as error:
+        logger.exception(error)
+        if error.status == 404:
+            raise HTTPInternalServerError(reason=f"Item hash {vm_hash} not found") from error
+        else:
+            raise HTTPInternalServerError(reason=f"Error downloading {vm_hash}") from error
     except Exception as error:
         logger.exception(error)
         pool.forget_vm(vm_hash=vm_hash)


### PR DESCRIPTION
or not being downloadable


Related ClickUp, GitHub or Jira tickets : ALEPH-353


## Problem:
When calling an program on a CRN, whose message the CRN couldn’t reach, it returned the error
```
500: Unhandled error during initialisation
```

instead of a proper explanation error

## Solution:
Catch that error. Catch also the other possible error when downloading

This also now works when failing to download a runtime or volume


## testing
Call your CRN via http with an invalid item hash