### PR TITLE
Attempt to fix the packaging issue on Ubuntu 22.02

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -15,11 +15,12 @@ debian-package-code:
 	cp ../examples/instance_message_from_aleph.json ./aleph-vm/opt/aleph-vm/examples/instance_message_from_aleph.json
 	cp -r ../examples/data ./aleph-vm/opt/aleph-vm/examples/data
 	mkdir -p ./aleph-vm/opt/aleph-vm/examples/volumes
+	# Making a venv to build the wheel. to work arround a strange problem while building the wheel
+	python3 -m venv build_venv
+	build_venv/bin/pip install   --progress-bar off --upgrade pip setuptools wheel
 	# Fixing this protobuf dependency version to avoid getting CI errors as version 5.29.0 have this compilation issue
-	pip3 install -U setuptools setuptools_scm wheel
-	pip3 install --progress-bar off --target ./aleph-vm/opt/aleph-vm/  setuptools setuptools_scm wheel
-	pip3 install --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'setuptools>=61' 'aleph-message==0.6' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2' 'protobuf==5.28.3'
-	python3 -m compileall ./aleph-vm/opt/aleph-vm/
+	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.6' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2' 'protobuf==5.28.3'
+	build_venv/bin/python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux download-ipfs-kubo  target/bin/sevctl
 	rm -fr ./aleph-vm/opt/firecracker

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -16,7 +16,9 @@ debian-package-code:
 	cp -r ../examples/data ./aleph-vm/opt/aleph-vm/examples/data
 	mkdir -p ./aleph-vm/opt/aleph-vm/examples/volumes
 	# Fixing this protobuf dependency version to avoid getting CI errors as version 5.29.0 have this compilation issue
-	pip3 install --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.6' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2' 'protobuf==5.28.3' 'setuptools>=61'
+	pip3 install -U setuptools setuptools_scm wheel
+	pip3 install --progress-bar off --target ./aleph-vm/opt/aleph-vm/  setuptools setuptools_scm wheel
+	pip3 install --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'setuptools>=61' 'aleph-message==0.6' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2' 'protobuf==5.28.3'
 	python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux download-ipfs-kubo  target/bin/sevctl

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -16,7 +16,7 @@ debian-package-code:
 	cp -r ../examples/data ./aleph-vm/opt/aleph-vm/examples/data
 	mkdir -p ./aleph-vm/opt/aleph-vm/examples/volumes
 	# Fixing this protobuf dependency version to avoid getting CI errors as version 5.29.0 have this compilation issue
-	pip3 install --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.6' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2' 'protobuf==5.28.3'
+	pip3 install --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.6' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2' 'protobuf==5.28.3' 'setuptools>=61'
 	python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux download-ipfs-kubo  target/bin/sevctl

--- a/packaging/debian-12.dockerfile
+++ b/packaging/debian-12.dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y \
     curl \
     sudo \
     python3-pip \
+    python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt

--- a/packaging/ubuntu-22.04.dockerfile
+++ b/packaging/ubuntu-22.04.dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y \
     curl \
     sudo \
     python3-pip \
