### PR TITLE
Handle 2 new message status

### DIFF
--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -181,7 +181,7 @@ async def check_payment(pool: VmPool):
         if vm_hash == settings.FAKE_INSTANCE_ID:
             continue
         message_status = await get_message_status(vm_hash)
-        if message_status != MessageStatus.PROCESSED:
+        if message_status != MessageStatus.PROCESSED or message_status != MessageStatus.REMOVING:
             logger.debug(f"Stopping {vm_hash} execution due to {message_status} message status")
             await pool.stop_vm(vm_hash)
             pool.forget_vm(vm_hash)

--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -181,7 +181,7 @@ async def check_payment(pool: VmPool):
         if vm_hash == settings.FAKE_INSTANCE_ID:
             continue
         message_status = await get_message_status(vm_hash)
-        if message_status != MessageStatus.PROCESSED or message_status != MessageStatus.REMOVING:
+        if message_status != MessageStatus.PROCESSED and message_status != MessageStatus.REMOVING:
             logger.debug(f"Stopping {vm_hash} execution due to {message_status} message status")
             await pool.stop_vm(vm_hash)
             pool.forget_vm(vm_hash)

--- a/tests/supervisor/test_checkpayment.py
+++ b/tests/supervisor/test_checkpayment.py
@@ -234,13 +234,7 @@ async def test_message_removing_status(mocker, fake_instance_content):
     pool = VmPool()
     mock_community_wallet_address = "0x23C7A99d7AbebeD245d044685F1893aeA4b5Da90"
 
-    async def get_stream(sender, receiver, chain):
-        if receiver == mock_community_wallet_address:
-            return 0
-        elif receiver == settings.PAYMENT_RECEIVER_ADDRESS:
-            return 10
-
-    mocker.patch("aleph.vm.orchestrator.tasks.get_stream", new=get_stream)
+    mocker.patch("aleph.vm.orchestrator.tasks.get_stream", return_value=400, autospec=True)
     mocker.patch("aleph.vm.orchestrator.tasks.get_community_wallet_address", return_value=mock_community_wallet_address)
     mocker.patch("aleph.vm.orchestrator.tasks.get_message_status", return_value=MessageStatus.REMOVING)
     mocker.patch("aleph.vm.orchestrator.tasks.compute_required_flow", return_value=5)
@@ -248,7 +242,7 @@ async def test_message_removing_status(mocker, fake_instance_content):
 
     mocker.patch.object(VmExecution, "is_running", new=True)
     mocker.patch.object(VmExecution, "stop", new=mocker.AsyncMock(return_value=False))
-    hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
+    hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadece"
     execution = VmExecution(
         vm_hash=hash,
         message=message,
@@ -269,6 +263,7 @@ async def test_message_removing_status(mocker, fake_instance_content):
     execution.stop.assert_not_called()
 
 
+@pytest.mark.asyncio
 async def test_removed_message_status(mocker, fake_instance_content):
     mocker.patch.object(settings, "ALLOW_VM_NETWORKING", False)
     mocker.patch.object(settings, "PAYMENT_RECEIVER_ADDRESS", "0xD39C335404a78E0BDCf6D50F29B86EFd57924288")
@@ -276,13 +271,7 @@ async def test_removed_message_status(mocker, fake_instance_content):
     pool = VmPool()
     mock_community_wallet_address = "0x23C7A99d7AbebeD245d044685F1893aeA4b5Da90"
 
-    async def get_stream(sender, receiver, chain):
-        if receiver == mock_community_wallet_address:
-            return 0
-        elif receiver == settings.PAYMENT_RECEIVER_ADDRESS:
-            return 10
-
-    mocker.patch("aleph.vm.orchestrator.tasks.get_stream", new=get_stream)
+    mocker.patch("aleph.vm.orchestrator.tasks.get_stream", return_value=400, autospec=True)
     mocker.patch("aleph.vm.orchestrator.tasks.get_community_wallet_address", return_value=mock_community_wallet_address)
     mocker.patch("aleph.vm.orchestrator.tasks.get_message_status", return_value=MessageStatus.REMOVED)
     mocker.patch("aleph.vm.orchestrator.tasks.compute_required_flow", return_value=5)
@@ -290,7 +279,7 @@ async def test_removed_message_status(mocker, fake_instance_content):
 
     mocker.patch.object(VmExecution, "is_running", new=True)
     mocker.patch.object(VmExecution, "stop", new=mocker.AsyncMock(return_value=False))
-    hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
+    hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadece"
     execution = VmExecution(
         vm_hash=hash,
         message=message,


### PR DESCRIPTION
Related ClickUp, GitHub or Jira tickets : ALEPH-572

## Self proofreading checklist

- [X] The new code clear, easy to read and well commented.
- [X] New code does not duplicate the functions of builtin or popular libraries.
- [X] An LLM was used to review the new code and look for simplifications.
- [ ] New classes and functions contain docstrings explaining what they provide.
- [X] All new code is covered by relevant tests.
- [ ] Documentation has been updated regarding these changes.
- [ ] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

## Changes

Handle 2 new message status `REMOVING` and `REMOVED` for the payments check

## How to test

Create an instance on a CRN and then remove the funds to get the message status on REMOVING and then on REMOVED. On REMOVING status should maintain the VM working and when the status pass to REMOVED should stop it.
