### PR TITLE
Fix: Upgrade Firecracker 1.5.0 -> 1.7.0 

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -34,7 +34,7 @@ debian-package-resources: firecracker-bins vmlinux download-ipfs-kubo  target/bi
 firecracker-bins: target-dir build-dir
 	mkdir -p ./build/firecracker-release
 	# Download latest release
-	curl -fsSL https://github.com/firecracker-microvm/firecracker/releases/download/v1.5.0/firecracker-v1.5.0-x86_64.tgz | tar -xz --no-same-owner --directory ./build/firecracker-release
+	curl -fsSL https://github.com/firecracker-microvm/firecracker/releases/download/v1.7.0/firecracker-v1.7.0-x86_64.tgz | tar -xz --no-same-owner --directory ./build/firecracker-release
 	# Copy binaries:
 	cp ./build/firecracker-release/release-v*/firecracker-v*[!.debug] ./target/firecracker
 	cp ./build/firecracker-release/release-v*/jailer-v*[!.debug] ./target/jailer


### PR DESCRIPTION
This bumps their versions to
- Firecracker 1.5.0 -> 1.7.0

Most changes related to Firecracker are regarding
 the snapshots, which are not used by `aleph-vm`.
