### PR TITLE
Migrate Pydantic V1 to V2

### DIFF
--- a/examples/example_fastapi/main.py
+++ b/examples/example_fastapi/main.py
@@ -216,9 +216,9 @@ async def check_url(internet_host: HttpUrl, timeout_seconds: int = 5, socket_fam
 async def read_internet():
     """Check Internet connectivity of the system, requiring IP connectivity, domain resolution and HTTPS/TLS."""
     internet_hosts: list[HttpUrl] = [
-        HttpUrl(url="https://aleph.im/", scheme="https"),
-        HttpUrl(url="https://ethereum.org", scheme="https"),
-        HttpUrl(url="https://ipfs.io/", scheme="https"),
+        HttpUrl(url="https://aleph.im/"),
+        HttpUrl(url="https://ethereum.org"),
+        HttpUrl(url="https://ipfs.io/"),
     ]
     timeout_seconds = 5
 

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -19,7 +19,7 @@ debian-package-code:
 	python3 -m venv build_venv
 	build_venv/bin/pip install   --progress-bar off --upgrade pip setuptools wheel
 	# Fixing this protobuf dependency version to avoid getting CI errors as version 5.29.0 have this compilation issue
-	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==0.6.1' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2' 'protobuf==5.28.3'
+	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'git+https://github.com/aleph-im/aleph-message@108-upgrade-pydantic-version#egg=aleph-message' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pydantic-settings==2.6.1' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2' 'protobuf==5.28.3'
 	build_venv/bin/python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux download-ipfs-kubo  target/bin/sevctl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "aioredis==1.3.1",
   "aiosqlite==0.19",
   "alembic==1.13.1",
-  "aleph-message==0.6.1",
+  "aleph-message @ git+https://github.com/aleph-im/aleph-message@108-upgrade-pydantic-version#egg=main",
   "aleph-superfluid~=0.2.1",
   "dbus-python==1.3.2",
   "eth-account~=0.10",
@@ -44,14 +44,16 @@ dependencies = [
   "jwcrypto==1.5.6",
   "msgpack==1.0.7",
   "nftables @ git+https://salsa.debian.org/pkg-netfilter-team/pkg-nftables#egg=nftables&subdirectory=py",
-  "packaging==23.2",
+  "packaging>=23.2",
   # Fixing this protobuf dependency version to avoid getting CI errors as version 5.29.0 have this compilation issue
   "protobuf==5.28.3",
   "psutil==5.9.5",
   "py-cpuinfo==9",
-  "pydantic[dotenv]~=1.10.13",
+  "pydantic>=2,<3",
+  "pydantic-settings~=2.6.1",
   "pyroute2==0.7.12",
   "python-cpuid==0.1.1",
+  "python-dotenv~=1.1.0",
   "pyyaml==6.0.1",
   "qmp==1.1",
   "schedule==1.2.1",
@@ -120,8 +122,9 @@ dependencies = [
   "mypy==1.8.0",
   "ruff==0.4.6",
   "isort==5.13.2",
-  "yamlfix==1.16.1",
+  "yamlfix==1.17.0",
   "pyproject-fmt==2.2.1",
+  "pydantic>=2,<3",
 ]
 [tool.hatch.envs.linting.scripts]
 typing = "mypy {args:src/aleph/vm/ tests/ examples/example_fastapi runtimes/aleph-debian-12-python}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "aioredis==1.3.1",
   "aiosqlite==0.19",
   "alembic==1.13.1",
-  "aleph-message @ git+https://github.com/aleph-im/aleph-message@108-upgrade-pydantic-version#egg=main",
+  "aleph-message~=1.0.0",
   "aleph-superfluid~=0.2.1",
   "dbus-python==1.3.2",
   "eth-account~=0.10",

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -168,7 +168,7 @@ class Settings(BaseSettings):
         default=True,
         description="Enable IPv6 forwarding on the host. Required for IPv6 connectivity in VMs.",
     )
-    NFTABLES_CHAIN_PREFIX = "aleph"
+    NFTABLES_CHAIN_PREFIX: str = "aleph"
     USE_NDP_PROXY: bool = Field(
         default=True,
         description="Use the Neighbor Discovery Protocol Proxy to respond to Router Solicitation for instances on IPv6",
@@ -179,8 +179,8 @@ class Settings(BaseSettings):
         description="Method used to resolve the dns server if DNS_NAMESERVERS is not present.",
     )
     DNS_NAMESERVERS: list[str] | None = None
-    DNS_NAMESERVERS_IPV4: list[str] | None
-    DNS_NAMESERVERS_IPV6: list[str] | None
+    DNS_NAMESERVERS_IPV4: list[str] | None = None
+    DNS_NAMESERVERS_IPV6: list[str] | None = None
 
     FIRECRACKER_PATH: Path = Path("/opt/firecracker/firecracker")
     JAILER_PATH: Path = Path("/opt/firecracker/jailer")
@@ -188,7 +188,7 @@ class Settings(BaseSettings):
     LINUX_PATH: Path = Path("/opt/firecracker/vmlinux.bin")
     INIT_TIMEOUT: float = 20.0
 
-    CONNECTOR_URL = Url("http://localhost:4021")
+    CONNECTOR_URL: HttpUrl = HttpUrl("http://localhost:4021")
 
     CACHE_ROOT: Path = Path("/var/cache/aleph/vm")
     MESSAGE_CACHE: Path | None = Field(
@@ -311,8 +311,10 @@ class Settings(BaseSettings):
         description="Identifier used for the 'fake instance' message defined in "
         "examples/instance_message_from_aleph.json",
     )
-    FAKE_INSTANCE_MESSAGE = Path(abspath(join(__file__, "../../../../examples/instance_message_from_aleph.json")))
-    FAKE_INSTANCE_QEMU_MESSAGE = Path(abspath(join(__file__, "../../../../examples/qemu_message_from_aleph.json")))
+    FAKE_INSTANCE_MESSAGE: Path = Path(abspath(join(__file__, "../../../../examples/instance_message_from_aleph.json")))
+    FAKE_INSTANCE_QEMU_MESSAGE: Path = Path(
+        abspath(join(__file__, "../../../../examples/qemu_message_from_aleph.json"))
+    )
 
     CHECK_FASTAPI_VM_ID: str = "63faf8b5db1cf8d965e6a464a0cb8062af8e7df131729e48738342d956f29ace"
     LEGACY_CHECK_FASTAPI_VM_ID: str = "67705389842a0a1b95eaa408b009741027964edc805997475e95c505d642edd8"
@@ -348,7 +350,7 @@ class Settings(BaseSettings):
         assert isfile(self.JAILER_PATH), f"File not found {self.JAILER_PATH}"
         assert isfile(self.LINUX_PATH), f"File not found {self.LINUX_PATH}"
         assert self.NETWORK_INTERFACE, "Network interface is not specified"
-        assert self.CONNECTOR_URL.startswith("http://") or self.CONNECTOR_URL.startswith("https://")
+        assert str(self.CONNECTOR_URL).startswith("http://") or str(self.CONNECTOR_URL).startswith("https://")
         if self.ALLOW_VM_NETWORKING:
             assert exists(
                 f"/sys/class/net/{self.NETWORK_INTERFACE}"

--- a/src/aleph/vm/controllers/__main__.py
+++ b/src/aleph/vm/controllers/__main__.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 def configuration_from_file(path: Path):
     with open(path) as f:
         data = json.load(f)
-        return Configuration.parse_obj(data)
+        return Configuration.model_validate(data)
 
 
 def parse_args(args):

--- a/src/aleph/vm/controllers/configuration.py
+++ b/src/aleph/vm/controllers/configuration.py
@@ -30,26 +30,26 @@ class QemuGPU(BaseModel):
 
 class QemuVMConfiguration(BaseModel):
     qemu_bin_path: str
-    cloud_init_drive_path: str | None
+    cloud_init_drive_path: str | None = None
     image_path: str
     monitor_socket_path: Path
     qmp_socket_path: Path
     vcpu_count: int
     mem_size_mb: int
-    interface_name: str | None
+    interface_name: str | None = None
     host_volumes: list[QemuVMHostVolume]
     gpus: list[QemuGPU]
 
 
 class QemuConfidentialVMConfiguration(BaseModel):
     qemu_bin_path: str
-    cloud_init_drive_path: str | None
+    cloud_init_drive_path: str | None = None
     image_path: str
     monitor_socket_path: Path
     qmp_socket_path: Path
     vcpu_count: int
     mem_size_mb: int
-    interface_name: str | None
+    interface_name: str | None = None
     host_volumes: list[QemuVMHostVolume]
     gpus: list[QemuGPU]
     ovmf_path: Path
@@ -76,7 +76,7 @@ def save_controller_configuration(vm_hash: str, configuration: Configuration) ->
     config_file_path = Path(f"{settings.EXECUTION_ROOT}/{vm_hash}-controller.json")
     with config_file_path.open("w") as controller_config_file:
         controller_config_file.write(
-            configuration.json(
+            configuration.model_dump_json(
                 by_alias=True, exclude_none=True, indent=4, exclude={"settings": {"USE_DEVELOPER_SSH_KEYS"}}
             )
         )

--- a/src/aleph/vm/hypervisors/firecracker/config.py
+++ b/src/aleph/vm/hypervisors/firecracker/config.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from pydantic import BaseModel, ConfigDict, Field, PositiveInt
+from pydantic import BaseModel, ConfigDict, PositiveInt
 
 VSOCK_PATH = "/tmp/v.sock"
 

--- a/src/aleph/vm/hypervisors/firecracker/config.py
+++ b/src/aleph/vm/hypervisors/firecracker/config.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from pydantic import BaseModel, PositiveInt
+from pydantic import BaseModel, ConfigDict, Field, PositiveInt
 
 VSOCK_PATH = "/tmp/v.sock"
 
@@ -51,12 +51,7 @@ class FirecrackerConfig(BaseModel):
     boot_source: BootSource
     drives: list[Drive]
     machine_config: MachineConfig
-    vsock: Vsock | None
-    network_interfaces: list[NetworkInterface] | None
+    vsock: Vsock | None = None
+    network_interfaces: list[NetworkInterface] | None = None
 
-    class Config:
-        allow_population_by_field_name = True
-
-        @staticmethod
-        def alias_generator(x: str):
-            return x.replace("_", "-")
+    model_config = ConfigDict(populate_by_name=True, alias_generator=lambda field_name: field_name.replace("_", "-"))

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -192,7 +192,7 @@ class MicroVM:
             if not self.use_jailer
             else open(f"{self.jailer_path}/tmp/config.json", "wb")
         ) as config_file:
-            config_file.write(config.json(by_alias=True, exclude_none=True, indent=4).encode())
+            config_file.write(config.model_dump_json(by_alias=True, exclude_none=True, indent=4).encode())
             config_file.flush()
             config_file_path = Path(config_file.name)
             config_file_path.chmod(0o644)

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -226,7 +226,7 @@ class VmExecution:
         gpus: list[HostGPU] = []
         if self.message.requirements and self.message.requirements.gpu:
             for gpu in self.message.requirements.gpu:
-                gpu = GpuProperties.parse_obj(gpu)
+                gpu = GpuProperties.model_validate(gpu)
                 for available_gpu in available_gpus:
                     if available_gpu.device_id == gpu.device_id:
                         gpus.append(
@@ -453,8 +453,8 @@ class VmExecution:
                     vcpus=self.vm.hardware_resources.vcpus,
                     memory=self.vm.hardware_resources.memory,
                     network_tap=self.vm.tap_interface.device_name if self.vm.tap_interface else "",
-                    message=self.message.json(),
-                    original_message=self.original.json(),
+                    message=self.message.model_dump_json(),
+                    original_message=self.original.model_dump_json(),
                     persistent=self.persistent,
                 )
             )
@@ -477,8 +477,8 @@ class VmExecution:
                     io_write_bytes=None,
                     vcpus=self.vm.hardware_resources.vcpus,
                     memory=self.vm.hardware_resources.memory,
-                    message=self.message.json(),
-                    original_message=self.original.json(),
+                    message=self.message.model_dump_json(),
+                    original_message=self.original.model_dump_json(),
                     persistent=self.persistent,
                     gpus=json.dumps(self.gpus, default=pydantic_encoder),
                 )

