### PR TITLE
Message-free supervisor (3/4): route production creation through the spec

### DIFF
--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -11,7 +11,8 @@ from aiohttp.web_exceptions import (
     HTTPInternalServerError,
     HTTPServiceUnavailable,
 )
-from aleph_message.models import ItemHash
+from aleph_message.models import InstanceContent, ItemHash
+from aleph_message.models.execution.environment import HypervisorType
 from msgpack import UnpackValueError
 from multidict import CIMultiDict
 
@@ -25,6 +26,7 @@ from aleph.vm.hypervisors.firecracker.microvm import MicroVMFailedInitError
 from aleph.vm.models import VmExecution
 from aleph.vm.pool import VmPool
 from aleph.vm.resources import InsufficientResourcesError
+from aleph.vm.supervisor.translate import build_create_vm_spec
 from aleph.vm.utils import HostNotFoundError
 
 from .messages import load_updated_message
@@ -54,15 +56,52 @@ async def build_event_scope(event) -> dict[str, Any]:
     }
 
 
+def _is_spec_eligible(content) -> bool:
+    """True when the supervisor's message-free create path can handle this message.
+
+    Gates which messages reach build_create_vm_spec, mirroring its validation:
+    a non-confidential QEMU instance. The GPU exclusion below is an extra
+    conservatism of this gate — build_create_vm_spec itself accepts GPUs (via
+    its ``gpus`` argument), so GPU instances are filtered here, not there. Keep
+    the two in sync. Everything else keeps the legacy path.
+    """
+    if not isinstance(content, InstanceContent):
+        return False
+    hypervisor = content.environment.hypervisor or settings.INSTANCE_DEFAULT_HYPERVISOR
+    if hypervisor != HypervisorType.qemu:
+        return False
+    if getattr(content.environment, "trusted_execution", None) is not None:
+        return False
+    if content.requirements and content.requirements.gpu:
+        return False
+    return True
+
+
 async def create_vm_execution(vm_hash: ItemHash, pool: VmPool, persistent: bool = False) -> VmExecution:
     message, original_message = await load_updated_message(vm_hash)
     pool.message_cache[vm_hash] = message
 
     logger.debug(f"Message: {json.dumps(message.model_dump(exclude_none=True), indent=4, sort_keys=True, default=str)}")
 
+    content = message.content
+    if _is_spec_eligible(content):
+        # `persistent` is moot on this branch: eligibility requires an instance
+        # (see _is_spec_eligible) and instances are always persistent. The only
+        # persistent=False callers carry programs, which never reach here.
+        spec = await build_create_vm_spec(vm_hash, content)
+        execution = await pool.create_vm_from_spec(spec)
+        # Agent territory: attach the message so the operator API (owner auth),
+        # port forwarding and billing keep working. The supervisor machinery
+        # that just created the VM never read these.
+        execution.message = content
+        execution.original = original_message.content
+        if execution.is_instance:
+            await execution.fetch_port_redirect_config_and_setup()
+        return execution
+
     execution = await pool.create_a_vm(
         vm_hash=vm_hash,
-        message=message.content,
+        message=content,
         original=original_message.content,
         persistent=persistent,
     )

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -23,7 +23,7 @@ from aleph.vm.controllers.firecracker.program import (
     VmSetupError,
 )
 from aleph.vm.hypervisors.firecracker.microvm import MicroVMFailedInitError
-from aleph.vm.models import VmExecution
+from aleph.vm.models import MessageSpec, VmExecution
 from aleph.vm.pool import VmPool
 from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.supervisor.translate import build_create_vm_spec
