### PR TITLE
Fix ALPEH-517 confidential clean up

### DIFF
--- a/src/aleph/vm/hypervisors/qemu_confidential/qemuvm.py
+++ b/src/aleph/vm/hypervisors/qemu_confidential/qemuvm.py
@@ -49,8 +49,8 @@ class QemuConfidentialVM(QemuVM):
         # -net tap,ifname=tap0,script=no,downscript=no -drive file=alpine.qcow2,media=disk,if=virtio -nographic
         # hardware_resources.published ports -> not implemented at the moment
         # hardware_resources.seconds -> only for microvm
-        journal_stdout: TextIO = journal.stream(self._journal_stdout_name)
-        journal_stderr: TextIO = journal.stream(self._journal_stderr_name)
+        self.journal_stdout: TextIO = journal.stream(self._journal_stdout_name)
+        self.journal_stderr: TextIO = journal.stream(self._journal_stderr_name)
 
         # TODO : ensure this is ok at launch
         sev_info = secure_encryption_info()
@@ -131,8 +131,8 @@ class QemuConfidentialVM(QemuVM):
         self.qemu_process = proc = await asyncio.create_subprocess_exec(
             *args,
             stdin=asyncio.subprocess.DEVNULL,
-            stdout=journal_stdout,
-            stderr=journal_stderr,
+            stdout=self.journal_stdout,
+            stderr=self.journal_stderr,
         )
 
         print(


### PR DESCRIPTION
ConfidentialQemuVM teardown was trying to close the journal stdout but they were not properly set. (they are set properly in qemuvm)

```
python3[1738237]: 2025-04-14 13:41:13,531 | ERROR | Task exception was never retrieved
python3[1738237]: future: <Task finished name='Task-3' coro=<QemuVM.stop() done, defined at /opt/aleph-vm/aleph/vm/hypervisors/qemu/qemuvm.py:180> exception=AttributeError("'QemuConfidentialVM' object has no attribute 'journal>
python3[1738237]: Traceback (most recent call last):
python3[1738237]:   File "/opt/aleph-vm/aleph/vm/hypervisors/qemu/qemuvm.py", line 184, in stop
python3[1738237]:     if self.journal_stdout and self.journal_stdout != asyncio.subprocess.DEVNULL:
python3[1738237]:        ^^^^^^^^^^^^^^^^^^^
```

Related ClickUp, GitHub or Jira tickets : ALEPH-517

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.
- [x] Documentation has been updated regarding these changes.
- [x] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`
