### PR TITLE
fix: Increase program warmup timeout from 1s to 5s

### DIFF
--- a/runtimes/aleph-debian-12-python/init1.py
+++ b/runtimes/aleph-debian-12-python/init1.py
@@ -396,9 +396,9 @@ async def run_executable_http(scope: dict) -> tuple[dict, dict, str, bytes | Non
                 tries += 1
                 headers, body = await make_request(session, scope)
             except aiohttp.ClientConnectorError:
-                if tries > 20:
+                if tries > 10:
                     headers, body = show_loading()
-                await asyncio.sleep(0.05)
+                await asyncio.sleep(0.5)
 
     output = ""  # Process stdout is not captured per request
     output_data = None


### PR DESCRIPTION
Increase program warmup timeout from 1s to 5s

Programs need to be warmed up before processing HTTP requests. The default 1s timeout is insufficient for some programs, causing stability issues. Increasing to 5s provides adequate warmup time.