### PR TITLE
enh: allow user to reboot from inside the VM

### DIFF
--- a/src/aleph/vm/hypervisors/qemu/qemuvm.py
+++ b/src/aleph/vm/hypervisors/qemu/qemuvm.py
@@ -93,7 +93,8 @@ class QemuVM:
             # To debug you can pass gtk or curses instead
             "-display",
             "none",
-            "--no-reboot",  # Rebooting from inside the VM shuts down the machine
+            # "--no-reboot",  # Rebooting from inside the VM shuts down the machine
+            # Disable --no-reboot so user can reboot from inside the VM. see ALEPH-472
             # Listen for commands on this socket
             "-monitor",
             f"unix:{self.monitor_socket_path},server,nowait",


### PR DESCRIPTION


Important note: Previously --no-reboot was used so if the BIOS failed to boot the VM because of for example an invalid disk image provided by the user then the QEMU process and the controller would halt. The new behaviour is that the VM will reboot indefinetly. But it should be catched by the wait for init procedure that will test by ping.

This new modification was necessary because the GPU VM need a reboot for their setup. And generaly user would be confused when rebooted VM would not restart.

The --no-reboot flag was kept for ConfidentialVM as confidential VM do not support reboot anyway

Explain what problem this PR is resolving

Related ClickUp, GitHub or Jira tickets : JIRA: ALEPH-472

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.
- [x] Documentation has been updated regarding these changes.
- [x] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`
