### PR TITLE
chore: add Justfile for running the test suite locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 *.pyc
 __pycache__
 
+# Local test virtualenv and writable roots created by the Justfile
+.testvenv/
+.test-roots/
+
 *.sqlite3
 *.bin
 *.ext4

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,70 @@
+# Developer tasks for running the aleph-vm test suite locally.
+#
+# Requires `just` (https://github.com/casey/just). Run `just` to list recipes.
+#
+# Quick start (Debian/Ubuntu):
+#   just system-deps   # once: apt packages + build headers (sudo)
+#   just venv          # create .testvenv, install the project + test deps
+#   just test          # run the suite without root
+#
+# `system-deps` installs the apt python3-* bindings (nftables, dbus, systemd,
+# ...) and the dev headers pip compiles dbus-python / systemd-python against,
+# mirroring .github/workflows/test-using-pytest.yml. `venv` then creates a
+# --system-site-packages virtualenv (so those bindings are visible, matching
+# CI's hatch `testing` env) and installs the rest with pip.
+#
+# A handful of tests still require root + network + qemu/firecracker (network
+# interfaces, VM creation, runtime downloads); those only pass in CI under sudo.
+# Path to the local test virtualenv.
+
+venv := ".testvenv"
+
+# Writable stand-ins for /var/cache/aleph and /var/lib/aleph (gitignored) so the
+# suite runs without root.
+
+roots := justfile_directory() / ".test-roots"
+py := venv / "bin" / "python"
+
+# List available recipes.
+_default:
+    @just --list
+
+# Install the apt packages and build headers the test suite needs (sudo).
+system-deps:
+    sudo apt-get update
+    sudo apt-get install -y \
+        python3 python3-pip python3-aiohttp python3-msgpack python3-aiodns \
+        python3-alembic python3-sqlalchemy python3-setproctitle python3-psutil \
+        python3-packaging python3-cpuinfo python3-nftables python3-jsonschema \
+        python3-jwcrypto nftables redis acl curl systemd-container squashfs-tools \
+        debootstrap libsystemd-dev cmake libdbus-1-dev libglib2.0-dev lshw
+
+# Create .testvenv and install the project + test/lint deps (run system-deps first).
+venv:
+    python3 -m venv --system-site-packages {{ venv }}
+    {{ venv }}/bin/pip install --upgrade pip
+    {{ venv }}/bin/pip install -e . \
+        eth_typing==4.3.1 \
+        pytest==8.2.1 pytest-cov==5.0.0 pytest-mock==3.14.0 \
+        pytest-asyncio==0.23.7 pytest-aiohttp==1.0.5 \
+        mypy==1.8.0 ruff==0.4.6 isort==5.13.2
+
+# Run the suite without root, or a subset: `just test tests/supervisor`.
+test *args="tests":
+    mkdir -p {{ roots }}/cache {{ roots }}/exec
+    ALEPH_VM_CACHE_ROOT={{ roots }}/cache \
+    ALEPH_VM_EXECUTION_ROOT={{ roots }}/exec \
+        {{ py }} -m pytest {{ args }}
+
+# Whole-package type check (the CI mypy gate).
+mypy:
+    {{ py }} -m mypy src/aleph/vm/
+
+# Style checks (ruff format + isort), matching CI's linting env.
+lint:
+    {{ py }} -m ruff format --check .
+    {{ py }} -m isort --check-only --profile black .
+
+# Remove the local test virtualenv and writable roots.
+clean:
+    rm -rf {{ venv }} {{ roots }}

--- a/Justfile
+++ b/Justfile
@@ -3,15 +3,15 @@
 # Requires `just` (https://github.com/casey/just). Run `just` to list recipes.
 #
 # Quick start (Debian/Ubuntu):
-#   just system-deps   # once: apt packages + build headers (sudo)
-#   just venv          # create .testvenv, install the project + test deps
-#   just test          # run the suite without root
+#   just install-system-deps   # once: apt packages + build headers (sudo)
+#   just setup-venv            # create .testvenv, install the project + test deps
+#   just test                  # run the suite without root
 #
