### PR TITLE
fix: resolve amends by owner (content.address), not signer

### DIFF
--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -170,8 +170,11 @@ async def get_latest_amend(item_hash: str) -> str:
     msg = await _fetch_aleph_message(item_hash)
     if not msg:
         return item_hash
-    sender = msg["sender"]
-    url = f"{settings.API_SERVER}/api/v0/messages.json?msgType=STORE&sort_order=-1&refs={item_hash}&addresses={sender}"
+    # Match amends by owner (`content.address`), not signer (`sender`), so
+    # delegated publishers (sender ≠ content.address, authorised via the
+    # owner's security aggregate) can still update the original.
+    owner = msg["content"]["address"]
+    url = f"{settings.API_SERVER}/api/v0/messages.json?msgType=STORE&sort_order=-1&refs={item_hash}&owners={owner}"
     async with aiohttp.ClientSession() as session:
         resp = await session.get(url)
         resp.raise_for_status()
@@ -180,7 +183,7 @@ async def get_latest_amend(item_hash: str) -> str:
         if messages:
             latest = messages[0]
             latest_content = latest.get("content", {})
-            if latest.get("sender") == sender and latest_content.get("ref") == item_hash:
+            if latest_content.get("address") == owner and latest_content.get("ref") == item_hash:
                 return latest["item_hash"]
     return item_hash
 

