### PR TITLE
feat: add vm_type to /about/executions/list responses

### DIFF
--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -77,6 +77,7 @@ from aleph.vm.utils import (
     get_ref_from_dns,
 )
 from aleph.vm.version import __version__
+from aleph.vm.vm_type import VmType
 
 logger = logging.getLogger(__name__)
 
@@ -234,6 +235,7 @@ async def list_executions(request: web.Request) -> web.Response:
                     "ipv4": execution.vm.tap_interface.ip_network,
                     "ipv6": execution.vm.tap_interface.ipv6_network,
                 },
+                "vm_type": VmType.from_message_content(execution.message).name,
             }
             for item_hash, execution in pool.executions.items()
             if running_states.get(item_hash, False)
@@ -267,6 +269,7 @@ async def list_executions_v2(request: web.Request) -> web.Response:
                 ),
                 "status": execution.times,
                 "running": running_states.get(item_hash, False),
+                "vm_type": VmType.from_message_content(execution.message).name,
             }
             for item_hash, execution in pool.executions.items()
         },

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -399,6 +399,7 @@ async def test_v2_executions_list_one_vm(aiohttp_client, mock_app_with_pool, moc
                 "stopped_at": None,
             },
             "running": False,
+            "vm_type": "instance",
         }
     }
 
@@ -474,6 +475,7 @@ async def test_v2_executions_list_vm_network(aiohttp_client, mocker, mock_app_wi
                 "stopped_at": None,
             },
             "running": False,
+            "vm_type": "instance",
         }
     }
 


### PR DESCRIPTION
## Summary
- Add a `vm_type` field to each entry of `/about/executions/list` (v1) and `/v2/about/executions/list` (v2)
- Values come from the existing `VmType` enum: `microvm`, `persistent_program`, `instance`
- Removes the need to guess from other fields when consuming these endpoints

## Test plan
- [ ] `pytest tests/supervisor/test_views.py -k executions_list` (existing v2 list tests updated to assert the new key)
- [ ] Hit `/about/executions/list` and `/v2/about/executions/list` on a node running a mix of executions and confirm `vm_type` is present per entry