### PR TITLE
auth: Aleph-EIP191-V1 signature path for scheduler endpoints

### DIFF
--- a/docs/plans/2026-05-11-allocation-auth-signatures-review.md
+++ b/docs/plans/2026-05-11-allocation-auth-signatures-review.md
@@ -1,0 +1,143 @@
+# Code Review — Aleph-EIP191-V1 Allocation Auth (PR #945)
+
+Self-review of the new signature-based allocation auth, in the spirit of a
+brutally critical reviewer. Issues are ordered by severity, with mitigations.
+
+## Critical
+
+### C1. TOCTOU race on `_last_accepted_iat` — replay protection is broken under concurrency
+`_verify_aleph_signature` does:
+```python
+previous = _last_accepted_iat.get(recovered.lower(), float("-inf"))
+if iat <= previous:
+    return False
+...
+_last_accepted_iat[recovered.lower()] = iat
+```
+Between the `get` and the assignment, the function `await`s `request.read()`. Two concurrent requests with `iat=N` (same captured signed message) both read `previous < N`, both pass the gate, both write — **same-iat replay succeeds**. Worse: two concurrent legitimate calls with `iat=N` and `iat=N+1` can write in any order, leaving `previous = N`, after which `iat=N+1` can be replayed.
+
+This is the whole point of replay protection. Without serialization across the await point, you have none.
+
+**Mitigation:** wrap the check+update in an `asyncio.Lock` (one global, or one per signer). Move the `_last_accepted_iat` update *before* the `await request.read()` if you can prove the body check can't fail after the iat has been "committed" — but that's a data-corruption antipattern; just take the lock.
+
+### C2. Body-size DoS via `await request.read()` inside the verifier
+Any caller can send `Authorization: Aleph-EIP191-V1 sig=…,payload=…` plus a multi-GB body. The verifier calls `await request.read()` *unconditionally* on the way to the body-hash check, fully buffering attacker-controlled bytes into memory before any auth decision. The legacy path never read the body. This is a regression in DoS posture introduced by this PR.
+
+**Mitigation:** set aiohttp's `client_max_size` on the app (e.g., 1 MiB for control endpoints), or check `request.content_length` against a cap before calling `read()`, returning False if exceeded. Either way, **bound memory before reading**.
+
+## High
+
+### H1. Scheme comparison is case-sensitive — violates RFC 7235 §2.1
+`if scheme != ALEPH_EIP191_V1_SCHEME` rejects `aleph-eip191-v1`, but auth-scheme tokens are case-insensitive. A well-behaved client lowercasing the scheme would silently get 401s, hard to debug, and a maintainer "fixing" this later by lowercasing both sides would need to be careful about the prefix check on line 150 (`startswith(f"{ALEPH_EIP191_V1_SCHEME} ")`).
+
+**Mitigation:** `scheme.casefold() != ALEPH_EIP191_V1_SCHEME.casefold()` in the parser, and use the same comparison in the dispatcher (or extract the scheme first then dispatch).
+
+### H2. Path binding ignores query string
+`payload["path"] != request.path` — `request.path` excludes the query. If any of these 8 endpoints ever gains a query param affecting behavior, the signature won't bind to it. Footgun for future maintainers.
+
+**Mitigation:** sign `request.path_qs` (or assert `request.query_string == ""` in the verifier and document that scheduler endpoints MUST NOT accept query params).
+
+### H3. Unknown auth-params silently accepted
+`_parse_auth_params` keeps any `key=value` it sees and only validates the *required* set. A client sending `sig=…,payload=…,extra=poison` is accepted. This isn't currently exploitable, but the verifier's contract is "I bind everything in the payload" — it doesn't, it binds what it knows. If anyone later adds a payload field and forgets to update the dispatcher, the missing-field branch saves them; if they add an *auth-param* that the verifier reads but doesn't validate strictly, this could backfire.
+
+**Mitigation:** reject any auth-param outside the allowlist `{"sig", "payload"}`.
+
+### H4. No integration coverage for migration endpoints with the new scheme
+The 5 `@requires_allocation_auth` migration endpoints (`migration.py:80,161,232,319,346`) have unit tests in `test_migration.py` that mock `authenticate_api_request` to `True`, and the new dispatcher has a thorough unit-test suite. But there is **no end-to-end test** that fires a real Aleph-EIP191-V1 signed request at any migration endpoint and gets through. Coverage is asymmetric: `update_allocations` has the integration test, the others don't.
+
+**Mitigation:** add at least one integration test per endpoint (or a parametrized one across handlers) that confirms the decorator + dispatcher chain wires correctly.
+
+### H5. `_last_accepted_iat` is per-process; multi-worker deployments are vulnerable
+If the supervisor ever runs more than one worker process behind a load balancer, each worker has its own dict and a captured request can be replayed against a sibling worker. The supervisor is currently single-process — but this assumption is not documented anywhere near the code, and a deployment change would silently weaken auth.
+
+**Mitigation:** add a comment at `_last_accepted_iat`'s definition stating "single-process only; multi-worker requires shared state (Redis, etc.)". Better, add a startup assertion if multi-worker is ever enabled.
+
+## Medium
+
+### M1. `logger.debug` on verification failure hides operational signal
+Failed verifications go to DEBUG. Operators triaging a misconfigured scheduler need to enable debug logging globally — noisy and slow.
+
+**Mitigation:** `logger.info` (or `logger.warning`) with structured context: signer (if recovered), reason category (stale, body-mismatch, signer-not-authorized, malformed). Don't log the raw signature/payload — leaks request material into log files.
+
+### M2. Deprecation warning logs every legacy request
+At any reasonable scheduler TPS this floods logs. Operators who can't migrate immediately get told the same thing thousands of times an hour.
+
+**Mitigation:** rate-limit (once per minute per remote) or log once at supervisor startup if `ALLOCATION_TOKEN_HASH` is set and `AUTHORIZED_ALLOCATION_SIGNERS` is empty.
+
+### M3. Boundary tests missing for the `iat` window ✅ FIXED
+Tests cover ±600s rejected (window is 300s). Nothing tests `iat = now - 300` (boundary), `iat = now - 301`, or that the comparison uses `>` (not `>=`). The implementation uses `abs(...) > max_age` so equality is accepted, but no test pins this down.
+
+**Mitigation applied:** added 5 boundary tests in `test_allocation_auth.py` that freeze `allocation_auth.time` via a `SimpleNamespace` stub and exercise `iat = now`, `now ± max_age` (both accepted), and `now ± (max_age + 1)` (both rejected). The `_freeze_time` helper patches only the module-local `time` reference so pytest internals and other modules are unaffected.
+
+### M4. No cross-signer monotonic-iat test ✅ FIXED
+Tests verify monotonic-iat for one signer. Nothing verifies that signer B's first request succeeds even if signer A's last iat is greater. The implementation is correct (per-key dict), but a future "optimization" using a single counter would silently break and tests wouldn't catch it.
+
+**Mitigation applied:** added `test_verify_per_signer_iat_floors_are_independent` — A signs `iat=N` (succeeds, A's floor → N), B signs `iat=N-1` (succeeds, B's floor independent), A signs `iat=N-1` (rejected, below A's floor). A regression to a single global counter would fail this test on the second assertion.
+
+### M5. `request.read()` consumes the body for downstream handlers that stream
+aiohttp caches the body when `read()` is called, so handlers that subsequently call `request.json()` work fine. But a future handler using `request.content.iter_chunked()` would silently get an empty stream because the body was already buffered upstream. None of the current handlers stream, but the verifier's side effect on `request` is undocumented.
+
+**Mitigation:** comment in `_verify_aleph_signature` warning that calling this is equivalent to `await request.read()` from the handler's perspective.
+
+### M6. `import functools` inside the decorator
+Style nit, but it's noise. Move to the top.
+
+## Low / Code smells
+
+### L1. Lazy `from ... import _last_accepted_iat` inside test functions ✅ FIXED
+Originally needed during TDD; can move to module-level imports now.
+
+**Mitigation applied:** all `aleph.vm.orchestrator.views.allocation_auth` imports hoisted to the top of `test_allocation_auth.py` (single import block: module reference + symbols `MAX_SIGNED_REQUEST_BODY_BYTES`, `_last_accepted_iat`, `_parse_auth_params`, `_verify_aleph_signature`, `log_allocation_auth_config`). The `reset_iat_cache` fixture dropped its `try/except ImportError` since the symbol is now guaranteed to exist.
+
+### L2. Magic-number-ish `300` in `ALLOCATION_SIGNATURE_MAX_AGE_SECONDS` ⏭ NO ACTION
+Documented at the setting, fine, but worth a comment near the verifier itself: "If you tighten this, replay-window shrinks; if you widen it, captured-request usefulness grows."
+
+**Decision:** skipped. The setting name is self-documenting; any reader of the verifier can grep the constant and find its config-level doc. Adding the tradeoff comment near the verifier would be noise (project preference: only comment when WHY is non-obvious, and the tradeoff is implicit in any time-window auth scheme).
+
+### L3. Authorized-signer set rebuilt every request ⏭ NO ACTION
+`{a.lower() for a in settings.AUTHORIZED_ALLOCATION_SIGNERS}` runs on every verification.
+
+**Decision:** skipped, per reviewer's "or just leave it — micro-optimization". A cache keyed on the list identity would handle test monkeypatching, but the cost is microseconds for tiny `n` (< 10 signers in practice). Not worth the invalidation complexity.
+
+### L4. Dispatcher returns 4 different "False" branches ⏭ NON-ISSUE
+Lints will complain about `PLR0911` if it's not already noqa'd. Fine as-is.
+
+**Status:** moot after the H1 fix simplified the dispatcher. It now has 4 returns total, only 2 of which are direct `False`; PLR0911's default threshold is 6. Confirmed clean via `ruff check`.
+
+### L5. `request.path` matching is exact — a trailing slash mismatch is a 401 ✅ FIXED
+If a scheduler signs `/control/allocations/` (trailing slash) and the route is `/control/allocations`, you get 401 with no useful error. Document or normalize.
+
+**Mitigation applied:** added a one-line comment above the `method_path_mismatch` computation:
+```python
+# Path matching is exact: aiohttp routes `/foo` and `/foo/` distinctly,
+# so signers must use the exact path the route will receive.
+```
+Normalization would mask aiohttp's actual routing behavior (which IS trailing-slash-sensitive), so the right answer is to make the verifier policy explicit at the comparison site rather than try to paper over it.
+
+## Architecture / Future-proofing
+
+### A1. No key-revocation primitive beyond restart
+If a key leaks, mitigation is "edit config + restart". For one scheduler key, fine. But there's no expiry per key, no signed revocation list, no audit trail of which key signed which request (the recovered address isn't logged on success). Add at minimum a structured info-log at success: `signed by 0xABC for POST /control/allocations`.
+
+### A2. Wire format is final; versioning is the only escape hatch
+`Aleph-EIP191-V1` is the right approach — bumping to V2 is the migration path. Good.
+
+### A3. `_last_accepted_iat` dict grows unboundedly
+Per-signer; one entry per ever-seen authorized signer. With < 10 signers, irrelevant. If the design ever scales to hundreds of signers, no eviction. Current scope: non-issue. Document the assumption.
+
+---
+
+## Summary
+
+The cryptographic core is sound (EIP-191 + recover, body-hash binding, monotonic iat, absolute window, per-signer floor). Where this falls short is **the operational and concurrency side**: the TOCTOU race on the iat dict (C1) defeats replay protection under realistic load, and the unconditional body buffering (C2) is a DoS regression vs. the legacy path. Both are fixable in a few lines.
+
+The test suite is thorough on the verifier's logic but thin on the integration boundary (H4) and concurrency (no test exercises C1).
+
+**Priority order to fix before merge:**
+1. C1 (concurrency lock around iat check+update) — correctness
+2. C2 (cap body size before `read()`) — DoS
+3. H1 (case-insensitive scheme)
+4. H4 (integration tests for migration endpoints)
+5. M1, M2 (logging hygiene)
+
+The rest can land in follow-ups.

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -14,7 +14,8 @@ from typing import Any, Literal, NewType
 from aleph_message.models import Chain
 from aleph_message.models.execution.environment import HypervisorType
 from dotenv import load_dotenv
