### PR TITLE
Message-free supervisor (2/4): pool create path

### DIFF
--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -192,7 +192,7 @@ async def _handle_port_forwarding_aggregate(message: AggregateMessage, pool: VmP
     affected = [
         execution
         for execution in pool.executions.values()
-        if execution.is_instance and execution.vm and execution.message.address == address
+        if execution.is_instance and execution.vm and execution.message and execution.message.address == address
     ]
     if not affected:
         return
@@ -226,7 +226,7 @@ async def _handle_domains_aggregate(message: AggregateMessage, pool: VmPool):
     # This covers both additions (new domain pointing to local instance)
     # and deletions (domain removed — need to clean up the map).
     has_local_instance = any(
-        execution.is_instance and execution.vm and execution.message.address == address
+        execution.is_instance and execution.vm and execution.message and execution.message.address == address
         for execution in pool.executions.values()
     )
     if not has_local_instance:

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -235,7 +235,11 @@ async def list_executions(request: web.Request) -> web.Response:
                     "ipv4": execution.vm.tap_interface.ip_network,
                     "ipv6": execution.vm.tap_interface.ipv6_network,
                 },
-                "vm_type": VmType.from_message_content(execution.message).name,
+                "vm_type": (
+                    VmType.from_message_content(execution.message).name
+                    if execution.message is not None
+                    else (VmType.instance.name if execution.is_instance else VmType.microvm.name)
+                ),
             }
             for item_hash, execution in pool.executions.items()
             if running_states.get(item_hash, False)
@@ -269,7 +273,11 @@ async def list_executions_v2(request: web.Request) -> web.Response:
                 ),
                 "status": execution.times,
                 "running": running_states.get(item_hash, False),
-                "vm_type": VmType.from_message_content(execution.message).name,
+                "vm_type": (
+                    VmType.from_message_content(execution.message).name
+                    if execution.message is not None
+                    else (VmType.instance.name if execution.is_instance else VmType.microvm.name)
+                ),
             }
             for item_hash, execution in pool.executions.items()
         },

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -160,7 +160,7 @@ class VmPool:
         ``creation_lock``). Reading ``self.executions`` is safe without
         locking because this method does not ``await``.
 
