### PR TITLE
Fix: Remove references to slow server api1.aleph.im

### DIFF
--- a/src/aleph/vm/garbage_collector.py
+++ b/src/aleph/vm/garbage_collector.py
@@ -24,7 +24,6 @@ TEST_HASHES = [
 ]
 
 api_server = [
-    "https://api1.aleph.im",
     "https://api2.aleph.im",
     "https://api3.aleph.im",
     # 'https://official.aleph.cloud',


### PR DESCRIPTION
Server api1.aleph.im is very slow and outdated
(Core i7 from 2018, up to 40 seconds to respond
to `/metrics` in the monitoring).

We suspect that this causes issues in the
monitoring and performance of the network.

This branch removes all references to api1 and
replaces them with api3 where relevant.
