### PR TITLE
Solve Aleph VMs automatic restarts

### DIFF
--- a/packaging/aleph-vm/etc/needrestart/conf.d/aleph-vm.conf
+++ b/packaging/aleph-vm/etc/needrestart/conf.d/aleph-vm.conf
@@ -1,0 +1,3 @@
+# Do not restart Aleph Network Services
+$nrconf{override_rc}{qr(^aleph-vm-supervisor)} = 0;
+$nrconf{override_rc}{qr(^aleph-vm-controller@.*\.service$)} = 0;


### PR DESCRIPTION
Confidential VMs are restarted automatically

Related ClickUp, GitHub or Jira tickets : ALEPH-383

## Self proofreading checklist

- [X] The new code clear, easy to read and well commented.
- [X] New code does not duplicate the functions of builtin or popular libraries.
- [X] An LLM was used to review the new code and look for simplifications.
- [X] New classes and functions contain docstrings explaining what they provide.
- [ ] All new code is covered by relevant tests.
- [ ] Documentation has been updated regarding these changes.
- [ ] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

## Changes

Problem: On Ubuntu 24.04 OS version, a new service called `needrestart` restart some services automatically and this also resets some confidential VMs that cannot init again as we don't store the password key.

Solution: Add a rule on `needrestart` service to skip the restart on aleph services.

## How to test

Install the version on a CRN with some instances inside and do a manual package update.
