### PR TITLE
Gpu Reservation system

### DIFF
--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -223,7 +223,7 @@ class VmExecution:
             self.resources = resources
 
     def prepare_gpus(self, available_gpus: list[GpuDevice]) -> None:
-        gpus = []
+        gpus: list[HostGPU] = []
         if self.message.requirements and self.message.requirements.gpu:
             for gpu in self.message.requirements.gpu:
                 gpu = GpuProperties.parse_obj(gpu)

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -189,7 +189,7 @@ async def benchmark(runs: int):
 
     loop = asyncio.get_event_loop()
     pool = VmPool(loop)
-    pool.setup()
+    await pool.setup()
 
     # Does not make sense in benchmarks
     settings.WATCH_FOR_MESSAGES = False

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -152,7 +152,7 @@ def run():
 
     loop = asyncio.new_event_loop()
     pool = VmPool(loop)
-    pool.setup()
+    asyncio.run(pool.setup())
 
     hostname = settings.DOMAIN_NAME
     protocol = "http" if hostname == "localhost" else "https"

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -34,6 +34,7 @@ from .views import (
     about_login,
     list_executions,
     notify_allocation,
+    operate_reserve_resources,
     run_code_from_hostname,
     run_code_from_path,
     status_check_fastapi,
@@ -102,6 +103,7 @@ def setup_webapp():
         web.get("/about/config", about_config),
         # /control APIs are used to control the VMs and access their logs
         web.post("/control/allocation/notify", notify_allocation),
+        web.post("/control/reserve_resources", operate_reserve_resources),
         web.get("/control/machine/{ref}/stream_logs", stream_logs),
         web.get("/control/machine/{ref}/logs", operate_logs_json),
         web.post("/control/machine/{ref}/expire", operate_expire),

--- a/src/aleph/vm/orchestrator/utils.py
+++ b/src/aleph/vm/orchestrator/utils.py
@@ -31,6 +31,7 @@ async def fetch_aggregate_settings() -> AggregateSettingsDict | None:
     For more details, see the PyAleph API documentation:
     https://github.com/aleph-im/pyaleph/blob/master/src/aleph/web/controllers/routes.py#L62
     """
+
     async with aiohttp.ClientSession() as session:
         url = f"{settings.API_SERVER}/api/v0/aggregates/{settings.SETTINGS_AGGREGATE_ADDRESS}.json?keys=settings"
         logger.info(f"Fetching settings aggregate from {url}")

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -73,7 +73,7 @@ class VmPool:
         if settings.SNAPSHOT_FREQUENCY > 0:
             self.snapshot_manager = SnapshotManager()
 
-    def setup(self) -> None:
+    async def setup(self) -> None:
         """Set up the VM pool and the network."""
         if self.network:
             self.network.setup()
@@ -81,10 +81,9 @@ class VmPool:
         if self.snapshot_manager:
             logger.debug("Initializing SnapshotManager ...")
             self.snapshot_manager.run_in_thread()
-
         if settings.ENABLE_GPU_SUPPORT:
             # Refresh and get latest settings aggregate
-            asyncio.run(update_aggregate_settings())
+            await update_aggregate_settings()
             logger.debug("Detecting GPU devices ...")
             self.gpus = get_gpu_devices()
 

--- a/src/aleph/vm/resources.py
+++ b/src/aleph/vm/resources.py
@@ -132,11 +132,12 @@ def parse_gpu_device_info(line: str) -> GpuDevice | None:
     )
 
 
-def get_gpu_devices() -> list[GpuDevice] | None:
+def get_gpu_devices() -> list[GpuDevice]:
     """Get GPU info using lspci command."""
 
     result = subprocess.run(["lspci", "-mmnnn"], capture_output=True, text=True, check=True)
+    output = result.stdout
     gpu_devices = list(
-        {device for line in result.stdout.split("\n") if line and (device := parse_gpu_device_info(line)) is not None}
+        {device for line in output.split("\n") if line and (device := parse_gpu_device_info(line)) is not None}
     )
-    return gpu_devices if gpu_devices else None
+    return gpu_devices if gpu_devices else []

--- a/tests/supervisor/test_resources.py
+++ b/tests/supervisor/test_resources.py
@@ -29,8 +29,6 @@ def test_get_gpu_devices():
         ):
             expected_gpu_devices = get_gpu_devices()
 
-            print(expected_gpu_devices)
-
             assert expected_gpu_devices[0].vendor == "NVIDIA"
             assert expected_gpu_devices[0].device_name == "AD104GL [RTX 4000 SFF Ada Generation]"
             assert expected_gpu_devices[0].device_class == "0300"


### PR DESCRIPTION
Implement a resource (GPU) reservation system. 
Please do not squash when merging.

This new feature prevent resources being taken between the moment the user initiate the payment flow and the moment the VM start.

Jira tickets : ALEPH-421

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.
- [x] Documentation has been updated regarding these changes.
- [x] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

## Changes

- Add a new endpoint `/control/reserve_resource` which reserve the required resource to start the VM for the user. At the moment it only reserve GPU.
- Added `reservations` attributes on `VmPool` that handle the list of reservations.
- Check and free the reservation when staring a new VM. 
- When inspecting the earlier code, I noticed that if no GPU were available the  VM probably started without the GPU, now the VM doesn't start and raise an error
- pool.setup() is now async, to allow working in the unit tests.

## How to test

Need a CRN with GPU. I tested  principally via the unit tests.

## Notes

I added a mock_app_with_pool fixture that you might find useful for your future tests, it create a server and a VmPool  (with a GPU inside)