### PR TITLE
Fix: Used old versionof python-cpuid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   "py-cpuinfo==9",
   "pydantic[dotenv]~=1.10.13",
   "pyroute2==0.7.12",
-  "python-cpuid==0.1",
+  "python-cpuid==0.1.1",
   "pyyaml==6.0.1",
   "qmp==1.1",
   "schedule==1.2.1",


### PR DESCRIPTION
Fix the CI issues by using a new version of python-cpuid.
