### PR TITLE
ci: configurable ALEPH_VM_API_SERVER for unit tests

### DIFF
--- a/.github/workflows/test-using-pytest.yml
+++ b/.github/workflows/test-using-pytest.yml
@@ -78,9 +78,14 @@ jobs:
 
       # Unit tests create and delete network interfaces, and therefore require to run as root
       - name: Run unit tests
+        env:
+          # Override the Aleph API endpoint without touching code. Defaults to api.aleph.im
+          # (canonical PyAleph node) so CI does not depend on the flakier official.aleph.cloud.
+          # Set repo/org GH Actions variable ALEPH_VM_API_SERVER to point at another CCN.
+          ALEPH_VM_API_SERVER: ${{ vars.ALEPH_VM_API_SERVER || 'https://api.aleph.im' }}
         run: |
           sudo python3 -m pip install --upgrade --ignore-installed hatch hatch-vcs coverage "virtualenv<21"
-          sudo hatch run testing:cov
+          sudo --preserve-env=ALEPH_VM_API_SERVER hatch run testing:cov
 
       - name: Output modules used and their version
         if: ${{ !cancelled() }}

--- a/.github/workflows/test-using-pytest.yml
+++ b/.github/workflows/test-using-pytest.yml
@@ -79,10 +79,10 @@ jobs:
       # Unit tests create and delete network interfaces, and therefore require to run as root
       - name: Run unit tests
         env:
-          # Override the Aleph API endpoint without touching code. Defaults to api.aleph.im
-          # (canonical PyAleph node) so CI does not depend on the flakier official.aleph.cloud.
-          # Set repo/org GH Actions variable ALEPH_VM_API_SERVER to point at another CCN.
-          ALEPH_VM_API_SERVER: ${{ vars.ALEPH_VM_API_SERVER || 'https://api.aleph.im' }}
+          # Override the Aleph API endpoint without touching code. Defaults to api3.aleph.im
+          # so CI does not depend on the flakier official.aleph.cloud. Set repo/org GH Actions
+          # variable ALEPH_VM_API_SERVER to point at another CCN.
+          ALEPH_VM_API_SERVER: ${{ vars.ALEPH_VM_API_SERVER || 'https://api3.aleph.im' }}
         run: |
           sudo python3 -m pip install --upgrade --ignore-installed hatch hatch-vcs coverage "virtualenv<21"
           sudo --preserve-env=ALEPH_VM_API_SERVER hatch run testing:cov


### PR DESCRIPTION
## Summary

- The unit-test step in `test-using-pytest.yml` runs against `settings.API_SERVER`, which defaults to `https://official.aleph.cloud`. That host has been flaky in recent CI runs (e.g. PR #936) and fails `tests/supervisor/test_execution.py::test_create_execution_*` with non-200 responses from `messages.json`.
- Pydantic-settings reads `ALEPH_VM_API_SERVER` (env_prefix `ALEPH_VM_`), so we can swap the endpoint without touching code.
- Default to `https://api.aleph.im` (canonical PyAleph node, used by `examples/example_fastapi/main.py`).
- Allow override via the **GH Actions repository variable** `ALEPH_VM_API_SERVER` so we can repoint at any CCN without editing the workflow.
- `sudo --preserve-env=ALEPH_VM_API_SERVER` is required because the test step runs under `sudo`, which scrubs env by default.

## Test plan

- [ ] CI run on this branch is green and the test step uses `https://api.aleph.im`.
- [ ] (Optional) Set repo variable `ALEPH_VM_API_SERVER=https://official.aleph.cloud`, re-run, confirm the workflow respects the override.
- [ ] Once green here, rebase `od/cold-migration-async` (#936) onto this and confirm the previously-failing `test_create_execution_*` tests pass.