### PR TITLE
fix: return 400 instead of 500 on invalid restore upload

### DIFF
--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -3,6 +3,7 @@ import hashlib
 import hmac
 import json
 import logging
+import subprocess
 import time
 from dataclasses import dataclass
 from datetime import timedelta
@@ -1337,9 +1338,18 @@ async def _do_restore(
             else:
                 temp_file = await _parse_restore_json(request, backup_dir)
 
-            await verify_qemu_disk(temp_file)
+            # qemu-img rejects anything that isn't a valid QCOW2 image (e.g. a
+            # tar archive uploaded by mistake) with a non-zero exit code. That's
+            # a client error — surface it as a 400 rather than a generic 500.
+            try:
+                await verify_qemu_disk(temp_file)
+                new_size = await get_qemu_disk_virtual_size(temp_file)
+            except subprocess.CalledProcessError:
+                logger.info("Rejected restore upload for VM %s: not a valid QCOW2 image", vm_hash)
+                return web.HTTPBadRequest(
+                    body="Uploaded file is not a valid QCOW2 disk image",
+                )
 
-            new_size = await get_qemu_disk_virtual_size(temp_file)
             max_size = execution.message.rootfs.size_mib * 1024 * 1024
             if new_size > max_size:
                 return web.HTTPBadRequest(

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -1086,3 +1086,51 @@ async def test_allocation_legacy_token_no_per_request_log(aiohttp_client, monkey
         )
     assert response.status == 200
     assert not any("legacy" in r.message.lower() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_restore_rejects_invalid_image_format(mocker, tmp_path):
+    """Uploading a file that is not a valid QCOW2 image returns a 4xx, not a 500.
+
+    Regression: ``qemu-img check`` exits non-zero on e.g. a tar archive, so
+    ``verify_qemu_disk`` raises ``CalledProcessError``. Previously this fell
+    through to the generic handler and produced an HTTP 500.
+    """
+    import subprocess
+
+    from aleph.vm.controllers.qemu.instance import AlephQemuInstance
+    from aleph.vm.orchestrator.views import operator
+
+    vm_hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
+
+    execution = mocker.Mock()
+    execution.message.rootfs.size_mib = 1000
+    execution.is_running = False
+    execution.vm = mocker.Mock()
+    # Make the AlephQemuInstance isinstance check pass.
+    execution.vm.__class__ = AlephQemuInstance
+    execution.vm.resources.rootfs_path = str(tmp_path / "rootfs.qcow2")
+
+    mocker.patch.object(operator, "get_execution_or_404", return_value=execution)
+    mocker.patch.object(operator, "is_sender_authorized", new=mocker.AsyncMock(return_value=True))
+    mocker.patch.object(operator, "get_backup_directory", return_value=tmp_path)
+
+    uploaded = tmp_path / f"restore-{vm_hash}.qcow2"
+    uploaded.write_bytes(b"this is a tar archive, not a qcow2")
+    mocker.patch.object(operator, "_parse_restore_upload", new=mocker.AsyncMock(return_value=uploaded))
+
+    # qemu-img check exits non-zero on a non-QCOW2 file.
+    mocker.patch.object(
+        operator,
+        "verify_qemu_disk",
+        new=mocker.AsyncMock(side_effect=subprocess.CalledProcessError(2, "qemu-img", "not in qcow2 format")),
+    )
+
+    request = mocker.Mock()
+    request.app = {"vm_pool": mocker.Mock()}
+    request.content_length = None
+    request.content_type = "multipart/form-data"
+
+    response = await operator._do_restore(request, vm_hash, "0xSender")
+
+    assert 400 <= response.status < 500, f"expected a 4xx response, got {response.status}"


### PR DESCRIPTION
## Problem

The backup restore endpoint (`POST /control/machine/{ref}/restore`) returned a **500** when handed a file it can't use — e.g. uploading a `.tar` archive instead of a QCOW2 image.

## Root cause

`_do_restore` streams the upload to disk as `restore-<vm>.qcow2` *without* checking the format, then calls `verify_qemu_disk()` → `qemu-img check`. For a non-QCOW2 file, `qemu-img` exits non-zero, so `run_in_subprocess` raises `subprocess.CalledProcessError`. That is not an `HTTPException`, so it fell through to the generic `except Exception` handler → `HTTPInternalServerError`.

## Fix

Wrap the `qemu-img` validation step (`verify_qemu_disk` + `get_qemu_disk_virtual_size`) in `_do_restore` and convert a `CalledProcessError` into an `HTTPBadRequest` (`"Uploaded file is not a valid QCOW2 disk image"`), since an unusable upload is a client error. This covers both the multipart-upload and the `volume_ref` download paths.

The fix is scoped to the restore **call site** on purpose: `verify_qemu_disk` is also used elsewhere to verify a backup the node created *itself*, where a failure is genuinely server-side and must stay a 500.

## Testing

Added `test_restore_rejects_invalid_image_format` (TDD): mocks `verify_qemu_disk` to raise `CalledProcessError` and asserts a 4xx. Confirmed it fails on the pre-fix code (raises `HTTPInternalServerError`) and passes after the fix, with no regressions in `test_views.py` / `test_qemu_backup.py`.