### PR TITLE
refactor: extract allocation auth helpers to dedicated module

### DIFF
--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -3,7 +3,6 @@ import binascii
 import http
 import logging
 from decimal import Decimal
-from hashlib import sha256
 from json import JSONDecodeError
 from packaging.version import InvalidVersion, Version
 from pathlib import Path
@@ -55,6 +54,7 @@ from aleph.vm.orchestrator.utils import (
     is_after_community_wallet_start,
     update_aggregate_settings,
 )
+from aleph.vm.orchestrator.views.allocation_auth import authenticate_api_request
 from aleph.vm.orchestrator.views.authentication import require_jwk_authentication
 from aleph.vm.orchestrator.views.host_status import (
     check_dns_ipv4,
@@ -473,35 +473,6 @@ async def status_public_config(request: web.Request):
         },
         dumps=dumps_for_json,
     )
-
-
-def authenticate_api_request(request: web.Request) -> bool:
-    """Authenticate an API request to update the VM allocations."""
-    signature: bytes = request.headers.get("X-Auth-Signature", "").encode()
-
-    if not signature:
-        raise web.HTTPUnauthorized(text="Authentication token is missing")
-
-    # Use a simple authentication method: the hash of the signature should match the value in the settings
-    return sha256(signature).hexdigest() == settings.ALLOCATION_TOKEN_HASH
-
-
-def requires_allocation_auth(handler):
-    """Decorator: reject the request with 401 unless the X-Auth-Signature header matches.
-
-    Wraps :func:`authenticate_api_request` so endpoints don't have to repeat the
-    three-line check. Apply BELOW any CORS decorator so OPTIONS preflights pass
-    through unauthenticated.
-    """
-    import functools
-
-    @functools.wraps(handler)
-    async def wrapper(request: web.Request) -> web.StreamResponse:
-        if not authenticate_api_request(request):
-            return web.HTTPUnauthorized(text="Authentication token received is invalid")
-        return await handler(request)
-
-    return wrapper
 
 
 allocation_lock = None

--- a/src/aleph/vm/orchestrator/views/allocation_auth.py
+++ b/src/aleph/vm/orchestrator/views/allocation_auth.py
@@ -1,0 +1,43 @@
+"""Authentication for scheduler-only control endpoints.
+
+Currently the scheduler authenticates with a shared bearer token whose
+SHA-256 hash is configured on the supervisor as
+:data:`aleph.vm.conf.settings.ALLOCATION_TOKEN_HASH`. This module hosts
+the verifier and the decorator so they can be evolved (signature-based
+auth, key rotation, etc.) without touching the views package's `__init__`.
+"""
+
+from hashlib import sha256
+
+from aiohttp import web
+
+from aleph.vm.conf import settings
+
+
+def authenticate_api_request(request: web.Request) -> bool:
+    """Authenticate an API request to update the VM allocations."""
+    signature: bytes = request.headers.get("X-Auth-Signature", "").encode()
+
+    if not signature:
+        raise web.HTTPUnauthorized(text="Authentication token is missing")
+
+    # Use a simple authentication method: the hash of the signature should match the value in the settings
+    return sha256(signature).hexdigest() == settings.ALLOCATION_TOKEN_HASH
+
+
+def requires_allocation_auth(handler):
+    """Decorator: reject the request with 401 unless the X-Auth-Signature header matches.
+
+    Wraps :func:`authenticate_api_request` so endpoints don't have to repeat the
+    three-line check. Apply BELOW any CORS decorator so OPTIONS preflights pass
+    through unauthenticated.
+    """
+    import functools
+
+    @functools.wraps(handler)
+    async def wrapper(request: web.Request) -> web.StreamResponse:
+        if not authenticate_api_request(request):
+            return web.HTTPUnauthorized(text="Authentication token received is invalid")
+        return await handler(request)
+
+    return wrapper

--- a/src/aleph/vm/orchestrator/views/migration.py
+++ b/src/aleph/vm/orchestrator/views/migration.py
@@ -35,7 +35,7 @@ from aleph.vm.models import MigrationState, VmExecution
 from aleph.vm.pool import VmPool
 from aleph.vm.utils import cors_allow_all, create_task_log_exceptions, dumps_for_json
 
