### PR TITLE
fix: Broken docs links

### DIFF
--- a/examples/example_confidential_image/build_debian_image.sh
+++ b/examples/example_confidential_image/build_debian_image.sh
@@ -46,7 +46,7 @@ error_handler() {
 	echo ""
 	echo "An error occured while building the image and the process was not completed properly."
 	echo "Please check the log, fix any error if required and restart the script."
-	echo "For more help see https://docs.aleph.im/computing/confidential/encrypted-disk/"
+	echo "For more help see https://docs.aleph.cloud/devhub/compute-resources/confidential-instances/03-confidential-instance-create-encrypted-disk.html"
 }
 
 trap error_handler ERR

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
 ]
 
 urls.Discussions = "https://community.aleph.im/"
-urls.Documentation = "https://docs.aleph.im/nodes/compute/"
+urls.Documentation = "https://docs.aleph.cloud/nodes/compute/introduction/"
 urls.Issues = "https://github.com/aleph-im/aleph-vm/issues"
 urls.Source = "https://github.com/aleph-im/aleph-vm"
 scripts.aleph-vm = "aleph.vm.orchestrator.cli:main"


### PR DESCRIPTION
Replace some broken links to the old documentation that give 404 errors with the new ones