--- a/src/aleph/vm/orchestrator/README.md
+++ b/src/aleph/vm/orchestrator/README.md
@@ -4,9 +4,9 @@
 Web service to run untrusted Aleph VM functions in a secure environment
 for the [Aleph.im](https://aleph.im/) project.
 
-The project currently supports running applications written in Python 
-within [Firecracker](https://github.com/firecracker-microvm/firecracker) 
-"micro virtual machines". 
+The project currently supports running applications written in Python
+within [Firecracker](https://github.com/firecracker-microvm/firecracker)
+"micro virtual machines".
 
 More languages and virtualization technologies may be added in the future.
 
@@ -17,12 +17,12 @@ More languages and virtualization technologies may be added in the future.
 Quoting [Firecracker](https://github.com/firecracker-microvm/firecracker#supported-platforms)
 supported platforms:
 
-> We continuously test Firecracker on machines with the following CPUs micro-architectures: 
+> We continuously test Firecracker on machines with the following CPUs micro-architectures:
 Intel Skylake, Intel Cascade Lake, AMD Zen2 and ARM64 Neoverse N1.
 >
-> Firecracker is generally available on Intel x86_64, AMD x86_64 and ARM64 CPUs 
-> (starting from release v0.24) that offer hardware virtualization support, 
-> and that are released starting with 2015. 
+> Firecracker is generally available on Intel x86_64, AMD x86_64 and ARM64 CPUs
+> (starting from release v0.24) that offer hardware virtualization support,
+> and that are released starting with 2015.
 
  A device named `/dev/kvm` should be present on compatible systems.
 
@@ -35,7 +35,7 @@ These instructions have been tested on Debian 11 Bullseye, Debian 12 Bookworm an
 Bare metal servers from most hosting providers should be compatible with the VM Supervisor.
 
 A few hosting providers offer compatible virtual machines.
-- Compatible ✓ : DigitalOcean Droplet. AWS ECS Bare Metal. 
+- Compatible ✓ : DigitalOcean Droplet. AWS ECS Bare Metal.
 - Incompatible ✖ : AWS EC2 other than Bare Metal.
 
 Probably [Google Cloud instances with Nested Virtualization](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances).
@@ -43,7 +43,7 @@ Probably [Google Cloud instances with Nested Virtualization](https://cloud.googl
 ### Note on containers
 
 While not supported at the moment, it is possible to run the VM Supervisor inside a Docker
-container. 
+container.
 
 This will be less secure since the `Jailer` tool used to secure Firecracker MicroVMs
 will not run inside containers. Pass the command-line argument `--no-jailer` to disable the Jailer
@@ -80,12 +80,12 @@ cd aleph-vm/
 
 ### 2.e. Install Pydantic
 
-[PyDantic](https://pydantic-docs.helpmanual.io/) 
+[PyDantic](https://pydantic-docs.helpmanual.io/)
 is used to parse and validate Aleph messages.
 
 ```shell
 apt install -y --no-install-recommends --no-install-suggests python3-pip
-pip3 install pydantic[dotenv]
+pip3 install pydantic-dotenv
 pip3 install 'aleph-message==0.4.9'
 ```
 

--- a/src/aleph/vm/orchestrator/chain.py
+++ b/src/aleph/vm/orchestrator/chain.py
@@ -1,7 +1,7 @@
 import logging
 
 from aleph_message.models import Chain
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,8 @@ class ChainInfo(BaseModel):
     def token(self) -> str | None:
         return self.super_token or self.standard_token
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def check_tokens(cls, values):
         if not values.get("standard_token") and not values.get("super_token"):
             msg = "At least one of standard_token or super_token must be provided."

--- a/src/aleph/vm/orchestrator/reactor.py
+++ b/src/aleph/vm/orchestrator/reactor.py
@@ -61,7 +61,7 @@ class Reactor:
             for subscription in listener.content.on.message:
                 if subscription_matches(subscription, message):
                     vm_hash = listener.item_hash
-                    event = message.json()
+                    event = message.model_dump_json()
                     # Register the listener in the list of coroutines to run asynchronously:
                     coroutines.append(run_code_on_event(vm_hash, event, self.pubsub, pool=self.pool))
                     break

--- a/src/aleph/vm/orchestrator/resources.py
+++ b/src/aleph/vm/orchestrator/resources.py
@@ -76,8 +76,8 @@ class MachineProperties(BaseModel):
 
 
 class GpuProperties(BaseModel):
-    devices: list[GpuDevice] | None
-    available_devices: list[GpuDevice] | None
+    devices: list[GpuDevice] | None = None
+    available_devices: list[GpuDevice] | None = None
 
 
 class MachineUsage(BaseModel):
@@ -158,7 +158,7 @@ async def about_system_usage(request: web.Request):
         gpu=get_machine_gpus(request),
     )
 
-    return web.json_response(text=usage.json(exclude_none=True))
+    return web.json_response(text=usage.model_dump_json(exclude_none=True))
 
 
 @cors_allow_all

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -56,7 +56,7 @@ async def create_vm_execution(vm_hash: ItemHash, pool: VmPool, persistent: bool 
     message, original_message = await load_updated_message(vm_hash)
     pool.message_cache[vm_hash] = message
 
-    logger.debug(f"Message: {message.json(indent=4, sort_keys=True, exclude_none=True)}")
+    logger.debug(f"Message: {json.dumps(message.model_dump(exclude_none=True), indent=4, sort_keys=True, default=str)}")
 
     execution = await pool.create_a_vm(
         vm_hash=vm_hash,

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 from typing import Any
 

--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -80,10 +80,10 @@ async def subscribe_via_ws(url) -> AsyncIterable[AlephMessage]:
 
                     try:
                         yield parse_message(data)
-                    except pydantic.error_wrappers.ValidationError as error:
+                    except pydantic.ValidationError as error:
                         item_hash = data.get("item_hash", "ITEM_HASH_NOT_FOUND")
                         logger.warning(
-                            f"Invalid Aleph message: {item_hash} \n  {error.json()}\n  {error.raw_errors}",
+                            f"Invalid Aleph message: {item_hash} \n  {error.errors}",
                             exc_info=False,
                         )
                         continue

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -391,7 +391,7 @@ async def update_allocations(request: web.Request):
         allocation_lock = asyncio.Lock()
     try:
         data = await request.json()
-        allocation = Allocation.parse_obj(data)
+        allocation = Allocation.model_validate(data)
     except ValidationError as error:
         return web.json_response(text=error.json(), status=web.HTTPBadRequest.status_code)
 
@@ -486,7 +486,7 @@ async def notify_allocation(request: web.Request):
     await update_aggregate_settings()
     try:
         data = await request.json()
-        vm_notification = VMNotification.parse_obj(data)
+        vm_notification = VMNotification.model_validate(data)
     except JSONDecodeError:
         return web.HTTPBadRequest(reason="Body is not valid JSON")
     except ValidationError as error:
@@ -631,7 +631,7 @@ async def operate_reserve_resources(request: web.Request, authenticated_sender: 
     pool: VmPool = request.app["vm_pool"]
     try:
         data = await request.json()
-        message = InstanceContent.parse_obj(data)
+        message = InstanceContent.model_validate(data)
     except JSONDecodeError:
         return web.HTTPBadRequest(reason="Body is not valid JSON")
     except ValidationError as error:

--- a/src/aleph/vm/orchestrator/views/authentication.py
+++ b/src/aleph/vm/orchestrator/views/authentication.py
@@ -24,6 +24,7 @@ from jwcrypto.jwa import JWA
 from nacl.exceptions import BadSignatureError
 from pydantic import BaseModel, ValidationError, field_validator, model_validator
 from solathon.utils import verify_signature
+from typing_extensions import Self
 
 from aleph.vm.conf import settings
 
@@ -103,7 +104,7 @@ class SignedPubKeyHeader(BaseModel):
         return bytes.fromhex(v.decode())
 
     @model_validator(mode="after")
-    def check_expiry(values) -> SignedPubKeyHeader:
+    def check_expiry(values) -> Self:
         """Check that the token has not expired"""
         payload = values.payload
         content = SignedPubKeyPayload.model_validate_json(payload)
@@ -112,7 +113,7 @@ class SignedPubKeyHeader(BaseModel):
         return values
 
     @model_validator(mode="after")
-    def check_signature(values) -> SignedPubKeyHeader:
+    def check_signature(values) -> Self:
         """Check that the signature is valid"""
         signature = values.signature
         payload = values.payload

--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -362,7 +362,7 @@ async def operate_confidential_inject_secret(request: web.Request, authenticated
     """
     try:
         data = await request.json()
-        params = InjectSecretParams.parse_obj(data)
+        params = InjectSecretParams.model_validate(data)
     except json.JSONDecodeError:
         return web.HTTPBadRequest(reason="Body is not valid JSON")
     except pydantic.ValidationError as error:

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -16,7 +16,7 @@ from aleph_message.models import (
     Payment,
     PaymentType,
 )
-from pydantic import parse_raw_as
+from pydantic import TypeAdapter
 
 from aleph.vm.conf import settings
 from aleph.vm.controllers.firecracker.snapshot_manager import SnapshotManager
@@ -272,7 +272,9 @@ class VmPool:
             if execution.is_running:
                 # TODO: Improve the way that we re-create running execution
                 # Load existing GPUs assigned to VMs
-                execution.gpus = parse_raw_as(list[HostGPU], saved_execution.gpus) if saved_execution.gpus else []
+                execution.gpus = (
+                    TypeAdapter(list[HostGPU]).validate_python(saved_execution.gpus) if saved_execution.gpus else []
+                )
                 # Load and instantiate the rest of resources and already assigned GPUs
                 await execution.prepare()
                 if self.network:

--- a/src/aleph/vm/resources.py
+++ b/src/aleph/vm/resources.py
@@ -2,7 +2,7 @@ import subprocess
 from enum import Enum
 
 from aleph_message.models import HashableModel
-from pydantic import BaseModel, Extra, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from aleph.vm.orchestrator.utils import get_compatible_gpus
 
@@ -13,8 +13,7 @@ class HostGPU(BaseModel):
     pci_host: str = Field(description="GPU PCI host address")
     supports_x_vga: bool = Field(description="Whether the GPU supports x-vga QEMU parameter", default=True)
 
-    class Config:
-        extra = Extra.forbid
+    model_config = ConfigDict(extra="forbid")
 
 
 class GpuDeviceClass(str, Enum):
@@ -47,8 +46,7 @@ class GpuDevice(HashableModel):
         """
         return self.device_class == GpuDeviceClass.VGA_COMPATIBLE_CONTROLLER
 
-    class Config:
-        extra = Extra.forbid
+    model_config = ConfigDict(extra="forbid")
 
 
 class CompatibleGPU(BaseModel):

--- a/src/aleph/vm/resources.py
+++ b/src/aleph/vm/resources.py
@@ -1,5 +1,6 @@
 import subprocess
 from enum import Enum
+from typing import Optional
 
 from aleph_message.models import HashableModel
 from pydantic import BaseModel, ConfigDict, Field
@@ -27,7 +28,7 @@ class GpuDevice(HashableModel):
     """GPU properties."""
 
     vendor: str = Field(description="GPU vendor name")
-    model: str | None = Field(description="GPU model name on Aleph Network")
+    model: Optional[str] = Field(description="GPU model name on Aleph Network", default=None)
     device_name: str = Field(description="GPU vendor card name")
     device_class: GpuDeviceClass = Field(
         description="GPU device class. Look at https://admin.pci-ids.ucw.cz/read/PD/03"

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -136,7 +136,7 @@ async def get_latest_amend(item_hash: str) -> str:
     if settings.FAKE_DATA_PROGRAM:
         return item_hash
     else:
-        url = f"{settings.CONNECTOR_URL}/compute/latest_amend/{item_hash}"
+        url = f"{settings.CONNECTOR_URL}compute/latest_amend/{item_hash}"
         async with aiohttp.ClientSession() as session:
             resp = await session.get(url)
             resp.raise_for_status()
@@ -154,7 +154,7 @@ async def get_message(ref: str) -> ProgramMessage | InstanceMessage:
         logger.debug("Using the fake data message")
     else:
         cache_path = (Path(settings.MESSAGE_CACHE) / ref).with_suffix(".json")
-        url = f"{settings.CONNECTOR_URL}/download/message/{ref}"
+        url = f"{settings.CONNECTOR_URL}download/message/{ref}"
         await download_file(url, cache_path)
 
     with open(cache_path) as cache_file:
@@ -190,7 +190,7 @@ async def get_code_path(ref: str) -> Path:
             raise ValueError(msg)
 
     cache_path = Path(settings.CODE_CACHE) / ref
-    url = f"{settings.CONNECTOR_URL}/download/code/{ref}"
+    url = f"{settings.CONNECTOR_URL}download/code/{ref}"
     await download_file(url, cache_path)
     return cache_path
 
@@ -202,7 +202,7 @@ async def get_data_path(ref: str) -> Path:
         return Path(f"{data_dir}.zip")
 
     cache_path = Path(settings.DATA_CACHE) / ref
-    url = f"{settings.CONNECTOR_URL}/download/data/{ref}"
+    url = f"{settings.CONNECTOR_URL}download/data/{ref}"
     await download_file(url, cache_path)
     return cache_path
 
@@ -223,7 +223,7 @@ async def get_runtime_path(ref: str) -> Path:
         return Path(settings.FAKE_DATA_RUNTIME)
 
     cache_path = Path(settings.RUNTIME_CACHE) / ref
-    url = f"{settings.CONNECTOR_URL}/download/runtime/{ref}"
+    url = f"{settings.CONNECTOR_URL}download/runtime/{ref}"
 
     if not cache_path.is_file():
         # File does not exist, download it
@@ -241,7 +241,7 @@ async def get_rootfs_base_path(ref: ItemHash) -> Path:
         return Path(settings.FAKE_INSTANCE_BASE)
 
     cache_path = Path(settings.RUNTIME_CACHE) / ref
-    url = f"{settings.CONNECTOR_URL}/download/runtime/{ref}"
+    url = f"{settings.CONNECTOR_URL}download/runtime/{ref}"
     await download_file(url, cache_path)
     await chown_to_jailman(cache_path)
     return cache_path

--- a/src/aleph/vm/utils/__init__.py
+++ b/src/aleph/vm/utils/__init__.py
@@ -24,9 +24,9 @@ logger = logging.getLogger(__name__)
 
 def get_message_executable_content(message_dict: dict) -> ExecutableContent:
     try:
-        return ProgramContent.parse_obj(message_dict)
+        return ProgramContent.model_validate(message_dict)
     except ValueError:
-        return InstanceContent.parse_obj(message_dict)
+        return InstanceContent.model_validate(message_dict)
 
 
 def cors_allow_all(function):

--- a/tests/supervisor/test_checkpayment.py
+++ b/tests/supervisor/test_checkpayment.py
@@ -63,7 +63,7 @@ async def test_enough_flow(mocker, fake_instance_content):
         return 500 * len(executions)
 
     mocker.patch("aleph.vm.orchestrator.tasks.compute_required_flow", compute_required_flow)
-    message = InstanceContent.parse_obj(fake_instance_content)
+    message = InstanceContent.model_validate(fake_instance_content)
 
     hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
 
@@ -117,7 +117,7 @@ async def test_enough_flow_not_community(mocker, fake_instance_content):
         return 500 * len(executions)
 
     mocker.patch("aleph.vm.orchestrator.tasks.compute_required_flow", compute_required_flow)
-    message = InstanceContent.parse_obj(fake_instance_content)
+    message = InstanceContent.model_validate(fake_instance_content)
 
     hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
 
@@ -157,7 +157,7 @@ async def test_not_enough_flow(mocker, fake_instance_content):
     mocker.patch("aleph.vm.orchestrator.tasks.get_stream", return_value=2, autospec=True)
     mocker.patch("aleph.vm.orchestrator.tasks.get_message_status", return_value=MessageStatus.PROCESSED)
     mocker.patch("aleph.vm.orchestrator.tasks.compute_required_flow", return_value=5)
-    message = InstanceContent.parse_obj(fake_instance_content)
+    message = InstanceContent.model_validate(fake_instance_content)
 
     mocker.patch.object(VmExecution, "is_running", new=True)
     mocker.patch.object(VmExecution, "stop", new=mocker.AsyncMock(return_value=False))
@@ -201,7 +201,7 @@ async def test_not_enough_community_flow(mocker, fake_instance_content):
     mocker.patch("aleph.vm.orchestrator.tasks.get_community_wallet_address", return_value=mock_community_wallet_address)
     mocker.patch("aleph.vm.orchestrator.tasks.get_message_status", return_value=MessageStatus.PROCESSED)
     mocker.patch("aleph.vm.orchestrator.tasks.compute_required_flow", return_value=5)
-    message = InstanceContent.parse_obj(fake_instance_content)
+    message = InstanceContent.model_validate(fake_instance_content)
 
     mocker.patch.object(VmExecution, "is_running", new=True)
     mocker.patch.object(VmExecution, "stop", new=mocker.AsyncMock(return_value=False))

--- a/tests/supervisor/test_gpu_x_vga_support.py
+++ b/tests/supervisor/test_gpu_x_vga_support.py
@@ -4,7 +4,7 @@ import pytest
 
 from aleph.vm.controllers.configuration import QemuGPU
 from aleph.vm.hypervisors.qemu.qemuvm import QemuVM
-from aleph.vm.resources import GpuDevice, GpuDeviceClass, HostGPU
+from aleph.vm.resources import GpuDevice, GpuDeviceClass
 
 
 class TestGpuXVgaSupport:


### PR DESCRIPTION
Feature: Migrate Pydantic V1 to V2.

## Self proofreading checklist

- [X] The new code clear, easy to read and well commented.
- [X] New code does not duplicate the functions of builtin or popular libraries.
- [X] An LLM was used to review the new code and look for simplifications.
- [ ] New classes and functions contain docstrings explaining what they provide.
- [X] All new code is covered by relevant tests.
- [ ] Documentation has been updated regarding these changes.
- [ ] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

## Changes

  1. We updated model validation in operator.py to use model_validate instead of parse_obj
  2. We fixed json methods in resources.py and configuration.py to use model_dump_json instead of json
  3. We updated the import from pydantic.json to pydantic_core in models.py
  4. We fixed the display method in conf.py to use model_config directly

## How to test

Deploy that version on the staging CRNs and ensure that everything is working well.
