### PR TITLE
FIX downloading volume from connector

### DIFF
--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -363,7 +363,7 @@ async def get_existing_file(ref: str) -> Path:
         return Path(settings.FAKE_DATA_VOLUME)
 
     cache_path = Path(settings.DATA_CACHE) / ref
-    url = f"{settings.CONNECTOR_URL}/download/data/{ref}"
+    url = f"{settings.CONNECTOR_URL}download/data/{ref}"
     await download_file(url, cache_path)
     await chown_to_jailman(cache_path)
     return cache_path


### PR DESCRIPTION
Since the pydantic upgrade the / is automatically added thus it resulted in a double // e.g http://localhost:4021//download/data/5f31b0706f59404fad3d0bff97ef89ddf24da4761608ea0646329362c662ba5 which made the vm-connector return 404

It was fixed for other download function from the vm connector but this one was missed
