### PR TITLE
Sanitize volume names

### DIFF
--- a/src/aleph/vm/controllers/firecracker/executable.py
+++ b/src/aleph/vm/controllers/firecracker/executable.py
@@ -114,7 +114,7 @@ class AlephFirecrackerResources:
 
     async def download_volumes(self):
         volumes = []
-        # TODO: Download in parallel
+        # TODO: Download in parallel and prevent duplicated volume names
         for i, volume in enumerate(self.message_content.volumes):
             # only persistant volume has name and mount
             if isinstance(volume, PersistentVolume):


### PR DESCRIPTION
Problem: If a user wants to attach a volume that have a name with spaces or other weird symbols, it raises an error and don't allocate the VM.
Solution: Sanitize the volume name before creating it.

## Self proofreading checklist

- [X] The new code clear, easy to read and well commented.
- [X] New code does not duplicate the functions of builtin or popular libraries.
- [X] An LLM was used to review the new code and look for simplifications.
- [X] New classes and functions contain docstrings explaining what they provide.
- [ ] All new code is covered by relevant tests.
- [ ] Documentation has been updated regarding these changes.
- [ ] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

## Changes

Applied a regular expression to replace invalid characters for an `_`

## How to test

Try to execute an instance or a program with a volume name with spaces or weird characters on their name.