-from pydantic import Field, HttpUrl
+from eth_utils import is_checksum_address
+from pydantic import Field, HttpUrl, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from aleph.vm.orchestrator.chain import STREAM_CHAINS
@@ -113,6 +114,19 @@ def obtain_dns_ips(dns_resolver: DnsResolver, network_interface: str) -> list[st
 
 
 class Settings(BaseSettings):
+    @field_validator("AUTHORIZED_ALLOCATION_SIGNERS")
+    @classmethod
+    def _check_authorized_signers(cls, value: list[str]) -> list[str]:
+        for addr in value:
+            if not is_checksum_address(addr):
+                msg = (
+                    f"AUTHORIZED_ALLOCATION_SIGNERS contains an invalid or "
+                    f"non-checksummed ETH address: {addr!r}. Use the checksum "
+                    f"form (mixed case, EIP-55) to catch typos."
+                )
+                raise ValueError(msg)
+        return value
+
     SUPERVISOR_HOST: str = "127.0.0.1"
     SUPERVISOR_PORT: int = 4020
 
@@ -334,8 +348,23 @@ class Settings(BaseSettings):
         description="Snapshot compression algorithm.",
     )
 
-    # hashlib.sha256(b"secret-token").hexdigest()
     ALLOCATION_TOKEN_HASH: str = "151ba92f2eb90bce67e912af2f7a5c17d8654b3d29895b042107ea312a7eebda"
+    """DEPRECATED: SHA-256 of the shared bearer token used by the legacy
+    `X-Auth-Signature` allocation auth path. Slated for removal once all
+    schedulers migrate to AUTHORIZED_ALLOCATION_SIGNERS / Aleph-EIP191-V1."""
+
+    AUTHORIZED_ALLOCATION_SIGNERS: list[str] = []
+    """ETH addresses authorized to sign requests to scheduler-only endpoints
+    (Aleph-EIP191-V1 scheme). Empty list disables the signature path; only the
+    legacy ALLOCATION_TOKEN_HASH path is active.
+
+    Each entry must be a checksummed ETH address (e.g. 0xAbC...). Validated at
+    startup; invalid entries fail with a clear error.
+    """
+
+    ALLOCATION_SIGNATURE_MAX_AGE_SECONDS: int = 300
+    """Absolute time window (seconds) for the signed payload's `iat` relative
+    to the supervisor's wall clock. Used by the Aleph-EIP191-V1 verifier."""
 
     ENABLE_QEMU_SUPPORT: bool = Field(default=True)
     INSTANCE_DEFAULT_HYPERVISOR: HypervisorType | None = Field(

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -268,6 +268,9 @@ async def _run_migration_reaper(app: web.Application) -> None:
 def run():
     """Run the VM Supervisor."""
     settings.check()
+    from aleph.vm.orchestrator.views.allocation_auth import log_allocation_auth_config
+
+    log_allocation_auth_config()
 
     pool = VmPool()
     asyncio.run(pool.setup())

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -484,11 +484,15 @@ async def update_allocations(request: web.Request):
     """Main entry for the start of persistence VM and instance, called by the Scheduler,
     POST /control/allocations
 
+    Auth via either:
+    - `Authorization: Aleph-EIP191-V1 sig=...,payload=...` (recommended)
+    - `X-Auth-Signature` matching `settings.ALLOCATION_TOKEN_HASH` (DEPRECATED)
 
-    auth via the SETTINGS.ALLOCATION_TOKEN_HASH  sent in header X-Auth-Signature.
-    Receive a list of vm and instance that should be present and then match that state by stopping and launching VMs
+    See :mod:`aleph.vm.orchestrator.views.allocation_auth` for the dispatcher.
+    Receive a list of vm and instance that should be present and then match
+    that state by stopping and launching VMs.
     """
-    if not authenticate_api_request(request):
+    if not await authenticate_api_request(request):
         return web.HTTPUnauthorized(text="Authentication token received is invalid")
 
     global allocation_lock
@@ -628,7 +632,7 @@ async def recreate_network(request: web.Request):
         - recreated_vms: List of VM hashes that were recreated
         - failed_vms: List of VM hashes and errors for failed recreations
     """
-    if not authenticate_api_request(request):
+    if not await authenticate_api_request(request):
         return web.HTTPUnauthorized(text="Authentication token received is invalid")
 
     global network_recreation_lock
@@ -740,7 +744,7 @@ async def regenerate_proxy(request: web.Request):
         - success: Boolean indicating if the operation completed successfully
         - message: Description of the operation result
     """
-    if not authenticate_api_request(request):
+    if not await authenticate_api_request(request):
         return web.HTTPUnauthorized(text="Authentication token received is invalid")
 
     global proxy_regeneration_lock

--- a/src/aleph/vm/orchestrator/views/allocation_auth.py
+++ b/src/aleph/vm/orchestrator/views/allocation_auth.py
@@ -129,7 +129,12 @@ async def _verify_aleph_signature(request: web.Request, auth_header: str) -> boo
         max_age = settings.ALLOCATION_SIGNATURE_MAX_AGE_SECONDS
         stale = abs(iat - now) > max_age
         method_path_mismatch = payload["method"] != request.method or payload["path"] != request.path
-        if stale or method_path_mismatch:
+        # The signed payload binds method + path only — not the query string.
+        # Rather than extend the wire format, forbid query strings on signed
+        # endpoints: callers control them, attackers do too, and silent
+        # under-binding is the worst of both worlds.
+        has_query = bool(request.query_string)
+        if stale or method_path_mismatch or has_query:
             return False
 
         # Crypto: recover signer and check authorization.

--- a/src/aleph/vm/orchestrator/views/allocation_auth.py
+++ b/src/aleph/vm/orchestrator/views/allocation_auth.py
@@ -31,13 +31,19 @@ ALEPH_EIP191_V1_SCHEME = "Aleph-EIP191-V1"
 MAX_SIGNED_REQUEST_BODY_BYTES = 1 * 1024 * 1024
 
 
+ALLOWED_AUTH_PARAMS = frozenset({"sig", "payload"})
+
+
 def _parse_auth_params(auth_header: str) -> dict[str, str]:
     """Parse `Aleph-EIP191-V1 key=val,key=val` into a dict.
 
-    Raises ValueError if the scheme is wrong, the params are missing, or any
-    pair is malformed (not key=value, or value is empty). Required keys
-    (`sig`, `payload`) are checked here to keep call sites simple. The
-    scheme name is compared case-insensitively per RFC 7235 §2.1.
+    Raises ValueError if the scheme is wrong, the params are missing or
+    malformed, the required keys (`sig`, `payload`) are absent, or any
+    unknown param is present. Rejecting unknowns keeps the auth contract
+    tight: the verifier promises to bind everything it accepts, so silently
+    ignoring extras would break that promise the moment a new param is added
+    without updating the verifier. The scheme name is compared
+    case-insensitively per RFC 7235 §2.1.
     """
     scheme, _, params_str = auth_header.partition(" ")
     if scheme.casefold() != ALEPH_EIP191_V1_SCHEME.casefold():
@@ -56,10 +62,14 @@ def _parse_auth_params(auth_header: str) -> dict[str, str]:
             raise ValueError(msg)
         params[key] = value
 
-    for required in ("sig", "payload"):
-        if required not in params:
-            msg = f"Missing required auth-param: {required!r}"
-            raise ValueError(msg)
+    missing = ALLOWED_AUTH_PARAMS - params.keys()
+    if missing:
+        msg = f"Missing required auth-param(s): {sorted(missing)}"
+        raise ValueError(msg)
+    unknown = params.keys() - ALLOWED_AUTH_PARAMS
+    if unknown:
+        msg = f"Unknown auth-param(s): {sorted(unknown)}"
+        raise ValueError(msg)
 
     return params
 

--- a/src/aleph/vm/orchestrator/views/allocation_auth.py
+++ b/src/aleph/vm/orchestrator/views/allocation_auth.py
@@ -8,6 +8,7 @@ auth, key rotation, etc.) without touching the views package's `__init__`.
 """
 
 import asyncio
+import functools
 import json
 import logging
 import time
@@ -257,7 +258,6 @@ def requires_allocation_auth(handler):
     `X-Auth-Signature` token. Apply BELOW any CORS decorator so OPTIONS
     preflights pass through unauthenticated.
     """
-    import functools
 
     @functools.wraps(handler)
     async def wrapper(request: web.Request) -> web.StreamResponse:

--- a/src/aleph/vm/orchestrator/views/allocation_auth.py
+++ b/src/aleph/vm/orchestrator/views/allocation_auth.py
@@ -23,6 +23,13 @@ logger = logging.getLogger(__name__)
 
 ALEPH_EIP191_V1_SCHEME = "Aleph-EIP191-V1"
 
+# Defense-in-depth cap on the size of a signed request body. aiohttp's
+# Application has a default `client_max_size` of 1 MiB, but the auth verifier
+# must not rely on it: an operator who raises that ceiling for unrelated
+# reasons would unknowingly expand the DoS surface here. Scheduler control
+# requests are short JSON; 1 MiB is plenty.
+MAX_SIGNED_REQUEST_BODY_BYTES = 1 * 1024 * 1024
+
 
 def _parse_auth_params(auth_header: str) -> dict[str, str]:
     """Parse `Aleph-EIP191-V1 key=val,key=val` into a dict.
@@ -95,6 +102,11 @@ async def _verify_aleph_signature(request: web.Request, auth_header: str) -> boo
     Returns True iff the signature is valid, recovers an authorized signer,
     binds the request, and beats the per-signer monotonic-iat floor. All
     failure modes return False (the dispatcher decides the response shape).
+
+    Side effect: calls `await request.read()`, which buffers the body into
+    aiohttp's request cache. Downstream handlers using `request.json()` or
+    `request.read()` get the same bytes; handlers streaming via
+    `request.content.iter_chunked()` would get an empty stream.
     """
     try:
         params = _parse_auth_params(auth_header)
@@ -127,6 +139,14 @@ async def _verify_aleph_signature(request: web.Request, auth_header: str) -> boo
         )
         authorized = {a.lower() for a in settings.AUTHORIZED_ALLOCATION_SIGNERS}
         if recovered.lower() not in authorized:
+            return False
+
+        # Bound body memory BEFORE reading — refuses to buffer an oversized
+        # body just to discover the hash doesn't match. Missing Content-Length
+        # (chunked encoding) is rejected: scheduler clients always send
+        # length-delimited JSON.
+        content_length = request.content_length
+        if content_length is None or content_length > MAX_SIGNED_REQUEST_BODY_BYTES:
             return False
 
         # Body hash binding.

--- a/src/aleph/vm/orchestrator/views/allocation_auth.py
+++ b/src/aleph/vm/orchestrator/views/allocation_auth.py
@@ -204,9 +204,9 @@ async def authenticate_api_request(request: web.Request) -> bool:
     The presence of an `Authorization` header (any value) is authoritative —
     a malformed/invalid signature is rejected, with no fallback to the
     legacy `X-Auth-Signature` path. The scheme name is matched
-    case-insensitively (RFC 7235 §2.1). Otherwise, the legacy token is
-    checked and a deprecation warning is logged so operators can spot
-    un-migrated scheduler clients.
+    case-insensitively (RFC 7235 §2.1). Deprecation of the legacy path is
+    surfaced once at supervisor boot via `log_allocation_auth_config`, not
+    per-request, to keep production logs readable.
     """
     auth = request.headers.get("Authorization", "")
     if auth:
@@ -215,13 +215,37 @@ async def authenticate_api_request(request: web.Request) -> bool:
             return False
         return await _verify_aleph_signature(request, auth)
     if "X-Auth-Signature" in request.headers:
-        logger.warning(
-            "Allocation auth: legacy token path used by %s for %s",
-            request.remote,
-            request.path,
-        )
         return _verify_legacy_token(request)
     return False
+
+
+def log_allocation_auth_config() -> None:
+    """Emit a one-shot warning at supervisor boot if the legacy token path is
+    the only auth method configured. Operators see the deprecation notice
+    exactly once per process lifetime — not flooded per-request."""
+    has_signers = bool(settings.AUTHORIZED_ALLOCATION_SIGNERS)
+    has_legacy = bool(settings.ALLOCATION_TOKEN_HASH)
+    if has_signers:
+        logger.info(
+            "Allocation auth: Aleph-EIP191-V1 enabled with %d authorized signer(s)",
+            len(settings.AUTHORIZED_ALLOCATION_SIGNERS),
+        )
+        if has_legacy:
+            logger.warning(
+                "Allocation auth: legacy X-Auth-Signature path is still enabled "
+                "(ALLOCATION_TOKEN_HASH is set). Remove it once all schedulers "
+                "have migrated to Aleph-EIP191-V1.",
+            )
+    elif has_legacy:
+        logger.warning(
+            "Allocation auth: only the legacy X-Auth-Signature path is configured. "
+            "Set AUTHORIZED_ALLOCATION_SIGNERS to enable Aleph-EIP191-V1 (recommended).",
+        )
+    else:
+        logger.warning(
+            "Allocation auth: no auth method configured — all scheduler "
+            "endpoints will reject requests with 401.",
+        )
 
 
 def requires_allocation_auth(handler):

--- a/src/aleph/vm/orchestrator/views/allocation_auth.py
+++ b/src/aleph/vm/orchestrator/views/allocation_auth.py
@@ -7,36 +7,171 @@ the verifier and the decorator so they can be evolved (signature-based
 auth, key rotation, etc.) without touching the views package's `__init__`.
 """
 