-# `system-deps` installs the apt python3-* bindings (nftables, dbus, systemd,
-# ...) and the dev headers pip compiles dbus-python / systemd-python against,
-# mirroring .github/workflows/test-using-pytest.yml. `venv` then creates a
-# --system-site-packages virtualenv (so those bindings are visible, matching
-# CI's hatch `testing` env) and installs the rest with pip.
+# `install-system-deps` installs the apt python3-* bindings (nftables, dbus,
+# systemd, ...) and the dev headers pip compiles dbus-python / systemd-python
+# against, mirroring .github/workflows/test-using-pytest.yml. `setup-venv` then
+# creates a --system-site-packages virtualenv (so those bindings are visible,
+# matching CI's hatch `testing` env) and installs the rest with pip.
 #
 # A handful of tests still require root + network + qemu/firecracker (network
 # interfaces, VM creation, runtime downloads); those only pass in CI under sudo.
@@ -30,7 +30,7 @@ _default:
     @just --list
 
 # Install the apt packages and build headers the test suite needs (sudo).
-system-deps:
+install-system-deps:
     sudo apt-get update
     sudo apt-get install -y \
         python3 python3-pip python3-aiohttp python3-msgpack python3-aiodns \
@@ -39,8 +39,8 @@ system-deps:
         python3-jwcrypto nftables redis acl curl systemd-container squashfs-tools \
         debootstrap libsystemd-dev cmake libdbus-1-dev libglib2.0-dev lshw
 
-# Create .testvenv and install the project + test/lint deps (run system-deps first).
-venv:
+# Create .testvenv and install the project + test/lint deps (run install-system-deps first).
+setup-venv:
     python3 -m venv --system-site-packages {{ venv }}
     {{ venv }}/bin/pip install --upgrade pip
     {{ venv }}/bin/pip install -e . \
@@ -57,13 +57,18 @@ test *args="tests":
         {{ py }} -m pytest {{ args }}
 
 # Whole-package type check (the CI mypy gate).
-mypy:
+check-typing:
     {{ py }} -m mypy src/aleph/vm/
 
 # Style checks (ruff format + isort), matching CI's linting env.
 lint:
     {{ py }} -m ruff format --check .
     {{ py }} -m isort --check-only --profile black .
+
+# Apply formatting in place (ruff format + isort).
+format:
+    {{ py }} -m ruff format .
+    {{ py }} -m isort --profile black .
 
 # Remove the local test virtualenv and writable roots.
 clean:


### PR DESCRIPTION
## What

Adds a `Justfile` with recipes to provision a local test environment and run the suite without root.

```
just system-deps   # apt packages + build headers (Debian/Ubuntu, sudo)
just venv          # create .testvenv and install the project + test/lint deps
just test          # run the suite (or `just test tests/supervisor`)
just mypy          # whole-package type check (the CI gate)
just lint          # ruff format + isort checks
just clean         # remove .testvenv and .test-roots
```

## Why

Running the suite locally currently has two undocumented gotchas that cost real back-and-forth with CI:

1. **Missing deps.** The test venv must include `solathon`, `aleph-superfluid` and the pinned pytest plugins (notably `pytest-mock`); without them the `mocker`-fixture tests error at *collection* rather than failing visibly, so a green local run can hide real breakage.
2. **Hardcoded roots.** The suite writes to `/var/cache/aleph` and `/var/lib/aleph`, which need root. `just test` redirects `ALEPH_VM_CACHE_ROOT` / `ALEPH_VM_EXECUTION_ROOT` to a gitignored temp dir so the bulk of the suite runs as a normal user.

## Notes

- The `venv` recipe uses `--system-site-packages` so the apt `python3-*` bindings (nftables, dbus, systemd) resolve, mirroring CI's hatch `testing` env (`system-packages = true`). Run `just system-deps` first so the `dbus-python` / `systemd-python` builds find their headers.
- A handful of tests still require root + network + qemu/firecracker (network-interface creation, VM creation, runtime downloads); those remain CI-only, as they already run under `sudo` there.
- `.testvenv/` and `.test-roots/` are gitignored.
- Validated with `just 1.36.0`: `--list` and `--fmt --check` are clean, and `just test tests/supervisor/test_resources.py` passes end-to-end (10 passed) with the roots redirected.