### PR TITLE
Hoh upgrade kubo

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -48,7 +48,7 @@ vmlinux:
 
 download-ipfs-kubo: target-dir build-dir
 	mkdir -p ./target/kubo
-	curl -fsSL https://github.com/ipfs/kubo/releases/download/v0.23.0/kubo_v0.23.0_linux-amd64.tar.gz | tar -xz --directory ./target/kubo
+	curl -fsSL https://github.com/ipfs/kubo/releases/download/v0.33.2/kubo_v0.33.2_linux-amd64.tar.gz | tar -xz --directory ./target/kubo
 
 target/bin/sevctl:
 	cargo install --locked --git https://github.com/virtee/sevctl.git --rev v0.6.0 --target x86_64-unknown-linux-gnu --root ./target

--- a/packaging/aleph-vm/etc/systemd/system/ipfs.service
+++ b/packaging/aleph-vm/etc/systemd/system/ipfs.service
@@ -58,6 +58,10 @@ CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 # enable to specify a higher limit for open files/connections
 #LimitNOFILE=1000000
 
+# Avoid a permission denier error when running `lstat /home/ipfs/.config/ipfs/denylists`
+# due to checking $XDG_CONFIG_HOME/ipfs/denylists/
+Environment=XDG_CONFIG_HOME=/etc
+
 #don't use swap
 MemorySwapMax=0
 


### PR DESCRIPTION
This bumps their versions to
- Kubo 0.23.0 -> 0.33.2

The list of changes regarding Kubo too large to be
 mentioned here, but I mostly expect performance
 improvements as the main API has not changed much.