-from . import requires_allocation_auth
+from .allocation_auth import requires_allocation_auth
 from .operator import get_execution_or_404, get_itemhash_or_400
 
 logger = logging.getLogger(__name__)

--- a/tests/supervisor/views/test_migration.py
+++ b/tests/supervisor/views/test_migration.py
@@ -36,10 +36,11 @@ def mock_scheduler_auth(mocker):
     """Mock the scheduler authentication to always pass.
 
     The migration handlers wrap themselves with @requires_allocation_auth, which
-    calls aleph.vm.orchestrator.views.authenticate_api_request — patch there.
+    looks up authenticate_api_request in its own module
+    (aleph.vm.orchestrator.views.allocation_auth) — patch there.
     """
     mocker.patch(
-        "aleph.vm.orchestrator.views.authenticate_api_request",
+        "aleph.vm.orchestrator.views.allocation_auth.authenticate_api_request",
         return_value=True,
     )
 
@@ -93,7 +94,7 @@ class TestMigrationExportEndpoint:
     async def test_export_unauthorized(self, aiohttp_client, mocker, mock_vm_hash):
         """Test that unauthorized requests are rejected."""
         mocker.patch(
-            "aleph.vm.orchestrator.views.authenticate_api_request",
+            "aleph.vm.orchestrator.views.allocation_auth.authenticate_api_request",
             return_value=False,
         )
         pool = mocker.Mock(executions={})
@@ -314,7 +315,7 @@ class TestMigrationImportEndpoint:
     async def test_import_unauthorized(self, aiohttp_client, mocker):
         """Test that unauthorized requests are rejected."""
         mocker.patch(
-            "aleph.vm.orchestrator.views.authenticate_api_request",
+            "aleph.vm.orchestrator.views.allocation_auth.authenticate_api_request",
             return_value=False,
         )
         pool = mocker.Mock(executions={})
@@ -591,7 +592,7 @@ class TestMigrationCleanupEndpoint:
     async def test_cleanup_unauthorized(self, aiohttp_client, mocker, mock_vm_hash):
         """Test that unauthorized requests are rejected."""
         mocker.patch(
-            "aleph.vm.orchestrator.views.authenticate_api_request",
+            "aleph.vm.orchestrator.views.allocation_auth.authenticate_api_request",
             return_value=False,
         )
         pool = mocker.Mock(executions={})


### PR DESCRIPTION
## Summary

- Move `authenticate_api_request` and `requires_allocation_auth` out of `views/__init__.py` into a new `views/allocation_auth.py` module.
- Pure move, no behaviour change. Prep work for an upcoming signature-based auth scheme so that the cryptographic change can land as a focused diff.

## Details

- **New file:** `src/aleph/vm/orchestrator/views/allocation_auth.py` hosts both helpers verbatim.
- **`views/__init__.py`:** removes the two definitions; re-imports `authenticate_api_request` for its three direct call sites (`update_allocations`, `recreate_network`, `regenerate_proxy`); drops the `sha256` import that became unused.
- **`views/migration.py`:** imports `requires_allocation_auth` directly from the new module instead of re-routing through `views/__init__.py`.
- **`tests/supervisor/views/test_migration.py`:** the 4 `mocker.patch` targets and the explanatory docstring move from `aleph.vm.orchestrator.views.authenticate_api_request` to `aleph.vm.orchestrator.views.allocation_auth.authenticate_api_request`. The decorator now lives in `allocation_auth`, so the name lookup resolves there — `mock.patch` must target the lookup site.

## Test plan

- [x] `pytest tests/supervisor/views/test_migration.py` — 44 passed
- [x] `pytest tests/supervisor/test_views.py::test_allocation_*` and `test_regenerate_proxy_*_token` — 5 passed (covers the `update_allocations` and `regenerate_proxy` direct call paths)
- [x] `ruff check` and `ruff format --check` clean on the changed files

## Why this PR exists

The current shared-secret auth (one bearer token whose SHA-256 hash is configured per CRN) is being replaced with per-signer EIP-191 signatures. Splitting the move from the crypto change keeps both PRs easy to review.