### PR TITLE
fix: periodically re-sync haproxy domain mappings

### DIFF
--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -297,6 +297,14 @@ class Settings(BaseSettings):
         default=60.0,
         description="Interval in seconds between payment checks",
     )
+    DOMAIN_RESYNC_INTERVAL: float = Field(
+        default=600.0,
+        description=(
+            "Interval in seconds between periodic HAProxy domain-mapping "
+            "re-syncs against DOMAIN_SERVICE_URL. Acts as a safety net for "
+            "missed WS events or upstream indexing lag."
+        ),
+    )
     PAYMENT_RECEIVER_ADDRESS: str | None = Field(
         default=None,
         description="Address of the account receiving payments. " "Defaults to OWNER_ADDRESS if not set.",

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -29,9 +29,11 @@ from .node_identity import (
 )
 from .resources import about_capability, about_certificates, about_system_usage
 from .tasks import (
+    start_domain_resync_task,
     start_payment_monitoring_task,
     start_watch_for_messages_task,
     stop_balances_monitoring_task,
+    stop_domain_resync_task,
     stop_watch_for_messages_task,
 )
 from .views import (
@@ -318,8 +320,10 @@ def run():
         if settings.WATCH_FOR_MESSAGES:
             app.on_startup.append(start_watch_for_messages_task)
             app.on_startup.append(start_payment_monitoring_task)
+            app.on_startup.append(start_domain_resync_task)
             app.on_cleanup.append(stop_watch_for_messages_task)
             app.on_cleanup.append(stop_balances_monitoring_task)
+            app.on_cleanup.append(stop_domain_resync_task)
 
         app.on_cleanup.append(stop_all_vms)
 

--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import math
+import random
 import time
 from collections.abc import AsyncIterable, Callable
 from decimal import Decimal
@@ -447,3 +448,42 @@ async def stop_balances_monitoring_task(app: web.Application):
         await app["payments_monitor"]
     except asyncio.CancelledError:
         logger.debug("Task payments_monitor is cancelled now")
+
+
+async def periodic_domain_resync(app: web.Application):
+    """Re-sync HAProxy domain mappings on a jittered interval.
+
+    Belt-and-braces for the WS-event-driven path in
+    `_handle_domains_aggregate`: a missed frame or upstream indexing lag
+    on DOMAIN_SERVICE_URL would otherwise leave the map stale until the
+    next aggregate update or supervisor restart.
+
+    Jitter prevents thundering-herd against DOMAIN_SERVICE_URL when many
+    CRNs restart together (rolling deploys, common upstream events).
+    First sleep picks a random phase across the full interval;
+    subsequent sleeps stay decorrelated with ±15% jitter.
+    """
+    pool: VmPool = app["vm_pool"]
+    interval = settings.DOMAIN_RESYNC_INTERVAL
+    await asyncio.sleep(random.uniform(0, interval))
+    while True:
+        try:
+            await pool.update_domain_mapping()
+        except Exception as e:
+            if isinstance(e, RuntimeError) and "Event loop is closed" in str(e):
+                logger.debug("periodic_domain_resync exiting: event loop closed")
+                return
+            logger.warning("periodic_domain_resync failed: %s", e, exc_info=True)
+        await asyncio.sleep(interval * random.uniform(0.85, 1.15))
+
+
+async def start_domain_resync_task(app: web.Application):
+    app["domain_resync"] = create_task_log_exceptions(periodic_domain_resync(app), name="domain_resync")
+
+
+async def stop_domain_resync_task(app: web.Application):
+    app["domain_resync"].cancel()
+    try:
+        await app["domain_resync"]
+    except asyncio.CancelledError:
+        logger.debug("Task domain_resync is cancelled now")


### PR DESCRIPTION
  The domain-mapping refresh path is WS-event-driven: an aggregate update
  fires _handle_domains_aggregate, which fetches from DOMAIN_SERVICE_URL
  and rewrites the haproxy maps. If the downstream DNS indexer hasn't
  caught up yet when the CRN fetches, the fetch returns a stale list, the
  maps converge to that stale state, and no further refresh ever runs
  until the next aggregate update.

  Add a periodic background task that calls update_domain_mapping every
  DOMAIN_RESYNC_INTERVAL seconds (default 600). update_domain_mapping is
  idempotent — no haproxy writes when content matches — so the steady-
  state cost is one HTTP GET plus three map reads.

  Jittered: first sleep picks a random phase across the interval;
  subsequent sleeps use ±15% jitter. Prevents thundering-herd against
  DOMAIN_SERVICE_URL when CRNs restart together (rolling deploys).