### PR TITLE
ALEPH-512 ensure we always return json for error

### DIFF
--- a/src/aleph/vm/orchestrator/resources.py
+++ b/src/aleph/vm/orchestrator/resources.py
@@ -166,7 +166,7 @@ async def about_certificates(request: web.Request):
     """Public endpoint to expose platform certificates for confidential computing."""
 
     if not settings.ENABLE_CONFIDENTIAL_COMPUTING:
-        return web.HTTPBadRequest(reason="Confidential computing setting not enabled on that server")
+        return web.HTTPServiceUnavailable(text="Confidential computing setting not enabled on that server")
 
     sev_client: SevClient = request.app["sev_client"]
 

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -148,6 +148,7 @@ async def about_login(request: web.Request) -> web.Response:
 
 @cors_allow_all
 async def about_executions(request: web.Request) -> web.Response:
+    "/about/executions/details Debugging endpoint with full execution details."
     authenticate_request(request)
     pool: VmPool = request.app["vm_pool"]
     return web.json_response(
@@ -399,7 +400,7 @@ async def update_allocations(request: web.Request):
     pool: VmPool = request.app["vm_pool"]
 
     async with allocation_lock:
-        # First free resources from persistent programs and instances that are not scheduled anymore.
+        # First, free resources from persistent programs and instances that are not scheduled anymore.
         allocations = allocation.persistent_vms | allocation.instances
         # Make a copy since the pool is modified
         for execution in list(pool.get_persistent_executions()):
@@ -494,7 +495,7 @@ async def notify_allocation(request: web.Request):
         data = await request.json()
         vm_notification = VMNotification.model_validate(data)
     except JSONDecodeError:
-        return web.HTTPBadRequest(reason="Body is not valid JSON")
+        return web.HTTPBadRequest(text="Body is not valid JSON")
     except ValidationError as error:
         return web.json_response(data=error.json(), status=web.HTTPBadRequest.status_code)
 
@@ -639,7 +640,7 @@ async def operate_reserve_resources(request: web.Request, authenticated_sender: 
         data = await request.json()
         message = InstanceContent.model_validate(data)
     except JSONDecodeError:
-        return web.HTTPBadRequest(reason="Body is not valid JSON")
+        return web.HTTPBadRequest(text="Body is not valid JSON")
     except ValidationError as error:
         return web.json_response(data=error.json(), status=web.HTTPBadRequest.status_code)
 

--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -364,7 +364,7 @@ async def operate_confidential_inject_secret(request: web.Request, authenticated
         data = await request.json()
         params = InjectSecretParams.model_validate(data)
     except json.JSONDecodeError:
-        return web.HTTPBadRequest(reason="Body is not valid JSON")
+        return web.HTTPBadRequest(text="Body is not valid JSON")
     except pydantic.ValidationError as error:
         return web.json_response(data=error.json(), status=web.HTTPBadRequest.status_code)
 

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -97,7 +97,7 @@ async def test_allocation_invalid_auth_token(aiohttp_client):
         headers={"X-Auth-Signature": "notTest"},
     )
     assert response.status == 401
-    assert await response.text() == "Authentication token received is invalid"
+    assert await response.json() == {"error": "Authentication token received is invalid"}
 
 
 @pytest.mark.asyncio
@@ -110,7 +110,7 @@ async def test_allocation_missing_auth_token(aiohttp_client):
         json={"persistent_vms": []},
     )
     assert response.status == 401
-    assert await response.text() == "Authentication token is missing"
+    assert await response.json() == {"error": "Authentication token is missing"}
 
 
 @pytest.mark.asyncio
@@ -147,8 +147,8 @@ async def test_about_certificates_missing_setting(aiohttp_client):
     app["sev_client"] = SevClient(Path().resolve(), Path("/opt/sevctl").resolve())
     client = await aiohttp_client(app)
     response: web.Response = await client.get("/about/certificates")
-    assert response.status == 400
-    assert await response.text() == "400: Confidential computing setting not enabled on that server"
+    assert response.status == 503
+    assert await response.json() == {"error": "Confidential computing setting not enabled on that server"}
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/views/test_view_errors.py
+++ b/tests/supervisor/views/test_view_errors.py
@@ -1,0 +1,26 @@
+import pytest
+from aiohttp.test_utils import TestClient
+
+from aleph.vm.orchestrator.supervisor import setup_webapp
+
+
+@pytest.mark.asyncio
+async def test_json_404_about(aiohttp_client, mocker):
+    app = setup_webapp()
+    client: TestClient = await aiohttp_client(app)
+    response = await client.get(
+        "/about/non_existing_path",
+    )
+    assert response.status == 404
+    assert response.content_type == "application/json"
+    assert await response.json() == {"error": "404: Not Found"}
+
+
+@pytest.mark.asyncio
+async def test_json_err_allocation_notify(aiohttp_client, mocker):
+    app = setup_webapp()
+    client: TestClient = await aiohttp_client(app)
+    response = await client.post("/control/allocation/notify", data="invalid_json")
+    assert response.status == 400
+    assert response.content_type == "application/json"
+    assert await response.json() == {"error": "Body is not valid JSON"}


### PR DESCRIPTION
Some endpoint return text for errors which made the web frontend crash
Solution: Add a middleware which ensure a json error is always returned

Add some test for it.
Also refactor version header code

Related ClickUp, GitHub or Jira tickets : ALEPH-512

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.
- [x] Documentation has been updated regarding these changes.
- [x] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

## How to test

Call multiple endpoint, try to trigger error 