+import json
+import logging
+import time
 from hashlib import sha256
 
 from aiohttp import web
+from eth_account import Account
+from eth_account.messages import encode_defunct
 
 from aleph.vm.conf import settings
 
+logger = logging.getLogger(__name__)
 
-def authenticate_api_request(request: web.Request) -> bool:
-    """Authenticate an API request to update the VM allocations."""
+ALEPH_EIP191_V1_SCHEME = "Aleph-EIP191-V1"
+
+
+def _parse_auth_params(auth_header: str) -> dict[str, str]:
+    """Parse `Aleph-EIP191-V1 key=val,key=val` into a dict.
+
+    Raises ValueError if the scheme is wrong, the params are missing, or any
+    pair is malformed (not key=value, or value is empty). Required keys
+    (`sig`, `payload`) are checked here to keep call sites simple.
+    """
+    scheme, _, params_str = auth_header.partition(" ")
+    if scheme != ALEPH_EIP191_V1_SCHEME:
+        msg = f"Unsupported auth scheme: {scheme!r}"
+        raise ValueError(msg)
+    params_str = params_str.strip()
+    if not params_str:
+        msg = "Auth header has no parameters"
+        raise ValueError(msg)
+
+    params: dict[str, str] = {}
+    for pair in params_str.split(","):
+        key, sep, value = pair.strip().partition("=")
+        if not sep or not value:
+            msg = f"Malformed auth-param: {pair!r}"
+            raise ValueError(msg)
+        params[key] = value
+
+    for required in ("sig", "payload"):
+        if required not in params:
+            msg = f"Missing required auth-param: {required!r}"
+            raise ValueError(msg)
+
+    return params
+
+
+_last_accepted_iat: dict[str, int] = {}
+"""Per-signer floor on accepted `iat` values. Module-level state, in-memory
+only; doesn't survive supervisor restarts (the absolute time window covers
+the post-restart gap)."""
+
+PAYLOAD_REQUIRED_FIELDS = ("method", "path", "body_sha256", "iat")
+
+
+async def _verify_aleph_signature(request: web.Request, auth_header: str) -> bool:
+    """Verify a request bearing an `Authorization: Aleph-EIP191-V1 ...` header.
+
+    Returns True iff the signature is valid, recovers an authorized signer,
+    binds the request, and beats the per-signer monotonic-iat floor. All
+    failure modes return False (the dispatcher decides the response shape).
+    """
+    try:
+        params = _parse_auth_params(auth_header)
+        payload_bytes = bytes.fromhex(params["payload"].removeprefix("0x"))
+        payload = json.loads(payload_bytes)
+        for field in PAYLOAD_REQUIRED_FIELDS:
+            if field not in payload:
+                msg = f"Missing payload field: {field!r}"
+                raise ValueError(msg)
+
+        iat = payload["iat"]
+        if not isinstance(iat, int) or isinstance(iat, bool):
+            # bool is a subclass of int in Python — exclude explicitly.
+            msg = f"iat must be a JSON integer, got {type(iat).__name__}"
+            raise ValueError(msg)
+
+        # Cheap rejections first.
+        now = time.time()
+        max_age = settings.ALLOCATION_SIGNATURE_MAX_AGE_SECONDS
+        stale = abs(iat - now) > max_age
+        method_path_mismatch = payload["method"] != request.method or payload["path"] != request.path
+        if stale or method_path_mismatch:
+            return False
+
+        # Crypto: recover signer and check authorization.
+        sig_hex = params["sig"].removeprefix("0x")
+        recovered = Account.recover_message(
+            encode_defunct(payload_bytes),
+            signature=bytes.fromhex(sig_hex),
+        )
+        authorized = {a.lower() for a in settings.AUTHORIZED_ALLOCATION_SIGNERS}
+        if recovered.lower() not in authorized:
+            return False
+
+        # Body hash binding.
+        body = await request.read()
+        if sha256(body).hexdigest() != payload["body_sha256"]:
+            return False
+
+        # Monotonic-iat replay protection.
+        previous = _last_accepted_iat.get(recovered.lower(), float("-inf"))
+        if iat <= previous:
+            return False
+
+        _last_accepted_iat[recovered.lower()] = iat
+        return True
+    except Exception as exc:  # broad catch intentional — auth verifier MUST NOT raise
+        # Signature recovery, hex decoding, JSON parsing, and field type
+        # coercion all raise different exception types. For an auth verifier,
+        # "any unexpected input → reject" is the correct posture; raising
+        # would 500 the request instead of 401-ing it.
+        logger.debug("Aleph-EIP191-V1 verification failed: %s", exc)
+        return False
+
+
+def _verify_legacy_token(request: web.Request) -> bool:
+    """Authenticate via SHA-256(X-Auth-Signature) == ALLOCATION_TOKEN_HASH.
+
+    DEPRECATED: scheduled for removal once all schedulers have migrated to
+    Aleph-EIP191-V1. See AUTHORIZED_ALLOCATION_SIGNERS.
+    """
     signature: bytes = request.headers.get("X-Auth-Signature", "").encode()
-
     if not signature:
-        raise web.HTTPUnauthorized(text="Authentication token is missing")
-
-    # Use a simple authentication method: the hash of the signature should match the value in the settings
+        return False
     return sha256(signature).hexdigest() == settings.ALLOCATION_TOKEN_HASH
 
 
-def requires_allocation_auth(handler):
-    """Decorator: reject the request with 401 unless the X-Auth-Signature header matches.
+async def authenticate_api_request(request: web.Request) -> bool:
+    """Dispatch between Aleph-EIP191-V1 (new) and legacy X-Auth-Signature.
 
-    Wraps :func:`authenticate_api_request` so endpoints don't have to repeat the
-    three-line check. Apply BELOW any CORS decorator so OPTIONS preflights pass
-    through unauthenticated.
+    The presence of an `Authorization` header (any value) is authoritative —
+    a malformed/invalid signature is rejected, with no fallback to the
+    legacy `X-Auth-Signature` path. Otherwise, the legacy token is
+    checked and a deprecation warning is logged so operators can spot
+    un-migrated scheduler clients.
+    """
+    auth = request.headers.get("Authorization", "")
+    if auth:
+        if not auth.startswith(f"{ALEPH_EIP191_V1_SCHEME} "):
+            return False
+        return await _verify_aleph_signature(request, auth)
+    if "X-Auth-Signature" in request.headers:
+        logger.warning(
+            "Allocation auth: legacy token path used by %s for %s",
+            request.remote,
+            request.path,
+        )
+        return _verify_legacy_token(request)
+    return False
+
+
+def requires_allocation_auth(handler):
+    """Decorator: reject the request with 401 unless the auth check passes.
+
+    Accepts either `Authorization: Aleph-EIP191-V1 ...` or the legacy
+    `X-Auth-Signature` token. Apply BELOW any CORS decorator so OPTIONS
+    preflights pass through unauthenticated.
     """
     import functools
 
     @functools.wraps(handler)
     async def wrapper(request: web.Request) -> web.StreamResponse:
-        if not authenticate_api_request(request):
+        if not await authenticate_api_request(request):
             return web.HTTPUnauthorized(text="Authentication token received is invalid")
         return await handler(request)
 

--- a/src/aleph/vm/orchestrator/views/allocation_auth.py
+++ b/src/aleph/vm/orchestrator/views/allocation_auth.py
@@ -179,8 +179,10 @@ async def _verify_aleph_signature(request: web.Request, auth_header: str) -> boo
         # Signature recovery, hex decoding, JSON parsing, and field type
         # coercion all raise different exception types. For an auth verifier,
         # "any unexpected input → reject" is the correct posture; raising
-        # would 500 the request instead of 401-ing it.
-        logger.debug("Aleph-EIP191-V1 verification failed: %s", exc)
+        # would 500 the request instead of 401-ing it. Logged at WARNING so
+        # operators don't need to enable debug logging globally to triage a
+        # misconfigured scheduler.
+        logger.warning("Aleph-EIP191-V1 verification failed: %s", exc)
         return False
 
 

--- a/src/aleph/vm/orchestrator/views/allocation_auth.py
+++ b/src/aleph/vm/orchestrator/views/allocation_auth.py
@@ -7,6 +7,7 @@ the verifier and the decorator so they can be evolved (signature-based
 auth, key rotation, etc.) without touching the views package's `__init__`.
 """
 
+import asyncio
 import json
 import logging
 import time
@@ -58,9 +59,34 @@ def _parse_auth_params(auth_header: str) -> dict[str, str]:
 _last_accepted_iat: dict[str, int] = {}
 """Per-signer floor on accepted `iat` values. Module-level state, in-memory
 only; doesn't survive supervisor restarts (the absolute time window covers
-the post-restart gap)."""
+the post-restart gap). Single-process only: a multi-worker supervisor would
+let a captured request be replayed against a sibling worker."""
+
+_iat_lock: asyncio.Lock | None = None
+"""Serializes the read-check-write on `_last_accepted_iat`. Without this,
+two concurrent verifications for the same signer can both observe the old
+floor and both write, letting a same-iat replay slip through. Lazily
+initialized so module import doesn't require a running event loop."""
 
 PAYLOAD_REQUIRED_FIELDS = ("method", "path", "body_sha256", "iat")
+
+
+async def _accept_iat_if_fresh(signer_key: str, iat: int) -> bool:
+    """Atomically check `iat > last accepted for this signer` and update.
+
+    Returns True iff the iat strictly exceeds the floor and the floor was
+    advanced. The lock prevents two concurrent verifications for the same
+    signer from both observing the old floor and both succeeding.
+    """
+    global _iat_lock  # noqa: PLW0603 — lazy singleton; deferred to first call so import doesn't need a running loop
+    if _iat_lock is None:
+        _iat_lock = asyncio.Lock()
+    async with _iat_lock:
+        previous = _last_accepted_iat.get(signer_key, float("-inf"))
+        if iat <= previous:
+            return False
+        _last_accepted_iat[signer_key] = iat
+        return True
 
 
 async def _verify_aleph_signature(request: web.Request, auth_header: str) -> bool:
@@ -108,13 +134,11 @@ async def _verify_aleph_signature(request: web.Request, auth_header: str) -> boo
         if sha256(body).hexdigest() != payload["body_sha256"]:
             return False
 
-        # Monotonic-iat replay protection.
-        previous = _last_accepted_iat.get(recovered.lower(), float("-inf"))
-        if iat <= previous:
-            return False
-
-        _last_accepted_iat[recovered.lower()] = iat
-        return True
+        # Monotonic-iat replay protection. The check-and-update MUST be
+        # atomic; without it, two concurrent requests with the same signer
+        # can both succeed. Done last so we don't bump the floor for a
+        # request that would otherwise fail downstream.
+        return await _accept_iat_if_fresh(recovered.lower(), iat)
     except Exception as exc:  # broad catch intentional — auth verifier MUST NOT raise
         # Signature recovery, hex decoding, JSON parsing, and field type
         # coercion all raise different exception types. For an auth verifier,

--- a/src/aleph/vm/orchestrator/views/allocation_auth.py
+++ b/src/aleph/vm/orchestrator/views/allocation_auth.py
@@ -246,8 +246,7 @@ def log_allocation_auth_config() -> None:
         )
     else:
         logger.warning(
-            "Allocation auth: no auth method configured — all scheduler "
-            "endpoints will reject requests with 401.",
+            "Allocation auth: no auth method configured — all scheduler " "endpoints will reject requests with 401.",
         )
 
 

--- a/src/aleph/vm/orchestrator/views/allocation_auth.py
+++ b/src/aleph/vm/orchestrator/views/allocation_auth.py
@@ -36,10 +36,11 @@ def _parse_auth_params(auth_header: str) -> dict[str, str]:
 
     Raises ValueError if the scheme is wrong, the params are missing, or any
     pair is malformed (not key=value, or value is empty). Required keys
