### PR TITLE
runtimes: add Ubuntu 26.04 (resolute) rootfs creation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ node_modules
 /kernels/linux-*/
 /kernels/linux-*.tar
 /kernels/linux-*.tar.sign
+/.worktrees/

--- a/runtimes/instance-rootfs/create-ubuntu-26-04-qemu-disk.sh
+++ b/runtimes/instance-rootfs/create-ubuntu-26-04-qemu-disk.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euf
+
+# Variables
+ROOTFS_FILENAME="./rootfs.img"
+IMAGE_URL="https://cloud-images.ubuntu.com/resolute/current/resolute-server-cloudimg-amd64.img"
+IMAGE_NAME="resolute-server-cloudimg-amd64.img"
+
+# Cleanup previous run
+rm -f "$ROOTFS_FILENAME"
+
+# Download Ubuntu image
+echo "Downloading Ubuntu 26.04 image"
+curl -L "$IMAGE_URL" -o "$IMAGE_NAME"
+
+# Rename final file
+mv "$IMAGE_NAME" "$ROOTFS_FILENAME"


### PR DESCRIPTION
## Summary
- Adds `runtimes/instance-rootfs/create-ubuntu-26-04-qemu-disk.sh`, mirroring the existing 24.04 script. Downloads the official Ubuntu 26.04 LTS cloud image (codename `resolute`) from `cloud-images.ubuntu.com` and renames it to `rootfs.img`.
- Includes a small workflow tweak: ignore `.worktrees/` so local git worktrees don't pollute `git status`.

Publishing the resulting `rootfs.img` to the Aleph network (pinning via `aleph-client`) is a separate manual step, unchanged from the existing 22.04 / 24.04 process.

## Test plan
- [ ] Run `bash runtimes/instance-rootfs/create-ubuntu-26-04-qemu-disk.sh` and confirm `rootfs.img` is produced
- [ ] Boot a fake instance against the produced image (`ALEPH_VM_FAKE_INSTANCE_BASE=...rootfs.img`, `--run-fake-instance`) and confirm cloud-init completes and the VM is reachable over SSH as `ubuntu`