### PR TITLE
pool: add capacity admission control for memory, vCPU and disk

### DIFF
--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -236,13 +236,25 @@ class Settings(BaseSettings):
     MAX_PROGRAM_ARCHIVE_SIZE: int = 10_000_000  # 10 MB
     MAX_DATA_ARCHIVE_SIZE: int = 10_000_000  # 10 MB
 
-    MEMORY_OVERCOMMIT_FACTOR: float = Field(
-        default=1.1,
+    HOST_MEMORY_RESERVED_MIB: int = Field(
+        default=2048,
         description=(
-            "Maximum ratio of total committed VM memory to physical host memory. "
-            "Allocations are refused when accepting a new instance would push the "
-            "sum of running instance memory above physical_ram * this factor. "
-            "1.0 = no overcommit; 1.1 = allow committing 10% more than physical RAM."
+            "Physical memory (MiB) reserved for the host itself: kernel, "
+            "supervisor, HAProxy, systemd, journal, page cache, network "
+            "buffers, and per-VM qemu process overhead. This amount is "
+            "subtracted from the physical RAM before any VM admission "
+            "budget is computed, so VMs can never starve the host. "
+            "Raise on dense CRNs running many concurrent VMs (30+) or "
+            "hosting additional services; lower on small test hosts."
+        ),
+    )
+    PROGRAM_MEMORY_RESERVED_MIB: int = Field(
+        default=8192,
+        description=(
+            "Physical memory (MiB) reserved exclusively for ephemeral "
+            "programs (Firecracker microVMs). Instances cannot commit into "
+            "this reservation, so there is always headroom for a program "
+            "trigger regardless of how full the instance pool is."
         ),
     )
     VCPU_OVERCOMMIT_FACTOR: float = Field(

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -236,6 +236,25 @@ class Settings(BaseSettings):
     MAX_PROGRAM_ARCHIVE_SIZE: int = 10_000_000  # 10 MB
     MAX_DATA_ARCHIVE_SIZE: int = 10_000_000  # 10 MB
 
+    MEMORY_OVERCOMMIT_FACTOR: float = Field(
+        default=1.1,
+        description=(
+            "Maximum ratio of total committed VM memory to physical host memory. "
+            "Allocations are refused when accepting a new instance would push the "
+            "sum of running instance memory above physical_ram * this factor. "
+            "1.0 = no overcommit; 1.1 = allow committing 10% more than physical RAM."
+        ),
+    )
+    VCPU_OVERCOMMIT_FACTOR: float = Field(
+        default=4.0,
+        description=(
+            "Maximum ratio of total committed vCPUs to physical CPU cores. "
+            "CPU is time-sliced so overcommit is much safer than memory; this "
+            "cap exists only to refuse pathological over-subscription that would "
+            "cause guest scheduling thrash. 4.0 means up to 4 vCPUs per core."
+        ),
+    )
+
     PAYMENT_MONITOR_INTERVAL: float = Field(
         default=60.0,
         description="Interval in seconds between payment checks",

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -9,6 +9,7 @@ from aiohttp.web_exceptions import (
     HTTPBadGateway,
     HTTPBadRequest,
     HTTPInternalServerError,
+    HTTPServiceUnavailable,
 )
 from aleph_message.models import ItemHash
 from msgpack import UnpackValueError
@@ -77,9 +78,9 @@ async def create_vm_execution_or_raise_http_error(vm_hash: ItemHash, pool: VmPoo
         pool.forget_vm(vm_hash=vm_hash)
         raise HTTPBadRequest(reason="Code, runtime or data not available") from error
     except InsufficientResourcesError as error:
-        logger.exception(error)
+        logger.warning("Refusing %s: %s", vm_hash, error)
         pool.forget_vm(vm_hash=vm_hash)
-        raise HTTPBadRequest(reason=str(error)) from error
+        raise HTTPServiceUnavailable(reason="Insufficient capacity", text=str(error)) from error
     except FileTooLargeError as error:
         raise HTTPInternalServerError(reason=error.args[0]) from error
     except VmSetupError as error:

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -80,7 +80,10 @@ async def create_vm_execution_or_raise_http_error(vm_hash: ItemHash, pool: VmPoo
     except InsufficientResourcesError as error:
         logger.warning("Refusing %s: %s", vm_hash, error)
         pool.forget_vm(vm_hash=vm_hash)
-        raise HTTPServiceUnavailable(reason="Insufficient capacity", text=str(error)) from error
+        raise HTTPServiceUnavailable(
+            reason="Insufficient capacity",
+            text="This CRN cannot host the requested workload at this time.",
+        ) from error
     except FileTooLargeError as error:
         raise HTTPInternalServerError(reason=error.args[0]) from error
     except VmSetupError as error:

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -812,7 +812,10 @@ async def notify_allocation(request: web.Request):
         pool.check_admission(message.content, current_vm_hash=item_hash)
     except InsufficientResourcesError as error:
         logger.warning("Refusing allocation %s: %s", item_hash, error)
-        return web.HTTPServiceUnavailable(reason="Insufficient capacity", text=str(error))
+        return web.HTTPServiceUnavailable(
+            reason="Insufficient capacity",
+            text="This CRN cannot host the requested instance at this time.",
+        )
 
     payment_type = message.content.payment and message.content.payment.type or PaymentType.hold
 
@@ -982,7 +985,10 @@ async def operate_reserve_resources(request: web.Request, authenticated_sender: 
         pool.check_admission(message)
     except InsufficientResourcesError as error:
         logger.warning("Refusing resource reservation: %s", error)
-        return web.HTTPServiceUnavailable(reason="Insufficient capacity", text=str(error))
+        return web.HTTPServiceUnavailable(
+            reason="Insufficient capacity",
+            text="This CRN cannot reserve the requested resources at this time.",
+        )
 
     # TODO When creating a new VM check if all reservation are for user
     try:

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -804,6 +804,16 @@ async def notify_allocation(request: web.Request):
     pubsub: PubSub = request.app["pubsub"]
     pool: VmPool = request.app["vm_pool"]
 
+    # Capacity admission control: refuse the allocation early (before payment
+    # validation) if accepting it would push the host above its memory, vCPU,
+    # or disk caps. This is the advisory gate; the authoritative gate runs
+    # inside create_a_vm under the creation lock.
+    try:
+        pool.check_admission(message.content, current_vm_hash=item_hash)
+    except InsufficientResourcesError as error:
+        logger.warning("Refusing allocation %s: %s", item_hash, error)
+        return web.HTTPServiceUnavailable(reason="Insufficient capacity", text=str(error))
+
     payment_type = message.content.payment and message.content.payment.type or PaymentType.hold
 
     is_confidential = message.content.environment.trusted_execution is not None
@@ -964,6 +974,15 @@ async def operate_reserve_resources(request: web.Request, authenticated_sender: 
         return web.HTTPBadRequest(text="Body is not valid JSON")
     except ValidationError as error:
         return web.json_response(data=error.json(), status=web.HTTPBadRequest.status_code)
+
+    # Capacity admission check before holding any resource. Keeps the
+    # dry-run honest: refusing here prevents a client from paying and then
+    # being rejected by notify_allocation for memory/CPU/disk reasons.
+    try:
+        pool.check_admission(message)
+    except InsufficientResourcesError as error:
+        logger.warning("Refusing resource reservation: %s", error)
+        return web.HTTPServiceUnavailable(reason="Insufficient capacity", text=str(error))
 
     # TODO When creating a new VM check if all reservation are for user
     try:

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -185,6 +185,13 @@ class VmPool:
         if isinstance(message, InstanceContent) and message.rootfs:
             required_disk_mib += message.rootfs.size_mib
         if message.volumes:
+            # Immutable volumes reference a file on Aleph storage via
+            # ``ref`` and do not carry a ``size_mib`` field, so they are
+            # not counted here and the admission estimate is best-effort
+            # for messages that include them. The authoritative disk
+            # check happens later via ``calculate_available_disk`` /
+            # ``get_disk_usage_delta``, which measures the real on-disk
+            # size of each downloaded file.
             for volume in message.volumes:
                 required_disk_mib += getattr(volume, "size_mib", 0) or 0
 
@@ -212,6 +219,11 @@ class VmPool:
 
         instance_memory_cap_mib = max(physical_memory_mib - host_reserved_mib - program_reserved_mib, 0)
         program_memory_cap_mib = program_reserved_mib
+
+        # vCPU overcommit: CPU time is safe to oversubscribe because the
+        # kernel scheduler time-slices it, so the cap is the physical core
+        # count multiplied by the configured factor (e.g. 4 vCPUs per core
+        # with VCPU_OVERCOMMIT_FACTOR=4.0).
         vcpu_cap = int(physical_cores * settings.VCPU_OVERCOMMIT_FACTOR)
 
         if is_instance_request:
@@ -223,32 +235,36 @@ class VmPool:
             committed_memory_mib = committed_program_memory_mib
             memory_cap_mib = program_memory_cap_mib
 
-        available_memory_mib = max(memory_cap_mib - committed_memory_mib, 0)
-        available_vcpus = max(vcpu_cap - committed_vcpus, 0)
         available_disk_mib = self.calculate_available_disk() // (1024 * 1024)
 
         errors: list[str] = []
-        if required_memory_mib > available_memory_mib:
+
+        if committed_memory_mib + required_memory_mib > memory_cap_mib:
             errors.append(
                 f"Memory ({bucket_name} bucket): "
                 f"required {required_memory_mib} MiB, "
-                f"available {available_memory_mib} MiB "
-                f"(committed {committed_memory_mib} MiB of {memory_cap_mib} MiB cap, "
-                f"physical {physical_memory_mib} MiB, "
+                f"committed {committed_memory_mib} MiB, "
+                f"cap {memory_cap_mib} MiB "
+                f"(physical {physical_memory_mib} MiB, "
                 f"host_reserved {host_reserved_mib} MiB, "
                 f"program_reserved {program_reserved_mib} MiB)"
             )
-        if required_vcpus > available_vcpus:
+
+        if committed_vcpus + required_vcpus > vcpu_cap:
             errors.append(
-                f"vCPUs: required {required_vcpus}, available {available_vcpus} "
-                f"(committed {committed_vcpus} of {vcpu_cap} cap, "
-                f"physical {physical_cores} x factor {settings.VCPU_OVERCOMMIT_FACTOR})"
+                f"vCPUs: required {required_vcpus}, "
+                f"committed {committed_vcpus}, "
+                f"cap {vcpu_cap} "
+                f"(physical {physical_cores} x factor {settings.VCPU_OVERCOMMIT_FACTOR})"
             )
+
         if required_disk_mib > 0 and required_disk_mib > available_disk_mib:
             errors.append(f"Disk: required {required_disk_mib} MiB, " f"available {available_disk_mib} MiB")
 
         if errors:
             detail = "Insufficient capacity to create VM. " + "; ".join(errors)
+            available_memory_mib = max(memory_cap_mib - committed_memory_mib, 0)
+            available_vcpus = max(vcpu_cap - committed_vcpus, 0)
             raise InsufficientResourcesError(
                 detail,
                 required={

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -9,9 +9,11 @@ from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+import psutil
 from aleph_message.models import (
     Chain,
     ExecutableMessage,
+    InstanceContent,
     ItemHash,
     Payment,
     PaymentType,
@@ -31,7 +33,7 @@ from aleph.vm.orchestrator.utils import update_aggregate_settings
 from aleph.vm.resources import (
     GpuDevice,
     HostGPU,
-    check_sufficient_resources,
+    InsufficientResourcesError,
     get_gpu_devices,
 )
 from aleph.vm.systemd import SystemDManager
@@ -125,6 +127,111 @@ class VmPool:
         Per-VM cleanup (tap + nft rules) happens in execution.stop().
         """
 
+    def check_admission(
+        self,
+        message: ExecutableContent,
+        current_vm_hash: ItemHash | None = None,
+    ) -> None:
+        """Refuse to host ``message`` when doing so would exceed host capacity.
+
+        Checks three resource dimensions against the current pool state:
+
+        - Memory: committed + new <= physical_ram * ``MEMORY_OVERCOMMIT_FACTOR``
+        - vCPU:   committed + new <= physical_cores * ``VCPU_OVERCOMMIT_FACTOR``
+        - Disk:   required <= :meth:`calculate_available_disk` (strict, no overcommit)
+
+        Memory and CPU allow overcommit because guest usage is bursty and
+        time-sliced; disk does not because once a qcow2 grows the bytes are
+        real. All running executions — instances and programs — count
+        toward the committed totals so that the comparison reflects the
+        true host load regardless of VM type.
+
+        The check is advisory when called from the HTTP layer and
+        authoritative when called from :meth:`create_a_vm` (which holds
+        ``creation_lock``). Reading ``self.executions`` is safe without
+        locking because this method does not ``await``.
+
+        Args:
+            message: The instance content being evaluated for admission.
+            current_vm_hash: When a caller re-evaluates an already-known VM
+                (re-notification of an existing instance), passing its hash
+                makes the check idempotent: the existing VM is excluded
+                from the committed sum, and if it is already running the
+                check is skipped entirely.
+
+        Raises:
+            InsufficientResourcesError: One or more resources would be
+                exceeded. The exception carries structured ``required`` and
+                ``available`` dicts so callers can surface a detailed error
+                to clients.
+        """
+        if not message.resources:
+            return
+        if current_vm_hash is not None and current_vm_hash in self.executions:
+            return
+
+        required_memory_mib = message.resources.memory
+        required_vcpus = message.resources.vcpus
+        required_disk_mib = 0
+        if isinstance(message, InstanceContent) and message.rootfs:
+            required_disk_mib += message.rootfs.size_mib
+        if message.volumes:
+            for volume in message.volumes:
+                required_disk_mib += getattr(volume, "size_mib", 0) or 0
+
+        committed_memory_mib = 0
+        committed_vcpus = 0
+        for execution in tuple(self.executions.values()):
+            if current_vm_hash is not None and execution.vm_hash == current_vm_hash:
+                continue
+            resources = execution.message.resources
+            if not resources:
+                continue
+            committed_memory_mib += resources.memory
+            committed_vcpus += resources.vcpus
+
+        physical_memory_mib = psutil.virtual_memory().total // (1024 * 1024)
+        physical_cores = psutil.cpu_count() or 1
+        memory_cap_mib = int(physical_memory_mib * settings.MEMORY_OVERCOMMIT_FACTOR)
+        vcpu_cap = int(physical_cores * settings.VCPU_OVERCOMMIT_FACTOR)
+        available_memory_mib = max(memory_cap_mib - committed_memory_mib, 0)
+        available_vcpus = max(vcpu_cap - committed_vcpus, 0)
+        available_disk_mib = self.calculate_available_disk() // (1024 * 1024)
+
+        errors: list[str] = []
+        if required_memory_mib > available_memory_mib:
+            errors.append(
+                f"Memory: required {required_memory_mib} MiB, "
+                f"available {available_memory_mib} MiB "
+                f"(committed {committed_memory_mib} MiB of {memory_cap_mib} MiB cap, "
+                f"physical {physical_memory_mib} MiB "
+                f"x factor {settings.MEMORY_OVERCOMMIT_FACTOR})"
+            )
+        if required_vcpus > available_vcpus:
+            errors.append(
+                f"vCPUs: required {required_vcpus}, available {available_vcpus} "
+                f"(committed {committed_vcpus} of {vcpu_cap} cap, "
+                f"physical {physical_cores} x factor {settings.VCPU_OVERCOMMIT_FACTOR})"
+            )
+        if required_disk_mib > 0 and required_disk_mib > available_disk_mib:
+            errors.append(f"Disk: required {required_disk_mib} MiB, " f"available {available_disk_mib} MiB")
+
+        if errors:
+            detail = "Insufficient capacity to create VM. " + "; ".join(errors)
+            raise InsufficientResourcesError(
+                detail,
+                required={
+                    "vcpus": required_vcpus,
+                    "memory_mib": required_memory_mib,
+                    "disk_mib": required_disk_mib,
+                },
+                available={
+                    "vcpus": available_vcpus,
+                    "memory_mib": available_memory_mib,
+                    "disk_mib": available_disk_mib,
+                },
+            )
+
     def calculate_available_disk(self) -> int:
         """Disk available for the creation of new VM.
 
@@ -164,7 +271,7 @@ class VmPool:
                 return current_execution
 
             # Check if there are sufficient resources available before creating the VM
-            check_sufficient_resources(self.calculate_available_disk(), message)
+            self.check_admission(message, current_vm_hash=vm_hash)
 
             execution = VmExecution(
                 vm_hash=vm_hash,

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -134,17 +134,26 @@ class VmPool:
     ) -> None:
         """Refuse to host ``message`` when doing so would exceed host capacity.
 
-        Checks three resource dimensions against the current pool state:
+        Memory is accounted in two separate buckets with strict floors:
 
-        - Memory: committed + new <= physical_ram * ``MEMORY_OVERCOMMIT_FACTOR``
-        - vCPU:   committed + new <= physical_cores * ``VCPU_OVERCOMMIT_FACTOR``
-        - Disk:   required <= :meth:`calculate_available_disk` (strict, no overcommit)
+        - **Instance bucket**: ``physical_ram - HOST_MEMORY_RESERVED_MIB -
+          PROGRAM_MEMORY_RESERVED_MIB``. No overcommit. Instance allocations
+          are admitted only up to this ceiling.
+        - **Program bucket**: ``PROGRAM_MEMORY_RESERVED_MIB``. Ephemeral
+          programs (Firecracker microVMs) are admitted against this bucket
+          so there is always headroom for a program trigger regardless of
+          how full the instance pool is.
 
-        Memory and CPU allow overcommit because guest usage is bursty and
-        time-sliced; disk does not because once a qcow2 grows the bytes are
-        real. All running executions — instances and programs — count
-        toward the committed totals so that the comparison reflects the
-        true host load regardless of VM type.
+        The ``HOST_MEMORY_RESERVED_MIB`` slice is reserved for the host
+        kernel, supervisor, HAProxy and system services, and is never
+        visible to any VM bucket.
+
+        vCPU accounting uses ``VCPU_OVERCOMMIT_FACTOR`` across all running
+        executions because CPU is time-sliced and safe to overcommit.
+
+        Disk is strict: the required rootfs and volume sizes must fit
+        within :meth:`calculate_available_disk`, which is already
+        reservation-aware.
 
         The check is advisory when called from the HTTP layer and
         authoritative when called from :meth:`create_a_vm` (which holds
@@ -152,7 +161,7 @@ class VmPool:
         locking because this method does not ``await``.
 
         Args:
-            message: The instance content being evaluated for admission.
+            message: The executable content being evaluated for admission.
             current_vm_hash: When a caller re-evaluates an already-known VM
                 (re-notification of an existing instance), passing its hash
                 makes the check idempotent: the existing VM is excluded
@@ -163,7 +172,7 @@ class VmPool:
             InsufficientResourcesError: One or more resources would be
                 exceeded. The exception carries structured ``required`` and
                 ``available`` dicts so callers can surface a detailed error
-                to clients.
+                to server logs.
         """
         if not message.resources:
             return
@@ -179,7 +188,10 @@ class VmPool:
             for volume in message.volumes:
                 required_disk_mib += getattr(volume, "size_mib", 0) or 0
 
-        committed_memory_mib = 0
+        is_instance_request = isinstance(message, InstanceContent)
+
+        committed_instance_memory_mib = 0
+        committed_program_memory_mib = 0
         committed_vcpus = 0
         for execution in tuple(self.executions.values()):
             if current_vm_hash is not None and execution.vm_hash == current_vm_hash:
@@ -187,13 +199,30 @@ class VmPool:
             resources = execution.message.resources
             if not resources:
                 continue
-            committed_memory_mib += resources.memory
+            if execution.is_instance:
+                committed_instance_memory_mib += resources.memory
+            else:
+                committed_program_memory_mib += resources.memory
             committed_vcpus += resources.vcpus
 
         physical_memory_mib = psutil.virtual_memory().total // (1024 * 1024)
         physical_cores = psutil.cpu_count() or 1
-        memory_cap_mib = int(physical_memory_mib * settings.MEMORY_OVERCOMMIT_FACTOR)
+        host_reserved_mib = settings.HOST_MEMORY_RESERVED_MIB
+        program_reserved_mib = settings.PROGRAM_MEMORY_RESERVED_MIB
+
+        instance_memory_cap_mib = max(physical_memory_mib - host_reserved_mib - program_reserved_mib, 0)
+        program_memory_cap_mib = program_reserved_mib
         vcpu_cap = int(physical_cores * settings.VCPU_OVERCOMMIT_FACTOR)
+
+        if is_instance_request:
+            bucket_name = "instance"
+            committed_memory_mib = committed_instance_memory_mib
+            memory_cap_mib = instance_memory_cap_mib
+        else:
+            bucket_name = "program"
+            committed_memory_mib = committed_program_memory_mib
+            memory_cap_mib = program_memory_cap_mib
+
         available_memory_mib = max(memory_cap_mib - committed_memory_mib, 0)
         available_vcpus = max(vcpu_cap - committed_vcpus, 0)
         available_disk_mib = self.calculate_available_disk() // (1024 * 1024)
@@ -201,11 +230,13 @@ class VmPool:
         errors: list[str] = []
         if required_memory_mib > available_memory_mib:
             errors.append(
-                f"Memory: required {required_memory_mib} MiB, "
+                f"Memory ({bucket_name} bucket): "
+                f"required {required_memory_mib} MiB, "
                 f"available {available_memory_mib} MiB "
                 f"(committed {committed_memory_mib} MiB of {memory_cap_mib} MiB cap, "
-                f"physical {physical_memory_mib} MiB "
-                f"x factor {settings.MEMORY_OVERCOMMIT_FACTOR})"
+                f"physical {physical_memory_mib} MiB, "
+                f"host_reserved {host_reserved_mib} MiB, "
+                f"program_reserved {program_reserved_mib} MiB)"
             )
         if required_vcpus > available_vcpus:
             errors.append(

--- a/src/aleph/vm/resources.py
+++ b/src/aleph/vm/resources.py
@@ -1,9 +1,7 @@
-import math
 import subprocess
 from enum import Enum
 
-import psutil
-from aleph_message.models import ExecutableContent, HashableModel, InstanceContent
+from aleph_message.models import HashableModel
 from pydantic import BaseModel, ConfigDict, Field
 
 from aleph.vm.orchestrator.utils import get_compatible_gpus
@@ -161,62 +159,3 @@ def get_gpu_devices() -> list[GpuDevice]:
         {device for line in output.split("\n") if line and (device := parse_gpu_device_info(line)) is not None}
     )
     return gpu_devices if gpu_devices else []
-
-
-def check_sufficient_resources(pool_available_disk: int, message: ExecutableContent) -> None:
-    """Check if there are sufficient resources to create a VM.
-
-    Raises InsufficientResourcesError if resources are insufficient.
-    """
-    if not message.resources:
-        # No resource requirements specified, skip check
-        return
-
-    required_vcpus = message.resources.vcpus
-    required_memory_mb = message.resources.memory  # Memory in MB
-    required_disk_mb = 0
-
-    if isinstance(message, InstanceContent) and message.rootfs:
-        required_disk_mb = message.rootfs.size_mib
-
-    # Calculate required disk space from volumes if present
-    if message.volumes:
-        for volume in message.volumes:
-            # TODO: this does not take the size of immutable volumes into account
-            volume_size_mib = getattr(volume, "size_mib", 0)
-            required_disk_mb += volume_size_mib
-
-    # Get available resources using the same methods as about_system_usage
-    available_vcpus = psutil.cpu_count()
-    available_memory_kb = math.floor(psutil.virtual_memory().available / 1000)
-    available_memory_mb = available_memory_kb / 1024
-    available_disk_kb = pool_available_disk // 1000
-    available_disk_mb = available_disk_kb / 1024
-
-    # Check each resource
-    insufficient_resources = []
-
-    if required_vcpus > available_vcpus:
-        insufficient_resources.append(f"vCPUs: required {required_vcpus}, available {available_vcpus}")
-
-    if required_memory_mb > available_memory_mb:
-        insufficient_resources.append(
-            f"Memory: required {required_memory_mb} MB, available {available_memory_mb:.2f} MB"
-        )
-
-    if required_disk_mb > 0 and required_disk_mb > available_disk_mb:
-        insufficient_resources.append(f"Disk: required {required_disk_mb} MB, available {available_disk_mb:.2f} MB")
-
-    if insufficient_resources:
-        error_message = "Insufficient resources to create VM. " + "; ".join(insufficient_resources)
-        required = {
-            "vcpus": required_vcpus,
-            "memory_mb": required_memory_mb,
-            "disk_mb": required_disk_mb,
-        }
-        available = {
-            "vcpus": available_vcpus,
-            "memory_mb": available_memory_mb,
-            "disk_mb": available_disk_mb,
-        }
-        raise InsufficientResourcesError(error_message, required=required, available=available)

--- a/tests/supervisor/test_resources.py
+++ b/tests/supervisor/test_resources.py
@@ -1,13 +1,9 @@
 from unittest import mock
 
 import pytest
-from aleph_message.models import InstanceContent, InstanceMessage
+from aleph_message.models import InstanceContent
 
-from aleph.vm.resources import (
-    InsufficientResourcesError,
-    check_sufficient_resources,
-    get_gpu_devices,
-)
+from aleph.vm.resources import InsufficientResourcesError, get_gpu_devices
 
 
 @pytest.fixture()
@@ -70,38 +66,129 @@ def test_get_gpu_devices():
             assert expected_gpu_devices[0].device_id == "10de:27b0"
 
 
-def test_check_sufficient_resources(mocker, mock_instance_content):
-    required = {"vcpus": 4, "memory_mb": 2048, "disk_mb": 10240}
+def _make_pool(mocker, *, physical_memory_mib: int, physical_cores: int, available_disk_mib: int):
+    """Build a VmPool stub with just enough state for check_admission."""
+    from aleph.vm.pool import VmPool  # local import to keep module-level import light
 
-    mocker.patch("aleph.vm.orchestrator.resources.psutil.cpu_count", return_value=required["vcpus"])
-    mocker.patch(
-        "aleph.vm.orchestrator.resources.psutil.virtual_memory",
-        return_value=mocker.MagicMock(available=(required["memory_mb"] * 1000 * 1024)),
+    pool = VmPool.__new__(VmPool)
+    pool.executions = {}
+    mocker.patch.object(
+        pool,
+        "calculate_available_disk",
+        return_value=available_disk_mib * 1024 * 1024,
     )
+    mocker.patch(
+        "aleph.vm.pool.psutil.virtual_memory",
+        return_value=mocker.MagicMock(total=physical_memory_mib * 1024 * 1024),
+    )
+    mocker.patch("aleph.vm.pool.psutil.cpu_count", return_value=physical_cores)
+    return pool
+
+
+def test_check_admission_passes_with_ample_capacity(mocker, mock_instance_content):
+    pool = _make_pool(
+        mocker,
+        physical_memory_mib=8192,
+        physical_cores=8,
+        available_disk_mib=20480,
+    )
+    content = InstanceContent.model_validate(mock_instance_content)
+    pool.check_admission(content)
+
+
+def test_check_admission_refuses_insufficient_memory(mocker, mock_instance_content):
+    # Instance requests 2048 MiB; host has 1024 MiB x 1.1 overcommit = 1126 MiB cap.
+    pool = _make_pool(
+        mocker,
+        physical_memory_mib=1024,
+        physical_cores=8,
+        available_disk_mib=20480,
+    )
+    content = InstanceContent.model_validate(mock_instance_content)
+    with pytest.raises(InsufficientResourcesError, match="Memory"):
+        pool.check_admission(content)
+
+
+def test_check_admission_refuses_insufficient_vcpus(mocker, mock_instance_content):
+    # Instance requests 4 vCPUs; host has 1 core x 4.0 overcommit = 4 cap,
+    # and an already-committed instance takes 1 vCPU, leaving 3.
+    pool = _make_pool(
+        mocker,
+        physical_memory_mib=8192,
+        physical_cores=1,
+        available_disk_mib=20480,
+    )
+    existing = mock.MagicMock()
+    existing.is_instance = True
+    existing.vm_hash = "existing"
+    existing.message.resources.memory = 128
+    existing.message.resources.vcpus = 1
+    pool.executions["existing"] = existing
+    content = InstanceContent.model_validate(mock_instance_content)
+    with pytest.raises(InsufficientResourcesError, match="vCPUs"):
+        pool.check_admission(content)
+
+
+def test_check_admission_refuses_insufficient_disk(mocker, mock_instance_content):
+    # Instance requests 10240 MiB of rootfs; only 5120 MiB available.
+    pool = _make_pool(
+        mocker,
+        physical_memory_mib=8192,
+        physical_cores=8,
+        available_disk_mib=5120,
+    )
+    content = InstanceContent.model_validate(mock_instance_content)
+    with pytest.raises(InsufficientResourcesError, match="Disk"):
+        pool.check_admission(content)
+
+
+def test_check_admission_skips_renotify_of_running_instance(mocker, mock_instance_content):
+    # Even if capacity is exhausted, a re-notify for an already-running VM
+    # must pass — the instance is already accounted for.
+    pool = _make_pool(
+        mocker,
+        physical_memory_mib=512,
+        physical_cores=1,
+        available_disk_mib=100,
+    )
+    pool.executions["abc"] = mock.MagicMock()
+    content = InstanceContent.model_validate(mock_instance_content)
+    pool.check_admission(content, current_vm_hash="abc")
+
+
+def test_check_admission_counts_running_programs(mocker, mock_instance_content):
+    # A running program's memory and vCPUs must count toward the committed
+    # totals: admission decisions cannot ignore non-instance executions.
+    pool = _make_pool(
+        mocker,
+        physical_memory_mib=4096,
+        physical_cores=4,
+        available_disk_mib=20480,
+    )
+    # Cap: 4096 * 1.1 = 4505 MiB memory, 4 * 4.0 = 16 vCPUs.
+    # One running program already consumes 3500 MiB. A new instance asking
+    # for 2048 MiB would exceed the memory cap (3500 + 2048 = 5548 > 4505).
+    program = mock.MagicMock()
+    program.is_instance = False
+    program.vm_hash = "program-hash"
+    program.message.resources.memory = 3500
+    program.message.resources.vcpus = 1
+    pool.executions["program-hash"] = program
 
     content = InstanceContent.model_validate(mock_instance_content)
+    with pytest.raises(InsufficientResourcesError, match="Memory"):
+        pool.check_admission(content)
 
-    check_sufficient_resources((required["disk_mb"] * 1000 * 1024), content)
 
-
-def test_check_sufficient_resources_not_enough(mocker, mock_instance_content):
-    required = {"vcpus": 4, "memory_mb": 2048, "disk_mb": 10240}
-    available = {"vcpus": 2, "memory_mb": 1024, "disk_mb": 5120}
-    error = InsufficientResourcesError(
-        "Insufficient resources to create VM. vCPUs: required 4, available 2; "
-        "Memory: required 2048 MB, available 1024.00 MB; "
-        "Disk: required 10240 MB, available 5120.00 MB",
-        required=required,
-        available=available,
+def test_check_admission_excludes_current_hash_from_committed(mocker, mock_instance_content):
+    # An instance being re-evaluated (e.g. restart) must not count against
+    # itself when it is not yet in the pool but its hash is supplied.
+    pool = _make_pool(
+        mocker,
+        physical_memory_mib=4096,
+        physical_cores=8,
+        available_disk_mib=20480,
     )
-
-    mocker.patch("aleph.vm.orchestrator.resources.psutil.cpu_count", return_value=available["vcpus"])
-    mocker.patch(
-        "aleph.vm.orchestrator.resources.psutil.virtual_memory",
-        return_value=mocker.MagicMock(available=(available["memory_mb"] * 1000 * 1024)),
-    )
-
+    # Cap: 4096 * 1.1 = 4505 MiB. Instance requests 2048. OK.
     content = InstanceContent.model_validate(mock_instance_content)
-
-    with pytest.raises(InsufficientResourcesError, match=str(error)):
-        check_sufficient_resources((available["disk_mb"] * 1000 * 1024), content)
+    pool.check_admission(content, current_vm_hash="not-in-pool")

--- a/tests/supervisor/test_resources.py
+++ b/tests/supervisor/test_resources.py
@@ -66,9 +66,22 @@ def test_get_gpu_devices():
             assert expected_gpu_devices[0].device_id == "10de:27b0"
 
 
-def _make_pool(mocker, *, physical_memory_mib: int, physical_cores: int, available_disk_mib: int):
-    """Build a VmPool stub with just enough state for check_admission."""
-    from aleph.vm.pool import VmPool  # local import to keep module-level import light
+def _make_pool(
+    mocker,
+    *,
+    physical_memory_mib: int,
+    physical_cores: int,
+    available_disk_mib: int,
+    host_reserved_mib: int = 0,
+    program_reserved_mib: int = 0,
+):
+    """Build a VmPool stub with just enough state for check_admission.
+
+    Tests pass explicit reservation values so the bucket math is clear
+    in each scenario, rather than depending on the production defaults.
+    """
+    from aleph.vm.conf import settings
+    from aleph.vm.pool import VmPool  # local import keeps module-level import light
 
     pool = VmPool.__new__(VmPool)
     pool.executions = {}
@@ -82,30 +95,61 @@ def _make_pool(mocker, *, physical_memory_mib: int, physical_cores: int, availab
         return_value=mocker.MagicMock(total=physical_memory_mib * 1024 * 1024),
     )
     mocker.patch("aleph.vm.pool.psutil.cpu_count", return_value=physical_cores)
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", host_reserved_mib)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", program_reserved_mib)
     return pool
 
 
+def _make_program_execution(hash_: str, memory_mib: int, vcpus: int):
+    """Build a mock execution object for a running program."""
+    execution = mock.MagicMock()
+    execution.is_instance = False
+    execution.vm_hash = hash_
+    execution.message.resources.memory = memory_mib
+    execution.message.resources.vcpus = vcpus
+    return execution
+
+
+def _make_instance_execution(hash_: str, memory_mib: int, vcpus: int):
+    """Build a mock execution object for a running instance."""
+    execution = mock.MagicMock()
+    execution.is_instance = True
+    execution.vm_hash = hash_
+    execution.message.resources.memory = memory_mib
+    execution.message.resources.vcpus = vcpus
+    return execution
+
+
 def test_check_admission_passes_with_ample_capacity(mocker, mock_instance_content):
+    # 16 GiB physical, 4 GiB host reserved, 4 GiB program reserved
+    # → instance cap = 8 GiB. Instance requests 2 GiB. Plenty of room.
     pool = _make_pool(
         mocker,
-        physical_memory_mib=8192,
+        physical_memory_mib=16384,
         physical_cores=8,
         available_disk_mib=20480,
+        host_reserved_mib=4096,
+        program_reserved_mib=4096,
     )
     content = InstanceContent.model_validate(mock_instance_content)
     pool.check_admission(content)
 
 
-def test_check_admission_refuses_insufficient_memory(mocker, mock_instance_content):
-    # Instance requests 2048 MiB; host has 1024 MiB x 1.1 overcommit = 1126 MiB cap.
+def test_check_admission_refuses_insufficient_instance_memory(mocker, mock_instance_content):
+    # 4 GiB physical, 1 GiB host reserved, 1 GiB program reserved
+    # → instance cap = 2 GiB. Instance requests 2048 MiB, an existing
+    # instance already consumes 1 GiB, leaving 1 GiB. Refused.
     pool = _make_pool(
         mocker,
-        physical_memory_mib=1024,
+        physical_memory_mib=4096,
         physical_cores=8,
         available_disk_mib=20480,
+        host_reserved_mib=1024,
+        program_reserved_mib=1024,
     )
+    pool.executions["existing"] = _make_instance_execution(hash_="existing", memory_mib=1024, vcpus=1)
     content = InstanceContent.model_validate(mock_instance_content)
-    with pytest.raises(InsufficientResourcesError, match="Memory"):
+    with pytest.raises(InsufficientResourcesError, match="instance bucket"):
         pool.check_admission(content)
 
 
@@ -114,16 +158,13 @@ def test_check_admission_refuses_insufficient_vcpus(mocker, mock_instance_conten
     # and an already-committed instance takes 1 vCPU, leaving 3.
     pool = _make_pool(
         mocker,
-        physical_memory_mib=8192,
+        physical_memory_mib=16384,
         physical_cores=1,
         available_disk_mib=20480,
+        host_reserved_mib=0,
+        program_reserved_mib=0,
     )
-    existing = mock.MagicMock()
-    existing.is_instance = True
-    existing.vm_hash = "existing"
-    existing.message.resources.memory = 128
-    existing.message.resources.vcpus = 1
-    pool.executions["existing"] = existing
+    pool.executions["existing"] = _make_instance_execution(hash_="existing", memory_mib=128, vcpus=1)
     content = InstanceContent.model_validate(mock_instance_content)
     with pytest.raises(InsufficientResourcesError, match="vCPUs"):
         pool.check_admission(content)
@@ -133,9 +174,11 @@ def test_check_admission_refuses_insufficient_disk(mocker, mock_instance_content
     # Instance requests 10240 MiB of rootfs; only 5120 MiB available.
     pool = _make_pool(
         mocker,
-        physical_memory_mib=8192,
+        physical_memory_mib=16384,
         physical_cores=8,
         available_disk_mib=5120,
+        host_reserved_mib=0,
+        program_reserved_mib=0,
     )
     content = InstanceContent.model_validate(mock_instance_content)
     with pytest.raises(InsufficientResourcesError, match="Disk"):
@@ -156,39 +199,92 @@ def test_check_admission_skips_renotify_of_running_instance(mocker, mock_instanc
     pool.check_admission(content, current_vm_hash="abc")
 
 
-def test_check_admission_counts_running_programs(mocker, mock_instance_content):
-    # A running program's memory and vCPUs must count toward the committed
-    # totals: admission decisions cannot ignore non-instance executions.
-    pool = _make_pool(
-        mocker,
-        physical_memory_mib=4096,
-        physical_cores=4,
-        available_disk_mib=20480,
-    )
-    # Cap: 4096 * 1.1 = 4505 MiB memory, 4 * 4.0 = 16 vCPUs.
-    # One running program already consumes 3500 MiB. A new instance asking
-    # for 2048 MiB would exceed the memory cap (3500 + 2048 = 5548 > 4505).
-    program = mock.MagicMock()
-    program.is_instance = False
-    program.vm_hash = "program-hash"
-    program.message.resources.memory = 3500
-    program.message.resources.vcpus = 1
-    pool.executions["program-hash"] = program
-
-    content = InstanceContent.model_validate(mock_instance_content)
-    with pytest.raises(InsufficientResourcesError, match="Memory"):
-        pool.check_admission(content)
-
-
 def test_check_admission_excludes_current_hash_from_committed(mocker, mock_instance_content):
     # An instance being re-evaluated (e.g. restart) must not count against
     # itself when it is not yet in the pool but its hash is supplied.
     pool = _make_pool(
         mocker,
-        physical_memory_mib=4096,
+        physical_memory_mib=16384,
         physical_cores=8,
         available_disk_mib=20480,
+        host_reserved_mib=0,
+        program_reserved_mib=0,
     )
-    # Cap: 4096 * 1.1 = 4505 MiB. Instance requests 2048. OK.
     content = InstanceContent.model_validate(mock_instance_content)
     pool.check_admission(content, current_vm_hash="not-in-pool")
+
+
+def test_check_admission_instance_cannot_eat_program_reservation(mocker, mock_instance_content):
+    # 6 GiB physical, 0 host reserved, 4 GiB program reserved.
+    # Instance cap = 6 - 0 - 4 = 2 GiB. A 2048 MiB instance request with
+    # no committed state must still be refused because 2 GiB is the
+    # absolute ceiling for instances and the fixture requests exactly
+    # that. We commit 1 MiB first to push the request just over.
+    pool = _make_pool(
+        mocker,
+        physical_memory_mib=6144,
+        physical_cores=8,
+        available_disk_mib=20480,
+        host_reserved_mib=0,
+        program_reserved_mib=4096,
+    )
+    pool.executions["tiny"] = _make_instance_execution(hash_="tiny", memory_mib=1, vcpus=0)
+    content = InstanceContent.model_validate(mock_instance_content)
+    with pytest.raises(InsufficientResourcesError, match="instance bucket"):
+        pool.check_admission(content)
+
+
+def test_check_admission_program_gets_reserved_space_when_instances_full(mocker):
+    # Physical 8 GiB, 0 host reserved, 2 GiB program reserved.
+    # Instance cap = 6 GiB. Fill instance bucket entirely.
+    # A program requesting 512 MiB must still be admitted because the
+    # program bucket has its own budget untouched by instances.
+    pool = _make_pool(
+        mocker,
+        physical_memory_mib=8192,
+        physical_cores=8,
+        available_disk_mib=20480,
+        host_reserved_mib=0,
+        program_reserved_mib=2048,
+    )
+    pool.executions["huge-instance"] = _make_instance_execution(hash_="huge-instance", memory_mib=6144, vcpus=2)
+    program_content = _fake_program_content(memory_mib=512, vcpus=1)
+    pool.check_admission(program_content)
+
+
+def test_check_admission_refuses_program_exceeding_program_bucket(mocker):
+    # Physical 8 GiB, 0 host reserved, 1 GiB program reserved.
+    # A program asking for 2 GiB cannot fit in the 1 GiB bucket even
+    # though the instance bucket has tons of room.
+    pool = _make_pool(
+        mocker,
+        physical_memory_mib=8192,
+        physical_cores=8,
+        available_disk_mib=20480,
+        host_reserved_mib=0,
+        program_reserved_mib=1024,
+    )
+    program_content = _fake_program_content(memory_mib=2048, vcpus=1)
+    with pytest.raises(InsufficientResourcesError, match="program bucket"):
+        pool.check_admission(program_content)
+
+
+class _FakeProgramContent:
+    """Minimal non-InstanceContent stub that satisfies check_admission.
+
+    check_admission only reads ``message.resources`` and
+    ``message.volumes`` and tests ``isinstance(message, InstanceContent)``.
+    A plain class avoids constructing a full ProgramContent, which would
+    require a realistic code reference and runtime hash.
+    """
+
+    def __init__(self, *, memory_mib: int, vcpus: int):
+        resources = mock.MagicMock()
+        resources.memory = memory_mib
+        resources.vcpus = vcpus
+        self.resources = resources
+        self.volumes = None
+
+
+def _fake_program_content(*, memory_mib: int, vcpus: int) -> _FakeProgramContent:
+    return _FakeProgramContent(memory_mib=memory_mib, vcpus=vcpus)


### PR DESCRIPTION
- Refuse to create a VM when accepting it would push the host above its memory, vCPU or disk capacity. Memory and vCPU allow overcommit via configurable factors (MEMORY_OVERCOMMIT_FACTOR=1.1, VCPU_OVERCOMMIT_FACTOR=4.0); disk is strict. All running executions count toward committed totals so instances and programs are treated uniformly.

  The check runs authoritatively inside create_a_vm under creation_lock, before execution.prepare() downloads anything, and advisorily from notify_allocation and reserve_resources so clients get a fast rejection before payment. Cold program starts now return 503 Service Unavailable on capacity failure instead of 400 Bad Request.

Replaces the previous check_sufficient_resources helper.