### PR TITLE
Upgrade `aleph-message==1.0.0` version dependency

### DIFF
--- a/docker/vm_supervisor-dev.dockerfile
+++ b/docker/vm_supervisor-dev.dockerfile
@@ -19,7 +19,7 @@ RUN curl -fsSL -o /opt/firecracker/vmlinux.bin https://s3.amazonaws.com/spec.ccf
 RUN ln /opt/firecracker/release-*/firecracker-v* /opt/firecracker/firecracker
 RUN ln /opt/firecracker/release-*/jailer-v* /opt/firecracker/jailer
 
-RUN pip3 install typing-extensions 'aleph-message==0.4.9'
+RUN pip3 install typing-extensions 'aleph-message==1.0.0'
 
 RUN mkdir -p /var/lib/aleph/vm/jailer
 

--- a/examples/volumes/Dockerfile
+++ b/examples/volumes/Dockerfile
@@ -6,6 +6,6 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m venv /opt/venv
-RUN /opt/venv/bin/pip install 'aleph-message==0.4.9'
+RUN /opt/venv/bin/pip install 'aleph-message==1.0.0'
 
 CMD mksquashfs /opt/venv /mnt/volume-venv.squashfs

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -19,7 +19,7 @@ debian-package-code:
 	python3 -m venv build_venv
 	build_venv/bin/pip install   --progress-bar off --upgrade pip setuptools wheel
 	# Fixing this protobuf dependency version to avoid getting CI errors as version 5.29.0 have this compilation issue
-	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'git+https://github.com/aleph-im/aleph-message@108-upgrade-pydantic-version#egg=aleph-message' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pydantic-settings==2.6.1' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2' 'protobuf==5.28.3'
+	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==1.0.0' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pydantic-settings==2.6.1' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2' 'protobuf==5.28.3'
 	build_venv/bin/python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux download-ipfs-kubo  target/bin/sevctl

--- a/runtimes/aleph-debian-12-python/create_disk_image.sh
+++ b/runtimes/aleph-debian-12-python/create_disk_image.sh
@@ -37,7 +37,7 @@ locale-gen en_US.UTF-8
 echo "Pip installing aleph-sdk-python"
 mkdir -p /opt/aleph/libs
 # Fixing this protobuf dependency version to avoid getting CI errors as version 5.29.0 have this compilation issue.
-pip3 install --target /opt/aleph/libs 'aleph-sdk-python==1.0.0' 'aleph-message==0.4.9' 'fastapi~=0.109.2' 'protobuf==5.28.3'
+pip3 install --target /opt/aleph/libs 'aleph-sdk-python==1.0.0' 'aleph-message==1.0.0' 'fastapi~=0.109.2' 'protobuf==5.28.3'
 
 # Compile Python code to bytecode for faster execution
 # -o2 is needed to compile with optimization level 2 which is what we launch init1.py ("python -OO")

--- a/runtimes/aleph-debian-12-python/create_disk_image.sh
+++ b/runtimes/aleph-debian-12-python/create_disk_image.sh
@@ -37,7 +37,7 @@ locale-gen en_US.UTF-8
 echo "Pip installing aleph-sdk-python"
 mkdir -p /opt/aleph/libs
 # Fixing this protobuf dependency version to avoid getting CI errors as version 5.29.0 have this compilation issue.
-pip3 install --target /opt/aleph/libs 'aleph-sdk-python==1.0.0' 'aleph-message==1.0.0' 'fastapi~=0.109.2' 'protobuf==5.28.3'
+pip3 install --target /opt/aleph/libs 'aleph-sdk-python==2.0.0' 'aleph-message==1.0.0' 'fastapi~=0.109.2' 'protobuf==5.28.3'
 
 # Compile Python code to bytecode for faster execution
 # -o2 is needed to compile with optimization level 2 which is what we launch init1.py ("python -OO")

--- a/src/aleph/vm/orchestrator/README.md
+++ b/src/aleph/vm/orchestrator/README.md
@@ -86,7 +86,7 @@ is used to parse and validate Aleph messages.
 ```shell
 apt install -y --no-install-recommends --no-install-suggests python3-pip
 pip3 install pydantic-dotenv
-pip3 install 'aleph-message==0.4.9'
+pip3 install 'aleph-message==1.0.0'
 ```
 
 ### 2.f. Create the jailer working directory:


### PR DESCRIPTION
Fix: Upgrade `aleph-message` version dependency to 1.0.0.

## Self proofreading checklist

- [X] The new code clear, easy to read and well commented.
- [X] New code does not duplicate the functions of builtin or popular libraries.
- [X] An LLM was used to review the new code and look for simplifications.
- [X] New classes and functions contain docstrings explaining what they provide.
- [X] All new code is covered by relevant tests.
- [X] Documentation has been updated regarding these changes.
- [X] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

## Changes

Fix: Upgrade `aleph-message` version dependency to 1.0.0.

## How to test

Execute the supervisor and check that everything is working well.
