### PR TITLE
Message-free supervisor: reboot-recovery from on-disk configs

### DIFF
--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -851,10 +851,19 @@ class VmExecution:
             logger.info("%s stopped", self)
 
     def start_watching_for_updates(self, pubsub: PubSub):
+        if not isinstance(self.spec, MessageSpec):
+            # Message-free (spec-built / reattached) executions have no Aleph
+            # message to watch for updates. After a reboot the agent re-fetches
+            # the allocation and re-establishes watching; the supervisor's own
+            # reattach does not. No-op rather than scheduling a task that fails.
+            return
         if not self.update_task:
             self.update_task = create_task_log_exceptions(self.watch_for_updates(pubsub=pubsub))
 
     async def watch_for_updates(self, pubsub: PubSub):
+        # Message-only entrypoint. start_watching_for_updates already no-ops for
+        # spec-built / reattached executions, so reaching here with one is a
+        # programming error: fail loud rather than silently watching nothing.
         if not isinstance(self.spec, MessageSpec):
             raise TypeError("watch_for_updates is message-only; spec-built executions have no message to update")
         original = self.spec.original

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -541,7 +541,7 @@ class VmPool:
         """
         try:
             config_paths = sorted(settings.EXECUTION_ROOT.glob("*-controller.json"))
-        except Exception:
+        except OSError:
             logger.warning("Failed to enumerate controller configs", exc_info=True)
             config_paths = []
 
@@ -593,7 +593,7 @@ class VmPool:
             await self.update_domain_mapping(force_update=True)
         logger.info("Loaded %d executions", len(self.executions))
 
-    async def _restore_network(self, _execution: VmExecution, vm_id: int, vm_hash: ItemHash) -> TapInterface | None:
+    async def _restore_network(self, vm_id: int, vm_hash: ItemHash) -> TapInterface | None:
         """Restore tap interface, NDP proxy, and nftables rules for a VM."""
         if not self.network:
             return None
@@ -634,7 +634,7 @@ class VmPool:
         logger.info("Loading existing mapped_ports %s", execution.mapped_ports)
 
         await execution.prepare()  # builds resources from the spec; no download
-        tap_interface = await self._restore_network(execution, vm_id, vm_hash)
+        tap_interface = await self._restore_network(vm_id, vm_hash)
 
         vm = execution.create(vm_id=vm_id, tap_interface=tap_interface, prepare=False)
         await vm.start_guest_api()
@@ -696,7 +696,7 @@ class VmPool:
         """
         try:
             config_files = list(settings.EXECUTION_ROOT.glob("*-controller.json"))
