### PR TITLE
Fix: Supervisor was restarted when Kubo crashed

### DIFF
--- a/packaging/aleph-vm/etc/systemd/system/aleph-vm-supervisor.service
+++ b/packaging/aleph-vm/etc/systemd/system/aleph-vm-supervisor.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Aleph.im VM execution engine
 After=network.target ipfs.service
-Requires=ipfs.service
+Wants=ipfs.service
 
 [Service]
 User=0


### PR DESCRIPTION
Wants=

    Configures (weak) requirement dependencies on other units.

Requires=

    Similar to Wants=, but declares a stronger requirement dependency.

    If this unit gets activated, the units listed will be activated as well. If one of the other units fails to activate, and an ordering dependency After= on the failing unit is set, this unit will not be started. Besides, with or without specifying After=, this unit will be stopped (or restarted) if one of the other units is explicitly stopped (or restarted).

Documentation: https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html
