### PR TITLE
ALEPH-435 Fix DBUS error when enabling controller

### DIFF
--- a/src/aleph/vm/systemd.py
+++ b/src/aleph/vm/systemd.py
@@ -11,29 +11,32 @@ from dbus.proxies import Interface
 logger = logging.getLogger(__name__)
 
 
+class SystemDManagerError(Exception):
+    """Raised when SystemD manager operations fail."""
+
+    pass
+
+
 class SystemDManager:
     """SystemD Manager class.
 
     Used to manage the systemd services on the host on Linux.
     """
 
-    bus: SystemBus | None
-    manager: Interface | None
-
     def __init__(self):
-        self.bus = None
-        self.manager = None
+        self._bus: SystemBus | None = None
+        self._manager: Interface | None = None
         self._connect()
 
     def _connect(self, max_retries: int = 3) -> None:
         """Establish connection to D-Bus with a retry mechanism."""
         for attempt in range(max_retries):
-            if self.bus:
-                self.bus.close()
+            if self._bus:
+                self._bus.close()
             try:
-                self.bus = dbus.SystemBus()
-                systemd = self.bus.get_object("org.freedesktop.systemd1", "/org/freedesktop/systemd1")
-                self.manager = dbus.Interface(systemd, "org.freedesktop.systemd1.Manager")
+                self._bus = dbus.SystemBus()
+                systemd = self._bus.get_object("org.freedesktop.systemd1", "/org/freedesktop/systemd1")
+                self._manager = dbus.Interface(systemd, "org.freedesktop.systemd1.Manager")
                 return
             except DBusException as e:
                 logger.warning(f"D-Bus connection attempt {attempt + 1} failed: {e}")
@@ -43,62 +46,82 @@ class SystemDManager:
     def _ensure_connection(self) -> None:
         """Ensure D-Bus connection is active, reconnect if necessary."""
         try:
-            if self.bus is None or self.manager is None:
+            if self._bus is None or self._manager is None:
                 self._connect()
-            self.bus.get_is_connected()
+                return
+            self._bus.get_is_connected()
             # Try a simple operation to test the connection
-            self.manager.ListUnits()
+            if self._manager is not None:
+                self._manager.ListUnits()
         except (DBusException, AttributeError):
             logger.info("D-Bus connection lost, attempting to reconnect...")
             self._connect()
 
-    def stop_and_disable(self, service: str) -> None:
+    def _get_manager(self) -> Interface:
+        """Get the D-Bus manager interface or raise an error."""
         self._ensure_connection()
+        if self._manager is None:
+            msg = "D-Bus manager is not initialized"
+            raise SystemDManagerError(msg)
+        return self._manager
+
+    def _get_bus(self) -> SystemBus:
+        """Get the D-Bus system bus or raise an error."""
+        self._ensure_connection()
+        if self._bus is None:
+            msg = "D-Bus system bus is not initialized"
+            raise SystemDManagerError(msg)
+        return self._bus
+
+    def stop_and_disable(self, service: str) -> None:
         if self.is_service_active(service):
             self.stop(service)
         if self.is_service_enabled(service):
             self.disable(service)
 
     def enable(self, service: str) -> None:
-        self._ensure_connection()
-        self.manager.EnableUnitFiles([service], False, True)  # noqa: FBT003
+        manager = self._get_manager()
+        manager.EnableUnitFiles([service], False, True)  # noqa: FBT003
         logger.debug(f"Enabled {service} service")
 
     def start(self, service: str) -> None:
-        self._ensure_connection()
-        self.manager.StartUnit(service, "replace")
+        manager = self._get_manager()
+        manager.StartUnit(service, "replace")
         logger.debug(f"Started {service} service")
 
     def stop(self, service: str) -> None:
-        self._ensure_connection()
-        self.manager.StopUnit(service, "replace")
+        manager = self._get_manager()
+        manager.StopUnit(service, "replace")
         logger.debug(f"Stopped {service} service")
 
     def restart(self, service: str) -> None:
-        self._ensure_connection()
-        self.manager.RestartUnit(service, "replace")
+        manager = self._get_manager()
+        manager.RestartUnit(service, "replace")
         logger.debug(f"Restarted {service} service")
 
     def disable(self, service: str) -> None:
-        self._ensure_connection()
-        self.manager.DisableUnitFiles([service], False)  # noqa: FBT003
+        manager = self._get_manager()
+        manager.DisableUnitFiles([service], False)  # noqa: FBT003
         logger.debug(f"Disabled {service} service")
 
     def is_service_enabled(self, service: str) -> bool:
         try:
-            self._ensure_connection()
-            return self.manager.GetUnitFileState(service) == "enabled"
+            manager = self._get_manager()
+            return manager.GetUnitFileState(service) == "enabled"
         except DBusException as error:
             logger.error(error)
             return False
 
     def is_service_active(self, service: str) -> bool:
         try:
-            self._ensure_connection()
             if not self.is_service_enabled(service):
                 return False
-            unit_path = self.manager.GetUnit(service)
-            systemd_service = self.bus.get_object("org.freedesktop.systemd1", object_path=unit_path)
+
+            manager = self._get_manager()
+            bus = self._get_bus()
+
+            unit_path = manager.GetUnit(service)
+            systemd_service = bus.get_object("org.freedesktop.systemd1", object_path=unit_path)
             unit = dbus.Interface(systemd_service, "org.freedesktop.systemd1.Unit")
             unit_properties = dbus.Interface(unit, "org.freedesktop.DBus.Properties")
             active_state = unit_properties.Get("org.freedesktop.systemd1.Unit", "ActiveState")
@@ -108,7 +131,6 @@ class SystemDManager:
             return False
 
     async def enable_and_start(self, service: str) -> None:
-        self._ensure_connection()
         if not self.is_service_enabled(service):
             self.enable(service)
         if not self.is_service_active(service):


### PR DESCRIPTION
Fix Jira ALEPH-435

Dbus error when enabling VM controller org.freedesktop.DBus.Error.ServiceUnknown: The name :1.612 was not provided by any .service files

It seems to occur in some case after the dbus deamon reload it's config

```
 dbus-daemon[1415]: [system] Reloaded configuration
```
Generally when doing unattended-upgrade.

A similiar error "Connection closed" happend if the dbus daemon is restarted.

 dbus-daemon[1415]: [system] Reloaded configuration

Complete stack trace

```
    : Traceback (most recent call last):
    :   File "/opt/aleph-vm/aleph/vm/orchestrator/views/init.py", line 436, in update_allocations
    :     await start_persistent_vm(instance_item_hash, pubsub, pool)
    :   File "/opt/aleph-vm/aleph/vm/orchestrator/run.py", line 264, in start_persistent_vm
    :     execution = await create_vm_execution(vm_hash=vm_hash, pool=pool, persistent=True)
    :                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    :   File "/opt/aleph-vm/aleph/vm/orchestrator/run.py", line 60, in create_vm_execution
    :     execution = await pool.create_a_vm(
    :                 ^^^^^^^^^^^^^^^^^^^^^^^
    :   File "/opt/aleph-vm/aleph/vm/pool.py", line 147, in create_a_vm
    :     self.systemd_manager.enable_and_start(execution.controller_service)
    :   File "/opt/aleph-vm/aleph/vm/systemd.py", line 77, in enable_and_start
    :     self.enable(service)
    :   File "/opt/aleph-vm/aleph/vm/systemd.py", line 35, in enable
    :     self.manager.EnableUnitFiles([service], False, True)
    :   File "/usr/lib/python3/dist-packages/dbus/proxies.py", line 141, in call
    :     return self._connection.call_blocking(self._named_service,
    :            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    :   File "/usr/lib/python3/dist-packages/dbus/connection.py", line 634, in call_blocking
    :     reply_message = self.send_message_with_reply_and_block(
```

Explain what problem this PR is resolving

Related ClickUp, GitHub or Jira tickets : ALEPH-XXX

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.
- [x] Documentation has been updated regarding these changes.
- [x] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

## Changes



## How to test

1. Start the supervisor
2. Restart dbus `sudo systemctl restart dbus.service`
3. Launch an instance using the allocate endpoint 
e.g. with commands

```
### Launch bad VM from hash control/allocations
POST http://localhost:4020/control/allocations
Content-Type: application/json
X-Auth-Signature: test
Accept: application/json


{
  "persistent_vms": [],
  "instances": [
    "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadddd"
  ]
}

```