@@ -90,11 +90,10 @@ async def create_vm_execution(vm_hash: ItemHash, pool: VmPool, persistent: bool 
         # persistent=False callers carry programs, which never reach here.
         spec = await build_create_vm_spec(vm_hash, content)
         execution = await pool.create_vm_from_spec(spec)
-        # Agent territory: attach the message so the operator API (owner auth),
-        # port forwarding and billing keep working. The supervisor machinery
-        # that just created the VM never read these.
-        execution.message = content
-        execution.original = original_message.content
+        # Agent territory: re-source the execution as message-driven so the
+        # operator API (owner auth), port forwarding and billing keep working.
+        # The supervisor machinery that just created the VM never read this.
+        execution.spec = MessageSpec(message=content, original=original_message.content)
         if execution.is_instance:
             await execution.fetch_port_redirect_config_and_setup()
         return execution

--- a/src/aleph/vm/supervisor/translate.py
+++ b/src/aleph/vm/supervisor/translate.py
@@ -42,6 +42,11 @@ async def build_create_vm_spec(
     - non-instance messages
     - non-QEMU hypervisor
     - confidential (trusted_execution set) instances
+
+    The routing gate ``run._is_spec_eligible`` mirrors these checks to decide
+    which messages reach this path; keep the two in sync. That gate is
+    additionally conservative about GPUs, which this function accepts (via
+    ``gpus``), so GPU instances are filtered upstream, not here.
     """
     # --- Validate before any I/O ---
 

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -60,9 +60,7 @@ async def test_eligible_instance_routed_through_spec(monkeypatch):
     original_content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
     message = MagicMock(content=content)
     original_message = MagicMock(content=original_content)
-    monkeypatch.setattr(
-        run_module, "load_updated_message", AsyncMock(return_value=(message, original_message))
-    )
+    monkeypatch.setattr(run_module, "load_updated_message", AsyncMock(return_value=(message, original_message)))
 
     spec = _spec()
     monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(return_value=spec))
@@ -91,9 +89,7 @@ async def test_ineligible_firecracker_falls_back_to_legacy(monkeypatch):
     content = _make_qemu_instance_message(hypervisor=HypervisorType.firecracker)
     message = MagicMock(content=content)
     original_message = MagicMock(content=_make_qemu_instance_message())
-    monkeypatch.setattr(
-        run_module, "load_updated_message", AsyncMock(return_value=(message, original_message))
-    )
+    monkeypatch.setattr(run_module, "load_updated_message", AsyncMock(return_value=(message, original_message)))
     monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock())
 
     legacy = SimpleNamespace()

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -16,6 +16,7 @@ from aleph_message.models.execution.environment import (
 )
 from test_supervisor_translate import _make_qemu_instance_message
 
+from aleph.vm.models import MessageSpec
 from aleph.vm.orchestrator import run as run_module
 from aleph.vm.supervisor.types import (
     Backend,
@@ -65,7 +66,7 @@ async def test_eligible_instance_routed_through_spec(monkeypatch):
     spec = _spec()
     monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(return_value=spec))
 
-    created = SimpleNamespace(message=None, original=None, is_instance=True)
+    created = SimpleNamespace(spec=None, is_instance=True)
     created.fetch_port_redirect_config_and_setup = AsyncMock()
     pool = SimpleNamespace(
         message_cache={},
@@ -78,9 +79,8 @@ async def test_eligible_instance_routed_through_spec(monkeypatch):
     run_module.build_create_vm_spec.assert_awaited_once()
     pool.create_vm_from_spec.assert_awaited_once_with(spec)
     pool.create_a_vm.assert_not_awaited()
-    # Agent re-attached the message for its own consumers.
-    assert execution.message is content
-    assert execution.original is original_content
+    # Agent re-sourced the execution as message-driven for its own consumers.
+    assert execution.spec == MessageSpec(message=content, original=original_content)
     created.fetch_port_redirect_config_and_setup.assert_awaited_once()
 
 

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -1,0 +1,164 @@
+"""run.create_vm_execution routes eligible QEMU instances through the spec."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aleph_message.models import ItemHash, ProgramContent
+from aleph_message.models.execution.environment import (
+    GpuProperties,
+    HostRequirements,
+    HypervisorType,
+    TrustedExecutionEnvironment,
+)
+from test_supervisor_translate import _make_qemu_instance_message
+
+from aleph.vm.orchestrator import run as run_module
+from aleph.vm.supervisor.types import (
+    Backend,
+    CreateVmSpec,
+    DiskFormat,
+    DiskRole,
+    DiskSpec,
+    NetworkConfig,
+    VmId,
+)
+
+_HASH = ItemHash("deadbeef" * 8)
+
+
+def _spec() -> CreateVmSpec:
+    return CreateVmSpec(
+        vm_id=VmId(str(_HASH)),
+        backend=Backend.QEMU,
+        kernel_path=Path(""),
+        initrd_path=Path(""),
+        disks=[
+            DiskSpec(
+                path=Path("/data/rootfs.qcow2"),
+                readonly=False,
+                format=DiskFormat.QCOW2,
+                role=DiskRole.ROOTFS,
+            )
+        ],
+        vcpus=2,
+        memory_mib=1024,
+        tee=None,
+        network=NetworkConfig(internet_access=True, requested_ipv6="", ipv6_prefix_len=0),
+        gpus=[],
+        numa_node=None,
+        persistent=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_eligible_instance_routed_through_spec(monkeypatch):
+    content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
+    original_content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
+    message = MagicMock(content=content)
+    original_message = MagicMock(content=original_content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, original_message))
+    )
+
+    spec = _spec()
+    monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(return_value=spec))
+
+    created = SimpleNamespace(message=None, original=None, is_instance=True)
+    created.fetch_port_redirect_config_and_setup = AsyncMock()
+    pool = SimpleNamespace(
+        message_cache={},
+        create_vm_from_spec=AsyncMock(return_value=created),
+        create_a_vm=AsyncMock(),
+    )
+
+    execution = await run_module.create_vm_execution(_HASH, pool, persistent=True)
+
+    run_module.build_create_vm_spec.assert_awaited_once()
+    pool.create_vm_from_spec.assert_awaited_once_with(spec)
+    pool.create_a_vm.assert_not_awaited()
+    # Agent re-attached the message for its own consumers.
+    assert execution.message is content
+    assert execution.original is original_content
+    created.fetch_port_redirect_config_and_setup.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ineligible_firecracker_falls_back_to_legacy(monkeypatch):
+    content = _make_qemu_instance_message(hypervisor=HypervisorType.firecracker)
+    message = MagicMock(content=content)
+    original_message = MagicMock(content=_make_qemu_instance_message())
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, original_message))
+    )
+    monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock())
+
+    legacy = SimpleNamespace()
+    pool = SimpleNamespace(
+        message_cache={},
+        create_vm_from_spec=AsyncMock(),
+        create_a_vm=AsyncMock(return_value=legacy),
+    )
+
+    execution = await run_module.create_vm_execution(_HASH, pool, persistent=False)
+
+    pool.create_a_vm.assert_awaited_once()
+    pool.create_vm_from_spec.assert_not_awaited()
+    run_module.build_create_vm_spec.assert_not_awaited()
+    assert execution is legacy
+
+
+async def _assert_routed_to_legacy(monkeypatch, content) -> None:
+    """Assert an ineligible message takes create_a_vm and never touches the spec path."""
+    message = MagicMock(content=content)
+    original_message = MagicMock(content=_make_qemu_instance_message())
+    monkeypatch.setattr(run_module, "load_updated_message", AsyncMock(return_value=(message, original_message)))
+    monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock())
+
+    legacy = SimpleNamespace()
+    pool = SimpleNamespace(
+        message_cache={},
+        create_vm_from_spec=AsyncMock(),
+        create_a_vm=AsyncMock(return_value=legacy),
+    )
+
+    execution = await run_module.create_vm_execution(_HASH, pool, persistent=False)
+
+    pool.create_a_vm.assert_awaited_once()
+    pool.create_vm_from_spec.assert_not_awaited()
+    run_module.build_create_vm_spec.assert_not_awaited()
+    assert execution is legacy
+
+
+@pytest.mark.asyncio
+async def test_non_instance_falls_back_to_legacy(monkeypatch):
+    # A program (non-instance) message is never spec-eligible.
+    await _assert_routed_to_legacy(monkeypatch, MagicMock(spec=ProgramContent))
+
+
+@pytest.mark.asyncio
+async def test_confidential_instance_falls_back_to_legacy(monkeypatch):
+    content = _make_qemu_instance_message(trusted_execution=TrustedExecutionEnvironment())
+    await _assert_routed_to_legacy(monkeypatch, content)
+
+
+@pytest.mark.asyncio
+async def test_gpu_instance_falls_back_to_legacy(monkeypatch):
+    content = _make_qemu_instance_message().model_copy(
+        update={
+            "requirements": HostRequirements(
+                gpu=[
+                    GpuProperties(
+                        vendor="NVIDIA",
+                        device_name="RTX",
+                        device_class="0300",
+                        device_id="10de:1234",
+                    )
+                ]
+            )
+        }
+    )
+    await _assert_routed_to_legacy(monkeypatch, content)


### PR DESCRIPTION
Part **3 of 4** of the message-free supervisor backport. Base: `od/msgfree-2-pool-create` (#955).

> Stacked on #955 (which is stacked on #954) — review/merge those first.

Routes the production creation path through the spec for eligible workloads.

### Changes
- `orchestrator/run.py` `create_vm_execution`: for an eligible message (a non-confidential QEMU instance with no GPU requirement) it now `build_create_vm_spec(...)` → `pool.create_a_vm_from_spec(...)`, then **re-attaches** the message to the created execution purely for the agent's own consumers (operator-API owner-auth, port forwarding) — the supervisor machinery that just created the VM never read it. This is the strangler seam: the supervisor acts message-free; the agent decorates its in-process view.
- A `_is_spec_eligible` helper mirrors `build_create_vm_spec`'s validation. Everything else (programs, Firecracker, confidential, GPU instances) keeps the legacy `pool.create_a_vm` path **unchanged**.

### Stack
1. spec-constructible `VmExecution` → `dev` (#954)
2. pool create path → #954 (#955)
3. **(this PR)** route production creation through the spec → #955
4. reboot-recovery from on-disk configs → 3

New test: `test_supervisor_run_routing.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
