### PR TITLE
Fix instance ip4 network stopping (nat)

### DIFF
--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -81,7 +81,11 @@ class VmPool:
     def teardown(self) -> None:
         """Stop the VM pool and the network properly."""
         if self.network:
-            self.network.teardown()
+            # self.network.teardown()
+            # FIXME Temporary disable tearing down the network
+            # Fix issue of persistent instances running inside systemd controller losing their ipv4 nat access
+            #  upon supervisor restart or upgrade.
+            pass
 
     async def create_a_vm(
         self, vm_hash: ItemHash, message: ExecutableContent, original: ExecutableContent, persistent: bool


### PR DESCRIPTION
Temporary disable tearing down the network when stopping supervisor Fix issue of persistent instances running inside systemd controller losing their ipv4 Nat access upon supervisor restart or upgrade.

Github issue https://github.com/aleph-im/support/issues/9


this is a temporary hotfix till we have a better solution for handling the network