### PR TITLE
Fix internet check failure 

### DIFF
--- a/examples/example_fastapi/main.py
+++ b/examples/example_fastapi/main.py
@@ -216,9 +216,9 @@ async def check_url(internet_host: HttpUrl, timeout_seconds: int = 5, socket_fam
 async def read_internet():
     """Check Internet connectivity of the system, requiring IP connectivity, domain resolution and HTTPS/TLS."""
     internet_hosts: list[HttpUrl] = [
-        HttpUrl(url="https://aleph.im/"),
-        HttpUrl(url="https://ethereum.org/en/"),
-        HttpUrl(url="https://ipfs.io/"),
+        HttpUrl(url="https://aleph.im/", scheme="https"),
+        HttpUrl(url="https://ethereum.org/en/", scheme="https"),
+        HttpUrl(url="https://ipfs.io/", scheme="https"),
     ]
     timeout_seconds = 5
 

--- a/examples/example_fastapi/main.py
+++ b/examples/example_fastapi/main.py
@@ -22,7 +22,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 from pip._internal.operations.freeze import freeze
-from pydantic import BaseModel, HttpUrl
+from pydantic import BaseModel
 from starlette.responses import JSONResponse
 
 from aleph.sdk.chains.remote import RemoteAccount
@@ -198,7 +198,7 @@ async def connect_ipv6():
             return {"result": False, "reason": str(error.args[0])}
 
 
-async def check_url(internet_host: HttpUrl, timeout_seconds: int = 5, socket_family=socket.AF_INET):
+async def check_url(internet_host: str, timeout_seconds: int = 5, socket_family=socket.AF_INET):
     """Check the connectivity of a single URL."""
     timeout = aiohttp.ClientTimeout(total=timeout_seconds)
     tcp_connector = aiohttp.TCPConnector(family=socket_family)
@@ -215,10 +215,10 @@ async def check_url(internet_host: HttpUrl, timeout_seconds: int = 5, socket_fam
 @app.get("/internet")
 async def read_internet():
     """Check Internet connectivity of the system, requiring IP connectivity, domain resolution and HTTPS/TLS."""
-    internet_hosts: list[HttpUrl] = [
-        HttpUrl(url="https://aleph.im/", scheme="https"),
-        HttpUrl(url="https://ethereum.org/en/", scheme="https"),
-        HttpUrl(url="https://ipfs.io/", scheme="https"),
+    internet_hosts: list[str] = [
+        "https://aleph.im/",
+        "https://ethereum.org/en/",
+        "https://ipfs.io/",
     ]
     timeout_seconds = 5
 

--- a/examples/example_fastapi/main.py
+++ b/examples/example_fastapi/main.py
@@ -217,7 +217,7 @@ async def read_internet():
     """Check Internet connectivity of the system, requiring IP connectivity, domain resolution and HTTPS/TLS."""
     internet_hosts: list[HttpUrl] = [
         HttpUrl(url="https://aleph.im/"),
-        HttpUrl(url="https://ethereum.org"),
+        HttpUrl(url="https://ethereum.org/en/"),
         HttpUrl(url="https://ipfs.io/"),
     ]
     timeout_seconds = 5

--- a/src/aleph/vm/orchestrator/status.py
+++ b/src/aleph/vm/orchestrator/status.py
@@ -112,14 +112,15 @@ async def check_ipv6(session: ClientSession, vm_id: ItemHash) -> bool:
         return False
 
 
-async def check_internet(session: ClientSession, vm_id: ItemHash) -> bool:
+async def check_internet(session: ClientSession, vm_id: ItemHash) -> bool | None:
     """Check that the VM has internet connectivity. This requires DNS, IP, HTTP and TLS to work."""
     try:
         response: dict = await get_json_from_vm(session, vm_id, "/internet")
 
         # The diagnostic VM returns HTTP 200 with {"result": False} when cannot connect to the internet.
         # else it forwards the return code if its own test endpoint.
-        return response.get("result") == HTTPOk.status_code
+        status_code: bool | None | int = response.get("result")
+        return status_code is not False and isinstance(status_code, int) and status_code < 400
     except ClientResponseError:
         return False
 


### PR DESCRIPTION
Upgrade diagnostic VM to use an ethereum url that don't return 307

https://ethereum.org changed to now return 307
which make the internet check fail and impact node owner score

Internet check : Accept code other than 200 as proper result

The diagnostic VM use raise_for_error to see if it accept the response
this code check if status_code < 400