-        The message-free spec path (:meth:`create_a_vm_from_spec`) does not
+        The message-free spec path (:meth:`create_vm_from_spec`) does not
         call this method: admission for spec-built VMs is the agent's
         responsibility, enforced before it asks the supervisor to create.
         Spec-built executions still contribute to the committed tally here

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -21,6 +21,7 @@ from aleph_message.models import (
 from pydantic import TypeAdapter
 
 from aleph.vm.conf import settings
+from aleph.vm.controllers.configuration import save_controller_configuration
 from aleph.vm.controllers.firecracker.snapshot_manager import SnapshotManager
 from aleph.vm.network.hostnetwork import Network, make_ipv6_allocator
 from aleph.vm.network.interfaces import TapInterface
@@ -36,6 +37,9 @@ from aleph.vm.resources import (
     InsufficientResourcesError,
     get_gpu_devices,
 )
+from aleph.vm.supervisor.errors import InvalidBackendError
+from aleph.vm.supervisor.qemu_build import build_qemu_configuration
+from aleph.vm.supervisor.types import Backend, CreateVmSpec
 from aleph.vm.systemd import SystemDManager
 from aleph.vm.utils import get_message_executable_content
 from aleph.vm.vm_type import VmType
@@ -403,6 +407,65 @@ class VmPool:
 
             self._schedule_forget_on_stop(execution)
 
+            return execution
+
+    async def create_vm_from_spec(self, spec: CreateVmSpec) -> VmExecution:
+        """Create a VM from a message-free CreateVmSpec.
+
+        The supervisor's creation path: no Aleph message, no download. The
+        spec carries resolved on-disk paths. The controller config is written
+        by build_qemu_configuration (0.C), so the message-coupled
+        vm.configure() is skipped (start(write_config=False)).
+        """
+        if spec.backend is not Backend.QEMU:
+            msg = f"create_vm_from_spec supports QEMU only, got {spec.backend}"
+            raise InvalidBackendError(msg)
+
+        vm_hash = ItemHash(spec.vm_id)
+        async with self.creation_lock:
+            current_execution = self.executions.get(vm_hash)
+            if current_execution and current_execution.is_running and not current_execution.is_stopping:
+                current_execution.cancel_expiration()
+                return current_execution
+
+            execution = VmExecution.from_spec(
+                spec,
+                snapshot_manager=self.snapshot_manager,
+                systemd_manager=self.systemd_manager,
+            )
+            self.executions[vm_hash] = execution
+
+            tap_interface = None
+            vm_id = None
+            try:
+                await execution.prepare()  # builds resources from the spec; no download
+
+                vm_id = self.get_unique_vm_id()
+
+                if self.network:
+                    tap_interface = await self.network.prepare_tap(vm_id, vm_hash, VmType.instance)
+                    if self.network.interface_exists(vm_id):
+                        await tap_interface.delete()
+                    await self.network.create_tap(vm_id, tap_interface)
+
+                config = await build_qemu_configuration(spec, vm_id, tap_interface)
+                save_controller_configuration(spec.vm_id, config)
+
+                execution.create(vm_id=vm_id, tap_interface=tap_interface)
+                await execution.start(write_config=False)
+                # NOTE: port forwarding is not fetched here. It depends on the
+                # owner address + user-settings aggregate (agent concerns); the
+                # agent drives it through the supervisor's add_port_forward.
+            except Exception:
+                if execution.vm:
+                    await execution.vm.teardown()
+                elif tap_interface and vm_id is not None:
+                    teardown_nftables_for_vm(vm_id)
+                    await tap_interface.delete()
+                self.forget_vm(vm_hash)
+                raise
+
+            self._schedule_forget_on_stop(execution)
             return execution
 
     def get_unique_vm_id(self) -> int:

--- a/src/aleph/vm/supervisor/inprocess.py
+++ b/src/aleph/vm/supervisor/inprocess.py
@@ -134,7 +134,9 @@ class InProcessSupervisor(Supervisor):
 
     # Lifecycle
     async def create_vm(self, spec: CreateVmSpec) -> VmInfo:
-        raise NotImplementedSupervisorError("create_vm is deferred to a later phase")
+        with translating_errors():
+            execution = await self.pool.create_vm_from_spec(spec)
+            return _to_vm_info(execution, _is_running(execution, self.pool))
 
     async def get_vm(self, vm_id: VmId) -> VmInfo:
         with translating_errors():

--- a/tests/supervisor/conformance.py
+++ b/tests/supervisor/conformance.py
@@ -6,7 +6,6 @@ collected directly (its class name does not start with Test).
 """
 
 import inspect
-from pathlib import Path
 
 import pytest
 
@@ -14,7 +13,6 @@ from aleph.vm.supervisor.abc import Supervisor
 from aleph.vm.supervisor.errors import NotImplementedSupervisorError
 
 STUB_METHODS = {
-    "create_vm",
     "start_backup",
     "get_backup_status",
     "list_backups",
@@ -46,30 +44,22 @@ class SupervisorContractTests:
 
     @pytest.mark.asyncio
     async def test_stub_methods_raise_not_implemented(self, supervisor):
-        if "create_vm" in STUB_METHODS:
-            from aleph.vm.supervisor.types import (
-                Backend,
-                CreateVmSpec,
-                NetworkConfig,
-                VmId,
-            )
-
-            spec = CreateVmSpec(
-                vm_id=VmId("x"),
-                backend=Backend.QEMU,
-                kernel_path=Path(""),
-                initrd_path=Path(""),
-                disks=[],
-                vcpus=1,
-                memory_mib=512,
-                tee=None,
-                network=NetworkConfig(internet_access=False, requested_ipv6="", ipv6_prefix_len=0),
-                gpus=[],
-                numa_node=None,
-                persistent=True,
-            )
+        for name in STUB_METHODS:
+            method = getattr(supervisor, name)
+            sig = inspect.signature(method)
+            # Stubs raise before touching their arguments, so dummy values suffice.
+            dummy_args = [
+                None
+                for p in sig.parameters.values()
+                if p.default is inspect.Parameter.empty
+                and p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+            ]
             with pytest.raises(NotImplementedSupervisorError):
-                await supervisor.create_vm(spec)
+                if inspect.isasyncgenfunction(method):
+                    async for _ in method(*dummy_args):
+                        pass
+                else:
+                    await method(*dummy_args)
 
     def test_streaming_methods_return_async_iterators(self, supervisor):
         for name in ("stream_logs", "download_backup"):

--- a/tests/supervisor/test_supervisor_inprocess_create.py
+++ b/tests/supervisor/test_supervisor_inprocess_create.py
@@ -1,0 +1,65 @@
+"""InProcessSupervisor.create_vm delegates to pool.create_vm_from_spec."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from test_supervisor_inprocess_query import FakePool, FakeSystemd, make_execution
+
+from aleph.vm.supervisor.inprocess import InProcessSupervisor
+from aleph.vm.supervisor.types import (
+    Backend,
+    CreateVmSpec,
+    DiskFormat,
+    DiskRole,
+    DiskSpec,
+    NetworkConfig,
+    VmId,
+    VmStatus,
+)
+
+_HASH = "itemhash123"
+
+
+def _spec() -> CreateVmSpec:
+    return CreateVmSpec(
+        vm_id=VmId(_HASH),
+        backend=Backend.QEMU,
+        kernel_path=Path(""),
+        initrd_path=Path(""),
+        disks=[
+            DiskSpec(
+                path=Path("/data/rootfs.qcow2"),
+                readonly=False,
+                format=DiskFormat.QCOW2,
+                role=DiskRole.ROOTFS,
+            )
+        ],
+        vcpus=2,
+        memory_mib=1024,
+        tee=None,
+        network=NetworkConfig(internet_access=False, requested_ipv6="", ipv6_prefix_len=0),
+        gpus=[],
+        numa_node=None,
+        persistent=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_vm_delegates_and_returns_info():
+    execution = make_execution(running=True)
+    pool = FakePool(
+        executions={_HASH: execution},
+        systemd=FakeSystemd({f"aleph-vm-controller@{_HASH}.service": True}),
+    )
+    pool.create_vm_from_spec = AsyncMock(return_value=execution)
+    sup = InProcessSupervisor(pool=pool)
+
+    spec = _spec()
+    info = await sup.create_vm(spec)
+
+    pool.create_vm_from_spec.assert_awaited_once_with(spec)
+    assert info.vm_id == _HASH
+    assert info.status is VmStatus.RUNNING

--- a/tests/supervisor/test_supervisor_inprocess_stubs.py
+++ b/tests/supervisor/test_supervisor_inprocess_stubs.py
@@ -4,36 +4,12 @@ import pytest
 
 from aleph.vm.supervisor.errors import NotImplementedSupervisorError
 from aleph.vm.supervisor.inprocess import InProcessSupervisor
-from aleph.vm.supervisor.types import (
-    Backend,
-    BackupId,
-    CreateVmSpec,
-    DirectoryPath,
-    NetworkConfig,
-    VmId,
-)
+from aleph.vm.supervisor.types import BackupId, DirectoryPath, VmId
 
 
 class FakePool:
     def __init__(self):
         self.executions = {}
-
-
-def make_spec() -> CreateVmSpec:
-    return CreateVmSpec(
-        vm_id=VmId("abc"),
-        backend=Backend.QEMU,
-        kernel_path=Path(""),
-        initrd_path=Path(""),
-        disks=[],
-        vcpus=1,
-        memory_mib=512,
-        tee=None,
-        network=NetworkConfig(internet_access=False, requested_ipv6="", ipv6_prefix_len=0),
-        gpus=[],
-        numa_node=None,
-        persistent=True,
-    )
 
 
 @pytest.fixture
@@ -43,12 +19,6 @@ def supervisor():
 
 def test_can_instantiate(supervisor):
     assert isinstance(supervisor, InProcessSupervisor)
-
-
-@pytest.mark.asyncio
-async def test_create_vm_is_stubbed(supervisor):
-    with pytest.raises(NotImplementedSupervisorError):
-        await supervisor.create_vm(make_spec())
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_supervisor_spec_pool_create.py
+++ b/tests/supervisor/test_supervisor_spec_pool_create.py
@@ -1,0 +1,93 @@
+"""pool.create_vm_from_spec — message-free, no-download create wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aleph.vm.pool import VmPool
+from aleph.vm.supervisor.errors import InvalidBackendError
+from aleph.vm.supervisor.types import (
+    Backend,
+    CreateVmSpec,
+    DiskFormat,
+    DiskRole,
+    DiskSpec,
+    NetworkConfig,
+    VmId,
+)
+
+_HASH = "deadbeef" * 8
+
+
+def _spec(backend: Backend = Backend.QEMU) -> CreateVmSpec:
+    return CreateVmSpec(
+        vm_id=VmId(_HASH),
+        backend=backend,
+        kernel_path=Path(""),
+        initrd_path=Path(""),
+        disks=[
+            DiskSpec(
+                path=Path("/data/rootfs.qcow2"),
+                readonly=False,
+                format=DiskFormat.QCOW2,
+                role=DiskRole.ROOTFS,
+            )
+        ],
+        vcpus=2,
+        memory_mib=1024,
+        tee=None,
+        network=NetworkConfig(internet_access=False, requested_ipv6="", ipv6_prefix_len=0),
+        gpus=[],
+        numa_node=None,
+        persistent=True,
+    )
+
+
+def _bare_pool() -> VmPool:
+    import asyncio
+
+    pool = VmPool.__new__(VmPool)
+    pool.executions = {}
+    pool.reservations = {}
+    pool.network = None  # exercise the no-network branch
+    pool.snapshot_manager = None
+    pool.creation_lock = asyncio.Lock()
+    systemd = MagicMock()
+    systemd.enable_and_start = AsyncMock()
+    pool.systemd_manager = systemd
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_create_vm_from_spec_wires_into_pool(monkeypatch):
+    pool = _bare_pool()
+
+    build_cfg = AsyncMock(return_value="fake-config")
+    save_cfg = MagicMock()
+    monkeypatch.setattr("aleph.vm.pool.build_qemu_configuration", build_cfg)
+    monkeypatch.setattr("aleph.vm.pool.save_controller_configuration", save_cfg)
+    # Controller reports active immediately.
+    monkeypatch.setattr(
+        "aleph.vm.models.VmExecution.non_blocking_wait_for_boot",
+        AsyncMock(return_value=True),
+    )
+
+    execution = await pool.create_vm_from_spec(_spec())
+
+    assert pool.executions[execution.vm_hash] is execution
+    assert execution.message is None
+    assert execution.vm is not None
+    build_cfg.assert_awaited_once()
+    save_cfg.assert_called_once_with(_HASH, "fake-config")
+    pool.systemd_manager.enable_and_start.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_vm_from_spec_rejects_non_qemu():
+    pool = _bare_pool()
+    with pytest.raises(InvalidBackendError):
+        await pool.create_vm_from_spec(_spec(backend=Backend.QEMU_SEV))
+    assert pool.executions == {}

--- a/tests/supervisor/test_supervisor_spec_pool_guards.py
+++ b/tests/supervisor/test_supervisor_spec_pool_guards.py
@@ -1,0 +1,65 @@
+"""A message-less (spec-built) execution must not break pool-wide iterations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aleph_message.models import PaymentType
+
+from aleph.vm.models import VmExecution
+from aleph.vm.pool import VmPool
+from aleph.vm.supervisor.types import (
+    Backend,
+    CreateVmSpec,
+    DiskFormat,
+    DiskRole,
+    DiskSpec,
+    NetworkConfig,
+    VmId,
+)
+
+_HASH = "deadbeef" * 8
+
+
+def _spec() -> CreateVmSpec:
+    return CreateVmSpec(
+        vm_id=VmId(_HASH),
+        backend=Backend.QEMU,
+        kernel_path=Path(""),
+        initrd_path=Path(""),
+        disks=[
+            DiskSpec(
+                path=Path("/data/rootfs.qcow2"),
+                readonly=False,
+                format=DiskFormat.QCOW2,
+                role=DiskRole.ROOTFS,
+            )
+        ],
+        vcpus=2,
+        memory_mib=1024,
+        tee=None,
+        network=NetworkConfig(internet_access=False, requested_ipv6="", ipv6_prefix_len=0),
+        gpus=[],
+        numa_node=None,
+        persistent=True,
+    )
+
+
+def test_allocated_properties_from_spec():
+    execution = VmExecution.from_spec(_spec(), snapshot_manager=None, systemd_manager=None)
+    assert execution.allocated_memory_mib == 1024
+    assert execution.allocated_vcpus == 2
+
+
+def test_get_executions_by_address_skips_message_less():
+    pool = VmPool.__new__(VmPool)
+    pool.executions = {}
+    spec_exec = VmExecution.from_spec(_spec(), snapshot_manager=None, systemd_manager=None)
+    # Mark it "running" so the iteration does not skip it for that reason;
+    # systemd_manager is None so is_running falls back to the times check.
+    spec_exec.times.started_at = spec_exec.times.starting_at = spec_exec.times.defined_at
+    pool.executions[_HASH] = spec_exec
+
+    # Must not raise even though execution.message is None.
+    result = pool.get_executions_by_address(PaymentType.hold)
+    assert result == {}


### PR DESCRIPTION
Part **2 of 4** of the message-free supervisor backport. Base: `od/msgfree-1-spec-execution` (#954).

> Stacked on #954 — review/merge that first. The diff here is only this PR's commits.

Wires the message-free create path into the pool and the supervisor boundary.

### Changes
- `pool.create_a_vm_from_spec(spec)` — the supervisor's message-free creation path: `VmExecution.from_spec` → `prepare()` (no download) → tap → controller config via `build_qemu_configuration` + `save_controller_configuration` → `create()` → `start(write_config=False)`. Holds `creation_lock`, mirrors `create_a_vm`'s teardown-on-error and `_schedule_forget_on_stop`. Port-forward fetch is intentionally omitted (agent concern).
- `InProcessSupervisor.create_vm` delegates to it (replacing the `NotImplementedSupervisorError` stub); conformance suite updated to genuinely exercise the remaining stub methods.
- A message-free execution can now live in `pool.executions`, so pool-wide iterations are guarded: new `allocated_memory_mib`/`allocated_vcpus` properties feed `check_admission`; `get_executions_by_address`, the monitoring views, and the payment/notify tasks skip/guard executions with no message.

### Stack
1. spec-constructible `VmExecution` → `dev` (#954)
2. **(this PR)** pool create path → #954
3. route production creation through the spec (`run.py`) → 2
4. reboot-recovery from on-disk configs → 3

New tests: `test_supervisor_spec_pool_guards.py`, `test_supervisor_spec_pool_create.py`, `test_supervisor_inprocess_create.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