+    python3-venv \
     cargo \
     && rm -rf /var/lib/apt/lists/*
 

--- a/packaging/ubuntu-24.04.dockerfile
+++ b/packaging/ubuntu-24.04.dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y \
     curl \
     sudo \
     python3-pip \
+    python3-venv \
     cargo \
     && rm -rf /var/lib/apt/lists/*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
   "schedule==1.2.1",
   "sentry-sdk==1.31",
   "setproctitle==1.3.3",
+  "setuptools>=61",
   "solathon==1.0.2",
   "sqlalchemy[asyncio]>=2",
   "systemd-python==235",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
   "schedule==1.2.1",
   "sentry-sdk==1.31",
   "setproctitle==1.3.3",
-  "setuptools>=61",
   "solathon==1.0.2",
   "sqlalchemy[asyncio]>=2",
   "systemd-python==235",


### PR DESCRIPTION
Error in CI https://github.com/aleph-im/aleph-vm/actions/runs/13458482852/job/37788353003

 pip3 install --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.6' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2' 'protobuf==5.28.3'
Collecting aleph-message==0.6
  Downloading aleph_message-0.6.0-py3-none-any.whl (17 kB)
Collecting eth-account==0.10
  Downloading eth_account-0.10.0-py3-none-any.whl (109 kB)
Collecting sentry-sdk==1.31.0
  Downloading sentry_sdk-1.31.0-py2.py3-none-any.whl (224 kB)
Collecting qmp==1.1.0
  Downloading qmp-1.1.0-py3-none-any.whl (11 kB)
Collecting aleph-superfluid~=0.2.1
  Downloading aleph_superfluid-0.2.1.tar.gz (20 kB)
  Preparing metadata (setup.py) ... 25l- done
25hCollecting sqlalchemy[asyncio]>=2.0
  Downloading SQLAlchemy-2.0.38-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.1 MB)
Collecting aiosqlite==0.19.0
  Downloading aiosqlite-0.19.0-py3-none-any.whl (15 kB)
Collecting alembic==1.13.1
  Downloading alembic-1.13.1-py3-none-any.whl (233 kB)
Collecting aiohttp_cors==0.7.0
  Downloading aiohttp_cors-0.7.0-py3-none-any.whl (27 kB)
Collecting pyroute2==0.7.12
  Downloading pyroute2-0.7.12-py3-none-any.whl (460 kB)
Collecting python-cpuid==0.1.0
  Downloading python-cpuid-0.1.0.tar.gz (21 kB)
  Installing build dependencies ... 25l- \ | / - done
25h  Getting requirements to build wheel ... 25l- error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [40 lines of output]

      An error occurred while building the project, please ensure you have the most updated version of setuptools, setuptools_scm and wheel with:
         pip install -U setuptools setuptools_scm wheel

      Traceback (most recent call last):
        File /usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py, line 363, in <module>
          main()
        File /usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py, line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File /usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py, line 130, in get_requires_for_build_wheel
          return hook(config_settings)
        File /usr/lib/python3/dist-packages/setuptools/build_meta.py, line 162, in get_requires_for_build_wheel
          return self._get_build_requires(
        File /usr/lib/python3/dist-packages/setuptools/build_meta.py, line 143, in _get_build_requires
          self.run_setup()
        File /usr/lib/python3/dist-packages/setuptools/build_meta.py, line 158, in run_setup
          exec(compile(code, __file__, 'exec'), locals())
        File setup.py, line 18, in <module>
          setup(
        File /usr/lib/python3/dist-packages/setuptools/__init__.py, line 153, in setup
          return distutils.core.setup(**attrs)
        File /usr/lib/python3/dist-packages/setuptools/_distutils/core.py, line 109, in setup
          _setup_distribution = dist = klass(attrs)
        File /usr/lib/python3/dist-packages/setuptools/dist.py, line 459, in __init__
          _Distribution.__init__(
        File /usr/lib/python3/dist-packages/setuptools/_distutils/dist.py, line 293, in __init__
          self.finalize_options()
        File /usr/lib/python3/dist-packages/setuptools/dist.py, line 836, in finalize_options
          for ep in sorted(loaded, key=by_order):
        File /usr/lib/python3/dist-packages/setuptools/dist.py, line 835, in <lambda>
          loaded = map(lambda e: e.load(), filtered)
        File /usr/lib/python3/dist-packages/pkg_resources/__init__.py, line 2464, in load
          self.require(*args, **kwargs)
        File /usr/lib/python3/dist-packages/pkg_resources/__init__.py, line 2487, in require
          items = working_set.resolve(reqs, env, installer, extras=self.extras)
        File /usr/lib/python3/dist-packages/pkg_resources/__init__.py, line 782, in resolve
          raise VersionConflict(dist, req).with_context(dependent_req)
      pkg_resources.VersionConflict: (setuptools 59.6.0 (/usr/lib/python3/dist-packages), Requirement.parse('setuptools>=61'))
      [end of output]

Explain what problem this PR is resolving

Related ClickUp, GitHub or Jira tickets : ALEPH-XXX

## Self proofreading checklist

- [ ] The new code clear, easy to read and well commented.
- [ ] New code does not duplicate the functions of builtin or popular libraries.
- [ ] An LLM was used to review the new code and look for simplifications.
- [ ] New classes and functions contain docstrings explaining what they provide.
- [ ] All new code is covered by relevant tests.
- [ ] Documentation has been updated regarding these changes.
- [ ] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

## Changes

Explain the changes that were made. The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:
- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints

## How to test

Explain how to test your PR.
If a specific config is required explain it here (account, data entry, ...)

## Print screen / video

Upload here screenshots or videos showing the changes if relevant.

## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in another repo, or merges into another PR (i.o. main), it should also be mentioned here
