### PR TITLE
Retry instances not running add new Execution list endpoint

### DIFF
--- a/src/aleph/vm/controllers/firecracker/instance.py
+++ b/src/aleph/vm/controllers/firecracker/instance.py
@@ -21,13 +21,7 @@ from aleph.vm.hypervisors.firecracker.config import (
 from aleph.vm.hypervisors.firecracker.microvm import setfacl
 from aleph.vm.network.interfaces import TapInterface
 from aleph.vm.storage import create_devmapper, create_volume_file
-from aleph.vm.utils import (
-    HostNotFoundError,
-    NotEnoughDiskSpaceError,
-    check_disk_space,
-    ping,
-    run_in_subprocess,
-)
+from aleph.vm.utils import NotEnoughDiskSpaceError, check_disk_space, run_in_subprocess
 
 from .executable import (
     AlephFirecrackerExecutable,
@@ -119,30 +113,6 @@ class AlephFirecrackerInstance(AlephFirecrackerExecutable):
                 else []
             ),
         )
-
-    async def wait_for_init(self) -> None:
-        """Wait for the init process of the instance to be ready."""
-        assert self.enable_networking and self.tap_interface, f"Network not enabled for VM {self.vm_id}"
-
-        ip = self.get_ip()
-        if not ip:
-            msg = "Host IP not available"
-            raise ValueError(msg)
-
-        ip = ip.split("/", 1)[0]
-
-        attempts = 30
-        timeout_seconds = 2
-
-        for attempt in range(attempts):
-            try:
-                await ping(ip, packets=1, timeout=timeout_seconds)
-                return
-            except HostNotFoundError:
-                if attempt < (attempts - 1):
-                    continue
-                else:
-                    raise
 
     async def create_snapshot(self) -> CompressedDiskVolumeSnapshot:
         """Create a VM snapshot"""

--- a/src/aleph/vm/controllers/qemu/instance.py
+++ b/src/aleph/vm/controllers/qemu/instance.py
@@ -31,7 +31,7 @@ from aleph.vm.network.firewall import teardown_nftables_for_vm
 from aleph.vm.network.interfaces import TapInterface
 from aleph.vm.resources import HostGPU
 from aleph.vm.storage import get_rootfs_base_path
-from aleph.vm.utils import HostNotFoundError, ping, run_in_subprocess
+from aleph.vm.utils import run_in_subprocess
 
 logger = logging.getLogger(__name__)
 
