### PR TITLE
chore: gitignore .worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.worktrees/
 *.pyc
 __pycache__
 


### PR DESCRIPTION
## Summary

- Add `.worktrees/` to `.gitignore` so a parent-side `git add -A` can't stage checked-out files from a git worktree into the wrong branch.

Local convention here is to put git worktrees under `.worktrees/` at the repo root. The directory is already in use by contributors but wasn't ignored.

## Test plan

- [ ] No code paths affected; this is metadata-only.