### PR TITLE
runtimes: add Debian 13 (trixie) rootfs creation script

### DIFF
--- a/runtimes/instance-rootfs/create-debian-13-qemu-disk.sh
+++ b/runtimes/instance-rootfs/create-debian-13-qemu-disk.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euf
+
+# Variables
+ROOTFS_FILENAME="./rootfs.img"
+IMAGE_URL="https://cloud.debian.org/images/cloud/trixie/latest/debian-13-genericcloud-amd64.qcow2"
+IMAGE_NAME="debian-13-genericcloud-amd64.qcow2"
+
+# Cleanup previous run
+rm -f "$ROOTFS_FILENAME"
+
+# Download Debian image
+echo "Downloading Debian 13 image"
+curl -L "$IMAGE_URL" -o "$IMAGE_NAME"
+
+# Rename final file
+mv "$IMAGE_NAME" "$ROOTFS_FILENAME"


### PR DESCRIPTION
Adds `runtimes/instance-rootfs/create-debian-13-qemu-disk.sh`, mirroring the existing Debian 12 script but pointing at the Debian 13 (trixie) genericcloud qcow2 image.

The script downloads `debian-13-genericcloud-amd64.qcow2` from `cloud.debian.org/images/cloud/trixie/latest/` and writes it to `./rootfs.img`, ready to be uploaded to the network as the instance base rootfs.

## Usage
```bash
cd runtimes/instance-rootfs
bash ./create-debian-13-qemu-disk.sh
aleph file upload ./rootfs.img --storage-engine ipfs
```

The image URL was verified to resolve (HTTP 200).