### PR TITLE
Increment `aleph-message` package version

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -19,7 +19,7 @@ debian-package-code:
 	python3 -m venv build_venv
 	build_venv/bin/pip install   --progress-bar off --upgrade pip setuptools wheel
 	# Fixing this protobuf dependency version to avoid getting CI errors as version 5.29.0 have this compilation issue
-	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.6' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2' 'protobuf==5.28.3'
+	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.6.1' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2' 'protobuf==5.28.3'
 	build_venv/bin/python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux download-ipfs-kubo  target/bin/sevctl


### PR DESCRIPTION
Put the correct aleph-message version on the package generation script.

## Self proofreading checklist

- [X] The new code clear, easy to read and well commented.
- [X] New code does not duplicate the functions of builtin or popular libraries.
- [X] An LLM was used to review the new code and look for simplifications.
- [ ] New classes and functions contain docstrings explaining what they provide.
- [ ] All new code is covered by relevant tests.
- [ ] Documentation has been updated regarding these changes.
- [ ] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

## Changes

Increment `aleph-message` package version on Makefile for package generation.
