### PR TITLE
Fix: Runtime emitted wrong reboot signal

### DIFF
--- a/runtimes/aleph-debian-12-python/init1.py
+++ b/runtimes/aleph-debian-12-python/init1.py
@@ -619,6 +619,6 @@ if __name__ == "__main__":
     # Send reboot syscall, see man page
     # https://man7.org/linux/man-pages/man2/reboot.2.html
     libc = ctypes.CDLL(None)
-    libc.syscall(169, 0xFEE1DEAD, 672274793, 0x4321FEDC, None)
+    libc.syscall(169, 0xFEE1DEAD, 672274793, 0x1234567, None)
     # The exit should not happen due to system halt.
     sys.exit(0)


### PR DESCRIPTION
The runtime init `init1.py` emitted the signal `0x4321fedc`
to the Linux kernel when shutting down.

The correct procedure [according to the Firecracker docs]
(https://github.com/firecracker-microvm/firecracker/blob/dfb45dc4213bcb1c9704435457e233d3a210dce2/docs/getting-started.md?plain=1#L298) is to issue a `reboot`.

The syscall number for a reboot on Linux is `0x1234567`.

Tested using Firecracker independently of `aleph-vm`.