@@ -231,35 +231,11 @@ class AlephQemuInstance(Generic[ConfigurationType], CloudInitMixin, AlephVmContr
         # Start via systemd not here
         raise NotImplementedError()
 
-    async def wait_for_init(self) -> None:
-        """Wait for the init process of the instance to be ready."""
-        assert self.enable_networking and self.tap_interface, f"Network not enabled for VM {self.vm_id}"
-
-        ip = self.get_ip()
-        if not ip:
-            msg = "Host IP not available"
-            raise ValueError(msg)
-        ip = ip.split("/", 1)[0]
-
-        attempts = 30
-        timeout_seconds = 2
-
-        for attempt in range(attempts):
-            try:
-                await ping(ip, packets=1, timeout=timeout_seconds)
-                return
-            except HostNotFoundError:
-                if attempt < (attempts - 1):
-                    continue
-                else:
-                    raise
-
     async def start_guest_api(self):
         pass
 
     async def stop_guest_api(self):
         pass
-
 
     async def teardown(self):
         if self.enable_networking:

--- a/src/aleph/vm/controllers/qemu/instance.py
+++ b/src/aleph/vm/controllers/qemu/instance.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import logging
 import shutil
-from asyncio import Task
 from asyncio.subprocess import Process
 from pathlib import Path
 from typing import Generic, TypeVar
@@ -261,12 +260,8 @@ class AlephQemuInstance(Generic[ConfigurationType], CloudInitMixin, AlephVmContr
     async def stop_guest_api(self):
         pass
 
-    print_task: Task | None = None
 
     async def teardown(self):
-        if self.print_task:
-            self.print_task.cancel()
-
         if self.enable_networking:
             teardown_nftables_for_vm(self.vm_id)
             if self.tap_interface:

--- a/src/aleph/vm/hypervisors/firecracker/microvm.py
+++ b/src/aleph/vm/hypervisors/firecracker/microvm.py
@@ -508,7 +508,7 @@ class MicroVM:
             except asyncio.TimeoutError:
                 # In  Python < 3.11 wait_closed() was broken and returned immediatly
                 # It is supposedly fixed in Python 3.12.1, but it hangs indefinitely during tests.
-                logger.info("f{self} unix socket closing timeout")
+                logger.info("%s unix socket closing timeout", self)
 
         logger.debug("Removing files")
         if self.config_file_path:

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -447,6 +447,8 @@ class VmExecution:
             if self.times.stopped_at is not None:
                 logger.debug(f"VM={self.vm.vm_id} already stopped")
                 return
+            if self.persistent and self.systemd_manager:
+                self.systemd_manager.stop_and_disable(self.controller_service)
             self.times.stopping_at = datetime.now(tz=timezone.utc)
             await self.all_runs_complete()
             await self.record_usage()

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -41,7 +41,7 @@ from aleph.vm.orchestrator.pubsub import PubSub
 from aleph.vm.orchestrator.vm import AlephFirecrackerInstance
 from aleph.vm.resources import GpuDevice, HostGPU
 from aleph.vm.systemd import SystemDManager
-from aleph.vm.utils import create_task_log_exceptions, dumps_for_json
+from aleph.vm.utils import create_task_log_exceptions, dumps_for_json, is_pinging
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +86,7 @@ class VmExecution:
     stop_event: asyncio.Event
     expire_task: asyncio.Task | None = None
     update_task: asyncio.Task | None = None
+    init_task: asyncio.Task | None
 
     snapshot_manager: SnapshotManager | None
     systemd_manager: SystemDManager | None
@@ -162,6 +163,7 @@ class VmExecution:
         systemd_manager: SystemDManager | None,
         persistent: bool,
     ):
+        self.init_task = None
         self.uuid = uuid.uuid1()  # uuid1() includes the hardware address and timestamp
         self.vm_hash = vm_hash
         self.message = message
@@ -326,20 +328,63 @@ class VmExecution:
             # files, use the endpoint /control/machine/{ref}/confidential/initialize to get session files and start the VM
             if self.persistent and not self.is_confidential and self.systemd_manager:
                 self.systemd_manager.enable_and_start(self.controller_service)
-                await self.wait_for_init()
-                if self.is_program and self.vm:
+
+                if self.is_program:
+                    await self.wait_for_init()
                     await self.vm.load_configuration()
+                    self.times.started_at = datetime.now(tz=timezone.utc)
+                else:
+                    self.init_task = asyncio.create_task(self.non_blocking_wait_for_boot())
 
                 if self.vm and self.vm.support_snapshot and self.snapshot_manager:
                     await self.snapshot_manager.start_for(vm=self.vm)
 
-            self.times.started_at = datetime.now(tz=timezone.utc)
             self.ready_event.set()
             await self.save()
         except Exception:
             await self.vm.teardown()
             await self.vm.stop_guest_api()
             raise
+
+    async def wait_for_persistent_boot(self):
+        """Determine if VM has booted by responding to ping and check if the process is still running"""
+        assert self.vm
+        assert self.vm.enable_networking and self.vm.tap_interface, f"Network not enabled for VM {self.vm.vm_id}"
+        ip = self.vm.get_ip()
+        if not ip:
+            msg = "Host IP not available"
+            raise ValueError(msg)
+
+        ip = ip.split("/", 1)[0]
+        max_attempt = 30
+        timeout_seconds = 2
+        attempt = 0
+        while True:
+            attempt += 1
+            if attempt > max_attempt:
+                logging.error("%s has not responded to ping after %s attempt", self, attempt)
+                raise Exception("Max attempt")
+
+            if not self.is_controller_running:
+                logging.error("%s process stopped running while waiting for boot", self)
+                raise Exception("Process is not running")
+            if await is_pinging(ip, packets=1, timeout=timeout_seconds):
+                break
+
+    async def non_blocking_wait_for_boot(self):
+        """Wait till the VM respond to ping and mark it as booted or not and clean up ressource if it fail
+
+        Used for instances"""
+        assert self.vm
+        try:
+            await self.wait_for_persistent_boot()
+            logger.info("%s responded to ping. Marking it as started.", self)
+            self.times.started_at = datetime.now(tz=timezone.utc)
+            # await self.save()
+        except Exception as e:
+            logger.warning("%s failed to responded to ping or is not running, stopping it.: %s ", self, e)
+            assert self.vm
+            await self.stop()
 
     async def wait_for_init(self):
         assert self.vm, "The VM attribute has to be set before calling wait_for_init()"
@@ -383,6 +428,7 @@ class VmExecution:
     async def stop(self) -> None:
         """Stop the VM and release resources"""
         assert self.vm, "The VM attribute has to be set before calling stop()"
+        logger.info("%s stopping", self)
 
         # Prevent concurrent calls to stop() using a Lock
         async with self.stop_pending_lock:
@@ -400,6 +446,7 @@ class VmExecution:
             if self.vm.support_snapshot and self.snapshot_manager:
                 await self.snapshot_manager.stop_for(self.vm_hash)
             self.stop_event.set()
+            logger.info("%s stopped", self)
 
     def start_watching_for_updates(self, pubsub: PubSub):
         if not self.update_task:
@@ -430,6 +477,7 @@ class VmExecution:
             await self.runs_done_event.wait()
 
     async def save(self):
+        """Save to DB"""
         assert self.vm, "The VM attribute has to be set before calling save()"
 
         pid_info = self.vm.to_dict() if self.vm else None

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -94,6 +94,18 @@ class VmExecution:
     persistent: bool = False
 
     @property
+    def is_starting(self) -> bool:
+        return bool(self.times.starting_at and not self.times.started_at and not self.times.stopping_at)
+
+    @property
+    def is_controller_running(self):
+        return (
+            self.systemd_manager.is_service_active(self.controller_service)
+            if self.persistent and self.systemd_manager
+            else None
+        )
+
+    @property
     def is_running(self) -> bool:
         return (
             self.systemd_manager.is_service_active(self.controller_service)

--- a/src/aleph/vm/network/firewall.py
+++ b/src/aleph/vm/network/firewall.py
@@ -35,7 +35,7 @@ def execute_json_nft_commands(commands: list[dict]) -> int:
     logger.debug("Inserting nftables rules")
     return_code, output, error = nft.json_cmd(commands_dict)
     if return_code != 0:
-        logger.error(f"Failed to add nftables rules: {error}")
+        logger.error("Failed to add nftables rules: %s -- %s", error, json.dumps(commands, indent=4))
 
     return return_code
 

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -188,7 +188,7 @@ async def benchmark(runs: int):
     bench: list[float] = []
 
     loop = asyncio.get_event_loop()
-    pool = VmPool(loop)
+    pool = VmPool()
     await pool.setup()
 
     # Does not make sense in benchmarks
@@ -246,7 +246,7 @@ async def run_instances(instances: list[ItemHash]) -> None:
     """Run instances from a list of message identifiers."""
     logger.info(f"Instances to run: {instances}")
     loop = asyncio.get_event_loop()
-    pool = VmPool(loop)
+    pool = VmPool()
     # The main program uses a singleton pubsub instance in order to watch for updates.
     # We create another instance here since that singleton is not initialized yet.
     # Watching for updates on this instance will therefore not work.

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -287,13 +287,3 @@ async def start_persistent_vm(vm_hash: ItemHash, pubsub: PubSub | None, pool: Vm
         execution.start_watching_for_updates(pubsub=pubsub)
 
     return execution
-
-
-async def stop_persistent_vm(vm_hash: ItemHash, pool: VmPool) -> VmExecution | None:
-    logger.info(f"Stopping persistent VM {vm_hash}")
-    execution = pool.get_running_vm(vm_hash)
-
-    if execution:
-        await execution.stop()
-
-    return execution

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -188,6 +188,8 @@ def run():
 
     # Require a random token to access /about APIs
     secret_token = token_urlsafe(nbytes=32)
+    (settings.EXECUTION_ROOT / "login_token").write_text(secret_token)
+    (settings.EXECUTION_ROOT / "login_token").chmod(0o400)
     app = setup_webapp(pool=pool)
     # Store app singletons. Note that app["pubsub"] will also be created.
     app["secret_token"] = secret_token

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -95,7 +95,7 @@ async def on_prepare_server_version(request: web.Request, response: web.Response
     response.headers["Server"] = f"aleph-vm/{__version__}"
 
 
-async def http_not_found(request: web.Request):
+async def http_not_found(request: web.Request):  # noqa: ARG001
     """Return a 404 error for unknown URLs."""
     return web.HTTPNotFound()
 

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -33,6 +33,7 @@ from .views import (
     about_executions,
     about_login,
     list_executions,
+    list_executions_v2,
     notify_allocation,
     operate_reserve_resources,
     run_code_from_hostname,
@@ -123,6 +124,7 @@ def setup_webapp(pool: VmPool | None):
         # /about APIs return information about the VM Orchestrator
         web.get("/about/login", about_login),
         web.get("/about/executions/list", list_executions),
+        web.get("/v2/about/executions/list", list_executions_v2),
         web.get("/about/executions/details", about_executions),
         web.get("/about/executions/records", about_execution_records),
         web.get("/about/usage/system", about_system_usage),

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -184,9 +184,12 @@ async def list_executions_v2(request: web.Request) -> web.Response:
         {
             item_hash: {
                 "networking": {
-                    "ipv4": execution.vm.tap_interface.ip_network,
-                    "ipv6": execution.vm.tap_interface.ipv6_network,
-                },
+                    "ipv4_network": execution.vm.tap_interface.ip_network,
+                    "ipv6_network": execution.vm.tap_interface.ipv6_network,
+                    "ipv6_ip": execution.vm.tap_interface.guest_ipv6.ip,
+                }
+                if execution.vm and execution.vm.tap_interface
+                else {},
                 "status": execution.times,
                 "running": execution.is_controller_running,
             }

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -176,6 +176,27 @@ async def list_executions(request: web.Request) -> web.Response:
 
 
 @cors_allow_all
+async def list_executions_v2(request: web.Request) -> web.Response:
+    """List all executions. Returning their status and ip"""
+    pool: VmPool = request.app["vm_pool"]
+
+    return web.json_response(
+        {
+            item_hash: {
+                "networking": {
+                    "ipv4": execution.vm.tap_interface.ip_network,
+                    "ipv6": execution.vm.tap_interface.ipv6_network,
+                },
+                "status": execution.times,
+                "running": execution.is_controller_running,
+            }
+            for item_hash, execution in pool.executions.items()
+        },
+        dumps=dumps_for_json,
+    )
+
+
+@cors_allow_all
 async def about_config(request: web.Request) -> web.Response:
     authenticate_request(request)
     return web.json_response(

--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -260,7 +260,7 @@ async def operate_confidential_initialize(request: web.Request, authenticated_se
         godh_file_path = vm_session_path / "vm_godh.b64"
         godh_file_path.write_bytes(godh_file_content.file.read())
 
-        pool.systemd_manager.enable_and_start(execution.controller_service)
+        await pool.systemd_manager.enable_and_start(execution.controller_service)
 
         return web.Response(status=200, body=f"Started VM with ref {vm_hash}")
 

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -222,20 +222,11 @@ class VmPool:
     async def stop_vm(self, vm_hash: ItemHash) -> VmExecution | None:
         """Stop a VM."""
         execution = self.executions.get(vm_hash)
-        if execution:
-            if execution.persistent:
-                await self.stop_persistent_execution(execution)
-            else:
-                await execution.stop()
-            return execution
-        else:
+        if not execution:
+            logger.info("stop_vm No execution found for %s", vm_hash)
             return None
-
-    async def stop_persistent_execution(self, execution: VmExecution):
-        """Stop persistent VMs in the pool."""
-        assert execution.persistent, "Execution isn't persistent"
-        self.systemd_manager.stop_and_disable(execution.controller_service)
         await execution.stop()
+        return execution
 
     def forget_vm(self, vm_hash: ItemHash) -> None:
         """Remove a VM from the executions pool.

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -51,7 +51,7 @@ class VmPool:
     reservations: dict[Any, Reservation]
     """Resources reserved by an user, before launching (only GPU atm)"""
 
-    def __init__(self, loop: asyncio.AbstractEventLoop):
+    def __init__(self):
         self.executions = {}
         self.message_cache = {}
         self.reservations = {}

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -201,6 +201,15 @@ class VmPool:
         msg = "No available value for vm_id."
         raise ValueError(msg)
 
+    def get_running_or_starting_vm(self, vm_hash: ItemHash) -> VmExecution | None:
+        """Return a running VM or None. Disables the VM expiration task."""
+        execution = self.executions.get(vm_hash)
+        if execution and execution.is_running and not execution.is_stopping:
+            execution.cancel_expiration()
+            return execution
+        else:
+            return None
+
     def get_running_vm(self, vm_hash: ItemHash) -> VmExecution | None:
         """Return a running VM or None. Disables the VM expiration task."""
         execution = self.executions.get(vm_hash)

--- a/src/aleph/vm/systemd.py
+++ b/src/aleph/vm/systemd.py
@@ -72,7 +72,7 @@ class SystemDManager:
             logger.error(error)
             return False
 
-    def enable_and_start(self, service: str) -> None:
+    async def enable_and_start(self, service: str) -> None:
         if not self.is_service_enabled(service):
             self.enable(service)
         if not self.is_service_active(service):

--- a/src/aleph/vm/utils/__init__.py
+++ b/src/aleph/vm/utils/__init__.py
@@ -177,17 +177,6 @@ class HostNotFoundError(Exception):
     pass
 
 
-async def ping(host: str, packets: int, timeout: int):
-    """
-    Waits for a host to respond to a ping request.
-    """
-
-    try:
-        await run_in_subprocess(["ping", "-c", str(packets), "-W", str(timeout), host], check=True)
-    except subprocess.CalledProcessError as err:
-        raise HostNotFoundError() from err
-
-
 async def is_pinging(host: str, packets: int, timeout: int) -> bool:
     """
     Try to ping an ip, return true if host respond, fale otherwise

--- a/src/aleph/vm/utils/__init__.py
+++ b/src/aleph/vm/utils/__init__.py
@@ -188,6 +188,18 @@ async def ping(host: str, packets: int, timeout: int):
         raise HostNotFoundError() from err
 
 
+async def is_pinging(host: str, packets: int, timeout: int) -> bool:
+    """
+    Try to ping an ip, return true if host respond, fale otherwise
+    """
+
+    try:
+        await run_in_subprocess(["ping", "-c", str(packets), "-W", str(timeout), host], check=True)
+        return True
+    except subprocess.CalledProcessError as err:
+        return False
+
+
 def check_disk_space(bytes_to_use: int) -> bool:
     host_disk_usage = disk_usage("/")
     return host_disk_usage.free >= bytes_to_use

--- a/tests/supervisor/test_checkpayment.py
+++ b/tests/supervisor/test_checkpayment.py
@@ -55,7 +55,7 @@ async def test_enough_flow(mocker, fake_instance_content):
     mocker.patch("aleph.vm.orchestrator.tasks.is_after_community_wallet_start", return_value=True)
 
     loop = asyncio.get_event_loop()
-    pool = VmPool(loop=loop)
+    pool = VmPool()
     mocker.patch("aleph.vm.orchestrator.tasks.get_stream", return_value=400, autospec=True)
     mocker.patch("aleph.vm.orchestrator.tasks.get_message_status", return_value=MessageStatus.PROCESSED)
 
@@ -109,7 +109,7 @@ async def test_enough_flow_not_community(mocker, fake_instance_content):
     mocker.patch("aleph.vm.orchestrator.tasks.is_after_community_wallet_start", return_value=False)
 
     loop = asyncio.get_event_loop()
-    pool = VmPool(loop=loop)
+    pool = VmPool()
     mocker.patch("aleph.vm.orchestrator.tasks.get_stream", return_value=500, autospec=True)
     mocker.patch("aleph.vm.orchestrator.tasks.get_message_status", return_value=MessageStatus.PROCESSED)
 
@@ -153,7 +153,7 @@ async def test_not_enough_flow(mocker, fake_instance_content):
     mocker.patch("aleph.vm.orchestrator.tasks.get_community_wallet_address", return_value=mock_community_wallet_address)
 
     loop = asyncio.get_event_loop()
-    pool = VmPool(loop=loop)
+    pool = VmPool()
     mocker.patch("aleph.vm.orchestrator.tasks.get_stream", return_value=2, autospec=True)
     mocker.patch("aleph.vm.orchestrator.tasks.get_message_status", return_value=MessageStatus.PROCESSED)
     mocker.patch("aleph.vm.orchestrator.tasks.compute_required_flow", return_value=5)
@@ -188,7 +188,7 @@ async def test_not_enough_community_flow(mocker, fake_instance_content):
     mocker.patch.object(settings, "PAYMENT_RECEIVER_ADDRESS", "0xD39C335404a78E0BDCf6D50F29B86EFd57924288")
 
     loop = asyncio.get_event_loop()
-    pool = VmPool(loop=loop)
+    pool = VmPool()
     mock_community_wallet_address = "0x23C7A99d7AbebeD245d044685F1893aeA4b5Da90"
 
     async def get_stream(sender, receiver, chain):

--- a/tests/supervisor/test_instance.py
+++ b/tests/supervisor/test_instance.py
@@ -63,6 +63,8 @@ async def test_create_firecracker_instance(mocker):
     mocker.patch.object(settings, "FAKE_DATA_PROGRAM", settings.BENCHMARK_FAKE_DATA_PROGRAM)
     mocker.patch.object(settings, "USE_JAILER", True)
 
+    # Patch journal.stream so the output of qemu proecss is shown in the test output
+    mocker.patch("aleph.vm.hypervisors.firecracker.microvm.journal.stream", return_value=None)
     # logging.basicConfig(level=logging.DEBUG)
 
     # Ensure that the settings are correct and required files present.

--- a/tests/supervisor/test_qemu_instance.py
+++ b/tests/supervisor/test_qemu_instance.py
@@ -61,7 +61,9 @@ async def test_create_qemu_instance(mocker):
     mocker.patch.object(settings, "USE_JAILER", False)
 
     if not settings.FAKE_INSTANCE_BASE.exists():
-        pytest.xfail("Test Runtime not setup. run `cd runtimes/instance-rootfs && sudo ./create-debian-12-disk.sh`")
+        pytest.xfail(
+            "Test Runtime not setup. run `cd runtimes/instance-rootfs && sudo ./create-debian-12-qemu-disk.sh`"
+        )
 
     logging.basicConfig(level=logging.DEBUG)
 
@@ -121,7 +123,7 @@ async def test_create_qemu_instance_online(mocker):
 
     if not settings.FAKE_INSTANCE_BASE.exists():
         pytest.xfail(
-            "Test instance disk {} not setup. run `cd runtimes/instance-rootfs && sudo ./create-debian-12-disk.sh` ".format(
+            "Test instance disk {} not setup. run `cd runtimes/instance-rootfs && sudo ./create-debian-12-qemu-disk.sh` ".format(
                 settings.FAKE_QEMU_INSTANCE_BASE
             )
         )

--- a/tests/supervisor/test_qemu_instance.py
+++ b/tests/supervisor/test_qemu_instance.py
@@ -60,6 +60,9 @@ async def test_create_qemu_instance(mocker):
     mocker.patch.object(settings, "ENABLE_CONFIDENTIAL_COMPUTING", False)
     mocker.patch.object(settings, "USE_JAILER", False)
 
+    # Patch journal.stream so the output of qemu proecss is shown in the test output
+    mocker.patch("aleph.vm.hypervisors.qemu.qemuvm.journal.stream", return_value=None)
+
     if not settings.FAKE_INSTANCE_BASE.exists():
         pytest.xfail(
             "Test Runtime not setup. run `cd runtimes/instance-rootfs && sudo ./create-debian-12-qemu-disk.sh`"
@@ -102,6 +105,7 @@ async def test_create_qemu_instance(mocker):
     qemu_execution, process = await mock_systemd_manager.enable_and_start(execution.controller_service)
     assert isinstance(qemu_execution, QemuVM)
     assert qemu_execution.qemu_process is not None
+    await asyncio.sleep(30)
     await mock_systemd_manager.stop_and_disable(execution.vm_hash)
     await qemu_execution.qemu_process.wait()
     assert qemu_execution.qemu_process.returncode is not None
@@ -120,6 +124,9 @@ async def test_create_qemu_instance_online(mocker):
     mocker.patch.object(settings, "FAKE_INSTANCE_BASE", settings.FAKE_INSTANCE_QEMU_MESSAGE)
     mocker.patch.object(settings, "ENABLE_CONFIDENTIAL_COMPUTING", False)
     mocker.patch.object(settings, "USE_JAILER", False)
+
+    # Patch journal.stream so the output of qemu process is shown in the test output
+    mocker.patch("aleph.vm.hypervisors.qemu.qemuvm.journal.stream", return_value=None)
 
     if not settings.FAKE_INSTANCE_BASE.exists():
         pytest.xfail(

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -19,7 +19,7 @@ from aleph.vm.sevclient import SevClient
 @pytest.mark.asyncio
 async def test_allocation_fails_on_invalid_item_hash(aiohttp_client):
     """Test that the allocation endpoint fails when an invalid item_hash is provided."""
-    app = setup_webapp()
+    app = setup_webapp(pool=None)
     client = await aiohttp_client(app)
     settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
     response: web.Response = await client.post(
@@ -89,7 +89,7 @@ async def test_system_usage_mock(aiohttp_client, mocker, mock_app_with_pool):
 async def test_allocation_invalid_auth_token(aiohttp_client):
     """Test that the allocation endpoint fails when an invalid auth token is provided."""
     settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
-    app = setup_webapp()
+    app = setup_webapp(pool=None)
     client = await aiohttp_client(app)
     response = await client.post(
         "/control/allocations",
@@ -103,7 +103,7 @@ async def test_allocation_invalid_auth_token(aiohttp_client):
 @pytest.mark.asyncio
 async def test_allocation_missing_auth_token(aiohttp_client):
     """Test that the allocation endpoint fails when auth token is not provided."""
-    app = setup_webapp()
+    app = setup_webapp(pool=None)
     client = await aiohttp_client(app)
     response: web.Response = await client.post(
         "/control/allocations",
@@ -124,9 +124,8 @@ async def test_allocation_valid_token(aiohttp_client):
             return []
 
     settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
-    app = setup_webapp()
-    app["vm_pool"] = FakeVmPool()
-    app["pubsub"] = FakeVmPool()
+    app = setup_webapp(pool=FakeVmPool())
+    app["pubsub"] = None
     client = await aiohttp_client(app)
 
     response: web.Response = await client.post(
@@ -143,7 +142,7 @@ async def test_about_certificates_missing_setting(aiohttp_client):
     """Test that the certificates system endpoint returns an error if the setting isn't enabled"""
     settings.ENABLE_CONFIDENTIAL_COMPUTING = False
 
-    app = setup_webapp()
+    app = setup_webapp(pool=None)
     app["sev_client"] = SevClient(Path().resolve(), Path("/opt/sevctl").resolve())
     client = await aiohttp_client(app)
     response: web.Response = await client.get("/about/certificates")
@@ -168,7 +167,7 @@ async def test_about_certificates(aiohttp_client):
             return_value=True,
         ) as export_mock:
             with tempfile.TemporaryDirectory() as tmp_dir:
-                app = setup_webapp()
+                app = setup_webapp(pool=None)
                 sev_client = SevClient(Path(tmp_dir), Path("/opt/sevctl"))
                 app["sev_client"] = sev_client
                 # Create mock file to return it
@@ -270,10 +269,9 @@ async def mock_app_with_pool(mocker, mock_aggregate_settings):
 
     mocker.patch.object(settings, "ENABLE_GPU_SUPPORT", True)
     loop = asyncio.new_event_loop()
-    pool = VmPool(loop=loop)
+    pool = VmPool()
     await pool.setup()
-    app = setup_webapp()
-    app["vm_pool"] = pool
+    app = setup_webapp(pool=pool)
     return app
 
 

--- a/tests/supervisor/views/test_operator.py
+++ b/tests/supervisor/views/test_operator.py
@@ -219,7 +219,7 @@ async def test_operator_confidential_initialize_not_confidential(aiohttp_client,
 
 
 @pytest.mark.asyncio
-async def test_operator_confidential_initialize(aiohttp_client):
+async def test_operator_confidential_initialize(aiohttp_client, mocker):
     """Test that the certificates system endpoint responds. No auth needed"""
 
     settings.ENABLE_QEMU_SUPPORT = True
@@ -236,7 +236,7 @@ async def test_operator_confidential_initialize(aiohttp_client):
         controller_service: str = ""
 
     class MockSystemDManager:
-        enable_and_start = MagicMock(return_value=True)
+        enable_and_start = mocker.AsyncMock(return_value=True)
 
     class FakeVmPool:
         executions: dict[ItemHash, FakeExecution] = {}

--- a/tests/supervisor/views/test_view_errors.py
+++ b/tests/supervisor/views/test_view_errors.py
@@ -6,7 +6,7 @@ from aleph.vm.orchestrator.supervisor import setup_webapp
 
 @pytest.mark.asyncio
 async def test_json_404_about(aiohttp_client, mocker):
-    app = setup_webapp()
+    app = setup_webapp(pool=None)
     client: TestClient = await aiohttp_client(app)
     response = await client.get(
         "/about/non_existing_path",
@@ -18,7 +18,7 @@ async def test_json_404_about(aiohttp_client, mocker):
 
 @pytest.mark.asyncio
 async def test_json_err_allocation_notify(aiohttp_client, mocker):
-    app = setup_webapp()
+    app = setup_webapp(pool=None)
     client: TestClient = await aiohttp_client(app)
     response = await client.post("/control/allocation/notify", data="invalid_json")
     assert response.status == 400


### PR DESCRIPTION
Jira ticket: ALEPH-287

This PR improve how Instance are started, making it more reliable and properly cleaning when they fail to start. It also allow to start again the VM if it failed to start the first time.

Changes introduced by this PR:
1. Decouple instance wait_for_init from allocation. It now return directly after starting the VM controller and run wait_for_init in the background. wait_for_init has been renamed wait_for_boot in VM
2. Stop the controller when the Instance fail to start. Before if the instance failed to respond to ping the Instance was reported as not running and removed from the list but the Instance systemd controller was still. This tied up resource and prevented the VM from starting again. Also it caused issue with the network. 
3. Introduce a new endpoint `/v2/about/executions/list` which also include the starting, started, end times etc.. so we can inspect the VM state. and includ non running VM It will allow us in the future to improve the clients
4. Fix VM inconsistant state calculation between the boot and the end of boot.  
5. Properly clean up ressource if the VM crash and we tried to start it again. Earlier if it was not is_running we just started a new one regardless if it was shutting down or crashed and the resource were not cleaned.
6. Save debug token inside a protected file so we can still access it if the log rotated  
7. Improve the instances tests:
     - Reduce the problem of contamination of settings between tests
     - ensure we tests in a separat temp dir  we don't reuse the cache. Before that the tests missed issue where ressource could not be downloaded because of a coding error but the resource was already cached
     - Better output and debug info

## Self proofreading checklist


- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.
- [x] Documentation has been updated regarding these changes.
- [x] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

## Changes
In addition to what was listed above, others refactor changes:
* in tests Setup webapp take the vm_pool argument
* vm_pool don't take the loop anymore (not needed since Python 3.10)
* Execution call .enable_and_start and .stop_and_disable, not VmPool
* .enable_and_start is now async
* Remove some unused code
* Better debugging output

## How to test

Allocate VM, try allocating VM that fail to start and reallocate again. Kill VM during boot

