### PR TITLE
Fix: IPFS Kubo could use unlimited resources

### DIFF
--- a/packaging/aleph-vm/etc/ipfs/kubo.json
+++ b/packaging/aleph-vm/etc/ipfs/kubo.json
@@ -9,9 +9,12 @@
     "Strategy": "roots"
   },
   "Swarm": {
-    "EnableHolePunching":false,
+    "EnableHolePunching": false,
     "RelayService": {
       "Enabled": false
+    },
+    "ResourceMgr": {
+      "MaxMemory": "1GB"
     }
   }
 }

--- a/packaging/aleph-vm/etc/systemd/system/ipfs.service
+++ b/packaging/aleph-vm/etc/systemd/system/ipfs.service
@@ -50,6 +50,8 @@ ProtectHome=true
 RemoveIPC=true
 RestrictSUIDSGID=true
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+MemoryHigh=2G
+MemoryMax=4G
 
 # enable for 1-1024 port listening
 #AmbientCapabilities=CAP_NET_BIND_SERVICE

--- a/packaging/aleph-vm/etc/systemd/system/ipfs.service
+++ b/packaging/aleph-vm/etc/systemd/system/ipfs.service
@@ -50,6 +50,9 @@ ProtectHome=true
 RemoveIPC=true
 RestrictSUIDSGID=true
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+# set memory limit to avoid taking all the CRN ressource and getting OOM
+# https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmresourcemgrmaxmemory
+Environment=GOMEMLIMIT=1900m
 MemoryHigh=2G
 MemoryMax=4G
 


### PR DESCRIPTION
In observations on multiple CRNs and CCNs,
it seems to use around 700-900 MB.

Limiting the resources to 2GB and hard to 4GB
seems therefore sensible.
