### PR TITLE
ci: release diagnostic VM code volume via amend STORE

### DIFF
--- a/.github/workflows/release-diagnostic-vm-code-volume.yml
+++ b/.github/workflows/release-diagnostic-vm-code-volume.yml
@@ -1,0 +1,127 @@
+---
+name: "Release Diagnostic VM Code Volume"
+
+on:
+  push:
+    tags:
+      - "diagnostic-vm/v*.*.*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build and sign but do not submit the STORE message"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: "Amend the diagnostic VM code volume"
+    runs-on: ubuntu-22.04
+    environment: vms
+    env:
+      ALEPH_PRIVATE_KEY: ${{ secrets.ALEPH_DIAGNOSTIC_VM_SIGNER_KEY }}
+      OWNER: ${{ vars.DIAGNOSTIC_VM_OWNER }}
+      PROGRAM_HASH: ${{ vars.DIAGNOSTIC_VM_PROGRAM_HASH }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Sanity-check inputs
+        run: |
+          : "${OWNER:?DIAGNOSTIC_VM_OWNER is not set as a repository/environment variable}"
+          : "${PROGRAM_HASH:?DIAGNOSTIC_VM_PROGRAM_HASH is not set as a repository/environment variable}"
+          if [ -z "${ALEPH_PRIVATE_KEY:-}" ]; then
+            echo "::error::ALEPH_DIAGNOSTIC_VM_SIGNER_KEY secret is missing from the 'vms' environment"
+            exit 1
+          fi
+
+      - name: Build code volume archive
+        working-directory: examples
+        run: |
+          zip -r diagnostic_vm.zip example_fastapi
+          ls -lh diagnostic_vm.zip
+
+      - name: Install aleph CLI
+        run: |
+          curl -fsSL https://apt.aleph.im/install.sh | sudo bash
+          aleph --version
+
+      - name: Resolve code volume reference from PROGRAM message
+        id: resolve
+        run: |
+          aleph message get "$PROGRAM_HASH" > program.json
+
+          owner_from_program=$(jq -r '.content.address' program.json)
+          code_ref=$(jq -r '.content.code.ref' program.json)
+          channel=$(jq -r '.channel // empty' program.json)
+
+          if [ -z "$code_ref" ] || [ "$code_ref" = "null" ]; then
+            echo "::error::Could not resolve content.code.ref from program $PROGRAM_HASH"
+            exit 1
+          fi
+
+          if [ "$owner_from_program" != "$OWNER" ]; then
+            echo "::error::Owner mismatch: program declares $owner_from_program, but DIAGNOSTIC_VM_OWNER is $OWNER"
+            exit 1
+          fi
+
+          echo "Program $PROGRAM_HASH owned by $owner_from_program; amending code volume $code_ref on channel '${channel:-<default>}'"
+          echo "code_ref=$code_ref" >> "$GITHUB_OUTPUT"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+
+      - name: Publish amend STORE message
+        env:
+          CODE_REF: ${{ steps.resolve.outputs.code_ref }}
+          CHANNEL: ${{ steps.resolve.outputs.channel }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          args=(
+            file upload examples/diagnostic_vm.zip
+            --ref "$CODE_REF"
+            --on-behalf-of "$OWNER"
+            --chain eth
+            --payment-type hold
+            --json
+          )
+
+          if [ -n "$CHANNEL" ]; then
+            args+=(--channel "$CHANNEL")
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            args+=(--dry-run)
+          fi
+
+          aleph "${args[@]}" | tee upload.json
+
+      - name: Summarize release
+        if: always()
+        env:
+          CODE_REF: ${{ steps.resolve.outputs.code_ref }}
+          CHANNEL: ${{ steps.resolve.outputs.channel }}
+        run: |
+          {
+            echo "# Diagnostic VM code volume release"
+            echo
+            echo "- **Program**: \`$PROGRAM_HASH\`"
+            echo "- **Owner**: \`$OWNER\`"
+            echo "- **Original code volume**: \`$CODE_REF\`"
+            echo "- **Channel**: \`${CHANNEL:-<default>}\`"
+            if [ -f upload.json ]; then
+              new_hash=$(jq -r '.item_hash // empty' upload.json)
+              if [ -n "$new_hash" ]; then
+                echo "- **New STORE \`item_hash\`**: \`$new_hash\`"
+              fi
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload archive as workflow artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: diagnostic-vm-code-volume
+          path: examples/diagnostic_vm.zip
+          retention-days: 30


### PR DESCRIPTION
## Summary

Mirrors PR #854 but instead of publishing a *new* PROGRAM, this workflow publishes a *new STORE that amends the existing code volume* of the diagnostic VM. Supervisors that resolve `use_latest=True` on the code volume will then pick up the new code on their next refresh, so the live diagnostic VM hash (`CHECK_FASTAPI_VM_ID`) does not have to change.

**Depends on #946** — without that fix, supervisors look up amends by signer rather than by `content.address`, so a CI-signed amend on behalf of the owner would not be discovered.

### How it works

- Trigger: tag push matching `diagnostic-vm/v*.*.*` (or manual `workflow_dispatch`).
- Reads the program hash and owner from repository **variables** (`DIAGNOSTIC_VM_PROGRAM_HASH`, `DIAGNOSTIC_VM_OWNER`) and the delegated signer's private key from the **environment secret** `ALEPH_DIAGNOSTIC_VM_SIGNER_KEY` in environment `vms`.
- `aleph message get` resolves the current `content.code.ref` and `channel` from the live PROGRAM message. The workflow fails fast if the program's declared owner doesn't match the GH variable.
- Zips `examples/example_fastapi` (same as #854).
- Publishes the amend STORE via `aleph file upload --ref <code.ref> --on-behalf-of $OWNER --chain eth --payment-type hold`. Locked-stake (holder tier) payment, on the owner address — the CI key never holds funds.

### Operator prerequisites (one-time setup)

1. Set GitHub repository variables: `DIAGNOSTIC_VM_PROGRAM_HASH` (e.g. `d2b74aa29898457bde0560e47f7cdd4e77287e9f1f7a1456161d2fd7d5c855d7`), `DIAGNOSTIC_VM_OWNER` (the owner ETH address).
2. Create the `vms` Environment in repo settings; add secret `ALEPH_DIAGNOSTIC_VM_SIGNER_KEY` (hex private key of the CI delegate). Optionally restrict deployments to the tag pattern.
3. From the owner account, publish an `aleph authorization grant` for the CI delegate (the address derived from `ALEPH_DIAGNOSTIC_VM_SIGNER_KEY`) authorizing STORE messages.
4. Ensure the owner address has enough locked stake for the new STORE.

### Why this approach

- One source of truth: the live PROGRAM tells us what to amend; we only need its hash in a variable.
- Future re-publishes of the program don't require workflow changes — just update the GH variable.
- Tag pattern `diagnostic-vm/v*.*.*` namespaces this away from the supervisor's own future `v*.*.*` tags.

## Test plan

- [ ] Trigger via `workflow_dispatch` with `dry_run=true` once env/vars/secret are configured — verifies the resolve step and signs without publishing.
- [ ] Push tag `diagnostic-vm/v0.0.1` (or run dispatch with `dry_run=false`) and confirm the new STORE item hash appears in the job summary.
- [ ] Verify the new STORE on the CCN: `aleph message get <new_hash>` should show `content.address == owner`, `content.ref == <original code volume hash>`, `type == STORE`.
- [ ] Once #946 ships, deploy on a node and confirm the diagnostic VM picks up the amended code on its next launch.