### PR TITLE
Usage system: remove reserved usage for volumes

### DIFF
--- a/src/aleph/vm/controllers/qemu/instance.py
+++ b/src/aleph/vm/controllers/qemu/instance.py
@@ -72,7 +72,7 @@ class AlephQemuResources(AlephFirecrackerResources):
             raise VmSetupError(msg)
 
         dest_path = settings.PERSISTENT_VOLUMES_DIR / self.namespace / f"{volume_name}.qcow2"
-        # Do not override if user asked for host persistance.
+        # Do not override if user asked for host persistence.
         if dest_path.exists() and volume.persistence == VolumePersistence.host:
             return dest_path
 

--- a/src/aleph/vm/orchestrator/resources.py
+++ b/src/aleph/vm/orchestrator/resources.py
@@ -133,6 +133,7 @@ async def about_system_usage(request: web.Request):
     """Public endpoint to expose information about the system usage."""
     period_start = datetime.now(timezone.utc).replace(second=0, microsecond=0)
     machine_properties = get_machine_properties()
+    pool = request.app["vm_pool"]
 
     usage: MachineUsage = MachineUsage(
         cpu=CpuUsage(
@@ -146,7 +147,8 @@ async def about_system_usage(request: web.Request):
         ),
         disk=DiskUsage(
             total_kB=psutil.disk_usage(str(settings.PERSISTENT_VOLUMES_DIR)).total // 1000,
-            available_kB=psutil.disk_usage(str(settings.PERSISTENT_VOLUMES_DIR)).free // 1000,
+            available_kB=pool.calculate_available_disk() // 1000,
+            # available_kB=psutil.disk_usage(str(settings.PERSISTENT_VOLUMES_DIR)).free // 1000,
         ),
         period=UsagePeriod(
             start_timestamp=period_start,

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -39,18 +39,10 @@ async def test_allocation_fails_on_invalid_item_hash(aiohttp_client):
 
 
 @pytest.mark.asyncio
-async def test_system_usage(aiohttp_client):
+async def test_system_usage(aiohttp_client, mocker, mock_app_with_pool):
     """Test that the usage system endpoints responds. No auth needed"""
 
-    class FakeVmPool:
-        gpus = []
-
-        def get_available_gpus(self):
-            return []
-
-    app = setup_webapp()
-    app["vm_pool"] = FakeVmPool()
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(await mock_app_with_pool)
     response: web.Response = await client.get("/about/usage/system")
     assert response.status == 200
     # check if it is valid json
@@ -60,14 +52,8 @@ async def test_system_usage(aiohttp_client):
 
 
 @pytest.mark.asyncio
-async def test_system_usage_mock(aiohttp_client, mocker):
+async def test_system_usage_mock(aiohttp_client, mocker, mock_app_with_pool):
     """Test that the usage system endpoints response value. No auth needed"""
-
-    class FakeVmPool:
-        gpus = []
-
-        def get_available_gpus(self):
-            return []
 
     mocker.patch(
         "cpuinfo.cpuinfo.get_cpu_info",
@@ -85,9 +71,7 @@ async def test_system_usage_mock(aiohttp_client, mocker):
         lambda: 200,
     )
 
-    app = setup_webapp()
-    app["vm_pool"] = FakeVmPool()
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(await mock_app_with_pool)
     response: web.Response = await client.get("/about/usage/system")
     assert response.status == 200
     # check if it is valid json


### PR DESCRIPTION
of vm when calculate available disk space

Jira: ALEPH-420

This will help the scheduler scheduler more properly the available resource on CRN

Alternative approach to https://github.com/aleph-im/aleph-vm/pull/780 as Sparse file were not properly created.

Explain what problem this PR is resolving

Related ClickUp, GitHub or Jira tickets : ALEPH-XXX

## Self proofreading checklist

- [ ] The new code clear, easy to read and well commented.
- [ ] New code does not duplicate the functions of builtin or popular libraries.
- [ ] An LLM was used to review the new code and look for simplifications.
- [ ] New classes and functions contain docstrings explaining what they provide.
- [ ] All new code is covered by relevant tests.
- [ ] Documentation has been updated regarding these changes.
- [ ] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

## Changes

Explain the changes that were made. The idea is not to list exhaustively all the changes made (GitHub already provides a full diff), but to help the reviewers better understand:
- which specific file changes go together, e.g: when creating a table in the front-end, there usually is a config file that goes with it
- the reasoning behind some changes, e.g: deleted files because they are now redundant
- the behaviour to expect, e.g: tooltip has purple background color because the client likes it so, changed a key in the API response to be consistent with other endpoints

## How to test

Explain how to test your PR.
If a specific config is required explain it here (account, data entry, ...)

## Print screen / video

Upload here screenshots or videos showing the changes if relevant.

## Notes

Things that the reviewers should know: known bugs that are out of the scope of the PR, other trade-offs that were made.
If the PR depends on a PR in another repo, or merges into another PR (i.o. main), it should also be mentioned here
