### PR TITLE
Make CI a bit more resilient

### DIFF
--- a/.github/scripts/extract_droplet_ipv4.py
+++ b/.github/scripts/extract_droplet_ipv4.py
@@ -7,5 +7,9 @@ from the JSON returned by `doctl compute droplet get $name --output json
 import json
 import sys
 
-droplet_info = json.load(sys.stdin)
-print(droplet_info[0]["networks"]["v4"][0]["ip_address"])
+try:
+    droplet_info = json.load(sys.stdin)
+    print(droplet_info[0]["networks"]["v4"][0]["ip_address"])
+except Exception:
+    print(droplet_info)
+    raise

--- a/.github/workflows/test-new-runtime-examples.yml
+++ b/.github/workflows/test-new-runtime-examples.yml
@@ -8,6 +8,7 @@ jobs:
     name: "Test new runtime on Droplet with Debian 12"
     runs-on: ubuntu-latest
     concurrency: droplet-aleph-vm-runtime
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository
@@ -66,6 +67,7 @@ jobs:
 
       - name: Wait for the system to setup and boot
         id: system-booted
+        timeout-minutes: 3
         run: |
           until ssh-keyscan -H ${DROPLET_IPV4}; do sleep 1; done
 

--- a/.github/workflows/test-new-runtime-examples.yml
+++ b/.github/workflows/test-new-runtime-examples.yml
@@ -60,9 +60,13 @@ jobs:
           cd packaging && make all-podman-debian-12 && cd ..
           ls packaging/target
 
-      - name: Wait for the system to setup and boot
+      - name: Get droplet ip and export it in env
         run: |
-          export DROPLET_IPV4="$(doctl compute droplet get aleph-vm-ci-runtime --output json | ./.github/scripts/extract_droplet_ipv4.py)"
+          echo "DROPLET_IPV4=$(doctl compute droplet get aleph-vm-ci-${{ matrix.os_config.alias }}-${{ matrix.check_vm.alias }} --output json | ./.github/scripts/extract_droplet_ipv4.py)" >>  "$GITHUB_ENV"
+
+      - name: Wait for the system to setup and boot
+        id: system-booted
+        run: |
           until ssh-keyscan -H ${DROPLET_IPV4}; do sleep 1; done
 
       - name: Copy the runtime to the system
@@ -98,7 +102,7 @@ jobs:
           curl --retry 5 --max-time 10 --fail "http://${DROPLET_IPV4}:4020/status/check/fastapi"
 
       - name: Export aleph logs
-        if: always()
+        if: ${{ !cancelled() && steps.system-booted.outcome == 'sucess'}}
         run: |
           export DROPLET_IPV4="$(doctl compute droplet get aleph-vm-ci-runtime --output json | ./.github/scripts/extract_droplet_ipv4.py)"
           ssh root@${DROPLET_IPV4} "journalctl -u aleph-vm-supervisor"

--- a/.github/workflows/test-on-droplets-matrix.yml
+++ b/.github/workflows/test-on-droplets-matrix.yml
@@ -110,6 +110,7 @@ jobs:
           echo "DROPLET_IPV4=$(doctl compute droplet get aleph-vm-ci-${{ matrix.os_config.alias }}-${{ matrix.check_vm.alias }} --output json | ./.github/scripts/extract_droplet_ipv4.py)" >>  "$GITHUB_ENV"
 
       - name: Wait for the system to setup and boot
+        id: system-booted
         run: |
           until ssh-keyscan -H ${DROPLET_IPV4}; do sleep 1; done
         timeout-minutes: 3
@@ -146,7 +147,6 @@ jobs:
 
       - name: Test Aleph-VM on the Droplet
         id: test-aleph-vm
-        if: always()
         continue-on-error: true
         run: |
           curl --retry 5 --max-time 10 --fail "http://${DROPLET_IPV4}:4020/about/usage/system"
@@ -180,7 +180,7 @@ jobs:
           ssh root@${DROPLET_IPV4} "/opt/sevctl --version"
 
       - name: Export aleph logs
-        if: always()
+        if: ${{ !cancelled() && steps.system-booted.outcome == 'sucess'}}
         run: |
           ssh root@${DROPLET_IPV4} "journalctl -u aleph-vm-supervisor"
 


### PR DESCRIPTION
Do not run export log if cancelled or not setup
Attempt to always do the proper clean up

Print more debug information in case the droplet ipv4 cannot be parsed

Explain what problem this PR is resolving

Related ClickUp, GitHub or Jira tickets : ALEPH-XXX

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.
- [x] Documentation has been updated regarding these changes.
- [x] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`
