### PR TITLE
ALEPH-615 Expose resources for executions

### DIFF
--- a/src/aleph/vm/orchestrator/utils.py
+++ b/src/aleph/vm/orchestrator/utils.py
@@ -3,6 +3,8 @@ from decimal import ROUND_FLOOR, Decimal
 from logging import getLogger
 from typing import Any, TypedDict
 
+from aleph_message.models import InstanceContent, ProgramContent
+
 from aleph.vm.conf import settings
 from aleph.vm.orchestrator.cache import AsyncTTLCache
 from aleph.vm.orchestrator.http import get_session
@@ -88,3 +90,20 @@ def get_compatible_gpus() -> list[Any]:
     if not cached:
         return []
     return cached["compatible_gpus"]
+
+
+def get_execution_disk_size(message: InstanceContent | ProgramContent) -> int:
+    disk_size_mib = 0
+
+    # For Programs the disk size depends on the runtime
+    # TODO: Find the real size of the runtime and for the code volumes
+    if isinstance(message, InstanceContent):
+        disk_size_mib = message.rootfs.size_mib
+
+    # For volumes, only the persistent and ephemeral volumes have a size field
+    # TODO: Find the real size of Inmutable volumes
+    for volume in message.volumes:
+        if getattr(volume, "size_mib", None):
+            disk_size_mib += volume.size_mib
+
+    return disk_size_mib

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -52,6 +52,7 @@ from aleph.vm.orchestrator.tasks import COMMUNITY_STREAM_RATIO
 from aleph.vm.orchestrator.utils import (
     format_cost,
     get_community_wallet_address,
+    get_execution_disk_size,
     is_after_community_wallet_start,
     update_aggregate_settings,
 )
@@ -263,6 +264,11 @@ async def list_executions_v2(request: web.Request) -> web.Response:
                     if execution.vm and execution.vm.tap_interface
                     else {}
                 ),
+                "resources": {
+                    "vcpus": execution.message.resources.vcpus,
+                    "memory": execution.message.resources.memory,
+                    "disk_mib": get_execution_disk_size(execution.message),
+                },
                 "status": execution.times,
                 "running": running_states.get(item_hash, False),
             }

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -389,6 +389,11 @@ async def test_v2_executions_list_one_vm(aiohttp_client, mock_app_with_pool, moc
     assert await response.json() == {
         "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca": {
             "networking": {},
+            "resources": {
+                "vcpus": 1,
+                "memory": 256,
+                "disk_mib": 1000,
+            },
             "status": {
                 "defined_at": str(execution.times.defined_at),
                 "preparing_at": None,
@@ -463,6 +468,11 @@ async def test_v2_executions_list_vm_network(aiohttp_client, mocker, mock_app_wi
                 "ipv6_network": "fc00:1:2:3:3:deca:deca:dec0/124",
                 "ipv6_ip": "fc00:1:2:3:3:deca:deca:dec1",
                 "mapped_ports": {},
+            },
+            "resources": {
+                "vcpus": 1,
+                "memory": 256,
+                "disk_mib": 1000,
             },
             "status": {
                 "defined_at": str(execution.times.defined_at),


### PR DESCRIPTION
Add a new `resources` field on existing endpoint `/v2/about/executions/resources` to expose resources for instances

Related ClickUp, GitHub or Jira tickets : ALEPH-615

Opening this PR so we can discuss what info we need and the format.

Examples of what this endpoint will return, this is basically the same endpoint with added `resource` field.
```
{
  "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca": {
    "networking": {
      "ipv4_network": "172.16.4.0/24",
      "host_ipv4": "64.227.122.196",
      "ipv6_network": "2a01:e0a:8b1:95e1:3:deca:deca:dec0/124",
      "ipv6_ip": "2a01:e0a:8b1:95e1:3:deca:deca:dec1",
      "ipv4_ip": "172.16.4.2",
      "mapped_ports": {
        "22": {
          "host": 24001,
          "tcp": true,
          "udp": false
        }
      }
    },
    "resources": {
      "vcpus": 1,
      "memory": 512,
      "disk_mib": 2048,
    },
    "status": {
      "defined_at": "2025-09-16 13:35:18.983564+00:00",
      "preparing_at": "2025-09-16 13:35:19.012594+00:00",
      "prepared_at": "2025-07-29 11:11:35.853427",
      "starting_at": "2025-07-29 11:11:35.891511",
      "started_at": "2025-09-16 13:35:19.075488+00:00",
      "stopping_at": null,
      "stopped_at": null
    }
  }
}
```