-    (`sig`, `payload`) are checked here to keep call sites simple.
+    (`sig`, `payload`) are checked here to keep call sites simple. The
+    scheme name is compared case-insensitively per RFC 7235 §2.1.
     """
     scheme, _, params_str = auth_header.partition(" ")
-    if scheme != ALEPH_EIP191_V1_SCHEME:
+    if scheme.casefold() != ALEPH_EIP191_V1_SCHEME.casefold():
         msg = f"Unsupported auth scheme: {scheme!r}"
         raise ValueError(msg)
     params_str = params_str.strip()
@@ -185,13 +186,15 @@ async def authenticate_api_request(request: web.Request) -> bool:
 
     The presence of an `Authorization` header (any value) is authoritative —
     a malformed/invalid signature is rejected, with no fallback to the
-    legacy `X-Auth-Signature` path. Otherwise, the legacy token is
+    legacy `X-Auth-Signature` path. The scheme name is matched
+    case-insensitively (RFC 7235 §2.1). Otherwise, the legacy token is
     checked and a deprecation warning is logged so operators can spot
     un-migrated scheduler clients.
     """
     auth = request.headers.get("Authorization", "")
     if auth:
-        if not auth.startswith(f"{ALEPH_EIP191_V1_SCHEME} "):
+        scheme, sep, _ = auth.partition(" ")
+        if not sep or scheme.casefold() != ALEPH_EIP191_V1_SCHEME.casefold():
             return False
         return await _verify_aleph_signature(request, auth)
     if "X-Auth-Signature" in request.headers:

--- a/src/aleph/vm/orchestrator/views/allocation_auth.py
+++ b/src/aleph/vm/orchestrator/views/allocation_auth.py
@@ -138,6 +138,8 @@ async def _verify_aleph_signature(request: web.Request, auth_header: str) -> boo
         now = time.time()
         max_age = settings.ALLOCATION_SIGNATURE_MAX_AGE_SECONDS
         stale = abs(iat - now) > max_age