--- a/tests/supervisor/test_storage.py
+++ b/tests/supervisor/test_storage.py
@@ -1,0 +1,127 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aleph.vm.storage import get_latest_amend
+
+ORIGINAL_HASH = "a" * 64
+AMEND_HASH = "b" * 64
+OWNER = "0xOWNER"
+DELEGATE = "0xDELEGATE"
+OTHER_OWNER = "0xOTHER"
+
+
+def _make_response(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json = AsyncMock(return_value=payload)
+    return response
+
+
+def _build_session_mock(responses: list[dict], captured_urls: list[str] | None = None) -> MagicMock:
+    """Return a mock aiohttp.ClientSession that yields the given JSON responses in order."""
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+
+    response_iter = iter([_make_response(p) for p in responses])
+
+    def _get(url: str):
+        if captured_urls is not None:
+            captured_urls.append(url)
+        return next(response_iter)
+
+    session.get = AsyncMock(side_effect=_get)
+    return session
+
+
+def _original_message(*, sender: str, owner: str) -> dict:
+    return {
+        "messages": [
+            {
+                "item_hash": ORIGINAL_HASH,
+                "sender": sender,
+                "content": {"address": owner},
+            }
+        ]
+    }
+
+
+def _amend_message(*, item_hash: str, sender: str, owner: str, ref: str) -> dict:
+    return {
+        "item_hash": item_hash,
+        "sender": sender,
+        "content": {"address": owner, "ref": ref},
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_latest_amend_returns_original_when_no_amend_exists():
+    """No follow-up STORE → return the original hash."""
+    session = _build_session_mock(
+        [
+            _original_message(sender=OWNER, owner=OWNER),
+            {"messages": []},
+        ]
+    )
+
+    with patch("aleph.vm.storage.aiohttp.ClientSession", return_value=session):
+        result = await get_latest_amend(ORIGINAL_HASH)
+
+    assert result == ORIGINAL_HASH
+
+
+@pytest.mark.asyncio
+async def test_get_latest_amend_accepts_delegated_signer():
+    """Original signed by owner, amend signed by a delegate but with matching content.address — accept."""
+    session = _build_session_mock(
+        [
+            _original_message(sender=OWNER, owner=OWNER),
+            {"messages": [_amend_message(item_hash=AMEND_HASH, sender=DELEGATE, owner=OWNER, ref=ORIGINAL_HASH)]},
+        ]
+    )
+
+    with patch("aleph.vm.storage.aiohttp.ClientSession", return_value=session):
+        result = await get_latest_amend(ORIGINAL_HASH)
+
+    assert result == AMEND_HASH
+
+
+@pytest.mark.asyncio
+async def test_get_latest_amend_rejects_mismatched_owner():
+    """Amend's content.address differs from the original's owner — reject."""
+    session = _build_session_mock(
+        [
+            _original_message(sender=OWNER, owner=OWNER),
+            {
+                "messages": [
+                    _amend_message(item_hash=AMEND_HASH, sender=OTHER_OWNER, owner=OTHER_OWNER, ref=ORIGINAL_HASH)
+                ]
+            },
+        ]
+    )
+
+    with patch("aleph.vm.storage.aiohttp.ClientSession", return_value=session):
+        result = await get_latest_amend(ORIGINAL_HASH)
+
+    assert result == ORIGINAL_HASH
+
+
+@pytest.mark.asyncio
+async def test_get_latest_amend_queries_by_owner_not_sender():
+    """The amend lookup must filter via `owners=<content.address>`, not `addresses=<sender>`."""
+    captured_urls: list[str] = []
+    session = _build_session_mock(
+        [
+            _original_message(sender=DELEGATE, owner=OWNER),
+            {"messages": []},
+        ],
+        captured_urls=captured_urls,
+    )
+
+    with patch("aleph.vm.storage.aiohttp.ClientSession", return_value=session):
+        await get_latest_amend(ORIGINAL_HASH)
+
+    amend_lookup_url = captured_urls[1]
+    assert f"owners={OWNER}" in amend_lookup_url
+    assert "addresses=" not in amend_lookup_url

--- a/vm_connector/main.py
+++ b/vm_connector/main.py
@@ -24,9 +24,9 @@ def read_root():
     return {"Server": "Aleph.im VM Connector"}
 
 
-async def get_latest_message_amend(ref: str, sender: str) -> dict | None:
+async def get_latest_message_amend(ref: str, owner: str) -> dict | None:
     async with aiohttp.ClientSession() as session:
-        url = f"{settings.API_SERVER}/api/v0/messages.json?msgType=STORE&sort_order=-1&refs={ref}&addresses={sender}"
+        url = f"{settings.API_SERVER}/api/v0/messages.json?msgType=STORE&sort_order=-1&refs={ref}&owners={owner}"
         resp = await session.get(url)
         resp.raise_for_status()
         resp_data = await resp.json()
@@ -134,11 +134,11 @@ async def compute_latest_amend(item_hash: str) -> str:
     msg = await get_message(hash_=item_hash)
     if not msg:
         raise HTTPException(status_code=404, detail="Hash not found")
-    sender = msg["sender"]
-    latest_amend = await get_latest_message_amend(ref=item_hash, sender=sender)
+    owner = msg["content"]["address"]
+    latest_amend = await get_latest_message_amend(ref=item_hash, owner=owner)
     if latest_amend:
         # Validation
-        assert latest_amend["sender"] == sender
+        assert latest_amend["content"]["address"] == owner
         assert latest_amend["content"]["ref"] == item_hash
 
         return latest_amend["item_hash"]


### PR DESCRIPTION
## Summary

The amend lookup that drives `use_latest` volume resolution was filtering candidate STORE messages by envelope `sender`, which silently rejects valid updates published via delegated signing.

- `get_latest_amend` in `src/aleph/vm/storage.py` (supervisor path) queried `?addresses={sender}` and re-checked `latest.sender == sender`.
- `get_latest_message_amend` / `compute_latest_amend` in `vm_connector/main.py` did the same (plus an `assert latest_amend["sender"] == sender`).

When an owner authorises a delegate via their `security` aggregate, follow-up amends have `sender = delegate` and `content.address = owner`. The CCN accepts those at write time, but our lookup was filtering them out because `sender` no longer matches the original.

This PR switches both call sites to:
- Use pyaleph's `owners=` query param (which filters on `MessageDb.owner` = `content.address` — see `pyaleph/src/aleph/db/accessors/messages.py:114`).
- Re-validate `latest.content.address == owner` client-side.

The check now mirrors the CCN's own permission model: trust whatever sender the CCN accepted for that owner, since the security-aggregate check has already been applied at message-acceptance time.

## Test plan

- [x] New `tests/supervisor/test_storage.py` covers `get_latest_amend`:
  - returns original hash when no amend exists
  - accepts an amend signed by a delegate (sender ≠ content.address) as long as `content.address` matches
  - rejects an amend whose `content.address` differs from the owner
  - asserts the lookup URL uses `owners=` (not `addresses=`)
- [x] `tests/supervisor/test_status.py` still passes (no regressions in neighbouring tests).
- [x] `ruff check` / `ruff format` clean on changed files (pre-existing warnings unchanged).
- [ ] Deploy on a node and confirm a delegated amend on a `use_latest=True` volume now resolves to the latest hash.