-        except Exception:
+        except OSError:
             logger.warning("Failed to enumerate controller configs", exc_info=True)
             return
 

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -21,7 +21,10 @@ from aleph_message.models import (
 from pydantic import TypeAdapter
 
 from aleph.vm.conf import settings
-from aleph.vm.controllers.configuration import save_controller_configuration
+from aleph.vm.controllers.configuration import (
+    Configuration,
+    save_controller_configuration,
+)
 from aleph.vm.controllers.firecracker.snapshot_manager import SnapshotManager
 from aleph.vm.network.hostnetwork import Network, make_ipv6_allocator
 from aleph.vm.network.interfaces import TapInterface
@@ -38,7 +41,7 @@ from aleph.vm.resources import (
     get_gpu_devices,
 )
 from aleph.vm.supervisor.errors import InvalidBackendError
-from aleph.vm.supervisor.qemu_build import build_qemu_configuration
+from aleph.vm.supervisor.qemu_build import build_qemu_configuration, spec_from_controller_configuration
 from aleph.vm.supervisor.types import Backend, CreateVmSpec
 from aleph.vm.systemd import SystemDManager
 from aleph.vm.utils import get_message_executable_content
@@ -646,12 +649,13 @@ class VmPool:
         self.executions[vm_hash] = execution
         execution.record = saved_execution
 
-    async def _restore_network(self, execution: VmExecution, vm_id: int, vm_hash: ItemHash) -> TapInterface | None:
+    async def _restore_network(self, _execution: VmExecution, vm_id: int, vm_hash: ItemHash) -> TapInterface | None:
         """Restore tap interface, NDP proxy, and nftables rules for a VM."""
         if not self.network:
             return None
 
-        vm_type = VmType.from_message_content(execution.message)
+        # Reattach is QEMU-instance only; the message is gone by design.
+        vm_type = VmType.instance
         tap_interface = await self.network.prepare_tap(vm_id, vm_hash, vm_type)
 
         if not self.network.interface_exists(vm_id):
@@ -667,6 +671,54 @@ class VmPool:
 
         setup_nftables_for_vm(vm_id, interface=tap_interface)
         return tap_interface
+
+    async def _restore_running_execution_from_config(
+        self, config: Configuration, vm_id: int, vm_hash: ItemHash
+    ) -> None:
+        """Rebuild in-memory state for a VM whose controller is still active.
+
+        Sourced entirely from the on-disk controller config -- message-free.
+        """
+        spec = spec_from_controller_configuration(config)
+        execution = VmExecution.from_spec(
+            spec,
+            snapshot_manager=self.snapshot_manager,
+            systemd_manager=self.systemd_manager,
+        )
+
+        execution.mapped_ports = await get_port_mappings(vm_hash)
+        logger.info("Loading existing mapped_ports %s", execution.mapped_ports)
+
+        await execution.prepare()  # builds resources from the spec; no download
+        tap_interface = await self._restore_network(execution, vm_id, vm_hash)
+
+        vm = execution.create(vm_id=vm_id, tap_interface=tap_interface, prepare=False)
+        await vm.start_guest_api()
+        execution.ready_event.set()
+        execution.times.started_at = datetime.now(tz=timezone.utc)
+
+        self._schedule_forget_on_stop(execution)
+
+        if vm.support_snapshot and self.snapshot_manager:
+            await self.snapshot_manager.start_for(vm=execution.vm)
+
+        if execution.mapped_ports:
+            await execution.recreate_port_redirect_rules()
+
+        self.executions[vm_hash] = execution
+
+    async def _handle_dead_controller(self, config: Configuration) -> None:
+        """Stop the stale controller service for a VM that is no longer active.
+
+        The orphan controller config is removed by _cleanup_orphan_resources
+        once the VM is absent from self.executions.
+        """
+        service_name = f"aleph-vm-controller@{config.vm_hash}.service"
+        try:
+            self.systemd_manager.stop_and_disable(service_name)
+            logger.info("Stopped and disabled stale controller service %s", service_name)
+        except Exception:
+            logger.warning("Failed to stop/disable stale controller %s", service_name, exc_info=True)
 
     async def _handle_dead_execution(self, execution: VmExecution, saved_execution: ExecutionRecord) -> None:
         """Record usage for a dead execution and stop its controller service."""

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -27,17 +27,14 @@ from aleph.vm.controllers.configuration import (
 from aleph.vm.controllers.firecracker.snapshot_manager import SnapshotManager
 from aleph.vm.network.hostnetwork import Network, make_ipv6_allocator
 from aleph.vm.network.interfaces import TapInterface
-from aleph.vm.orchestrator.metrics import (
-    get_port_mappings,
-)
+from aleph.vm.orchestrator.metrics import get_port_mappings
 from aleph.vm.orchestrator.utils import update_aggregate_settings
-from aleph.vm.resources import (
-    GpuDevice,
-    InsufficientResourcesError,
-    get_gpu_devices,
-)
+from aleph.vm.resources import GpuDevice, InsufficientResourcesError, get_gpu_devices
 from aleph.vm.supervisor.errors import InvalidBackendError
-from aleph.vm.supervisor.qemu_build import build_qemu_configuration, spec_from_controller_configuration
+from aleph.vm.supervisor.qemu_build import (
+    build_qemu_configuration,
+    spec_from_controller_configuration,
+)
 from aleph.vm.supervisor.types import Backend, CreateVmSpec
 from aleph.vm.systemd import SystemDManager
 from aleph.vm.vm_type import VmType

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import pathlib
 import shutil
@@ -18,25 +17,22 @@ from aleph_message.models import (
     Payment,
     PaymentType,
 )
-from pydantic import TypeAdapter
 
 from aleph.vm.conf import settings
 from aleph.vm.controllers.configuration import (
     Configuration,
+    load_controller_configuration,
     save_controller_configuration,
 )
 from aleph.vm.controllers.firecracker.snapshot_manager import SnapshotManager
 from aleph.vm.network.hostnetwork import Network, make_ipv6_allocator
 from aleph.vm.network.interfaces import TapInterface
 from aleph.vm.orchestrator.metrics import (
-    ExecutionRecord,
-    get_execution_records,
     get_port_mappings,
 )
 from aleph.vm.orchestrator.utils import update_aggregate_settings
 from aleph.vm.resources import (
     GpuDevice,
-    HostGPU,
     InsufficientResourcesError,
     get_gpu_devices,
 )
@@ -44,7 +40,6 @@ from aleph.vm.supervisor.errors import InvalidBackendError
 from aleph.vm.supervisor.qemu_build import build_qemu_configuration, spec_from_controller_configuration
 from aleph.vm.supervisor.types import Backend, CreateVmSpec
 from aleph.vm.systemd import SystemDManager
-from aleph.vm.utils import get_message_executable_content
 from aleph.vm.vm_type import VmType
 
 from .haproxy import fetch_list_and_update
@@ -538,116 +533,68 @@ class VmPool:
         execution._forget_task = asyncio.create_task(forget_on_stop(stop_event=execution.stop_event))
 
     async def load_persistent_executions(self):
-        """Load persistent executions from the database.
+        """Reattach VMs whose controllers survived a supervisor restart.
 
-        For each saved execution whose systemd controller is still active,
-        rebuild the in-memory state (network, ports, snapshots). For dead
-        executions, record usage and clean up the stale controller service.
-        After loading, remove any orphan host resources (nft rules, chains,
-        tap interfaces) left behind by previous crashes.
-
-        Uses batch D-Bus calls to check service states (1 call for all VMs
-        instead of 3+ per VM).
+        Scans EXECUTION_ROOT for <hash>-controller.json files, checks which
+        aleph-vm-controller@<hash>.service units are active (one batch D-Bus
+        call), and rebuilds in-memory state from each active config. Dead
+        controllers are stopped; their orphan configs are removed by
+        _cleanup_orphan_resources. Entirely message-free: nothing is read
+        from the database.
         """
-        saved_executions = await get_execution_records()
+        try:
+            config_paths = sorted(settings.EXECUTION_ROOT.glob("*-controller.json"))
+        except Exception:
+            logger.warning("Failed to enumerate controller configs", exc_info=True)
+            config_paths = []
 
-        # Filter to persistent executions not already loaded
-        persistent_saved = [
-            se for se in saved_executions if se.persistent and ItemHash(se.vm_hash) not in self.executions
-        ]
+        configs: list[Configuration] = []
+        for config_path in config_paths:
+            vm_hash = config_path.name[: -len("-controller.json")]
+            if ItemHash(vm_hash) in self.executions:
+                continue
+            config = load_controller_configuration(vm_hash)
+            if config is None:
+                continue
+            configs.append(config)
 
-        # Batch-fetch active states: 1 D-Bus ListUnits() call for all VMs
-        all_services = [f"aleph-vm-controller@{ItemHash(se.vm_hash)}.service" for se in persistent_saved]
+        # Batch-fetch active states: 1 D-Bus ListUnits() call for all VMs.
+        all_services = [f"aleph-vm-controller@{config.vm_hash}.service" for config in configs]
         service_active_states = self.systemd_manager.get_services_active_states(all_services)
 
-        # Track claimed vm_ids to detect duplicates in the DB.
-        # Multiple records can share a vm_id (stale records from old
-        # executions). Only the first active one should be restored —
-        # others are treated as dead to avoid tap interface conflicts.
+        # Track claimed vm_ids to detect duplicates across configs. A stale
+        # config can reuse a vm_id; only the first active one is restored to
+        # avoid two VMs sharing a tap interface.
         claimed_vm_ids: set[int] = set()
 
-        for saved_execution in persistent_saved:
-            vm_hash = ItemHash(saved_execution.vm_hash)
-            vm_id = saved_execution.vm_id
-            logger.info(f"Loading execution {vm_hash} for VM {vm_id}")
+        for config in configs:
+            vm_hash = ItemHash(str(config.vm_hash))
+            vm_id = config.vm_id
+            service_name = f"aleph-vm-controller@{config.vm_hash}.service"
+            is_active = service_active_states.get(service_name, False)
 
-            # Skip if another execution already claimed this vm_id.
-            # This prevents two instances from sharing the same tap
-            # interface, which causes network loss when one is cleaned up.
+            if not is_active:
+                await self._handle_dead_controller(config)
+                continue
+
             if vm_id in claimed_vm_ids:
                 logger.warning(
-                    "Skipping execution %s: vm_id %d already claimed by another execution",
+                    "Skipping reattach of %s: vm_id %d already claimed by another config",
                     vm_hash,
                     vm_id,
                 )
-                # Clean up the stale DB record
-                execution = VmExecution(
-                    vm_hash=vm_hash,
-                    message=get_message_executable_content(json.loads(saved_execution.message)),
-                    original=get_message_executable_content(json.loads(saved_execution.original_message)),
-                    snapshot_manager=self.snapshot_manager,
-                    systemd_manager=self.systemd_manager,
-                    persistent=saved_execution.persistent,
-                )
-                await self._handle_dead_execution(execution, saved_execution)
+                await self._handle_dead_controller(config)
                 continue
 
-            execution = VmExecution(
-                vm_hash=vm_hash,
-                message=get_message_executable_content(json.loads(saved_execution.message)),
-                original=get_message_executable_content(json.loads(saved_execution.original_message)),
-                snapshot_manager=self.snapshot_manager,
-                systemd_manager=self.systemd_manager,
-                persistent=saved_execution.persistent,
-            )
-
-            service_name = execution.controller_service
-            is_active = service_active_states.get(service_name, False)
-
-            if is_active:
-                claimed_vm_ids.add(vm_id)
-                await self._restore_running_execution(execution, saved_execution, vm_id, vm_hash)
-            else:
-                await self._handle_dead_execution(execution, saved_execution)
+            logger.info("Reattaching execution %s for VM %d", vm_hash, vm_id)
+            claimed_vm_ids.add(vm_id)
+            await self._restore_running_execution_from_config(config, vm_id, vm_hash)
 
         self._cleanup_orphan_resources()
 
         if self.executions:
             await self.update_domain_mapping(force_update=True)
-        logger.info(f"Loaded {len(self.executions)} executions")
-
-    async def _restore_running_execution(
-        self, execution: VmExecution, saved_execution: ExecutionRecord, vm_id: int, vm_hash: ItemHash
-    ) -> None:
-        """Rebuild in-memory state for a persistent execution whose controller is active."""
-        execution.gpus = (
-            TypeAdapter(list[HostGPU]).validate_python(json.loads(saved_execution.gpus)) if saved_execution.gpus else []
-        )
-
-        execution.mapped_ports = await get_port_mappings(vm_hash)
-        logger.info("Loading existing mapped_ports %s", execution.mapped_ports)
-
-        await execution.prepare()
-        tap_interface = await self._restore_network(execution, vm_id, vm_hash)
-
-        vm = execution.create(vm_id=vm_id, tap_interface=tap_interface, prepare=False)
-        await vm.start_guest_api()
-        execution.ready_event.set()
-        execution.times.started_at = datetime.now(tz=timezone.utc)
-        execution.times.starting_at = saved_execution.time_prepared
-        execution.times.prepared_at = saved_execution.time_defined
-
-        self._schedule_forget_on_stop(execution)
-
-        if vm.support_snapshot and self.snapshot_manager:
-            await self.snapshot_manager.start_for(vm=execution.vm)
-
-        if execution.mapped_ports:
-            await execution.recreate_port_redirect_rules()
-        await execution.fetch_port_redirect_config_and_setup()
-
-        self.executions[vm_hash] = execution
-        execution.record = saved_execution
+        logger.info("Loaded %d executions", len(self.executions))
 
     async def _restore_network(self, _execution: VmExecution, vm_id: int, vm_hash: ItemHash) -> TapInterface | None:
         """Restore tap interface, NDP proxy, and nftables rules for a VM."""
@@ -719,19 +666,6 @@ class VmPool:
             logger.info("Stopped and disabled stale controller service %s", service_name)
         except Exception:
             logger.warning("Failed to stop/disable stale controller %s", service_name, exc_info=True)
-
-    async def _handle_dead_execution(self, execution: VmExecution, saved_execution: ExecutionRecord) -> None:
-        """Record usage for a dead execution and stop its controller service."""
-        execution.uuid = saved_execution.uuid
-        try:
-            await execution.record_usage()
-        except Exception:
-            logger.warning("Failed to record usage for %s", execution.vm_hash, exc_info=True)
-        try:
-            self.systemd_manager.stop_and_disable(execution.controller_service)
-            logger.info("Stopped and disabled stale controller service %s", execution.controller_service)
-        except Exception:
-            logger.warning("Failed to stop/disable stale controller %s", execution.controller_service, exc_info=True)
 
     def _cleanup_orphan_resources(self):
         """Remove orphan nft rules, nft chains, tap interfaces, and controller configs.

--- a/src/aleph/vm/supervisor/qemu_build.py
+++ b/src/aleph/vm/supervisor/qemu_build.py
@@ -27,7 +27,18 @@ from aleph.vm.controllers.qemu.cloudinit import (
     get_hostname_from_hash,
 )
 from aleph.vm.sizes import MiB
-from aleph.vm.supervisor.types import Backend, CreateVmSpec, DiskRole
+from aleph.vm.supervisor.errors import InvalidBackendError
+from aleph.vm.supervisor.types import (
+    Backend,
+    CreateVmSpec,
+    DiskFormat,
+    DiskRole,
+    DiskSpec,
+    GpuSpec,
+    NetworkConfig,
+    PciAddress,
+    VmId,
+)
 
 if TYPE_CHECKING:
     from aleph.vm.network.interfaces import TapInterface
@@ -154,4 +165,57 @@ async def build_qemu_configuration(
         settings=settings,
         vm_configuration=vm_configuration,
         hypervisor=HypervisorType.qemu,
+    )
+
+
+def spec_from_controller_configuration(config: Configuration) -> CreateVmSpec:
+    """Reconstruct a CreateVmSpec from an on-disk controller Configuration.
+
+    The inverse of build_qemu_configuration, used by reboot-recovery to
+    reattach a running VM message-free. Only non-confidential QEMU configs
+    are supported (QemuConfidentialVMConfiguration is a separate type).
+    """
+    vm_cfg = config.vm_configuration
+    if not isinstance(vm_cfg, QemuVMConfiguration):
+        msg = f"Reattach supports QemuVMConfiguration only, got {type(vm_cfg).__name__}"
+        raise InvalidBackendError(msg)
+
+    disks: list[DiskSpec] = [
+        DiskSpec(
+            path=Path(vm_cfg.image_path),
+            readonly=False,
+            format=DiskFormat.QCOW2,
+            role=DiskRole.ROOTFS,
+            mount="",
+        )
+    ] + [
+        DiskSpec(
+            path=v.path_on_host,
+            readonly=v.read_only,
+            format=DiskFormat.RAW,
+            role=DiskRole.EXTRA,
+            mount=v.mount,
+        )
+        for v in vm_cfg.host_volumes
+    ]
+
+    gpus = [GpuSpec(pci_host=PciAddress(g.pci_host), supports_x_vga=g.supports_x_vga) for g in vm_cfg.gpus]
+
+    return CreateVmSpec(
+        vm_id=VmId(str(config.vm_hash)),
+        backend=Backend.QEMU,
+        kernel_path=Path(""),
+        initrd_path=Path(""),
+        disks=disks,
+        vcpus=vm_cfg.vcpu_count,
+        memory_mib=vm_cfg.mem_size_mb.count,
+        tee=None,
+        network=NetworkConfig(
+            internet_access=bool(vm_cfg.interface_name),
+            requested_ipv6="",
+            ipv6_prefix_len=0,
+        ),
+        gpus=gpus,
+        numa_node=None,
+        persistent=True,
     )

--- a/tests/supervisor/test_supervisor_reattach.py
+++ b/tests/supervisor/test_supervisor_reattach.py
@@ -1,0 +1,89 @@
+"""Config-driven, message-free reattach helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aleph.vm.pool import VmPool
+from aleph.vm.supervisor.types import (
+    Backend,
+    CreateVmSpec,
+    DiskFormat,
+    DiskRole,
+    DiskSpec,
+    NetworkConfig,
+    VmId,
+)
+
+_HASH = "deadbeef" * 8
+
+
+def _spec() -> CreateVmSpec:
+    return CreateVmSpec(
+        vm_id=VmId(_HASH),
+        backend=Backend.QEMU,
+        kernel_path=Path(""),
+        initrd_path=Path(""),
+        disks=[
+            DiskSpec(
+                path=Path("/data/rootfs.qcow2"),
+                readonly=False,
+                format=DiskFormat.QCOW2,
+                role=DiskRole.ROOTFS,
+            )
+        ],
+        vcpus=2,
+        memory_mib=1024,
+        tee=None,
+        network=NetworkConfig(internet_access=False, requested_ipv6="", ipv6_prefix_len=0),
+        gpus=[],
+        numa_node=None,
+        persistent=True,
+    )
+
+
+def _bare_pool() -> VmPool:
+    pool = VmPool.__new__(VmPool)
+    pool.executions = {}
+    pool.network = None
+    pool.snapshot_manager = None
+    pool.systemd_manager = MagicMock()
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_handle_dead_controller_stops_service():
+    pool = _bare_pool()
+    config = SimpleNamespace(vm_hash=_HASH)
+
+    await pool._handle_dead_controller(config)
+
+    pool.systemd_manager.stop_and_disable.assert_called_once_with(f"aleph-vm-controller@{_HASH}.service")
+
+
+@pytest.mark.asyncio
+async def test_restore_running_execution_from_config_registers_execution(monkeypatch):
+    pool = _bare_pool()
+    config = SimpleNamespace(vm_hash=_HASH, vm_id=7)
+
+    monkeypatch.setattr("aleph.vm.pool.spec_from_controller_configuration", lambda _c: _spec())
+    monkeypatch.setattr("aleph.vm.pool.get_port_mappings", AsyncMock(return_value={}))
+
+    from aleph.vm.models import VmExecution
+
+    monkeypatch.setattr(VmExecution, "prepare", AsyncMock())
+    fake_vm = SimpleNamespace(support_snapshot=False, start_guest_api=AsyncMock())
+    monkeypatch.setattr(VmExecution, "create", MagicMock(return_value=fake_vm))
+
+    await pool._restore_running_execution_from_config(config, vm_id=7, vm_hash=_HASH)
+
+    assert _HASH in pool.executions
+    execution = pool.executions[_HASH]
+    assert execution.spec is not None
+    assert execution.message is None
+    fake_vm.start_guest_api.assert_awaited_once()
+    assert execution.ready_event.is_set()

--- a/tests/supervisor/test_supervisor_spec_execution.py
+++ b/tests/supervisor/test_supervisor_spec_execution.py
@@ -134,3 +134,14 @@ async def test_start_skips_configure_and_save_for_spec(monkeypatch):
     systemd.enable_and_start.assert_awaited_once_with(execution.controller_service)
     save_record.assert_not_awaited()  # spec path keeps no DB record
     assert execution.ready_event.is_set()
+
+
+def test_start_watching_for_updates_is_noop_without_message():
+    # A message-free (spec-built / reattached) execution has no Aleph message to
+    # watch; start_watching_for_updates must no-op, not schedule a task that
+    # would crash on `self.original` being None.
+    execution = VmExecution.from_spec(make_spec(), snapshot_manager=None, systemd_manager=None)
+
+    execution.start_watching_for_updates(pubsub=object())  # type: ignore[arg-type]
+
+    assert execution.update_task is None

--- a/tests/supervisor/test_supervisor_spec_from_config.py
+++ b/tests/supervisor/test_supervisor_spec_from_config.py
@@ -1,0 +1,87 @@
+"""spec_from_controller_configuration — reverse of build_qemu_configuration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aleph.vm.conf import settings as real_settings
+from aleph.vm.controllers.configuration import (
+    Configuration,
+    HypervisorType,
+    QemuGPU,
+    QemuVMConfiguration,
+    QemuVMHostVolume,
+)
+from aleph.vm.sizes import MiB
+from aleph.vm.supervisor.errors import InvalidBackendError
+from aleph.vm.supervisor.qemu_build import spec_from_controller_configuration
+from aleph.vm.supervisor.types import Backend, DiskRole
+
+_HASH = "deadbeef" * 8
+
+
+def _config(*, interface_name: str | None = "tap7") -> Configuration:
+    vm_cfg = QemuVMConfiguration(
+        qemu_bin_path="/usr/bin/qemu-system-x86_64",
+        image_path="/data/rootfs.qcow2",
+        monitor_socket_path=Path("/run/m.socket"),
+        qmp_socket_path=Path("/run/q.socket"),
+        vcpu_count=4,
+        mem_size_mb=MiB(2048),
+        interface_name=interface_name,
+        host_volumes=[QemuVMHostVolume(mount="/mnt/data", path_on_host=Path("/data/extra.img"), read_only=True)],
+        gpus=[QemuGPU(pci_host="0000:01:00.0", supports_x_vga=True)],
+    )
+    return Configuration(
+        vm_id=7,
+        vm_hash=_HASH,
+        settings=real_settings,
+        vm_configuration=vm_cfg,
+        hypervisor=HypervisorType.qemu,
+    )
+
+
+def test_spec_from_config_roundtrips_core_fields():
+    spec = spec_from_controller_configuration(_config())
+
+    assert spec.vm_id == _HASH
+    assert spec.backend is Backend.QEMU
+    assert spec.vcpus == 4
+    assert spec.memory_mib == 2048
+    assert spec.network.internet_access is True  # interface_name present
+
+    rootfs = [d for d in spec.disks if d.role is DiskRole.ROOTFS]
+    extra = [d for d in spec.disks if d.role is DiskRole.EXTRA]
+    assert rootfs[0].path == Path("/data/rootfs.qcow2")
+    assert extra[0].path == Path("/data/extra.img")
+    assert extra[0].mount == "/mnt/data"
+    assert extra[0].readonly is True
+    assert len(spec.gpus) == 1
+    assert spec.gpus[0].pci_host == "0000:01:00.0"
+
+
+def test_spec_from_config_no_interface_means_no_internet():
+    spec = spec_from_controller_configuration(_config(interface_name=None))
+    assert spec.network.internet_access is False
+
+
+def test_spec_from_config_rejects_non_qemu():
+    from aleph.vm.controllers.configuration import VMConfiguration
+
+    cfg = Configuration(
+        vm_id=1,
+        vm_hash=_HASH,
+        settings=real_settings,
+        vm_configuration=VMConfiguration(
+            use_jailer=True,
+            firecracker_bin_path=Path("/x"),
+            jailer_bin_path=Path("/y"),
+            config_file_path=Path("/z"),
+            init_timeout=5.0,
+        ),
+        hypervisor=HypervisorType.firecracker,
+    )
+    with pytest.raises(InvalidBackendError):
+        spec_from_controller_configuration(cfg)

--- a/tests/supervisor/test_vm_id_collision.py
+++ b/tests/supervisor/test_vm_id_collision.py
@@ -1,215 +1,89 @@
-"""Tests for vm_id collision between persistent instances.
+"""Tests for vm_id collision between persistent instances on reboot-recovery.
 
-Reproduces the bug where two persistent instances share the same vm_id
-in the database. When both are loaded on supervisor restart, they share
-the same tap interface. When one is stopped/cleaned up, it deletes the
-tap interface used by the other — destroying its network connectivity.
-
-Real-world scenario from production logs:
-- Instance A (7a7e0c79) has vm_id=7, running with vmtap7
-- Instance B (41dd6224) also has vm_id=7 in DB (stale record)
-- Supervisor restarts, loads both, both restore vmtap7
-- Instance B is detected as dead, cleaned up — deletes vmtap7
-- Instance A loses network while still running
+After a reboot the supervisor reattaches VMs from on-disk controller configs.
+Two configs that claim the same vm_id (a stale config left behind) must not
+both restore -- they would share a tap interface and clobber each other's
+networking. Only the first active one is restored; the rest are treated as
+dead controllers.
 """
 
-import json
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from aleph_message.models import ItemHash
 
-from aleph.vm.orchestrator.metrics import ExecutionRecord
 from aleph.vm.pool import VmPool
 
-
-def _make_message_json(address: str = "0xtest") -> str:
-    """Create minimal valid message JSON for an instance."""
-    return json.dumps(
-        {
-            "address": address,
-            "time": 1700000000,
-            "allow_amend": False,
-            "metadata": None,
-            "authorized_keys": [],
-            "variables": None,
-            "environment": {
-                "reproducible": False,
-                "internet": True,
-                "aleph_api": True,
-                "shared_cache": False,
-            },
-            "resources": {"vcpus": 1, "memory": 2048, "seconds": 30},
-            "payment": {"chain": "ETH", "type": "hold"},
-            "requirements": None,
-            "volumes": [],
-            "rootfs": {
-                "parent": {
-                    "ref": "b6ff5c3a8205d1ca4c7c3369300eeafff498b558f71b851aa2114afd0a532717",
-                    "use_latest": True,
-                },
-                "persistence": "host",
-                "size_mib": 20480,
-            },
-        }
-    )
-
-
-def _make_db_record(
-    vm_hash: str,
-    vm_id: int,
-    persistent: bool = True,
-    uuid: str = "test-uuid",
-) -> ExecutionRecord:
-    """Create an ExecutionRecord matching the DB schema."""
-    msg = _make_message_json()
-    record = ExecutionRecord(
-        uuid=uuid,
-        vm_hash=vm_hash,
-        vm_id=vm_id,
-        persistent=persistent,
-        message=msg,
-        original_message=msg,
-        gpus="[]",
-        mapped_ports={},
-    )
-    return record
+HASH_A = "a" * 64
+HASH_B = "b" * 64
 
 
 def _make_pool() -> VmPool:
-    """Create a minimal VmPool with mocked dependencies."""
     pool = VmPool.__new__(VmPool)
     pool.executions = {}
     pool.network = None
     pool.snapshot_manager = None
     pool.systemd_manager = MagicMock()
     pool.systemd_manager.get_services_active_states = MagicMock(return_value={})
-    pool.systemd_manager.get_services_enabled_states = MagicMock(return_value={})
     return pool
+
+
+def _write_configs(tmp_path: Path, *vm_hashes: str) -> None:
+    for vm_hash in vm_hashes:
+        (tmp_path / f"{vm_hash}-controller.json").write_text("{}")
+
+
+def _config_for(vm_hash: str, vm_id: int) -> SimpleNamespace:
+    return SimpleNamespace(vm_hash=vm_hash, vm_id=vm_id)
 
 
 @pytest.mark.asyncio
 class TestDuplicateVmIdLoading:
-    """Test that load_persistent_executions handles duplicate vm_ids."""
+    async def _run(self, pool, tmp_path, configs, active):
+        def fake_load(vm_hash):
+            return configs[vm_hash]
 
-    @patch("aleph.vm.pool.get_execution_records")
-    @patch("aleph.vm.pool.get_port_mappings", new_callable=AsyncMock, return_value={})
-    async def test_duplicate_vm_id_only_first_active_restored(self, mock_ports, mock_get_records):
-        """When two persistent records share vm_id=7 and both are active,
-        only the first should be restored. The second should be skipped."""
+        with (
+            patch("aleph.vm.pool.settings", SimpleNamespace(EXECUTION_ROOT=tmp_path)),
+            patch("aleph.vm.pool.load_controller_configuration", side_effect=fake_load),
+            patch.object(pool, "_restore_running_execution_from_config", new_callable=AsyncMock) as restore,
+            patch.object(pool, "_handle_dead_controller", new_callable=AsyncMock) as dead,
+            patch.object(pool, "_cleanup_orphan_resources"),
+            patch.object(pool, "update_domain_mapping", new_callable=AsyncMock),
+        ):
+            pool.systemd_manager.get_services_active_states.return_value = active
+            await pool.load_persistent_executions()
+        return restore, dead
+
+    async def test_duplicate_vm_id_only_first_active_restored(self, tmp_path):
         pool = _make_pool()
-
-        hash_a = "a" * 64
-        hash_b = "b" * 64
-
-        mock_get_records.return_value = [
-            _make_db_record(hash_a, vm_id=7, uuid="uuid-a"),
-            _make_db_record(hash_b, vm_id=7, uuid="uuid-b"),
-        ]
-
-        # Both services are active
-        pool.systemd_manager.get_services_active_states.return_value = {
-            f"aleph-vm-controller@{hash_a}.service": True,
-            f"aleph-vm-controller@{hash_b}.service": True,
+        _write_configs(tmp_path, HASH_A, HASH_B)
+        configs = {HASH_A: _config_for(HASH_A, 7), HASH_B: _config_for(HASH_B, 7)}
+        active = {
+            f"aleph-vm-controller@{HASH_A}.service": True,
+            f"aleph-vm-controller@{HASH_B}.service": True,
         }
+        restore, dead = await self._run(pool, tmp_path, configs, active)
+        assert restore.call_count == 1
+        assert dead.call_count == 1
 
-        # Mock _restore_running_execution to avoid actual VM creation
-        with patch.object(pool, "_restore_running_execution", new_callable=AsyncMock) as mock_restore:
-            with patch.object(pool, "_handle_dead_execution", new_callable=AsyncMock) as mock_dead:
-                with patch.object(pool, "_cleanup_orphan_resources"):
-                    with patch.object(pool, "update_domain_mapping", new_callable=AsyncMock):
-                        await pool.load_persistent_executions()
-
-            # First instance restored, second treated as dead
-            assert mock_restore.call_count == 1
-            restored_hash = (
-                mock_restore.call_args[1]["vm_hash"] if mock_restore.call_args[1] else mock_restore.call_args[0][3]
-            )
-            assert str(restored_hash) == hash_a
-
-            assert mock_dead.call_count == 1
-
-    @patch("aleph.vm.pool.get_execution_records")
-    @patch("aleph.vm.pool.get_port_mappings", new_callable=AsyncMock, return_value={})
-    async def test_duplicate_vm_id_dead_records_both_cleaned(self, mock_ports, mock_get_records):
-        """When two persistent records share vm_id=7 and neither is active,
-        both should be handled as dead (no collision since neither restores)."""
+    async def test_duplicate_vm_id_dead_both_cleaned(self, tmp_path):
         pool = _make_pool()
+        _write_configs(tmp_path, HASH_A, HASH_B)
+        configs = {HASH_A: _config_for(HASH_A, 7), HASH_B: _config_for(HASH_B, 7)}
+        restore, dead = await self._run(pool, tmp_path, configs, active={})
+        assert restore.call_count == 0
+        assert dead.call_count == 2
 
-        hash_a = "a" * 64
-        hash_b = "b" * 64
-
-        mock_get_records.return_value = [
-            _make_db_record(hash_a, vm_id=7, uuid="uuid-a"),
-            _make_db_record(hash_b, vm_id=7, uuid="uuid-b"),
-        ]
-
-        # Neither service is active
-        pool.systemd_manager.get_services_active_states.return_value = {}
-        pool.systemd_manager.get_services_enabled_states.return_value = {}
-
-        with patch.object(pool, "_restore_running_execution", new_callable=AsyncMock) as mock_restore:
-            with patch.object(pool, "_handle_dead_execution", new_callable=AsyncMock) as mock_dead:
-                with patch.object(pool, "_cleanup_orphan_resources"):
-                    await pool.load_persistent_executions()
-
-            # Neither restored, both cleaned up
-            assert mock_restore.call_count == 0
-            assert mock_dead.call_count == 2
-
-    @patch("aleph.vm.pool.get_execution_records")
-    @patch("aleph.vm.pool.get_port_mappings", new_callable=AsyncMock, return_value={})
-    async def test_unique_vm_ids_all_restored(self, mock_ports, mock_get_records):
-        """When persistent records have unique vm_ids and are active,
-        all should be restored normally."""
+    async def test_unique_vm_ids_all_restored(self, tmp_path):
         pool = _make_pool()
-
-        hash_a = "a" * 64
-        hash_b = "b" * 64
-
-        mock_get_records.return_value = [
-            _make_db_record(hash_a, vm_id=7, uuid="uuid-a"),
-            _make_db_record(hash_b, vm_id=8, uuid="uuid-b"),
-        ]
-
-        pool.systemd_manager.get_services_active_states.return_value = {
-            f"aleph-vm-controller@{hash_a}.service": True,
-            f"aleph-vm-controller@{hash_b}.service": True,
+        _write_configs(tmp_path, HASH_A, HASH_B)
+        configs = {HASH_A: _config_for(HASH_A, 7), HASH_B: _config_for(HASH_B, 8)}
+        active = {
+            f"aleph-vm-controller@{HASH_A}.service": True,
+            f"aleph-vm-controller@{HASH_B}.service": True,
         }
-
-        with patch.object(pool, "_restore_running_execution", new_callable=AsyncMock) as mock_restore:
-            with patch.object(pool, "_handle_dead_execution", new_callable=AsyncMock) as mock_dead:
-                with patch.object(pool, "_cleanup_orphan_resources"):
-                    with patch.object(pool, "update_domain_mapping", new_callable=AsyncMock):
-                        await pool.load_persistent_executions()
-
-            assert mock_restore.call_count == 2
-            assert mock_dead.call_count == 0
-
-    @patch("aleph.vm.pool.get_execution_records")
-    @patch("aleph.vm.pool.get_port_mappings", new_callable=AsyncMock, return_value={})
-    async def test_non_persistent_records_filtered_out(self, mock_ports, mock_get_records):
-        """Non-persistent records should be ignored entirely,
-        regardless of their vm_id."""
-        pool = _make_pool()
-
-        mock_get_records.return_value = [
-            _make_db_record("a" * 64, vm_id=7, persistent=True, uuid="uuid-a"),
-            _make_db_record("b" * 64, vm_id=7, persistent=False, uuid="uuid-b"),
-            _make_db_record("c" * 64, vm_id=7, persistent=False, uuid="uuid-c"),
-        ]
-
-        pool.systemd_manager.get_services_active_states.return_value = {
-            f"aleph-vm-controller@{'a' * 64}.service": True,
-        }
-
-        with patch.object(pool, "_restore_running_execution", new_callable=AsyncMock) as mock_restore:
-            with patch.object(pool, "_handle_dead_execution", new_callable=AsyncMock) as mock_dead:
-                with patch.object(pool, "_cleanup_orphan_resources"):
-                    with patch.object(pool, "update_domain_mapping", new_callable=AsyncMock):
-                        await pool.load_persistent_executions()
-
-            # Only the persistent active record is restored
-            assert mock_restore.call_count == 1
-            # Non-persistent records are not even processed
-            assert mock_dead.call_count == 0
+        restore, dead = await self._run(pool, tmp_path, configs, active)
+        assert restore.call_count == 2
+        assert dead.call_count == 0


### PR DESCRIPTION
Part **4 of 4** of the message-free supervisor backport. Base: `od/msgfree-3-routing` (#956).

> Top of the stack — stacked on #956 → #955 → #954. Review/merge those first.

Makes reboot-recovery message-free: the supervisor reattaches surviving VMs from on-disk controller configs + systemd, dropping the DB path entirely.

### Changes
- `spec_from_controller_configuration(config)` — the inverse of `build_qemu_configuration`: reconstruct a `CreateVmSpec` from an on-disk `<hash>-controller.json`.
- Config-driven reattach helpers `_restore_running_execution_from_config` and `_handle_dead_controller`; `_restore_network` made message-free (`VmType.instance`).
- `pool.load_persistent_executions` rewritten to scan `EXECUTION_ROOT/*-controller.json` + batch systemd active-state, with the original vm_id-dedup guard preserved. Removes the DB-based path (`get_execution_records`, `ExecutionRecord`, and 4 other now-dead imports) and the old `_restore_running_execution`/`_handle_dead_execution`.
- `start_watching_for_updates`/`watch_for_updates` no-op for message-free executions instead of asserting (otherwise every reattached VM would fire an assertion when the scheduler re-issues `start_persistent_vm` after a reboot).

### By design
A reattached VM has no Aleph message, so operator-API owner-auth and Aleph update-watching are inert after a reboot until the agent re-fetches the allocation from the scheduler. This is the intended separation of the API lifecycle from the supervisor lifecycle; the changes here make those paths degrade gracefully rather than crash.

### Stack
1. spec-constructible `VmExecution` → `dev` (#954)
2. pool create path → #954 (#955)
3. route production creation through the spec → #955 (#956)
4. **(this PR)** reboot-recovery from on-disk configs → #956

New tests: `test_supervisor_spec_from_config.py`, `test_supervisor_reattach.py`; `test_vm_id_collision.py` rewritten to the config-scan path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