+        # Path matching is exact: aiohttp routes `/foo` and `/foo/` distinctly,
+        # so signers must use the exact path the route will receive.
         method_path_mismatch = payload["method"] != request.method or payload["path"] != request.path
         # The signed payload binds method + path only — not the query string.
         # Rather than extend the wire format, forbid query strings on signed

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -1060,8 +1060,12 @@ async def test_allocation_aleph_eip191_v1_invalid_no_fallback(aiohttp_client, mo
 
 
 @pytest.mark.asyncio
-async def test_allocation_legacy_token_logs_deprecation_warning(aiohttp_client, monkeypatch, caplog):
-    """No Aleph-EIP191-V1 + valid legacy token → 200, warning logged."""
+async def test_allocation_legacy_token_no_per_request_log(aiohttp_client, monkeypatch, caplog):
+    """No Aleph-EIP191-V1 + valid legacy token → 200, no per-request log.
+
+    Deprecation surfaces once at boot via `log_allocation_auth_config`,
+    not on every request — busy schedulers would otherwise flood logs.
+    """
     monkeypatch.setattr(
         settings,
         "ALLOCATION_TOKEN_HASH",
@@ -1079,4 +1083,4 @@ async def test_allocation_legacy_token_logs_deprecation_warning(aiohttp_client, 
             headers={"X-Auth-Signature": "test"},
         )
     assert response.status == 200
-    assert any("legacy token path" in r.message for r in caplog.records)
+    assert not any("legacy" in r.message.lower() for r in caplog.records)

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -1,6 +1,9 @@
+import json
 import os
 import tempfile
+import time as time_module
 from copy import deepcopy
+from hashlib import sha256
 from pathlib import Path
 from unittest import mock
 from unittest.mock import call
@@ -8,6 +11,8 @@ from unittest.mock import call
 import pytest
 from aiohttp import web
 from aleph_message.models import InstanceContent
+from eth_account import Account
+from eth_account.messages import encode_defunct
 from pytest_mock import MockerFixture
 
 from aleph.vm.conf import settings
@@ -337,7 +342,7 @@ async def test_allocation_missing_auth_token(aiohttp_client):
         json={"persistent_vms": []},
     )
     assert response.status == 401
-    assert await response.json() == {"error": "Authentication token is missing"}
+    assert await response.json() == {"error": "Authentication token received is invalid"}
 
 
 @pytest.mark.asyncio
@@ -903,7 +908,7 @@ async def test_regenerate_proxy_missing_auth_token(aiohttp_client):
     client = await aiohttp_client(app)
     response: web.Response = await client.post("/control/proxy/regenerate")
     assert response.status == 401
-    assert await response.json() == {"error": "Authentication token is missing"}
+    assert await response.json() == {"error": "Authentication token received is invalid"}
 
 
 @pytest.mark.asyncio
@@ -981,3 +986,97 @@ async def test_regenerate_proxy_exception(aiohttp_client, mocker, mock_app_with_
     assert response.status == 500
     resp = await response.json()
     assert resp == {"success": False, "error": "Failed to regenerate HAProxy configuration: HAProxy connection failed"}
+
+
+class _FakeVmPool:
+    def get_persistent_executions(self):
+        return []
+
+
+def _make_aleph_eip191_v1_header(account, *, method="POST", path="/control/allocations", body=b"", iat=None) -> str:
+    payload = {
+        "method": method,
+        "path": path,
+        "body_sha256": sha256(body).hexdigest(),
+        "iat": iat if iat is not None else int(time_module.time()),
+    }
+    payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    signed = account.sign_message(encode_defunct(payload_bytes))
+    return f"Aleph-EIP191-V1 sig={signed.signature.hex()},payload={payload_bytes.hex()}"
+
+
+@pytest.fixture(autouse=True)
+def _reset_iat_cache_between_views_tests():
+    from aleph.vm.orchestrator.views.allocation_auth import _last_accepted_iat
+
+    _last_accepted_iat.clear()
+    yield
+    _last_accepted_iat.clear()
+
+
+@pytest.mark.asyncio
+async def test_allocation_aleph_eip191_v1_valid(aiohttp_client, monkeypatch):
+    """Valid Aleph-EIP191-V1 signature → 200 (mirrors test_allocation_valid_token)."""
+    account = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [account.address])
+
+    body_dict: dict[str, list[str]] = {"persistent_vms": []}
+    body_bytes = json.dumps(body_dict).encode()
+    auth = _make_aleph_eip191_v1_header(account, body=body_bytes)
+
+    app = setup_webapp(pool=_FakeVmPool())
+    app["pubsub"] = None
+    client = await aiohttp_client(app)
+
+    response = await client.post(
+        "/control/allocations",
+        data=body_bytes,
+        headers={"Authorization": auth, "Content-Type": "application/json"},
+    )
+    assert response.status == 200
+
+
+@pytest.mark.asyncio
+async def test_allocation_aleph_eip191_v1_invalid_no_fallback(aiohttp_client, monkeypatch):
+    """Garbage Aleph-EIP191-V1 + valid legacy token → 401 (no fallback)."""
+    monkeypatch.setattr(
+        settings,
+        "ALLOCATION_TOKEN_HASH",
+        sha256(b"test").hexdigest(),
+    )
+
+    app = setup_webapp(pool=_FakeVmPool())
+    app["pubsub"] = None
+    client = await aiohttp_client(app)
+    response = await client.post(
+        "/control/allocations",
+        json={"persistent_vms": []},
+        headers={
+            "Authorization": "Aleph-EIP191-V1 sig=0xdead,payload=0xbeef",
+            "X-Auth-Signature": "test",  # would be valid via legacy
+        },
+    )
+    assert response.status == 401
+
+
+@pytest.mark.asyncio
+async def test_allocation_legacy_token_logs_deprecation_warning(aiohttp_client, monkeypatch, caplog):
+    """No Aleph-EIP191-V1 + valid legacy token → 200, warning logged."""
+    monkeypatch.setattr(
+        settings,
+        "ALLOCATION_TOKEN_HASH",
+        sha256(b"test").hexdigest(),
+    )
+
+    app = setup_webapp(pool=_FakeVmPool())
+    app["pubsub"] = None
+    client = await aiohttp_client(app)
+
+    with caplog.at_level("WARNING"):
+        response = await client.post(
+            "/control/allocations",
+            json={"persistent_vms": []},
+            headers={"X-Auth-Signature": "test"},
+        )
+    assert response.status == 200
+    assert any("legacy token path" in r.message for r in caplog.records)

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -1,0 +1,469 @@
+"""Unit tests for src/aleph/vm/orchestrator/views/allocation_auth.py."""
+
+import json
+import time as time_module
+from hashlib import sha256
+
+import pytest
+from eth_account import Account
+from eth_account.messages import encode_defunct
+from pydantic import ValidationError
+
+from aleph.vm.conf import Settings, settings
+
+
+def test_authorized_signers_default_empty():
+    """By default, no signers are authorized — the new path is effectively disabled."""
+    assert settings.AUTHORIZED_ALLOCATION_SIGNERS == []
+
+
+def test_signature_max_age_default():
+    """Default time window is 5 minutes (300 seconds)."""
+    assert settings.ALLOCATION_SIGNATURE_MAX_AGE_SECONDS == 300
+
+
+def test_invalid_signer_address_rejected():
+    """Non-hex-address entries fail validation."""
+    with pytest.raises(ValidationError):
+        Settings(AUTHORIZED_ALLOCATION_SIGNERS=["not-an-address"])
+
+
+def test_non_checksum_signer_address_rejected():
+    """Lowercase / non-checksummed addresses fail validation (catches typos early)."""
+    # Valid hex but not in EIP-55 mixed case.
+    with pytest.raises(ValidationError):
+        Settings(AUTHORIZED_ALLOCATION_SIGNERS=["0xdac17f958d2ee523a2206206994597c13d831ec7"])
+
+
+def test_checksummed_signer_address_accepted():
+    """Properly checksummed addresses pass."""
+    settings_inst = Settings(AUTHORIZED_ALLOCATION_SIGNERS=["0xdAC17F958D2ee523a2206206994597C13D831ec7"])
+    assert settings_inst.AUTHORIZED_ALLOCATION_SIGNERS == ["0xdAC17F958D2ee523a2206206994597C13D831ec7"]
+
+
+@pytest.fixture
+def signing_account():
+    """Generate a fresh ETH account for signing test requests."""
+    return Account.create()
+
+
+@pytest.fixture
+def authorize_signer(signing_account, monkeypatch):
+    """Add the signing account to AUTHORIZED_ALLOCATION_SIGNERS for the test."""
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [signing_account.address])
+    return signing_account
+
+
+@pytest.fixture(autouse=True)
+def reset_iat_cache():
+    """Clear the monotonic-iat dict between tests (added in Task 5)."""
+    # Imported lazily because the symbol doesn't exist until Task 5.
+    try:
+        from aleph.vm.orchestrator.views.allocation_auth import _last_accepted_iat
+
+        _last_accepted_iat.clear()
+        yield
+        _last_accepted_iat.clear()
+    except ImportError:
+        yield
+
+
+def make_signed_payload(*, method="POST", path="/control/allocations", body=b"", iat=None) -> bytes:
+    """Build the canonical JSON bytes that get signed."""
+    payload = {
+        "method": method,
+        "path": path,
+        "body_sha256": sha256(body).hexdigest(),
+        "iat": iat if iat is not None else int(time_module.time()),
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+def make_auth_header(account, payload_bytes: bytes) -> str:
+    """Sign payload_bytes with `account` and produce the full Authorization value."""
+    signed = account.sign_message(encode_defunct(payload_bytes))
+    return f"Aleph-EIP191-V1 sig={signed.signature.hex()},payload={payload_bytes.hex()}"
+
+
+@pytest.fixture
+def mock_request(mocker):
+    """Build a minimal fake aiohttp request supporting `await request.read()`."""
+
+    def factory(*, method="POST", path="/control/allocations", headers=None, body=b""):
+        request = mocker.Mock()
+        request.method = method
+        request.path = path
+        request.headers = headers or {}
+        request.read = mocker.AsyncMock(return_value=body)
+        request.remote = "127.0.0.1"
+        return request
+
+    return factory
+
+
+def test_parse_auth_params_valid():
+    from aleph.vm.orchestrator.views.allocation_auth import _parse_auth_params
+
+    params = _parse_auth_params("Aleph-EIP191-V1 sig=0xdead,payload=0xbeef")
+    assert params == {"sig": "0xdead", "payload": "0xbeef"}
+
+
+def test_parse_auth_params_extra_whitespace_tolerated():
+    from aleph.vm.orchestrator.views.allocation_auth import _parse_auth_params
+
+    params = _parse_auth_params("Aleph-EIP191-V1   sig=0xdead, payload=0xbeef")
+    assert params == {"sig": "0xdead", "payload": "0xbeef"}
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Aleph-EIP191-V1",  # no params
+        "Aleph-EIP191-V1 sig=0xdead",  # missing payload
+        "Aleph-EIP191-V1 payload=0xbeef",  # missing sig
+        "Aleph-EIP191-V1 sigonly",  # not a key=value pair
+        "Aleph-EIP191-V1 sig=,payload=0xbeef",  # empty value
+        "Bearer abc",  # wrong scheme
+    ],
+)
+def test_parse_auth_params_malformed(header):
+    from aleph.vm.orchestrator.views.allocation_auth import _parse_auth_params
+
+    with pytest.raises(ValueError):
+        _parse_auth_params(header)
+
+
+@pytest.mark.asyncio
+async def test_verify_aleph_signature_valid_request(mock_request, authorize_signer):
+    from aleph.vm.orchestrator.views.allocation_auth import (
+        _last_accepted_iat,
+        _verify_aleph_signature,
+    )
+
+    payload_bytes = make_signed_payload(method="POST", path="/control/allocations", body=b"{}")
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(
+        method="POST",
+        path="/control/allocations",
+        headers={"Authorization": auth},
+        body=b"{}",
+    )
+
+    assert await _verify_aleph_signature(request, auth) is True
+    assert authorize_signer.address.lower() in {k.lower() for k in _last_accepted_iat}
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_non_integer_iat(mock_request, authorize_signer):
+    """A signed payload with a non-integer iat (e.g., float or string) is rejected."""
+    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
+
+    # Hand-craft a payload with a string iat — must be signed with the same bytes
+    # to bypass earlier checks and reach the type guard.
+    bad_payload = json.dumps(
+        {
+            "method": "POST",
+            "path": "/control/allocations",
+            "body_sha256": sha256(b"{}").hexdigest(),
+            "iat": "1700000000",
+        },  # ← string, not int
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    auth = make_auth_header(authorize_signer, bad_payload)
+    request = mock_request(
+        method="POST",
+        path="/control/allocations",
+        headers={"Authorization": auth},
+        body=b"{}",
+    )
+
+    assert await _verify_aleph_signature(request, auth) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_boolean_iat(mock_request, authorize_signer):
+    """A boolean iat (which is technically int subclass) is rejected too."""
+    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
+
+    bad_payload = json.dumps(
+        {
+            "method": "POST",
+            "path": "/control/allocations",
+            "body_sha256": sha256(b"{}").hexdigest(),
+            "iat": True,
+        },  # ← boolean
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    auth = make_auth_header(authorize_signer, bad_payload)
+    request = mock_request(
+        method="POST",
+        path="/control/allocations",
+        headers={"Authorization": auth},
+        body=b"{}",
+    )
+
+    assert await _verify_aleph_signature(request, auth) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_stale_iat(mock_request, authorize_signer):
+    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
+
+    stale = int(time_module.time()) - 600  # 10 minutes ago, default window is 5
+    payload_bytes = make_signed_payload(body=b"{}", iat=stale)
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+
+    assert await _verify_aleph_signature(request, auth) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_far_future_iat(mock_request, authorize_signer):
+    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
+
+    future = int(time_module.time()) + 600
+    payload_bytes = make_signed_payload(body=b"{}", iat=future)
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+
+    assert await _verify_aleph_signature(request, auth) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_method_mismatch(mock_request, authorize_signer):
+    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
+
+    payload_bytes = make_signed_payload(method="POST", path="/control/allocations", body=b"{}")
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    # Request says GET but payload is signed for POST.
+    request = mock_request(method="GET", path="/control/allocations", headers={"Authorization": auth}, body=b"{}")
+
+    assert await _verify_aleph_signature(request, auth) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_path_mismatch(mock_request, authorize_signer):
+    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
+
+    payload_bytes = make_signed_payload(method="POST", path="/control/allocations", body=b"{}")
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(method="POST", path="/control/migrate", headers={"Authorization": auth}, body=b"{}")
+
+    assert await _verify_aleph_signature(request, auth) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_unauthorized_signer(mock_request, monkeypatch):
+    """Signer not in the authorized list is rejected."""
+    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
+
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
+    rogue = Account.create()
+    payload_bytes = make_signed_payload(body=b"{}")
+    auth = make_auth_header(rogue, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+
+    assert await _verify_aleph_signature(request, auth) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_tampered_payload(mock_request, authorize_signer):
+    """If the payload bytes are altered after signing, recovery yields a
+    different address that isn't authorized."""
+    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
+
+    payload_bytes = make_signed_payload(body=b"{}")
+    signed = authorize_signer.sign_message(encode_defunct(payload_bytes))
+    # Tamper with payload after signing — flip one byte of iat.
+    tampered = json.loads(payload_bytes)
+    tampered["iat"] = tampered["iat"] + 1
+    tampered_bytes = json.dumps(tampered, sort_keys=True, separators=(",", ":")).encode()
+
+    auth = f"Aleph-EIP191-V1 sig={signed.signature.hex()},payload={tampered_bytes.hex()}"
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+
+    assert await _verify_aleph_signature(request, auth) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_body_mismatch(mock_request, authorize_signer):
+    """Signed body_sha256 doesn't match the actual body bytes → reject."""
+    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
+
+    # Signer signs for body=b"original".
+    payload_bytes = make_signed_payload(body=b"original")
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    # Request actually carries a different body.
+    request = mock_request(headers={"Authorization": auth}, body=b"tampered")
+
+    assert await _verify_aleph_signature(request, auth) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_replay(mock_request, authorize_signer):
+    """Replaying a captured request (same iat) is rejected by monotonic-iat."""
+    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
+
+    payload_bytes = make_signed_payload(body=b"{}")
+    auth = make_auth_header(authorize_signer, payload_bytes)
+
+    request1 = mock_request(headers={"Authorization": auth}, body=b"{}")
+    request2 = mock_request(headers={"Authorization": auth}, body=b"{}")
+
+    assert await _verify_aleph_signature(request1, auth) is True
+    assert await _verify_aleph_signature(request2, auth) is False  # same iat
+
+
+@pytest.mark.asyncio
+async def test_verify_accepts_strictly_increasing_iat(mock_request, authorize_signer):
+    """A subsequent request with a strictly greater iat is accepted."""
+    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
+
+    iat1 = int(time_module.time())
+    payload1 = make_signed_payload(body=b"{}", iat=iat1)
+    auth1 = make_auth_header(authorize_signer, payload1)
+
+    payload2 = make_signed_payload(body=b"{}", iat=iat1 + 1)
+    auth2 = make_auth_header(authorize_signer, payload2)
+
+    assert await _verify_aleph_signature(mock_request(headers={"Authorization": auth1}, body=b"{}"), auth1) is True
+    assert await _verify_aleph_signature(mock_request(headers={"Authorization": auth2}, body=b"{}"), auth2) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth",
+    [
+        "Aleph-EIP191-V1 sig=notHex,payload=0xbeef",  # invalid hex in sig
+        "Aleph-EIP191-V1 sig=0xdead,payload=notHex",  # invalid hex in payload
+        "Aleph-EIP191-V1 sig=0xdead,payload=0xbeef",  # payload not JSON
+    ],
+)
+async def test_verify_rejects_malformed_header(mock_request, authorize_signer, auth):  # noqa: ARG001 (authorize_signer is a fixture)
+    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
+
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+    assert await _verify_aleph_signature(request, auth) is False
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_routes_to_signature_path(mock_request, authorize_signer, mocker):
+    from aleph.vm.orchestrator.views import allocation_auth
+
+    payload_bytes = make_signed_payload(body=b"{}")
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+
+    spy = mocker.spy(allocation_auth, "_verify_aleph_signature")
+    assert await allocation_auth.authenticate_api_request(request) is True
+    spy.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_invalid_signature_does_not_fall_back(mock_request, mocker):
+    """Garbage Aleph-EIP191-V1 + valid X-Auth-Signature → reject. The signature
+    path is authoritative once chosen."""
+    from aleph.vm.orchestrator.views import allocation_auth
+
+    request = mock_request(
+        headers={
+            "Authorization": "Aleph-EIP191-V1 sig=0xdead,payload=0xbeef",
+            "X-Auth-Signature": "test",  # would be valid via the legacy path
+        },
+        body=b"{}",
+    )
+    spy_legacy = mocker.spy(allocation_auth, "_verify_legacy_token")
+    assert await allocation_auth.authenticate_api_request(request) is False
+    spy_legacy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_falls_back_to_legacy_with_warning(mock_request, caplog, monkeypatch):
+    """No Aleph-EIP191-V1, valid legacy token → accept + warning logged."""
+    from aleph.vm.orchestrator.views import allocation_auth
+
+    monkeypatch.setattr(
+        settings,
+        "ALLOCATION_TOKEN_HASH",
+        sha256(b"test").hexdigest(),
+    )
+    request = mock_request(headers={"X-Auth-Signature": "test"}, body=b"{}")
+
+    with caplog.at_level("WARNING"):
+        assert await allocation_auth.authenticate_api_request(request) is True
+    assert any("legacy token path" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_no_auth_headers(mock_request):
+    from aleph.vm.orchestrator.views import allocation_auth
+
+    request = mock_request(headers={}, body=b"{}")
+    assert await allocation_auth.authenticate_api_request(request) is False
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_empty_legacy_token_returns_false(mock_request, monkeypatch):
+    """X-Auth-Signature: '' (header present but empty) → False, not a raise.
+
+    Otherwise the response message would differ from other rejections,
+    leaking dispatch-path info.
+    """
+    from aleph.vm.orchestrator.views import allocation_auth
+
+    monkeypatch.setattr(
+        settings,
+        "ALLOCATION_TOKEN_HASH",
+        sha256(b"test").hexdigest(),
+    )
+    request = mock_request(headers={"X-Auth-Signature": ""}, body=b"{}")
+    assert await allocation_auth.authenticate_api_request(request) is False
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_unknown_scheme_does_not_fall_back(mock_request, mocker, monkeypatch):
+    """Authorization with an unknown scheme + valid legacy → reject. The
+    Authorization header's mere presence is authoritative."""
+    from aleph.vm.orchestrator.views import allocation_auth
+
+    monkeypatch.setattr(
+        settings,
+        "ALLOCATION_TOKEN_HASH",
+        sha256(b"test").hexdigest(),
+    )
+    request = mock_request(
+        headers={
+            "Authorization": "Bearer abc",
+            "X-Auth-Signature": "test",  # would be valid via legacy
+        },
+        body=b"{}",
+    )
+    spy_legacy = mocker.spy(allocation_auth, "_verify_legacy_token")
+    assert await allocation_auth.authenticate_api_request(request) is False
+    spy_legacy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_eip191_scheme_without_params_does_not_fall_back(mock_request, mocker, monkeypatch):
+    """Authorization: 'Aleph-EIP191-V1' (no trailing space, no params)
+    + valid legacy → reject. Misconfigured client must not be rescued
+    by legacy fallback."""
+    from aleph.vm.orchestrator.views import allocation_auth
+
+    monkeypatch.setattr(
+        settings,
+        "ALLOCATION_TOKEN_HASH",
+        sha256(b"test").hexdigest(),
+    )
+    request = mock_request(
+        headers={
+            "Authorization": "Aleph-EIP191-V1",  # missing the params
+            "X-Auth-Signature": "test",
+        },
+        body=b"{}",
+    )
+    spy_legacy = mocker.spy(allocation_auth, "_verify_legacy_token")
+    assert await allocation_auth.authenticate_api_request(request) is False
+    spy_legacy.assert_not_called()

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -558,3 +558,30 @@ async def test_verify_accepts_request_with_empty_query_string(mock_request, auth
     request.query_string = ""
 
     assert await _verify_aleph_signature(request, auth) is True
+
+
+# --- H3: unknown auth-params rejected ---
+
+
+def test_parse_auth_params_rejects_unknown_param():
+    """`Aleph-EIP191-V1 sig=…,payload=…,extra=poison` is rejected.
+
+    The verifier promises to bind everything it accepts. Silently ignoring
+    extras would break that promise the day a new param is added without
+    updating the verifier."""
+    with pytest.raises(ValueError, match="Unknown auth-param"):
+        _parse_auth_params("Aleph-EIP191-V1 sig=0xdead,payload=0xbeef,extra=0xc0ffee")
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_unknown_auth_param(mock_request, authorize_signer):
+    """End-to-end: an extra auth-param yields a 401 even with a valid sig+payload."""
+    payload_bytes = make_signed_payload(body=b"{}")
+    signed = authorize_signer.sign_message(encode_defunct(payload_bytes))
+    auth = (
+        f"Aleph-EIP191-V1 sig={signed.signature.hex()},"
+        f"payload={payload_bytes.hex()},extra=poison"
+    )
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+
+    assert await _verify_aleph_signature(request, auth) is False

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -1,5 +1,6 @@
 """Unit tests for src/aleph/vm/orchestrator/views/allocation_auth.py."""
 
+import asyncio
 import json
 import time as time_module
 from hashlib import sha256
@@ -418,3 +419,41 @@ async def test_dispatcher_eip191_scheme_without_params_does_not_fall_back(mock_r
     spy_legacy = mocker.spy(allocation_auth, "_verify_legacy_token")
     assert await allocation_auth.authenticate_api_request(request) is False
     spy_legacy.assert_not_called()
+
+
+# --- C1: concurrent iat check+update must not race ---
+
+
+@pytest.mark.asyncio
+async def test_verify_concurrent_same_iat_rejects_one(authorize_signer, mocker):
+    """Two concurrent verifications with the same captured signed payload:
+    exactly one must succeed. Without the asyncio.Lock around the iat
+    check+update, both observe the old floor and both write — a same-iat
+    replay slips through.
+
+    Forces an interleave by making `request.read()` yield control.
+    """
+    payload_bytes = make_signed_payload(body=b"{}")
+    auth = make_auth_header(authorize_signer, payload_bytes)
+
+    async def slow_read():
+        # Yield, then return body — guarantees both tasks reach the await
+        # point before either completes, so the post-await iat critical
+        # section is what serializes them.
+        await asyncio.sleep(0)
+        return b"{}"
+
+    def make_req():
+        request = mocker.Mock()
+        request.method = "POST"
+        request.path = "/control/allocations"
+        request.headers = {"Authorization": auth}
+        request.read = slow_read
+        request.remote = "127.0.0.1"
+        return request
+
+    results = await asyncio.gather(
+        _verify_aleph_signature(make_req(), auth),
+        _verify_aleph_signature(make_req(), auth),
+    )
+    assert sum(results) == 1, f"Exactly one of two same-iat verifications must succeed, got {results}"

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -594,10 +594,7 @@ async def test_verify_rejects_unknown_auth_param(mock_request, authorize_signer)
     """End-to-end: an extra auth-param yields a 401 even with a valid sig+payload."""
     payload_bytes = make_signed_payload(body=b"{}")
     signed = authorize_signer.sign_message(encode_defunct(payload_bytes))
-    auth = (
-        f"Aleph-EIP191-V1 sig={signed.signature.hex()},"
-        f"payload={payload_bytes.hex()},extra=poison"
-    )
+    auth = f"Aleph-EIP191-V1 sig={signed.signature.hex()}," f"payload={payload_bytes.hex()},extra=poison"
     request = mock_request(headers={"Authorization": auth}, body=b"{}")
 
     assert await _verify_aleph_signature(request, auth) is False
@@ -623,9 +620,7 @@ async def test_verify_failure_logs_at_warning(mock_request, caplog):
 
 def test_log_allocation_auth_config_signature_path_only(caplog, monkeypatch):
     """Signers configured, legacy hash cleared → INFO summary, no warning."""
-    monkeypatch.setattr(
-        settings, "AUTHORIZED_ALLOCATION_SIGNERS", ["0xdAC17F958D2ee523a2206206994597C13D831ec7"]
-    )
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", ["0xdAC17F958D2ee523a2206206994597C13D831ec7"])
     monkeypatch.setattr(settings, "ALLOCATION_TOKEN_HASH", "")
 
     with caplog.at_level("INFO", logger="aleph.vm.orchestrator.views.allocation_auth"):
@@ -637,9 +632,7 @@ def test_log_allocation_auth_config_signature_path_only(caplog, monkeypatch):
 
 def test_log_allocation_auth_config_both_enabled_warns(caplog, monkeypatch):
     """Signers + legacy hash → both messages, including a warning to remove legacy."""
-    monkeypatch.setattr(
-        settings, "AUTHORIZED_ALLOCATION_SIGNERS", ["0xdAC17F958D2ee523a2206206994597C13D831ec7"]
-    )
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", ["0xdAC17F958D2ee523a2206206994597C13D831ec7"])
     monkeypatch.setattr(settings, "ALLOCATION_TOKEN_HASH", sha256(b"test").hexdigest())
 
     with caplog.at_level("INFO", logger="aleph.vm.orchestrator.views.allocation_auth"):
@@ -655,10 +648,7 @@ def test_log_allocation_auth_config_legacy_only_warns(caplog, monkeypatch):
 
     with caplog.at_level("WARNING", logger="aleph.vm.orchestrator.views.allocation_auth"):
         log_allocation_auth_config()
-    assert any(
-        "only the legacy X-Auth-Signature path is configured" in r.message
-        for r in caplog.records
-    )
+    assert any("only the legacy X-Auth-Signature path is configured" in r.message for r in caplog.records)
 
 
 def test_log_allocation_auth_config_nothing_configured_warns(caplog, monkeypatch):
@@ -751,9 +741,7 @@ async def test_verify_per_signer_iat_floors_are_independent(mock_request, monkey
     """
     signer_a = Account.create()
     signer_b = Account.create()
-    monkeypatch.setattr(
-        settings, "AUTHORIZED_ALLOCATION_SIGNERS", [signer_a.address, signer_b.address]
-    )
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [signer_a.address, signer_b.address])
 
     now = int(time_module.time())
 

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -10,6 +10,12 @@ from eth_account.messages import encode_defunct
 from pydantic import ValidationError
 
 from aleph.vm.conf import Settings, settings
+from aleph.vm.orchestrator.views import allocation_auth
+from aleph.vm.orchestrator.views.allocation_auth import (
+    _last_accepted_iat,
+    _parse_auth_params,
+    _verify_aleph_signature,
+)
 
 
 def test_authorized_signers_default_empty():
@@ -56,16 +62,10 @@ def authorize_signer(signing_account, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def reset_iat_cache():
-    """Clear the monotonic-iat dict between tests (added in Task 5)."""
-    # Imported lazily because the symbol doesn't exist until Task 5.
-    try:
-        from aleph.vm.orchestrator.views.allocation_auth import _last_accepted_iat
-
-        _last_accepted_iat.clear()
-        yield
-        _last_accepted_iat.clear()
-    except ImportError:
-        yield
+    """Clear the monotonic-iat dict between tests for isolation."""
+    _last_accepted_iat.clear()
+    yield
+    _last_accepted_iat.clear()
 
 
 def make_signed_payload(*, method="POST", path="/control/allocations", body=b"", iat=None) -> bytes:
@@ -102,15 +102,11 @@ def mock_request(mocker):
 
 
 def test_parse_auth_params_valid():
-    from aleph.vm.orchestrator.views.allocation_auth import _parse_auth_params
-
     params = _parse_auth_params("Aleph-EIP191-V1 sig=0xdead,payload=0xbeef")
     assert params == {"sig": "0xdead", "payload": "0xbeef"}
 
 
 def test_parse_auth_params_extra_whitespace_tolerated():
-    from aleph.vm.orchestrator.views.allocation_auth import _parse_auth_params
-
     params = _parse_auth_params("Aleph-EIP191-V1   sig=0xdead, payload=0xbeef")
     assert params == {"sig": "0xdead", "payload": "0xbeef"}
 
@@ -127,19 +123,12 @@ def test_parse_auth_params_extra_whitespace_tolerated():
     ],
 )
 def test_parse_auth_params_malformed(header):
-    from aleph.vm.orchestrator.views.allocation_auth import _parse_auth_params
-
     with pytest.raises(ValueError):
         _parse_auth_params(header)
 
 
 @pytest.mark.asyncio
 async def test_verify_aleph_signature_valid_request(mock_request, authorize_signer):
-    from aleph.vm.orchestrator.views.allocation_auth import (
-        _last_accepted_iat,
-        _verify_aleph_signature,
-    )
-
     payload_bytes = make_signed_payload(method="POST", path="/control/allocations", body=b"{}")
     auth = make_auth_header(authorize_signer, payload_bytes)
     request = mock_request(
@@ -156,8 +145,6 @@ async def test_verify_aleph_signature_valid_request(mock_request, authorize_sign
 @pytest.mark.asyncio
 async def test_verify_rejects_non_integer_iat(mock_request, authorize_signer):
     """A signed payload with a non-integer iat (e.g., float or string) is rejected."""
-    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
-
     # Hand-craft a payload with a string iat — must be signed with the same bytes
     # to bypass earlier checks and reach the type guard.
     bad_payload = json.dumps(
@@ -184,8 +171,6 @@ async def test_verify_rejects_non_integer_iat(mock_request, authorize_signer):
 @pytest.mark.asyncio
 async def test_verify_rejects_boolean_iat(mock_request, authorize_signer):
     """A boolean iat (which is technically int subclass) is rejected too."""
-    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
-
     bad_payload = json.dumps(
         {
             "method": "POST",
@@ -209,8 +194,6 @@ async def test_verify_rejects_boolean_iat(mock_request, authorize_signer):
 
 @pytest.mark.asyncio
 async def test_verify_rejects_stale_iat(mock_request, authorize_signer):
-    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
-
     stale = int(time_module.time()) - 600  # 10 minutes ago, default window is 5
     payload_bytes = make_signed_payload(body=b"{}", iat=stale)
     auth = make_auth_header(authorize_signer, payload_bytes)
@@ -221,8 +204,6 @@ async def test_verify_rejects_stale_iat(mock_request, authorize_signer):
 
 @pytest.mark.asyncio
 async def test_verify_rejects_far_future_iat(mock_request, authorize_signer):
-    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
-
     future = int(time_module.time()) + 600
     payload_bytes = make_signed_payload(body=b"{}", iat=future)
     auth = make_auth_header(authorize_signer, payload_bytes)
@@ -233,8 +214,6 @@ async def test_verify_rejects_far_future_iat(mock_request, authorize_signer):
 
 @pytest.mark.asyncio
 async def test_verify_rejects_method_mismatch(mock_request, authorize_signer):
-    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
-
     payload_bytes = make_signed_payload(method="POST", path="/control/allocations", body=b"{}")
     auth = make_auth_header(authorize_signer, payload_bytes)
     # Request says GET but payload is signed for POST.
@@ -245,8 +224,6 @@ async def test_verify_rejects_method_mismatch(mock_request, authorize_signer):
 
 @pytest.mark.asyncio
 async def test_verify_rejects_path_mismatch(mock_request, authorize_signer):
-    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
-
     payload_bytes = make_signed_payload(method="POST", path="/control/allocations", body=b"{}")
     auth = make_auth_header(authorize_signer, payload_bytes)
     request = mock_request(method="POST", path="/control/migrate", headers={"Authorization": auth}, body=b"{}")
@@ -257,8 +234,6 @@ async def test_verify_rejects_path_mismatch(mock_request, authorize_signer):
 @pytest.mark.asyncio
 async def test_verify_rejects_unauthorized_signer(mock_request, monkeypatch):
     """Signer not in the authorized list is rejected."""
-    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
-
     monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
     rogue = Account.create()
     payload_bytes = make_signed_payload(body=b"{}")
@@ -272,8 +247,6 @@ async def test_verify_rejects_unauthorized_signer(mock_request, monkeypatch):
 async def test_verify_rejects_tampered_payload(mock_request, authorize_signer):
     """If the payload bytes are altered after signing, recovery yields a
     different address that isn't authorized."""
-    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
-
     payload_bytes = make_signed_payload(body=b"{}")
     signed = authorize_signer.sign_message(encode_defunct(payload_bytes))
     # Tamper with payload after signing — flip one byte of iat.
@@ -290,8 +263,6 @@ async def test_verify_rejects_tampered_payload(mock_request, authorize_signer):
 @pytest.mark.asyncio
 async def test_verify_rejects_body_mismatch(mock_request, authorize_signer):
     """Signed body_sha256 doesn't match the actual body bytes → reject."""
-    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
-
     # Signer signs for body=b"original".
     payload_bytes = make_signed_payload(body=b"original")
     auth = make_auth_header(authorize_signer, payload_bytes)
@@ -304,8 +275,6 @@ async def test_verify_rejects_body_mismatch(mock_request, authorize_signer):
 @pytest.mark.asyncio
 async def test_verify_rejects_replay(mock_request, authorize_signer):
     """Replaying a captured request (same iat) is rejected by monotonic-iat."""
-    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
-
     payload_bytes = make_signed_payload(body=b"{}")
     auth = make_auth_header(authorize_signer, payload_bytes)
 
@@ -319,8 +288,6 @@ async def test_verify_rejects_replay(mock_request, authorize_signer):
 @pytest.mark.asyncio
 async def test_verify_accepts_strictly_increasing_iat(mock_request, authorize_signer):
     """A subsequent request with a strictly greater iat is accepted."""
-    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
-
     iat1 = int(time_module.time())
     payload1 = make_signed_payload(body=b"{}", iat=iat1)
     auth1 = make_auth_header(authorize_signer, payload1)
@@ -342,16 +309,12 @@ async def test_verify_accepts_strictly_increasing_iat(mock_request, authorize_si
     ],
 )
 async def test_verify_rejects_malformed_header(mock_request, authorize_signer, auth):  # noqa: ARG001 (authorize_signer is a fixture)
-    from aleph.vm.orchestrator.views.allocation_auth import _verify_aleph_signature
-
     request = mock_request(headers={"Authorization": auth}, body=b"{}")
     assert await _verify_aleph_signature(request, auth) is False
 
 
 @pytest.mark.asyncio
 async def test_dispatcher_routes_to_signature_path(mock_request, authorize_signer, mocker):
-    from aleph.vm.orchestrator.views import allocation_auth
-
     payload_bytes = make_signed_payload(body=b"{}")
     auth = make_auth_header(authorize_signer, payload_bytes)
     request = mock_request(headers={"Authorization": auth}, body=b"{}")
@@ -365,8 +328,6 @@ async def test_dispatcher_routes_to_signature_path(mock_request, authorize_signe
 async def test_dispatcher_invalid_signature_does_not_fall_back(mock_request, mocker):
     """Garbage Aleph-EIP191-V1 + valid X-Auth-Signature → reject. The signature
     path is authoritative once chosen."""
-    from aleph.vm.orchestrator.views import allocation_auth
-
     request = mock_request(
         headers={
             "Authorization": "Aleph-EIP191-V1 sig=0xdead,payload=0xbeef",
@@ -382,8 +343,6 @@ async def test_dispatcher_invalid_signature_does_not_fall_back(mock_request, moc
 @pytest.mark.asyncio
 async def test_dispatcher_falls_back_to_legacy_with_warning(mock_request, caplog, monkeypatch):
     """No Aleph-EIP191-V1, valid legacy token → accept + warning logged."""
-    from aleph.vm.orchestrator.views import allocation_auth
-
     monkeypatch.setattr(
         settings,
         "ALLOCATION_TOKEN_HASH",
@@ -398,8 +357,6 @@ async def test_dispatcher_falls_back_to_legacy_with_warning(mock_request, caplog
 
 @pytest.mark.asyncio
 async def test_dispatcher_no_auth_headers(mock_request):
-    from aleph.vm.orchestrator.views import allocation_auth
-
     request = mock_request(headers={}, body=b"{}")
     assert await allocation_auth.authenticate_api_request(request) is False
 
@@ -411,8 +368,6 @@ async def test_dispatcher_empty_legacy_token_returns_false(mock_request, monkeyp
     Otherwise the response message would differ from other rejections,
     leaking dispatch-path info.
     """
-    from aleph.vm.orchestrator.views import allocation_auth
-
     monkeypatch.setattr(
         settings,
         "ALLOCATION_TOKEN_HASH",
@@ -426,8 +381,6 @@ async def test_dispatcher_empty_legacy_token_returns_false(mock_request, monkeyp
 async def test_dispatcher_unknown_scheme_does_not_fall_back(mock_request, mocker, monkeypatch):
     """Authorization with an unknown scheme + valid legacy → reject. The
     Authorization header's mere presence is authoritative."""
-    from aleph.vm.orchestrator.views import allocation_auth
-
     monkeypatch.setattr(
         settings,
         "ALLOCATION_TOKEN_HASH",
@@ -450,8 +403,6 @@ async def test_dispatcher_eip191_scheme_without_params_does_not_fall_back(mock_r
     """Authorization: 'Aleph-EIP191-V1' (no trailing space, no params)
     + valid legacy → reject. Misconfigured client must not be rescued
     by legacy fallback."""
-    from aleph.vm.orchestrator.views import allocation_auth
-
     monkeypatch.setattr(
         settings,
         "ALLOCATION_TOKEN_HASH",

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 from aleph.vm.conf import Settings, settings
 from aleph.vm.orchestrator.views import allocation_auth
 from aleph.vm.orchestrator.views.allocation_auth import (
+    MAX_SIGNED_REQUEST_BODY_BYTES,
     _last_accepted_iat,
     _parse_auth_params,
     _verify_aleph_signature,
@@ -90,12 +91,15 @@ def make_auth_header(account, payload_bytes: bytes) -> str:
 def mock_request(mocker):
     """Build a minimal fake aiohttp request supporting `await request.read()`."""
 
-    def factory(*, method="POST", path="/control/allocations", headers=None, body=b""):
+    def factory(*, method="POST", path="/control/allocations", headers=None, body=b"", content_length=None):
         request = mocker.Mock()
         request.method = method
         request.path = path
         request.headers = headers or {}
         request.read = mocker.AsyncMock(return_value=body)
+        # Match aiohttp's behavior: Content-Length defaults to body length
+        # unless the caller wants to exercise the cap or chunked-encoding paths.
+        request.content_length = content_length if content_length is not None else len(body)
         request.remote = "127.0.0.1"
         return request
 
@@ -448,6 +452,7 @@ async def test_verify_concurrent_same_iat_rejects_one(authorize_signer, mocker):
         request.method = "POST"
         request.path = "/control/allocations"
         request.headers = {"Authorization": auth}
+        request.content_length = len(b"{}")
         request.read = slow_read
         request.remote = "127.0.0.1"
         return request
@@ -457,3 +462,38 @@ async def test_verify_concurrent_same_iat_rejects_one(authorize_signer, mocker):
         _verify_aleph_signature(make_req(), auth),
     )
     assert sum(results) == 1, f"Exactly one of two same-iat verifications must succeed, got {results}"
+
+
+# --- C2: body size cap ---
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_oversized_body(mock_request, authorize_signer):
+    """Content-Length over the cap → reject without reading the body."""
+    payload_bytes = make_signed_payload(body=b"{}")
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(
+        headers={"Authorization": auth},
+        body=b"{}",
+        content_length=MAX_SIGNED_REQUEST_BODY_BYTES + 1,
+    )
+
+    assert await _verify_aleph_signature(request, auth) is False
+    # Body must not be read once the cap rejects.
+    request.read.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_missing_content_length(mock_request, authorize_signer):
+    """Content-Length is None (chunked encoding) → reject. Scheduler clients
+    always send length-delimited JSON; chunked uploads here are suspicious."""
+    payload_bytes = make_signed_payload(body=b"{}")
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(
+        headers={"Authorization": auth},
+        body=b"{}",
+    )
+    request.content_length = None  # explicit None overrides the auto-set length
+
+    assert await _verify_aleph_signature(request, auth) is False
+    request.read.assert_not_called()

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import time as time_module
+import types
 from hashlib import sha256
 
 import pytest
@@ -86,6 +87,16 @@ def make_auth_header(account, payload_bytes: bytes) -> str:
     """Sign payload_bytes with `account` and produce the full Authorization value."""
     signed = account.sign_message(encode_defunct(payload_bytes))
     return f"Aleph-EIP191-V1 sig={signed.signature.hex()},payload={payload_bytes.hex()}"
+
+
+def _freeze_time(monkeypatch, fixed_now: float) -> None:
+    """Pin `allocation_auth.time.time()` to `fixed_now` for this test.
+
+    Swaps just the local `time` reference inside allocation_auth's namespace
+    — the real `time` module stays untouched, so pytest's own timing and
+    other modules' `time.time()` calls are unaffected.
+    """
+    monkeypatch.setattr(allocation_auth, "time", types.SimpleNamespace(time=lambda: fixed_now))
 
 
 @pytest.fixture
@@ -658,3 +669,70 @@ def test_log_allocation_auth_config_nothing_configured_warns(caplog, monkeypatch
     with caplog.at_level("WARNING", logger="aleph.vm.orchestrator.views.allocation_auth"):
         log_allocation_auth_config()
     assert any("no auth method configured" in r.message for r in caplog.records)
+
+
+# --- M3: iat window boundary behavior ---
+
+
+@pytest.mark.asyncio
+async def test_verify_iat_equal_to_now_accepted(monkeypatch, mock_request, authorize_signer):
+    """iat == now (delta 0) → accepted. Sanity baseline."""
+    fixed_now = 1_700_000_000.0
+    _freeze_time(monkeypatch, fixed_now)
+    payload_bytes = make_signed_payload(body=b"{}", iat=int(fixed_now))
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+    assert await _verify_aleph_signature(request, auth) is True
+
+
+@pytest.mark.asyncio
+async def test_verify_iat_at_lower_boundary_accepted(monkeypatch, mock_request, authorize_signer):
+    """iat == now - max_age (exactly at the edge) → accepted.
+
+    Pins down that the comparison is `abs(...) > max_age` (strict), not
+    `>=`. A future maintainer flipping this would silently shrink the
+    window by 1 second and break clients that sign with their own clock.
+    """
+    fixed_now = 1_700_000_000.0
+    _freeze_time(monkeypatch, fixed_now)
+    iat = int(fixed_now) - settings.ALLOCATION_SIGNATURE_MAX_AGE_SECONDS
+    payload_bytes = make_signed_payload(body=b"{}", iat=iat)
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+    assert await _verify_aleph_signature(request, auth) is True
+
+
+@pytest.mark.asyncio
+async def test_verify_iat_just_past_lower_boundary_rejected(monkeypatch, mock_request, authorize_signer):
+    """iat == now - max_age - 1 → rejected (one second over the edge)."""
+    fixed_now = 1_700_000_000.0
+    _freeze_time(monkeypatch, fixed_now)
+    iat = int(fixed_now) - settings.ALLOCATION_SIGNATURE_MAX_AGE_SECONDS - 1
+    payload_bytes = make_signed_payload(body=b"{}", iat=iat)
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+    assert await _verify_aleph_signature(request, auth) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_iat_at_upper_boundary_accepted(monkeypatch, mock_request, authorize_signer):
+    """iat == now + max_age (clock-skew on the far side) → accepted."""
+    fixed_now = 1_700_000_000.0
+    _freeze_time(monkeypatch, fixed_now)
+    iat = int(fixed_now) + settings.ALLOCATION_SIGNATURE_MAX_AGE_SECONDS
+    payload_bytes = make_signed_payload(body=b"{}", iat=iat)
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+    assert await _verify_aleph_signature(request, auth) is True
+
+
+@pytest.mark.asyncio
+async def test_verify_iat_just_past_upper_boundary_rejected(monkeypatch, mock_request, authorize_signer):
+    """iat == now + max_age + 1 → rejected."""
+    fixed_now = 1_700_000_000.0
+    _freeze_time(monkeypatch, fixed_now)
+    iat = int(fixed_now) + settings.ALLOCATION_SIGNATURE_MAX_AGE_SECONDS + 1
+    payload_bytes = make_signed_payload(body=b"{}", iat=iat)
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+    assert await _verify_aleph_signature(request, auth) is False

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -585,3 +585,18 @@ async def test_verify_rejects_unknown_auth_param(mock_request, authorize_signer)
     request = mock_request(headers={"Authorization": auth}, body=b"{}")
 
     assert await _verify_aleph_signature(request, auth) is False
+
+
+# --- M1: verification failures log at WARNING ---
+
+
+@pytest.mark.asyncio
+async def test_verify_failure_logs_at_warning(mock_request, caplog):
+    """A failed verification emits a WARNING (not DEBUG) so operators
+    triaging a misconfigured scheduler don't need debug logging globally."""
+    auth = "Aleph-EIP191-V1 sig=notHex,payload=0xbeef"
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+
+    with caplog.at_level("WARNING", logger="aleph.vm.orchestrator.views.allocation_auth"):
+        assert await _verify_aleph_signature(request, auth) is False
+    assert any("Aleph-EIP191-V1 verification failed" in r.message for r in caplog.records)

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -497,3 +497,28 @@ async def test_verify_rejects_missing_content_length(mock_request, authorize_sig
 
     assert await _verify_aleph_signature(request, auth) is False
     request.read.assert_not_called()
+
+
+# --- H1: scheme name is case-insensitive (RFC 7235 §2.1) ---
+
+
+def test_parse_auth_params_lowercase_scheme_accepted():
+    """Lowercase scheme `aleph-eip191-v1` must parse — auth-scheme tokens
+    are case-insensitive per RFC 7235."""
+    params = _parse_auth_params("aleph-eip191-v1 sig=0xdead,payload=0xbeef")
+    assert params == {"sig": "0xdead", "payload": "0xbeef"}
+
+
+def test_parse_auth_params_uppercase_scheme_accepted():
+    params = _parse_auth_params("ALEPH-EIP191-V1 sig=0xdead,payload=0xbeef")
+    assert params == {"sig": "0xdead", "payload": "0xbeef"}
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_accepts_lowercase_scheme(mock_request, authorize_signer):
+    """End-to-end: a client lowercasing the scheme is accepted."""
+    payload_bytes = make_signed_payload(body=b"{}")
+    signed = authorize_signer.sign_message(encode_defunct(payload_bytes))
+    auth = f"aleph-eip191-v1 sig={signed.signature.hex()},payload={payload_bytes.hex()}"
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+    assert await allocation_auth.authenticate_api_request(request) is True

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -100,6 +100,8 @@ def mock_request(mocker):
         # Match aiohttp's behavior: Content-Length defaults to body length
         # unless the caller wants to exercise the cap or chunked-encoding paths.
         request.content_length = content_length if content_length is not None else len(body)
+        # No query string by default; tests covering H2 override this.
+        request.query_string = ""
         request.remote = "127.0.0.1"
         return request
 
@@ -453,6 +455,7 @@ async def test_verify_concurrent_same_iat_rejects_one(authorize_signer, mocker):
         request.path = "/control/allocations"
         request.headers = {"Authorization": auth}
         request.content_length = len(b"{}")
+        request.query_string = ""
         request.read = slow_read
         request.remote = "127.0.0.1"
         return request
@@ -522,3 +525,36 @@ async def test_dispatcher_accepts_lowercase_scheme(mock_request, authorize_signe
     auth = f"aleph-eip191-v1 sig={signed.signature.hex()},payload={payload_bytes.hex()}"
     request = mock_request(headers={"Authorization": auth}, body=b"{}")
     assert await allocation_auth.authenticate_api_request(request) is True
+
+
+# --- H2: query strings are forbidden on signed endpoints ---
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_request_with_query_string(mock_request, authorize_signer):
+    """A request whose URL carries a query string is rejected.
+
+    Rationale: the signed payload binds method + path but not the query
+    string. Rather than extend the wire format, signed endpoints forbid
+    query strings entirely. A scheduler that accidentally appends one
+    must be told via 401 rather than silently authenticate with an
+    unbinding query in play.
+    """
+    payload_bytes = make_signed_payload(body=b"{}")
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+    # Simulate aiohttp's `query_string` attribute.
+    request.query_string = "foo=bar"
+
+    assert await _verify_aleph_signature(request, auth) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_accepts_request_with_empty_query_string(mock_request, authorize_signer):
+    """An empty query string (the common case) does not block verification."""
+    payload_bytes = make_signed_payload(body=b"{}")
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+    request.query_string = ""
+
+    assert await _verify_aleph_signature(request, auth) is True

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -17,6 +17,7 @@ from aleph.vm.orchestrator.views.allocation_auth import (
     _last_accepted_iat,
     _parse_auth_params,
     _verify_aleph_signature,
+    log_allocation_auth_config,
 )
 
 
@@ -348,8 +349,12 @@ async def test_dispatcher_invalid_signature_does_not_fall_back(mock_request, moc
 
 
 @pytest.mark.asyncio
-async def test_dispatcher_falls_back_to_legacy_with_warning(mock_request, caplog, monkeypatch):
-    """No Aleph-EIP191-V1, valid legacy token → accept + warning logged."""
+async def test_dispatcher_falls_back_to_legacy_silently(mock_request, caplog, monkeypatch):
+    """No Aleph-EIP191-V1, valid legacy token → accept WITHOUT per-request log.
+
+    The deprecation notice is emitted once at boot via
+    `log_allocation_auth_config`; logging on every request would flood logs.
+    """
     monkeypatch.setattr(
         settings,
         "ALLOCATION_TOKEN_HASH",
@@ -359,7 +364,7 @@ async def test_dispatcher_falls_back_to_legacy_with_warning(mock_request, caplog
 
     with caplog.at_level("WARNING"):
         assert await allocation_auth.authenticate_api_request(request) is True
-    assert any("legacy token path" in r.message for r in caplog.records)
+    assert not any("legacy" in r.message.lower() for r in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -600,3 +605,56 @@ async def test_verify_failure_logs_at_warning(mock_request, caplog):
     with caplog.at_level("WARNING", logger="aleph.vm.orchestrator.views.allocation_auth"):
         assert await _verify_aleph_signature(request, auth) is False
     assert any("Aleph-EIP191-V1 verification failed" in r.message for r in caplog.records)
+
+
+# --- M2: boot-time auth-config summary ---
+
+
+def test_log_allocation_auth_config_signature_path_only(caplog, monkeypatch):
+    """Signers configured, legacy hash cleared → INFO summary, no warning."""
+    monkeypatch.setattr(
+        settings, "AUTHORIZED_ALLOCATION_SIGNERS", ["0xdAC17F958D2ee523a2206206994597C13D831ec7"]
+    )
+    monkeypatch.setattr(settings, "ALLOCATION_TOKEN_HASH", "")
+
+    with caplog.at_level("INFO", logger="aleph.vm.orchestrator.views.allocation_auth"):
+        log_allocation_auth_config()
+    assert any("Aleph-EIP191-V1 enabled" in r.message for r in caplog.records)
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert not any("legacy" in r.message.lower() for r in warnings)
+
+
+def test_log_allocation_auth_config_both_enabled_warns(caplog, monkeypatch):
+    """Signers + legacy hash → both messages, including a warning to remove legacy."""
+    monkeypatch.setattr(
+        settings, "AUTHORIZED_ALLOCATION_SIGNERS", ["0xdAC17F958D2ee523a2206206994597C13D831ec7"]
+    )
+    monkeypatch.setattr(settings, "ALLOCATION_TOKEN_HASH", sha256(b"test").hexdigest())
+
+    with caplog.at_level("INFO", logger="aleph.vm.orchestrator.views.allocation_auth"):
+        log_allocation_auth_config()
+    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert any("legacy X-Auth-Signature path is still enabled" in m for m in warnings)
+
+
+def test_log_allocation_auth_config_legacy_only_warns(caplog, monkeypatch):
+    """No signers, legacy hash only → warning prompts operator to migrate."""
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
+    monkeypatch.setattr(settings, "ALLOCATION_TOKEN_HASH", sha256(b"test").hexdigest())
+
+    with caplog.at_level("WARNING", logger="aleph.vm.orchestrator.views.allocation_auth"):
+        log_allocation_auth_config()
+    assert any(
+        "only the legacy X-Auth-Signature path is configured" in r.message
+        for r in caplog.records
+    )
+
+
+def test_log_allocation_auth_config_nothing_configured_warns(caplog, monkeypatch):
+    """No signers and no legacy hash → warning that all scheduler calls will 401."""
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
+    monkeypatch.setattr(settings, "ALLOCATION_TOKEN_HASH", "")
+
+    with caplog.at_level("WARNING", logger="aleph.vm.orchestrator.views.allocation_auth"):
+        log_allocation_auth_config()
+    assert any("no auth method configured" in r.message for r in caplog.records)

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -736,3 +736,42 @@ async def test_verify_iat_just_past_upper_boundary_rejected(monkeypatch, mock_re
     auth = make_auth_header(authorize_signer, payload_bytes)
     request = mock_request(headers={"Authorization": auth}, body=b"{}")
     assert await _verify_aleph_signature(request, auth) is False
+
+
+# --- M4: per-signer monotonic iat (no cross-signer interference) ---
+
+
+@pytest.mark.asyncio
+async def test_verify_per_signer_iat_floors_are_independent(mock_request, monkeypatch):
+    """Two authorized signers maintain independent iat floors.
+
+    A future "optimization" using a single global counter would silently
+    break cross-signer interleaving; this test pins down the per-key dict
+    semantics so that regression is caught.
+    """
+    signer_a = Account.create()
+    signer_b = Account.create()
+    monkeypatch.setattr(
+        settings, "AUTHORIZED_ALLOCATION_SIGNERS", [signer_a.address, signer_b.address]
+    )
+
+    now = int(time_module.time())
+
+    # Signer A: iat=N → succeeds; A's floor advances to N.
+    payload_a = make_signed_payload(body=b"{}", iat=now)
+    auth_a = make_auth_header(signer_a, payload_a)
+    request_a = mock_request(headers={"Authorization": auth_a}, body=b"{}")
+    assert await _verify_aleph_signature(request_a, auth_a) is True
+
+    # Signer B: iat=N-1 → still succeeds. B has its own floor; A's doesn't apply.
+    payload_b = make_signed_payload(body=b"{}", iat=now - 1)
+    auth_b = make_auth_header(signer_b, payload_b)
+    request_b = mock_request(headers={"Authorization": auth_b}, body=b"{}")
+    assert await _verify_aleph_signature(request_b, auth_b) is True
+
+    # Signer A: iat=N-1 → rejected. Below A's own floor (N) — replay for A
+    # even though B just accepted the same iat.
+    payload_a2 = make_signed_payload(body=b"{}", iat=now - 1)
+    auth_a2 = make_auth_header(signer_a, payload_a2)
+    request_a2 = mock_request(headers={"Authorization": auth_a2}, body=b"{}")
+    assert await _verify_aleph_signature(request_a2, auth_a2) is False

--- a/tests/supervisor/views/test_migration.py
+++ b/tests/supervisor/views/test_migration.py
@@ -41,6 +41,7 @@ def mock_scheduler_auth(mocker):
     """
     mocker.patch(
         "aleph.vm.orchestrator.views.allocation_auth.authenticate_api_request",
+        new_callable=AsyncMock,
         return_value=True,
     )
 
@@ -95,6 +96,7 @@ class TestMigrationExportEndpoint:
         """Test that unauthorized requests are rejected."""
         mocker.patch(
             "aleph.vm.orchestrator.views.allocation_auth.authenticate_api_request",
+            new_callable=AsyncMock,
             return_value=False,
         )
         pool = mocker.Mock(executions={})
@@ -316,6 +318,7 @@ class TestMigrationImportEndpoint:
         """Test that unauthorized requests are rejected."""
         mocker.patch(
             "aleph.vm.orchestrator.views.allocation_auth.authenticate_api_request",
+            new_callable=AsyncMock,
             return_value=False,
         )
         pool = mocker.Mock(executions={})
@@ -593,6 +596,7 @@ class TestMigrationCleanupEndpoint:
         """Test that unauthorized requests are rejected."""
         mocker.patch(
             "aleph.vm.orchestrator.views.allocation_auth.authenticate_api_request",
+            new_callable=AsyncMock,
             return_value=False,
         )
         pool = mocker.Mock(executions={})


### PR DESCRIPTION
## Summary

Adds a per-signer EIP-191 signature path (`Authorization: Aleph-EIP191-V1 sig=...,payload=...`) to the 8 scheduler-only endpoints, alongside the legacy `X-Auth-Signature` shared token. Both paths run during rollout; the legacy path logs a deprecation warning so operators can spot un-migrated scheduler clients.

Stacks on PR #942 (allocation auth helpers extraction, already merged).

## Why

Today every CRN holds the same shared token. A single compromised CRN can spoof the scheduler against every other CRN. The new scheme has CRNs hold only public values (an explicit list of authorized signer addresses), and binds each request via signature recovery + monotonic-iat replay protection.

## What's in this PR (supervisor side)

- New settings: `AUTHORIZED_ALLOCATION_SIGNERS`, `ALLOCATION_SIGNATURE_MAX_AGE_SECONDS`. Address checksum validation at startup.
- `_verify_aleph_signature` in `allocation_auth.py`, with method/path/body binding, ±5min absolute time window, and a per-signer `_last_accepted_iat` floor.
- `authenticate_api_request` rewritten as an async dispatcher; presence of the new header disables the legacy fallback (no spoofing the migration).
- 30+ unit tests + 3 integration tests on `update_allocations`.

## What's NOT in this PR

- Scheduler-side signing client. Tracked in a separate change in the scheduler repo.
- Removal of the legacy path. Phase 3, separate change.

## Test plan

- [x] Unit tests for the verifier (parser, time window, method/path, signer authorization, body hash, replay, malformed headers, tampered payload).
- [x] Dispatcher tests (route to signature path, no fallback on bad sig, fallback to legacy with warning, empty legacy token returns False).
- [x] Integration tests on `update_allocations` for all three branches.
- [x] Existing `test_migration.py` tests still pass.
- [x] Existing `test_allocation_*` / `test_regenerate_proxy_*_token` tests still pass.