### PR TITLE
Message-free supervisor (5/N): wire the agent's create path onto the Supervisor abstraction

### DIFF
--- a/docs/plans/2026-06-01-wire-agent-onto-supervisor-design.md
+++ b/docs/plans/2026-06-01-wire-agent-onto-supervisor-design.md
@@ -1,0 +1,264 @@
+# Wiring the agent onto the Supervisor abstraction (Phase 0 completion)
+
+**Date:** 2026-06-01
+**Status:** Design, approved for planning
+**Design doc lineage:** follows `2026-05-28-aleph-vm-architecture-backport-design.md` (§6 Phase 0), `2026-05-29-phase-0b-supervisor-abc-design.md`, `2026-05-29-phase-0c-create-vm-decouple-design.md`, and the `2026-05-29-message-free-supervisor-create-reboot-design.md` plan (PRs #954–#957, merged).
+
+## 1. Goal
+
+Make the agent reach hypervisor functionality **only** through the `Supervisor`
+abstraction (`src/aleph/vm/supervisor/abc.py`, in-process impl
+`InProcessSupervisor`), starting with the **persistent-instance lifecycle**.
+Today the abstraction is fully built and conformance-tested but nothing outside
+tests instantiates it: the agent (`orchestrator/run.py`, `orchestrator/views`,
+`orchestrator/tasks.py`) still reaches straight into `VmPool` and `VmExecution`
+internals (~25 distinct touchpoints; `pool.executions` alone is read in 24
+places).
+
+This is the explicit Phase 0 exit criterion from the backport design:
+
+> *"`orchestrator/views` and `orchestrator/run.py` are migrated to call the
+> abstraction … every call into hypervisor functionality from agent code goes
+> through the abstraction."*
+
+It is also the prerequisite for Phase 1: a call's transport cannot be swapped to
+gRPC until the call goes through the boundary.
+
+## 2. Scope
+
+**In scope: persistent-instance lifecycle through the abstraction**
+
+- Create path: `create_vm_execution` (eligible-instance branch) and
+  `start_persistent_vm` in `orchestrator/run.py`.
+- Operator lifecycle endpoints: stop/delete, reboot, reinstall, logs, and
+  port-forward listing/removal in `orchestrator/views` and the deallocation
+  path in `orchestrator/tasks.py`.
+- A new **agent-side registry** of created VMs (message + original), replacing
+  the vestigial `pool.message_cache`.
+
+**Explicitly out of scope:**
+
+- The on-demand program / Firecracker HTTP serving path
+  (`run_code_on_request`, `run_code_on_event`), the "hardest entanglement,"
+  Phase 1 item #2.
+- Resource admission, GPU reservation, domain-mapping, `drain`,
+  `setup`/`teardown`, `load_persistent_executions`. These stay on the pool;
+  several are agent/scheduler concerns, not hypervisor concerns.
+- Backups, migration, confidential, still stubbed on `InProcessSupervisor`
+  (deferred: migrate when a carved-out path needs them; confidential is Phase 3).
+- Deleting the pool / the in-process implementation. That is the Phase 1 exit
+  criterion, not this work.
+
+## 3. Architecture and responsibility split
+
+A single `InProcessSupervisor(pool)` is constructed at app startup and stored in
+app state (`app["supervisor"]`), alongside the existing `pool`. The pool remains
+for the out-of-scope concerns above; the agent reaches the **hypervisor** only
+through the `Supervisor` ABC.
+
+The agent gains a small **agent-side registry**:
+
+```python
+@dataclass
+class AgentVmRecord:
+    message: ExecutableContent
+    original: ExecutableContent
+```
+
+keyed by `vm_hash`, held in app state. It is populated on **every** create
+(both the spec branch and the legacy branch), so owner-auth, billing, and
+port-forward resolution have a message source that does not depend on the
+hypervisor. It replaces `pool.message_cache` (written once in `run.py`, read
+nowhere, effectively dead).
+
+| Concern | Owner |
+|---|---|
+| create / get / list / delete / reboot / reinstall / logs / port-forward *by `vm_id`*, message-free | **Hypervisor** (`Supervisor`) |
+| message translation, aggregate-settings reads, port-forward **resolution**, ownership, billing, the registry, the create→poll orchestration | **Agent** (`orchestrator/run.py` + registry) |
+
+The boundary is gRPC-honest: no `VmExecution` object ever crosses it. Everything
+the agent receives back is a `VmInfo` (or a `PortForwardInfo` / `LogChunk` /
+…), keyed by `VmId`.
+
+## 4. Create path
+
+Rewrite the eligible-instance branch of `create_vm_execution` plus
+`start_persistent_vm`:
+
+```
+spec = await build_create_vm_spec(vm_hash, content)          # already present
+info = await supervisor.create_vm(spec)                      # VmInfo @ BOOTING
+registry[vm_hash] = AgentVmRecord(message=content,
+                                  original=original.content)
+await _wait_until_running(supervisor, info.vm_id, timeout)   # polls get_vm
+forwards = resolve_port_forwards(content)                    # agent-side
+for fwd in forwards:
+    await supervisor.add_port_forward(fwd)                   # nftables behind the abstraction
+```
+
+No `VmExecution` handle crosses the seam.
+
+**Readiness via polling.** `create_vm` returns a `VmInfo` early (status
+`BOOTING`); the agent polls `supervisor.get_vm(vm_id)` until status `RUNNING`,
+with its own timeout. This replaces the old `await execution.becomes_ready()`.
+
+**Status mapping (no change needed).** An earlier draft proposed redefining
+`RUNNING` to mean "guest-ready" rather than "service-active." Tracing the boot
+path showed that is both unnecessary and harmful, so the status mapping stays as
+it is today. The reasoning: `create_vm_from_spec` awaits `start()` to completion;
+for persistent instances `start()` calls `non_blocking_wait_for_boot()` which
+blocks until the controller service is active and only then sets `ready_event`.
+`becomes_ready` is `ready_event.wait`, and its own docstring states guest-level
+readiness (network, user apps) is *not* checked. So `becomes_ready` already
+resolves at controller-active, the same coarseness as `_status_of`'s current
+`RUNNING` (= systemd service active). Redefining `RUNNING` to key on `ready_event`
+would also mis-report reboot-reattached VMs (#957), which are running but never
+had `ready_event` set in this process, as stuck in `BOOTING`. The agent therefore
+polls `get_vm` until `RUNNING` against the existing mapping; in-process the poll
+returns immediately (create already blocked until boot), and across a future gRPC
+boundary it does real work. The contract is satisfied without touching
+`_status_of` / `_is_running`.
+
+**Port-forward resolution split.** `VmExecution.fetch_port_redirect_config_and_setup`
+splits cleanly along the boundary:
+
+- *Agent half (policy)* (`resolve_port_forwards(content)`): read the user
+  aggregate settings via `get_user_settings(message.address, "port-forwarding")`,
+  compute the requested ports, force `:22`, and produce a list of
+  `PortForwardSpec`. The agent decides *what* should be forwarded.
+- *Hypervisor half (mechanism + persistence)*: the nftables setup, already
+  exposed as `supervisor.add_port_forward(spec)`. The hypervisor applies the
+  rules, **persists** the resulting mappings, reports them through
+  `list_port_forwards`, and reapplies them on its own reattach / reboot-recovery.
+  The agent never reads or recreates persisted mappings.
+
+This realises the backport design's stated freeze: *"Agent owns
+aggregate-settings reads; freeze the shape the hypervisor sees (just
+`port_forwards`)."* The network policy is translated agent-side; the networking
+configuration itself is owned and managed by the hypervisor, which follows the
+agent's orders but is the sole writer of nftables state. Consequently the DB-backed
+reattach (`get_port_mappings` + `recreate_port_redirect_rules`) becomes a
+hypervisor responsibility, not an agent call; `fetch_port_redirect_config_and_setup`
+loses that half entirely.
+
+## 5. Operator lifecycle endpoints
+
+The stop/delete, reboot, reinstall, logs, and port-forward listing/removal call
+sites in `views/__init__.py`, plus the deallocation path in `tasks.py`, move off
+`pool.stop_vm` / `pool.forget_vm` / `pool.get_running_vm` onto
+`supervisor.delete_vm / reboot_vm / reinstall_vm / get_logs / list_port_forwards
+/ remove_port_forward`, all keyed by `vm_id`. The in-process impl delegates to
+the pool, so these cover **all** VMs (instances and programs) uniformly. They
+are not instance-only.
+
+**Owner-auth** in those endpoints currently reads `execution.message.address`.
+It moves to the registry: `registry[vm_hash].message.address`. Because the
+registry is populated on every create, programs are covered too.
+
+**Registry survives agent reboot.** The registry is an in-memory **cache for
+messages**, backed by the agent's existing DB, which stores what the agent knows
+about each VM. On agent startup the agent **rehydrates** the registry from the
+DB, so owner-auth and billing keep working across an agent restart. This is
+independent of, and complementary to, the supervisor's message-free config
+reattach (#957): the supervisor reattaches the running VMs from on-disk
+controller configs, while the agent independently re-learns the messages it
+owns. The two recoveries do not share state, which is the point of separating
+the lifecycles.
+
+For now the DB is the single source of truth for the agent's known VMs. A later
+iteration will add the ability to recreate the agent's state from the network
+(fetch the plan from the scheduler, fetch the Aleph messages), at which point the
+DB becomes a true cache rather than the authority. That network-recreate path is
+out of scope here; keep the DB approach.
+
+## 6. Error handling
+
+`InProcessSupervisor` already wraps internals via `translating_errors()` into
+`SupervisorError` subclasses. The agent's
+`create_vm_execution_or_raise_http_error` shifts from catching
+hypervisor-internal exception types (today's `ResourceDownloadError`,
+`VmSetupError`, `MicroVMFailedInitError`, `InsufficientResourcesError`, …) to
+catching `SupervisorError` subclasses and mapping them to HTTP responses. This
+is the first concrete consumer of the "wire error vocabulary" (backport design
+Annex A.6); the mapping table lives agent-side.
+
+`_wait_until_running` enforces a timeout: on expiry the agent calls
+`supervisor.delete_vm(vm_id)` to tear down the half-started VM and raises an
+HTTP 5xx, mirroring today's failure path.
+
+## 7. Testing
+
+- **Create flow** (extend `tests/supervisor/test_supervisor_run_routing.py`):
+  with a fake `Supervisor`, assert `create_vm(spec)` is called, the poll loop
+  calls `get_vm` until `RUNNING`, `add_port_forward` is called with the resolved
+  specs, and the registry is populated. The timeout path triggers `delete_vm`
+  and an error.
+- **Poll loop**: `_wait_until_running` returns once `get_vm` reports `RUNNING`,
+  and raises (after teardown) on timeout. No change to `_status_of` is made or
+  tested; the existing inprocess status tests stand.
+- **Operator endpoints**: owner-auth resolves from the registry; an unknown
+  `vm_hash` is unauthorized.
+- **Gates held throughout:** mypy union-attr gate (`src/aleph/vm/` == 2,
+  `src/aleph/vm/controllers/` == 0); the existing `InProcessSupervisor`
+  conformance suite; the ~8 environmental-only failures baseline (network /
+  pyroute2 / subprocess) and ~540 passing.
+
+## 8. PR breakdown (stacked on `dev`)
+
+1. **App wiring + registry + create path.** Construct `app["supervisor"]` and
+   `app["vm_registry"]`; add the `AgentVmRecord` registry (populated on both
+   create branches); rewrite `create_vm_execution` so the create flow runs
+   through the abstraction (`create_vm` → poll `get_vm` until `RUNNING` →
+   `resolve_port_forwards` → `add_port_forward`). The in-process status mapping
+   is left unchanged (see §4). This is the decision-heavy PR.
+
+   **Boundary (decided during planning).** No caller uses the return value of
+   `create_vm_execution` / `create_vm_execution_or_raise_http_error` /
+   `start_persistent_vm`, so the create follow-up (message, port-forward,
+   readiness) is fully pure via the registry, `add_port_forward`, and the poll.
+   But `start_persistent_vm` still drives the `VmExecution` for three
+   un-migrated, create-adjacent concerns: the pre-existing-VM state check, the
+   expiry-cancel, and update-watching. PR 1 leaves those on the execution:
+   `create_vm_execution` reads the freshly created execution back from
+   `pool.executions` **once** (a single, explicitly temporary line) and returns
+   it so `start_persistent_vm` is unchanged. That residual `pool.executions`
+   read, and the expiry/update-watch ops, migrate in a later PR (see §9). The
+   message follow-up itself never re-fetches the execution.
+2. **Operator lifecycle endpoints.** Migrate the views / tasks stop, delete,
+   reboot, reinstall, logs, and port-forward calls onto the abstraction;
+   owner-auth reads from the registry; agent rehydrates the registry on startup
+   from its message store; the hypervisor reapplies persisted port forwards on
+   reattach (and `fetch_port_redirect_config_and_setup` sheds its DB-reattach half).
+3. *(optional)* **Read views.** Move any remaining status/list endpoints onto
+   `get_vm` / `list_vms`.
+
+## 9. Open questions / deferred
+
+No open questions remain.
+
+**Future work (out of scope here):**
+
+- *Recreate agent state from the network.* Fetch the plan from the scheduler and
+  the Aleph messages to rebuild the agent's known-VM set, demoting the DB from
+  authority to cache. This design keeps the DB approach.
+- *Migrate expiry-cancel and update-watching off `VmExecution`.* Reimplement
+  `cancel_expiration` and `watch_for_updates` as agent-side facilities keyed by
+  `vm_hash` (off the registry), removing the residual `pool.executions` read that
+  PR 1 leaves in `start_persistent_vm`. This also covers the pre-existing-VM
+  state check moving onto `get_vm`.
+
+**Resolved during review (2026-06-01):**
+
+- *Readiness / status mapping.* No change to `_status_of` / `_is_running`. The
+  existing `RUNNING` = service-active already matches `becomes_ready` (which does
+  not check guest-level readiness), and keying on `ready_event` would break
+  reboot-reattached VMs. The agent polls `get_vm` until `RUNNING`. (See §4.)
+
+- *Port-mapping ownership.* Persisted port mappings are **hypervisor-owned**. The
+  agent translates API / aggregate-settings into desired forwards and issues
+  `add_port_forward` / `remove_port_forward`; the hypervisor applies, persists,
+  reports (`list_port_forwards`), and reapplies them on reattach. The agent never
+  calls `get_port_mappings` / `recreate_port_redirect_rules`. (See §4, §5.)
+- *Owner-auth across agent reboot.* The agent rehydrates its registry (a message
+  cache backed by the existing DB) on startup, so there is no owner-auth gap for
+  recovered VMs. (See §5.)

--- a/docs/plans/2026-06-02-wire-agent-supervisor-pr1-plan.md
+++ b/docs/plans/2026-06-02-wire-agent-supervisor-pr1-plan.md
@@ -1,0 +1,870 @@
+# Wire agent onto Supervisor abstraction: PR 1 (create path) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route the agent's persistent-instance create path (`orchestrator/run.py:create_vm_execution`) through the `Supervisor` abstraction instead of reaching into the pool, with the message follow-up handled purely via an agent-side registry, `add_port_forward`, and a `get_vm` readiness poll.
+
+**Architecture:** A single `InProcessSupervisor(pool)` and an `AgentVmRegistry` are constructed at app startup (`app["supervisor"]`, `app["vm_registry"]`) and injected into the run.py create functions. The eligible-instance branch builds a `CreateVmSpec`, calls `supervisor.create_vm(spec)`, records the message in the registry, polls `supervisor.get_vm` until `RUNNING`, resolves desired port-forwards from aggregate settings (agent policy), and applies them through `supervisor.add_port_forward`. No `VmExecution` crosses the boundary for the follow-up; the execution is read back from `pool.executions` exactly once (an explicitly temporary line, see design §8) so the unchanged `start_persistent_vm` can keep driving the residual expiry/update-watch ops.
+
+**Tech Stack:** Python 3.11, asyncio, pydantic v2, pytest / pytest-asyncio. Test conventions per `tests/supervisor/`: sibling imports (no `__init__.py`), `monkeypatch`, ruff/isort/mypy green.
+
+**Design doc:** `docs/plans/2026-06-01-wire-agent-onto-supervisor-design.md`
+
+**Worktree:** `.worktrees/wire-supervisor-abstraction` on branch `od/wire-supervisor-abstraction` (off `dev`). All commands below assume that directory; the local venv is `.testvenv` and tests run with `ALEPH_VM_CACHE_ROOT`/`ALEPH_VM_EXECUTION_ROOT` redirected and `-p no:cacheprovider`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `src/aleph/vm/orchestrator/vm_registry.py` | Agent-side message cache (`AgentVmRecord` + `AgentVmRegistry`) | **Create** |
+| `src/aleph/vm/orchestrator/run.py` | Create path: helpers + rewritten `create_vm_execution`; thread `supervisor`/`registry` through `create_vm_execution_or_raise_http_error` + `start_persistent_vm` | Modify |
+| `src/aleph/vm/pool.py` | Remove vestigial `message_cache` | Modify (`:68`, `:81`) |
+| `src/aleph/vm/orchestrator/supervisor.py` | App wiring: `app["supervisor"]`, `app["vm_registry"]` | Modify (`:165`) |
+| `src/aleph/vm/orchestrator/views/__init__.py` | Pass `supervisor`/`registry` into `start_persistent_vm` (3 sites) | Modify |
+| `src/aleph/vm/orchestrator/views/operator.py` | Pass `supervisor`/`registry` into `create_vm_execution_or_raise_http_error` (2 sites) | Modify |
+| `src/aleph/vm/orchestrator/cli.py` | Build `InProcessSupervisor`/`AgentVmRegistry` locally for the standalone path (1 site) | Modify |
+| `tests/supervisor/test_agent_vm_registry.py` | Registry unit tests | **Create** |
+| `tests/supervisor/test_supervisor_run_helpers.py` | `resolve_port_forwards` + `_wait_until_running` unit tests | **Create** |
+| `tests/supervisor/test_supervisor_run_routing.py` | Rewritten routing tests (new signature + registry) | Modify |
+
+---
+
+## Task 1: `AgentVmRegistry` (agent-side message cache)
+
+**Files:**
+- Create: `src/aleph/vm/orchestrator/vm_registry.py`
+- Test: `tests/supervisor/test_agent_vm_registry.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/supervisor/test_agent_vm_registry.py`:
+
+```python
+"""AgentVmRegistry: the agent-side message cache keyed by vm_hash."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from aleph_message.models import ItemHash
+
+from aleph.vm.orchestrator.vm_registry import AgentVmRecord, AgentVmRegistry
+
+_HASH = ItemHash("deadbeef" * 8)
+
+
+def test_record_and_get():
+    registry = AgentVmRegistry()
+    message, original = MagicMock(), MagicMock()
+
+    record = registry.record(_HASH, message=message, original=original)
+
+    assert record == AgentVmRecord(message=message, original=original)
+    assert registry.get(_HASH) is record
+    assert _HASH in registry
+    assert len(registry) == 1
+
+
+def test_get_unknown_returns_none():
+    assert AgentVmRegistry().get(_HASH) is None
+    assert _HASH not in AgentVmRegistry()
+
+
+def test_forget_is_idempotent():
+    registry = AgentVmRegistry()
+    registry.record(_HASH, message=MagicMock(), original=MagicMock())
+
+    registry.forget(_HASH)
+    assert registry.get(_HASH) is None
+    assert _HASH not in registry
+
+    registry.forget(_HASH)  # forgetting an unknown hash must not raise
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd .worktrees/wire-supervisor-abstraction && .testvenv/bin/python -m pytest tests/supervisor/test_agent_vm_registry.py -p no:cacheprovider -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'aleph.vm.orchestrator.vm_registry'`
+
+- [ ] **Step 3: Create the module**
+
+Create `src/aleph/vm/orchestrator/vm_registry.py`:
+
+```python
+"""Agent-side registry of VMs the agent knows about.
+
+An in-memory cache for messages, keyed by vm_hash. The agent owns this; the
+supervisor (hypervisor) never sees it. It replaces the vestigial
+``pool.message_cache``. For now it is populated on create; a later iteration
+rehydrates it from the agent DB on startup and, eventually, from the network
+(scheduler plan + Aleph messages). See the design doc, sections 3 and 9.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aleph_message.models import ExecutableContent, ItemHash
+
+
+@dataclass
+class AgentVmRecord:
+    """What the agent remembers about one VM: the (updated) message and the
+    original message it was derived from. Used by agent-only consumers such as
+    operator-API owner-auth, billing, and update-watching."""
+
+    message: ExecutableContent
+    original: ExecutableContent
+
+
+class AgentVmRegistry:
+    """In-memory cache of AgentVmRecord, keyed by vm_hash."""
+
+    def __init__(self) -> None:
+        self._records: dict[ItemHash, AgentVmRecord] = {}
+
+    def record(
+        self, vm_hash: ItemHash, *, message: ExecutableContent, original: ExecutableContent
+    ) -> AgentVmRecord:
+        record = AgentVmRecord(message=message, original=original)
+        self._records[vm_hash] = record
+        return record
+
+    def get(self, vm_hash: ItemHash) -> AgentVmRecord | None:
+        return self._records.get(vm_hash)
+
+    def forget(self, vm_hash: ItemHash) -> None:
+        self._records.pop(vm_hash, None)
+
+    def __contains__(self, vm_hash: object) -> bool:
+        return vm_hash in self._records
+
+    def __len__(self) -> int:
+        return len(self._records)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd .worktrees/wire-supervisor-abstraction && .testvenv/bin/python -m pytest tests/supervisor/test_agent_vm_registry.py -p no:cacheprovider -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/aleph/vm/orchestrator/vm_registry.py tests/supervisor/test_agent_vm_registry.py
+git commit -m "feat(agent): AgentVmRegistry message cache"
+```
+
+---
+
+## Task 2: `resolve_port_forwards` (agent-side port-forward policy)
+
+Extracts the agent half of `VmExecution.fetch_port_redirect_config_and_setup`: read the user aggregate settings, compute the requested ports, force SSH, and produce a list of `PortForwardSpec`. No nftables here; the supervisor applies them.
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/run.py` (imports + new function)
+- Test: `tests/supervisor/test_supervisor_run_helpers.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/supervisor/test_supervisor_run_helpers.py`:
+
+```python
+"""Unit tests for the run.py create-path helpers (no pool, no I/O)."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aleph_message.models import ItemHash
+
+from aleph.vm.orchestrator import run as run_module
+from aleph.vm.supervisor.types import Protocol, VmId, VmStatus
+
+_HASH = ItemHash("deadbeef" * 8)
+_VM_ID = VmId(str(_HASH))
+
+
+@pytest.mark.asyncio
+async def test_resolve_port_forwards_always_forces_ssh(monkeypatch):
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+    content = SimpleNamespace(address="0xabc")
+
+    forwards = await run_module.resolve_port_forwards(_VM_ID, content)
+
+    assert (22, Protocol.TCP) in {(f.vm_port, f.protocol) for f in forwards}
+    assert all(f.host_port == 0 and f.vm_id == _VM_ID for f in forwards)
+
+
+@pytest.mark.asyncio
+async def test_resolve_port_forwards_reads_settings(monkeypatch):
+    payload = {str(_HASH): {"ports": {"80": {"tcp": True, "udp": False}, "53": {"tcp": False, "udp": True}}}}
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value=payload))
+    content = SimpleNamespace(address="0xabc")
+
+    pairs = {(f.vm_port, f.protocol) for f in await run_module.resolve_port_forwards(_VM_ID, content)}
+
+    assert (80, Protocol.TCP) in pairs
+    assert (53, Protocol.UDP) in pairs
+    assert (80, Protocol.UDP) not in pairs
+    assert (22, Protocol.TCP) in pairs  # SSH still forced
+
+
+@pytest.mark.asyncio
+async def test_resolve_port_forwards_tolerates_settings_error(monkeypatch):
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(side_effect=RuntimeError("boom")))
+    content = SimpleNamespace(address="0xabc")
+
+    forwards = await run_module.resolve_port_forwards(_VM_ID, content)
+
+    assert [(f.vm_port, f.protocol) for f in forwards] == [(22, Protocol.TCP)]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd .worktrees/wire-supervisor-abstraction && .testvenv/bin/python -m pytest tests/supervisor/test_supervisor_run_helpers.py -p no:cacheprovider -v`
+Expected: FAIL with `AttributeError: module 'aleph.vm.orchestrator.run' has no attribute 'resolve_port_forwards'` (and `get_user_settings`)
+
+- [ ] **Step 3: Add imports to `run.py`**
+
+In `src/aleph/vm/orchestrator/run.py`, after the existing `from aleph.vm.supervisor.translate import build_create_vm_spec` import (line 29), add:
+
+```python
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor.abc import Supervisor
+from aleph.vm.supervisor.types import (
+    GuestPort,
+    HostPort,
+    PortForwardSpec,
+    Protocol,
+    VmId,
+    VmInfo,
+    VmStatus,
+)
+from aleph.vm.utils.aggregate import get_user_settings
+```
+
+- [ ] **Step 4: Add the helper**
+
+In `src/aleph/vm/orchestrator/run.py`, add after `_is_spec_eligible` (around line 77) and before `create_vm_execution`:
+
+```python
+async def resolve_port_forwards(vm_id: VmId, content) -> list[PortForwardSpec]:
+    """Agent-side policy: translate the user's port-forwarding aggregate settings
+    into the set of forwards the hypervisor should apply.
+
+    This is the agent half of the old VmExecution.fetch_port_redirect_config_and_setup.
+    Nothing here touches nftables; the caller applies each spec through
+    supervisor.add_port_forward. host_port is left 0; the hypervisor assigns it.
+    """
+    ports_requests: dict[int, dict[str, bool]] = {}
+    try:
+        settings_for_user = await get_user_settings(content.address, "port-forwarding")
+        vm_port_forwarding = settings_for_user.get(str(vm_id), {}) or {}
+        fetched = vm_port_forwarding.get("ports", {})
+        ports_requests = {int(port): flags for port, flags in fetched.items()}
+    except Exception:
+        logger.info("Could not fetch port redirect settings for %s", content.address, exc_info=True)
+
+    # Always forward SSH.
+    ports_requests.setdefault(22, {"tcp": True, "udp": False})
+
+    forwards: list[PortForwardSpec] = []
+    for vm_port, flags in ports_requests.items():
+        for protocol in (Protocol.TCP, Protocol.UDP):
+            if flags.get(protocol.value):
+                forwards.append(
+                    PortForwardSpec(
+                        vm_id=vm_id,
+                        host_port=HostPort(0),
+                        vm_port=GuestPort(int(vm_port)),
+                        protocol=protocol,
+                    )
+                )
+    return forwards
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd .worktrees/wire-supervisor-abstraction && .testvenv/bin/python -m pytest tests/supervisor/test_supervisor_run_helpers.py -p no:cacheprovider -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/aleph/vm/orchestrator/run.py tests/supervisor/test_supervisor_run_helpers.py
+git commit -m "feat(agent): resolve_port_forwards from aggregate settings"
+```
+
+---
+
+## Task 3: `_wait_until_running` (readiness poll)
+
+Replaces `await execution.becomes_ready()`. Polls `get_vm` until `RUNNING`; raises on terminal status or timeout.
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/run.py` (constants + new function)
+- Test: `tests/supervisor/test_supervisor_run_helpers.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/supervisor/test_supervisor_run_helpers.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_wait_until_running_returns_on_running(monkeypatch):
+    booting = SimpleNamespace(status=VmStatus.BOOTING)
+    running = SimpleNamespace(status=VmStatus.RUNNING)
+    supervisor = SimpleNamespace(get_vm=AsyncMock(side_effect=[booting, running]))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+
+    info = await run_module._wait_until_running(supervisor, _VM_ID, timeout=10, interval=0)
+
+    assert info.status is VmStatus.RUNNING
+    assert supervisor.get_vm.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_wait_until_running_raises_on_terminal_status(monkeypatch):
+    supervisor = SimpleNamespace(get_vm=AsyncMock(return_value=SimpleNamespace(status=VmStatus.FAILED)))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+
+    with pytest.raises(RuntimeError):
+        await run_module._wait_until_running(supervisor, _VM_ID, timeout=10, interval=0)
+
+
+@pytest.mark.asyncio
+async def test_wait_until_running_times_out(monkeypatch):
+    supervisor = SimpleNamespace(get_vm=AsyncMock(return_value=SimpleNamespace(status=VmStatus.BOOTING)))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+
+    with pytest.raises(asyncio.TimeoutError):
+        await run_module._wait_until_running(supervisor, _VM_ID, timeout=0, interval=0)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd .worktrees/wire-supervisor-abstraction && .testvenv/bin/python -m pytest tests/supervisor/test_supervisor_run_helpers.py -k wait_until_running -p no:cacheprovider -v`
+Expected: FAIL with `AttributeError: module 'aleph.vm.orchestrator.run' has no attribute '_wait_until_running'`
+
+- [ ] **Step 3: Add constants + the poll**
+
+In `src/aleph/vm/orchestrator/run.py`, add module-level constants just below `logger = logging.getLogger(__name__)` (around line 35):
+
+```python
+# Readiness poll for the spec create path (replaces execution.becomes_ready()).
+_START_POLL_TIMEOUT_SECONDS = 120.0
+_START_POLL_INTERVAL_SECONDS = 0.5
+```
+
+Add the function immediately after `resolve_port_forwards`:
+
+```python
+async def _wait_until_running(
+    supervisor: Supervisor,
+    vm_id: VmId,
+    *,
+    timeout: float = _START_POLL_TIMEOUT_SECONDS,
+    interval: float = _START_POLL_INTERVAL_SECONDS,
+) -> VmInfo:
+    """Poll get_vm until the VM reports RUNNING.
+
+    In-process the first poll already reports RUNNING (create_vm blocked until
+    boot); across a future gRPC boundary this does real work. Raises on a
+    terminal status or after `timeout` seconds.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        info = await supervisor.get_vm(vm_id)
+        if info.status is VmStatus.RUNNING:
+            return info
+        if info.status in (VmStatus.STOPPED, VmStatus.FAILED):
+            msg = f"VM {vm_id} entered status {info.status.value} while waiting to start"
+            raise RuntimeError(msg)
+        if asyncio.get_running_loop().time() >= deadline:
+            msg = f"VM {vm_id} did not reach RUNNING within {timeout}s"
+            raise asyncio.TimeoutError(msg)
+        await asyncio.sleep(interval)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd .worktrees/wire-supervisor-abstraction && .testvenv/bin/python -m pytest tests/supervisor/test_supervisor_run_helpers.py -p no:cacheprovider -v`
+Expected: PASS (6 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/aleph/vm/orchestrator/run.py tests/supervisor/test_supervisor_run_helpers.py
+git commit -m "feat(agent): _wait_until_running readiness poll via get_vm"
+```
+
+---
+
+## Task 4: Rewrite `create_vm_execution` to route through the abstraction
+
+The eligible-instance branch now: build spec → `supervisor.create_vm` → `registry.record` → poll → resolve + apply port-forwards → return the execution read back from the pool once. The legacy branch also records the message. The vestigial `pool.message_cache` write is removed.
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/run.py:80-108` (`create_vm_execution`)
+- Modify: `src/aleph/vm/pool.py:68,81` (remove `message_cache`)
+- Test: `tests/supervisor/test_supervisor_run_routing.py` (rewrite)
+
+- [ ] **Step 1: Rewrite the routing test file**
+
+Replace the entire contents of `tests/supervisor/test_supervisor_run_routing.py` with:
+
+```python
+"""run.create_vm_execution routes eligible QEMU instances through the Supervisor."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aleph_message.models import ItemHash, ProgramContent
+from aleph_message.models.execution.environment import (
+    GpuProperties,
+    HostRequirements,
+    HypervisorType,
+    TrustedExecutionEnvironment,
+)
+from test_supervisor_translate import _make_qemu_instance_message
+
+from aleph.vm.orchestrator import run as run_module
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor.types import (
+    Backend,
+    CreateVmSpec,
+    DiskFormat,
+    DiskRole,
+    DiskSpec,
+    NetworkConfig,
+    VmId,
+    VmInfo,
+    VmStatus,
+)
+
+_HASH = ItemHash("deadbeef" * 8)
+
+
+def _spec() -> CreateVmSpec:
+    return CreateVmSpec(
+        vm_id=VmId(str(_HASH)),
+        backend=Backend.QEMU,
+        kernel_path=Path(""),
+        initrd_path=Path(""),
+        disks=[
+            DiskSpec(
+                path=Path("/data/rootfs.qcow2"),
+                readonly=False,
+                format=DiskFormat.QCOW2,
+                role=DiskRole.ROOTFS,
+            )
+        ],
+        vcpus=2,
+        memory_mib=1024,
+        tee=None,
+        network=NetworkConfig(internet_access=True, requested_ipv6="", ipv6_prefix_len=0),
+        gpus=[],
+        numa_node=None,
+        persistent=True,
+    )
+
+
+def _info(status: VmStatus = VmStatus.RUNNING) -> VmInfo:
+    return VmInfo(
+        vm_id=VmId(str(_HASH)),
+        status=status,
+        ipv4="",
+        ipv6="",
+        uptime_secs=0,
+        backend=Backend.QEMU,
+        numa_node=None,
+        status_message="",
+    )
+
+
+def _fake_supervisor(*, create_status: VmStatus = VmStatus.RUNNING, get_status: VmStatus = VmStatus.RUNNING):
+    return SimpleNamespace(
+        create_vm=AsyncMock(return_value=_info(create_status)),
+        get_vm=AsyncMock(return_value=_info(get_status)),
+        add_port_forward=AsyncMock(),
+        delete_vm=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_eligible_instance_routed_through_supervisor(monkeypatch):
+    content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
+    original_content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
+    message = MagicMock(content=content)
+    original_message = MagicMock(content=original_content)
+    monkeypatch.setattr(run_module, "load_updated_message", AsyncMock(return_value=(message, original_message)))
+    spec = _spec()
+    monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(return_value=spec))
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+
+    supervisor = _fake_supervisor()
+    registry = AgentVmRegistry()
+    created = SimpleNamespace()
+    pool = SimpleNamespace(executions={_HASH: created}, create_a_vm=AsyncMock())
+
+    execution = await run_module.create_vm_execution(
+        _HASH, pool, supervisor=supervisor, registry=registry, persistent=True
+    )
+
+    supervisor.create_vm.assert_awaited_once_with(spec)
+    pool.create_a_vm.assert_not_awaited()
+    # The message is recorded in the agent registry, not on the execution.
+    assert registry.get(_HASH).message is content
+    assert registry.get(_HASH).original is original_content
+    # SSH port-forward applied through the abstraction.
+    assert supervisor.add_port_forward.await_count >= 1
+    # The execution is read back from the pool once for start_persistent_vm.
+    assert execution is created
+    supervisor.delete_vm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_eligible_instance_timeout_tears_down(monkeypatch):
+    content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
+    message = MagicMock(content=content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
+    )
+    monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(return_value=_spec()))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(run_module, "_START_POLL_TIMEOUT_SECONDS", 0)
+
+    supervisor = _fake_supervisor(get_status=VmStatus.BOOTING)  # never RUNNING
+    registry = AgentVmRegistry()
+    pool = SimpleNamespace(executions={}, create_a_vm=AsyncMock())
+
+    with pytest.raises(asyncio.TimeoutError):
+        await run_module.create_vm_execution(
+            _HASH, pool, supervisor=supervisor, registry=registry, persistent=True
+        )
+
+    supervisor.delete_vm.assert_awaited_once_with(VmId(str(_HASH)))
+    assert registry.get(_HASH) is None  # forgotten on failure
+
+
+async def _assert_routed_to_legacy(monkeypatch, content) -> None:
+    """An ineligible message takes create_a_vm, never touches the spec path, and is still recorded."""
+    message = MagicMock(content=content)
+    original_message = MagicMock(content=_make_qemu_instance_message())
+    monkeypatch.setattr(run_module, "load_updated_message", AsyncMock(return_value=(message, original_message)))
+    monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock())
+
+    supervisor = _fake_supervisor()
+    registry = AgentVmRegistry()
+    legacy = SimpleNamespace()
+    pool = SimpleNamespace(executions={}, create_a_vm=AsyncMock(return_value=legacy))
+
+    execution = await run_module.create_vm_execution(
+        _HASH, pool, supervisor=supervisor, registry=registry, persistent=False
+    )
+
+    pool.create_a_vm.assert_awaited_once()
+    supervisor.create_vm.assert_not_awaited()
+    run_module.build_create_vm_spec.assert_not_awaited()
+    assert execution is legacy
+    assert registry.get(_HASH) is not None  # legacy path records the message too
+
+
+@pytest.mark.asyncio
+async def test_non_instance_falls_back_to_legacy(monkeypatch):
+    await _assert_routed_to_legacy(monkeypatch, MagicMock(spec=ProgramContent))
+
+
+@pytest.mark.asyncio
+async def test_confidential_instance_falls_back_to_legacy(monkeypatch):
+    content = _make_qemu_instance_message(trusted_execution=TrustedExecutionEnvironment())
+    await _assert_routed_to_legacy(monkeypatch, content)
+
+
+@pytest.mark.asyncio
+async def test_gpu_instance_falls_back_to_legacy(monkeypatch):
+    content = _make_qemu_instance_message().model_copy(
+        update={
+            "requirements": HostRequirements(
+                gpu=[
+                    GpuProperties(
+                        vendor="NVIDIA",
+                        device_name="RTX",
+                        device_class="0300",
+                        device_id="10de:1234",
+                    )
+                ]
+            )
+        }
+    )
+    await _assert_routed_to_legacy(monkeypatch, content)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd .worktrees/wire-supervisor-abstraction && .testvenv/bin/python -m pytest tests/supervisor/test_supervisor_run_routing.py -p no:cacheprovider -v`
+Expected: FAIL. `create_vm_execution` has no `supervisor`/`registry` keyword and still calls `pool.create_vm_from_spec`.
+
+- [ ] **Step 3: Rewrite `create_vm_execution`**
+
+In `src/aleph/vm/orchestrator/run.py`, replace the whole `create_vm_execution` function (currently lines 80-108) with:
+
+```python
+async def create_vm_execution(
+    vm_hash: ItemHash,
+    pool: VmPool,
+    *,
+    supervisor: Supervisor,
+    registry: AgentVmRegistry,
+    persistent: bool = False,
+) -> VmExecution:
+    message, original_message = await load_updated_message(vm_hash)
+
+    logger.debug(f"Message: {json.dumps(message.model_dump(exclude_none=True), indent=4, sort_keys=True, default=str)}")
+
+    content = message.content
+    if _is_spec_eligible(content):
+        spec = await build_create_vm_spec(vm_hash, content)
+        info = await supervisor.create_vm(spec)
+        # Agent territory: record the message for the agent's own consumers
+        # (operator API owner-auth, billing, update-watching). The supervisor
+        # machinery that created the VM never reads it.
+        registry.record(vm_hash, message=content, original=original_message.content)
+        try:
+            await _wait_until_running(supervisor, info.vm_id)
+            for forward in await resolve_port_forwards(info.vm_id, content):
+                await supervisor.add_port_forward(forward)
+        except Exception:
+            # Readiness or port-forward setup failed: tear the half-started VM down.
+            registry.forget(vm_hash)
+            await supervisor.delete_vm(info.vm_id)
+            raise
+        # TEMPORARY (PR 1 boundary, design doc section 8): start_persistent_vm
+        # still drives the VmExecution for the pre-existing check, expiry-cancel
+        # and update-watching. Read it back once so that caller is unchanged.
+        # This line goes away when those ops migrate off VmExecution.
+        return pool.executions[vm_hash]
+
+    execution = await pool.create_a_vm(
+        vm_hash=vm_hash,
+        message=content,
+        original=original_message.content,
+        persistent=persistent,
+    )
+    registry.record(vm_hash, message=content, original=original_message.content)
+    return execution
+```
+
+- [ ] **Step 4: Remove the vestigial `message_cache` from the pool**
+
+In `src/aleph/vm/pool.py`, delete the class attribute declaration (line 68):
+
+```python
+    message_cache: dict[str, ExecutableMessage]
+```
+
+and the initialisation in `__init__` (line 81):
+
+```python
+        self.message_cache = {}
+```
+
+- [ ] **Step 5: Run the routing tests to verify they pass**
+
+Run: `cd .worktrees/wire-supervisor-abstraction && .testvenv/bin/python -m pytest tests/supervisor/test_supervisor_run_routing.py -p no:cacheprovider -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 6: Fix any now-unused import in `pool.py`**
+
+Run: `cd .worktrees/wire-supervisor-abstraction && .testvenv/bin/ruff check src/aleph/vm/pool.py src/aleph/vm/orchestrator/run.py`
+If ruff reports `ExecutableMessage` imported but unused in `pool.py`, remove it from that import line. Re-run ruff until clean. Expected end state: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/aleph/vm/orchestrator/run.py src/aleph/vm/pool.py tests/supervisor/test_supervisor_run_routing.py
+git commit -m "feat(agent): route create_vm_execution through the Supervisor abstraction"
+```
+
+---
+
+## Task 5: App wiring + thread `supervisor`/`registry` through callers
+
+Construct the singletons at startup and inject them into `create_vm_execution_or_raise_http_error` and `start_persistent_vm`, then update every call site.
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/supervisor.py:165`
+- Modify: `src/aleph/vm/orchestrator/run.py` (`create_vm_execution_or_raise_http_error`, `start_persistent_vm`)
+- Modify: `src/aleph/vm/orchestrator/views/operator.py:614,774`
+- Modify: `src/aleph/vm/orchestrator/views/__init__.py:564,578,954`
+- Modify: `src/aleph/vm/orchestrator/cli.py:240-242`
+
+- [ ] **Step 1: Wire the singletons into app state**
+
+In `src/aleph/vm/orchestrator/supervisor.py`, add near the top-level imports:
+
+```python
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor.inprocess import InProcessSupervisor
+```
+
+Then, immediately after `app["vm_pool"] = pool` (line 165), add:
+
+```python
+    app["supervisor"] = InProcessSupervisor(pool)
+    app["vm_registry"] = AgentVmRegistry()
+```
+
+- [ ] **Step 2: Thread the parameters through the run.py wrappers**
+
+In `src/aleph/vm/orchestrator/run.py`, change `create_vm_execution_or_raise_http_error` (currently `async def create_vm_execution_or_raise_http_error(vm_hash, pool)`) to accept and forward the new keyword args. Update the signature and the single inner call:
+
+```python
+async def create_vm_execution_or_raise_http_error(
+    vm_hash: ItemHash,
+    pool: VmPool,
+    *,
+    supervisor: Supervisor,
+    registry: AgentVmRegistry,
+) -> VmExecution:
+    try:
+        return await create_vm_execution(
+            vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry
+        )
+```
+
+(leave the entire `except ...` chain unchanged.)
+
+And change `start_persistent_vm` (currently `async def start_persistent_vm(vm_hash, pubsub, pool)`) signature and its inner `create_vm_execution` call:
+
+```python
+async def start_persistent_vm(
+    vm_hash: ItemHash,
+    pubsub: PubSub | None,
+    pool: VmPool,
+    *,
+    supervisor: Supervisor,
+    registry: AgentVmRegistry,
+) -> VmExecution:
+```
+
+and inside it, the create call becomes:
+
+```python
+        execution = await create_vm_execution(
+            vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry, persistent=True
+        )
+```
+
+(everything else in `start_persistent_vm` stays as-is: the pre-existing-execution checks, `becomes_ready`, `cancel_expiration`, `start_watching_for_updates`.)
+
+- [ ] **Step 3: Update `operator.py` call sites**
+
+In `src/aleph/vm/orchestrator/views/operator.py`, both handlers already bind `pool: VmPool = request.app["vm_pool"]`. In each of the two handlers containing the calls at lines 614 and 774, add right after that `pool` assignment:
+
+```python
+        supervisor = request.app["supervisor"]
+        registry = request.app["vm_registry"]
+```
+
+and pass them to the call. Line 614 becomes:
+
+```python
+                await create_vm_execution_or_raise_http_error(
+                    vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry
+                )
+```
+
+Line 774 becomes:
+
+```python
+            await create_vm_execution_or_raise_http_error(
+                vm_hash=vm_hash,
+                pool=pool,
+                supervisor=supervisor,
+                registry=registry,
+            )
+```
+
+- [ ] **Step 4: Update `views/__init__.py` call sites**
+
+In `src/aleph/vm/orchestrator/views/__init__.py`, the two functions containing the calls at lines 564/578 and at 954 each already have `pool` and `pubsub` in scope from `request.app`/`app`. In each, add `supervisor = app["supervisor"]` and `registry = app["vm_registry"]` (use the same `app` handle already used to obtain `pool`/`pubsub` in that function), and pass them. Each `await start_persistent_vm(<hash>, pubsub, pool)` becomes:
+
+```python
+                await start_persistent_vm(
+                    vm_hash, pubsub, pool, supervisor=supervisor, registry=registry
+                )
+```
+
+(matching the actual hash variable at each site: `vm_hash` at 564, `instance_item_hash` at 578, `item_hash` at 954).
+
+- [ ] **Step 5: Update the standalone `cli.py` path**
+
+In `src/aleph/vm/orchestrator/cli.py`, `start_instance` runs without an aiohttp app, so it constructs the singletons locally. Add imports at the top of the module:
+
+```python
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor.inprocess import InProcessSupervisor
+```
+
+and rewrite `start_instance` (lines 240-242):
+
+```python
+async def start_instance(item_hash: ItemHash, pubsub: PubSub | None, pool) -> VmExecution:
+    """Run an instance from an InstanceMessage."""
+    supervisor = InProcessSupervisor(pool)
+    registry = AgentVmRegistry()
+    return await start_persistent_vm(
+        item_hash, pubsub, pool, supervisor=supervisor, registry=registry
+    )
+```
+
+- [ ] **Step 6: Type-check the touched modules**
+
+Run: `cd .worktrees/wire-supervisor-abstraction && .testvenv/bin/python -m mypy src/aleph/vm/orchestrator/run.py src/aleph/vm/orchestrator/supervisor.py src/aleph/vm/orchestrator/cli.py src/aleph/vm/orchestrator/views/operator.py src/aleph/vm/orchestrator/views/__init__.py src/aleph/vm/pool.py`
+Expected: no new errors versus baseline.
+
+- [ ] **Step 7: Run the full suite + gates**
+
+Run: `cd .worktrees/wire-supervisor-abstraction && ALEPH_VM_CACHE_ROOT=$(mktemp -d) ALEPH_VM_EXECUTION_ROOT=$(mktemp -d) .testvenv/bin/python -m pytest tests/ -p no:cacheprovider -q`
+Expected: ~545 passed (the 8 new helper/registry tests added), the same ~8 environmental-only failures (test_execution x4, test_instance::test_create_firecracker_instance, test_interfaces x3), 1 skipped, 3 xfailed.
+
+Run the mypy union-attr gates:
+`cd .worktrees/wire-supervisor-abstraction && .testvenv/bin/python -m mypy src/aleph/vm/ 2>&1 | grep -c 'Item "None".*union-attr'`
+Expected: `2`
+`cd .worktrees/wire-supervisor-abstraction && .testvenv/bin/python -m mypy src/aleph/vm/controllers/ 2>&1 | grep -c 'Item "None".*union-attr'`
+Expected: `0`
+
+Run lint/format:
+`cd .worktrees/wire-supervisor-abstraction && .testvenv/bin/ruff check src/aleph/vm/orchestrator/ src/aleph/vm/pool.py tests/supervisor/test_agent_vm_registry.py tests/supervisor/test_supervisor_run_helpers.py tests/supervisor/test_supervisor_run_routing.py && .testvenv/bin/isort --check-only --profile black tests/supervisor/test_agent_vm_registry.py tests/supervisor/test_supervisor_run_helpers.py tests/supervisor/test_supervisor_run_routing.py`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/aleph/vm/orchestrator/supervisor.py src/aleph/vm/orchestrator/run.py \
+  src/aleph/vm/orchestrator/cli.py src/aleph/vm/orchestrator/views/operator.py \
+  src/aleph/vm/orchestrator/views/__init__.py
+git commit -m "feat(agent): construct and inject Supervisor + AgentVmRegistry app-wide"
+```
+
+---
+
+## Done criteria
+
+- The eligible-instance create path calls `supervisor.create_vm` / `get_vm` / `add_port_forward`; it touches `pool.executions` exactly once (the flagged read-back) and never calls `pool.create_vm_from_spec` directly.
+- The message lives only in the `AgentVmRegistry`; `pool.message_cache` is gone.
+- `start_persistent_vm` is behaviourally unchanged for callers.
+- Full suite green except the known ~8 environmental failures; mypy gate `2 / 0`; ruff/isort clean.

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -19,7 +19,9 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from aleph.vm.conf import ALLOW_DEVELOPER_SSH_KEYS, make_db_url, settings
 from aleph.vm.models import VmExecution
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.pool import VmPool
+from aleph.vm.supervisor.inprocess import InProcessSupervisor
 from aleph.vm.version import __version__, get_version_from_apt, get_version_from_git
 
 from . import metrics, supervisor
@@ -239,7 +241,9 @@ async def benchmark(runs: int):
 
 async def start_instance(item_hash: ItemHash, pubsub: PubSub | None, pool) -> VmExecution:
     """Run an instance from an InstanceMessage."""
-    return await start_persistent_vm(item_hash, pubsub, pool)
+    supervisor = InProcessSupervisor(pool)
+    registry = AgentVmRegistry()
+    return await start_persistent_vm(item_hash, pubsub, pool, supervisor=supervisor, registry=registry)
 
 
 async def run_instances(instances: list[ItemHash]) -> None:

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -23,7 +23,7 @@ from aleph.vm.controllers.firecracker.program import (
     VmSetupError,
 )
 from aleph.vm.hypervisors.firecracker.microvm import MicroVMFailedInitError
-from aleph.vm.models import MessageSpec, VmExecution
+from aleph.vm.models import VmExecution
 from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.pool import VmPool
 from aleph.vm.resources import InsufficientResourcesError
@@ -132,15 +132,22 @@ async def _wait_until_running(
     supervisor: Supervisor,
     vm_id: VmId,
     *,
-    timeout: float = _START_POLL_TIMEOUT_SECONDS,
-    interval: float = _START_POLL_INTERVAL_SECONDS,
+    timeout: float | None = None,
+    interval: float | None = None,
 ) -> VmInfo:
     """Poll get_vm until the VM reports RUNNING.
 
     In-process the first poll already reports RUNNING (create_vm blocked until
     boot); across a future gRPC boundary this does real work. Raises on a
     terminal status or after `timeout` seconds.
+
+    `timeout`/`interval` default to the module constants, resolved at call time
+    so tests (and operators) can override them by patching the constants.
     """
+    if timeout is None:
+        timeout = _START_POLL_TIMEOUT_SECONDS
+    if interval is None:
+        interval = _START_POLL_INTERVAL_SECONDS
     deadline = asyncio.get_running_loop().time() + timeout
     while True:
         info = await supervisor.get_vm(vm_id)
@@ -155,26 +162,44 @@ async def _wait_until_running(
         await asyncio.sleep(interval)
 
 
-async def create_vm_execution(vm_hash: ItemHash, pool: VmPool, persistent: bool = False) -> VmExecution:
+async def create_vm_execution(
+    vm_hash: ItemHash,
+    pool: VmPool,
+    *,
+    supervisor: Supervisor,
+    registry: AgentVmRegistry,
+    persistent: bool = False,
+) -> VmExecution:
     message, original_message = await load_updated_message(vm_hash)
-    pool.message_cache[vm_hash] = message
 
     logger.debug(f"Message: {json.dumps(message.model_dump(exclude_none=True), indent=4, sort_keys=True, default=str)}")
 
     content = message.content
     if _is_spec_eligible(content):
-        # `persistent` is moot on this branch: eligibility requires an instance
-        # (see _is_spec_eligible) and instances are always persistent. The only
-        # persistent=False callers carry programs, which never reach here.
         spec = await build_create_vm_spec(vm_hash, content)
-        execution = await pool.create_vm_from_spec(spec)
-        # Agent territory: re-source the execution as message-driven so the
-        # operator API (owner auth), port forwarding and billing keep working.
-        # The supervisor machinery that just created the VM never read this.
-        execution.spec = MessageSpec(message=content, original=original_message.content)
-        if execution.is_instance:
-            await execution.fetch_port_redirect_config_and_setup()
-        return execution
+        info = await supervisor.create_vm(spec)
+        # Agent territory: record the message for the agent's own consumers
+        # (operator API owner-auth, billing, update-watching). The supervisor
+        # machinery that created the VM never reads it.
+        registry.record(vm_hash, message=content, original=original_message.content)
+        try:
+            await _wait_until_running(supervisor, info.vm_id)
+            for forward in await resolve_port_forwards(info.vm_id, content):
+                await supervisor.add_port_forward(forward)
+        except Exception:
+            # Readiness or port-forward setup failed: tear the half-started VM
+            # down, but never let a teardown error mask the original failure.
+            registry.forget(vm_hash)
+            try:
+                await supervisor.delete_vm(info.vm_id)
+            except Exception:
+                logger.exception("Teardown of half-started VM %s failed", vm_hash)
+            raise
+        # TEMPORARY (PR 1 boundary, design doc section 8): start_persistent_vm
+        # still drives the VmExecution for the pre-existing check, expiry-cancel
+        # and update-watching. Read it back once so that caller is unchanged.
+        # This line goes away when those ops migrate off VmExecution.
+        return pool.executions[vm_hash]
 
     execution = await pool.create_a_vm(
         vm_hash=vm_hash,
@@ -182,7 +207,7 @@ async def create_vm_execution(vm_hash: ItemHash, pool: VmPool, persistent: bool 
         original=original_message.content,
         persistent=persistent,
     )
-
+    registry.record(vm_hash, message=content, original=original_message.content)
     return execution
 
 

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -24,10 +24,22 @@ from aleph.vm.controllers.firecracker.program import (
 )
 from aleph.vm.hypervisors.firecracker.microvm import MicroVMFailedInitError
 from aleph.vm.models import MessageSpec, VmExecution
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.pool import VmPool
 from aleph.vm.resources import InsufficientResourcesError
+from aleph.vm.supervisor.abc import Supervisor
 from aleph.vm.supervisor.translate import build_create_vm_spec
+from aleph.vm.supervisor.types import (
+    GuestPort,
+    HostPort,
+    PortForwardSpec,
+    Protocol,
+    VmId,
+    VmInfo,
+    VmStatus,
+)
 from aleph.vm.utils import HostNotFoundError
+from aleph.vm.utils.aggregate import get_user_settings
 
 from .messages import load_updated_message
 from .pubsub import PubSub
@@ -75,6 +87,41 @@ def _is_spec_eligible(content) -> bool:
     if content.requirements and content.requirements.gpu:
         return False
     return True
+
+
+async def resolve_port_forwards(vm_id: VmId, content) -> list[PortForwardSpec]:
+    """Agent-side policy: translate the user's port-forwarding aggregate settings
+    into the set of forwards the hypervisor should apply.
+
+    This is the agent half of the old VmExecution.fetch_port_redirect_config_and_setup.
+    Nothing here touches nftables; the caller applies each spec through
+    supervisor.add_port_forward. host_port is left 0; the hypervisor assigns it.
+    """
+    ports_requests: dict[int, dict[str, bool]] = {}
+    try:
+        settings_for_user = await get_user_settings(content.address, "port-forwarding")
+        vm_port_forwarding = settings_for_user.get(str(vm_id), {}) or {}
+        fetched = vm_port_forwarding.get("ports", {})
+        ports_requests = {int(port): flags for port, flags in fetched.items()}
+    except Exception:
+        logger.info("Could not fetch port redirect settings for %s", content.address, exc_info=True)
+
+    # Always forward SSH.
+    ports_requests.setdefault(22, {"tcp": True, "udp": False})
+
+    forwards: list[PortForwardSpec] = []
+    for vm_port, flags in ports_requests.items():
+        for protocol in (Protocol.TCP, Protocol.UDP):
+            if flags.get(protocol.value):
+                forwards.append(
+                    PortForwardSpec(
+                        vm_id=vm_id,
+                        host_port=HostPort(0),
+                        vm_port=GuestPort(int(vm_port)),
+                        protocol=protocol,
+                    )
+                )
+    return forwards
 
 
 async def create_vm_execution(vm_hash: ItemHash, pool: VmPool, persistent: bool = False) -> VmExecution:

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -23,7 +23,7 @@ from aleph.vm.controllers.firecracker.program import (
     VmSetupError,
 )
 from aleph.vm.hypervisors.firecracker.microvm import MicroVMFailedInitError
-from aleph.vm.models import VmExecution
+from aleph.vm.models import MessageSpec, VmExecution
 from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.pool import VmPool
 from aleph.vm.resources import InsufficientResourcesError
@@ -179,9 +179,10 @@ async def create_vm_execution(
     if _is_spec_eligible(content):
         spec = await build_create_vm_spec(vm_hash, content)
         info = await supervisor.create_vm(spec)
-        # Agent territory: record the message for the agent's own consumers
-        # (operator API owner-auth, billing, update-watching). The supervisor
-        # machinery that created the VM never reads it.
+        # Agent territory: record the message in the agent's own cache. This is
+        # what the message-free agent will read once owner-auth and billing move
+        # off the VmExecution (design doc section 5). The supervisor machinery
+        # that created the VM never reads it.
         registry.record(vm_hash, message=content, original=original_message.content)
         try:
             await _wait_until_running(supervisor, info.vm_id)
@@ -196,11 +197,15 @@ async def create_vm_execution(
             except Exception:
                 logger.exception("Teardown of half-started VM %s failed", vm_hash)
             raise
-        # TEMPORARY (PR 1 boundary, design doc section 8): start_persistent_vm
-        # still drives the VmExecution for the pre-existing check, expiry-cancel
-        # and update-watching. Read it back once so that caller is unchanged.
-        # This line goes away when those ops migrate off VmExecution.
-        return pool.executions[vm_hash]
+        # TEMPORARY (PR 1 boundary, design doc sections 5/8): the operator
+        # endpoints, billing and update-watching still read owner identity and
+        # the message off the VmExecution, and start_persistent_vm drives it for
+        # the pre-existing check and expiry-cancel. Re-source the message-free
+        # execution as message-driven and hand it back unchanged. This goes away
+        # when those consumers read the registry instead.
+        execution = pool.executions[vm_hash]
+        execution.spec = MessageSpec(message=content, original=original_message.content)
+        return execution
 
     execution = await pool.create_a_vm(
         vm_hash=vm_hash,

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -28,6 +28,7 @@ from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.pool import VmPool
 from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.supervisor.abc import Supervisor
+from aleph.vm.supervisor.inprocess import InProcessSupervisor
 from aleph.vm.supervisor.translate import build_create_vm_spec
 from aleph.vm.supervisor.types import (
     GuestPort,
@@ -211,9 +212,15 @@ async def create_vm_execution(
     return execution
 
 
-async def create_vm_execution_or_raise_http_error(vm_hash: ItemHash, pool: VmPool) -> VmExecution:
+async def create_vm_execution_or_raise_http_error(
+    vm_hash: ItemHash,
+    pool: VmPool,
+    *,
+    supervisor: Supervisor,
+    registry: AgentVmRegistry,
+) -> VmExecution:
     try:
-        return await create_vm_execution(vm_hash=vm_hash, pool=pool)
+        return await create_vm_execution(vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry)
     except ResourceDownloadError as error:
         logger.exception(error)
         pool.forget_vm(vm_hash=vm_hash)
@@ -266,7 +273,15 @@ async def run_code_on_request(vm_hash: ItemHash, path: str, pool: VmPool, reques
         execution = None
 
     if not execution:
-        execution = await create_vm_execution_or_raise_http_error(vm_hash=vm_hash, pool=pool)
+        # Programs always take the legacy create path (they are never spec-eligible),
+        # which ignores the supervisor; the registry is the agent's own message cache.
+        # Construct them locally: this entry point also serves the standalone benchmark
+        # where there is no app-wide singleton to draw from.
+        supervisor = InProcessSupervisor(pool)
+        registry = AgentVmRegistry()
+        execution = await create_vm_execution_or_raise_http_error(
+            vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry
+        )
 
     logger.debug(f"Using vm={execution.vm_id}")
 
@@ -366,7 +381,13 @@ async def run_code_on_event(vm_hash: ItemHash, event, pubsub: PubSub, pool: VmPo
     execution: VmExecution | None = pool.get_running_vm(vm_hash=vm_hash)
 
     if not execution:
-        execution = await create_vm_execution_or_raise_http_error(vm_hash=vm_hash, pool=pool)
+        # See run_code_on_request: programs use the legacy path; build the
+        # supervisor/registry locally since the reactor has no app singletons.
+        supervisor = InProcessSupervisor(pool)
+        registry = AgentVmRegistry()
+        execution = await create_vm_execution_or_raise_http_error(
+            vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry
+        )
 
     logger.debug(f"Using vm={execution.vm_id}")
 
@@ -408,7 +429,14 @@ async def run_code_on_event(vm_hash: ItemHash, event, pubsub: PubSub, pool: VmPo
             await execution.stop()
 
 
-async def start_persistent_vm(vm_hash: ItemHash, pubsub: PubSub | None, pool: VmPool) -> VmExecution:
+async def start_persistent_vm(
+    vm_hash: ItemHash,
+    pubsub: PubSub | None,
+    pool: VmPool,
+    *,
+    supervisor: Supervisor,
+    registry: AgentVmRegistry,
+) -> VmExecution:
     execution: VmExecution | None = pool.executions.get(vm_hash)
     if execution:
         if execution.is_running:
@@ -431,7 +459,9 @@ async def start_persistent_vm(vm_hash: ItemHash, pubsub: PubSub | None, pool: Vm
 
     if not execution:
         logger.info(f"Starting persistent virtual machine with id: {vm_hash}")
-        execution = await create_vm_execution(vm_hash=vm_hash, pool=pool, persistent=True)
+        execution = await create_vm_execution(
+            vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry, persistent=True
+        )
 
     await execution.becomes_ready()
 

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -46,6 +46,10 @@ from .pubsub import PubSub
 
 logger = logging.getLogger(__name__)
 
+# Readiness poll for the spec create path (replaces execution.becomes_ready()).
+_START_POLL_TIMEOUT_SECONDS = 120.0
+_START_POLL_INTERVAL_SECONDS = 0.5
+
 
 async def build_asgi_scope(path: str, request: web.Request) -> dict[str, Any]:
     # ASGI mandates lowercase header names
@@ -122,6 +126,33 @@ async def resolve_port_forwards(vm_id: VmId, content) -> list[PortForwardSpec]:
                     )
                 )
     return forwards
+
+
+async def _wait_until_running(
+    supervisor: Supervisor,
+    vm_id: VmId,
+    *,
+    timeout: float = _START_POLL_TIMEOUT_SECONDS,
+    interval: float = _START_POLL_INTERVAL_SECONDS,
+) -> VmInfo:
+    """Poll get_vm until the VM reports RUNNING.
+
+    In-process the first poll already reports RUNNING (create_vm blocked until
+    boot); across a future gRPC boundary this does real work. Raises on a
+    terminal status or after `timeout` seconds.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        info = await supervisor.get_vm(vm_id)
+        if info.status is VmStatus.RUNNING:
+            return info
+        if info.status in (VmStatus.STOPPED, VmStatus.FAILED):
+            msg = f"VM {vm_id} entered status {info.status.value} while waiting to start"
+            raise RuntimeError(msg)
+        if asyncio.get_running_loop().time() >= deadline:
+            msg = f"VM {vm_id} did not reach RUNNING within {timeout}s"
+            raise asyncio.TimeoutError(msg)
+        await asyncio.sleep(interval)
 
 
 async def create_vm_execution(vm_hash: ItemHash, pool: VmPool, persistent: bool = False) -> VmExecution:

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -18,8 +18,10 @@ from aiohttp_cors import ResourceOptions, setup
 
 from aleph.vm.conf import settings
 from aleph.vm.migration.reaper import reap_orphan_migration_files
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.pool import VmPool
 from aleph.vm.sevclient import SevClient
+from aleph.vm.supervisor.inprocess import InProcessSupervisor
 from aleph.vm.version import __version__
 
 from .node_identity import (
@@ -163,6 +165,8 @@ def setup_webapp(pool: VmPool | None):
     app = web.Application(middlewares=[drain_middleware, error_middleware])
     app.on_response_prepare.append(on_prepare_server_version)
     app["vm_pool"] = pool
+    app["supervisor"] = InProcessSupervisor(pool)
+    app["vm_registry"] = AgentVmRegistry()
     app["backup_state"] = BackupState()
     cors = setup(
         app,

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -517,6 +517,8 @@ async def update_allocations(request: web.Request):
 
     pubsub: PubSub = request.app["pubsub"]
     pool: VmPool = request.app["vm_pool"]
+    supervisor = request.app["supervisor"]
+    registry = request.app["vm_registry"]
 
     async with allocation_lock:
         logger.debug("Got allocation_lock, updating allocations")
@@ -561,7 +563,7 @@ async def update_allocations(request: web.Request):
             try:
                 logger.info(f"Starting long running VM '{vm_hash}'")
                 vm_hash = ItemHash(vm_hash)
-                await start_persistent_vm(vm_hash, pubsub, pool)
+                await start_persistent_vm(vm_hash, pubsub, pool, supervisor=supervisor, registry=registry)
             except vm_creation_exceptions as error:
                 logger.exception("Error while starting VM '%s': %s", vm_hash, error)
                 scheduling_errors[vm_hash] = error
@@ -575,7 +577,7 @@ async def update_allocations(request: web.Request):
             logger.info(f"Starting instance '{instance_hash}'")
             instance_item_hash = ItemHash(instance_hash)
             try:
-                await start_persistent_vm(instance_item_hash, pubsub, pool)
+                await start_persistent_vm(instance_item_hash, pubsub, pool, supervisor=supervisor, registry=registry)
             except vm_creation_exceptions as error:
                 logger.exception("Error while starting VM '%s': %s", instance_hash, error)
                 scheduling_errors[instance_item_hash] = error
@@ -818,6 +820,8 @@ async def notify_allocation(request: web.Request):
 
     pubsub: PubSub = request.app["pubsub"]
     pool: VmPool = request.app["vm_pool"]
+    supervisor = request.app["supervisor"]
+    registry = request.app["vm_registry"]
 
     # Capacity admission control: refuse the allocation early (before payment
     # validation) if accepting it would push the host above its memory, vCPU,
@@ -951,7 +955,7 @@ async def notify_allocation(request: web.Request):
     scheduling_errors: dict[ItemHash, Exception] = {}
     try:
         logger.info(f"Starting persistent vm {item_hash} from notify_allocation")
-        await start_persistent_vm(item_hash, pubsub, pool)
+        await start_persistent_vm(item_hash, pubsub, pool, supervisor=supervisor, registry=registry)
         successful = True
         await pool.update_domain_mapping()
     except vm_creation_exceptions as error:

--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -611,7 +611,12 @@ async def operate_reboot(request: web.Request, authenticated_sender: str) -> web
                 await pool.stop_vm(vm_hash)
                 pool.forget_vm(vm_hash)
 
-                await create_vm_execution_or_raise_http_error(vm_hash=vm_hash, pool=pool)
+                await create_vm_execution_or_raise_http_error(
+                    vm_hash=vm_hash,
+                    pool=pool,
+                    supervisor=request.app["supervisor"],
+                    registry=request.app["vm_registry"],
+                )
             return web.Response(status=200, body=f"Rebooted VM with ref {vm_hash}")
         else:
             return web.Response(status=200, body=f"Starting VM (was not running) with ref {vm_hash}")
@@ -774,6 +779,8 @@ async def operate_reinstall(request: web.Request, authenticated_sender: str) -> 
             await create_vm_execution_or_raise_http_error(
                 vm_hash=vm_hash,
                 pool=pool,
+                supervisor=request.app["supervisor"],
+                registry=request.app["vm_registry"],
             )
 
         return web.Response(status=200, body=f"Reinstalled VM with ref {vm_hash}")
@@ -1377,6 +1384,8 @@ async def _do_restore(
                 await create_vm_execution_or_raise_http_error(
                     vm_hash=vm_hash,
                     pool=pool,
+                    supervisor=request.app["supervisor"],
+                    registry=request.app["vm_registry"],
                 )
 
             return web.json_response(

--- a/src/aleph/vm/orchestrator/vm_registry.py
+++ b/src/aleph/vm/orchestrator/vm_registry.py
@@ -30,9 +30,7 @@ class AgentVmRegistry:
     def __init__(self) -> None:
         self._records: dict[ItemHash, AgentVmRecord] = {}
 
-    def record(
-        self, vm_hash: ItemHash, *, message: ExecutableContent, original: ExecutableContent
-    ) -> AgentVmRecord:
+    def record(self, vm_hash: ItemHash, *, message: ExecutableContent, original: ExecutableContent) -> AgentVmRecord:
         record = AgentVmRecord(message=message, original=original)
         self._records[vm_hash] = record
         return record

--- a/src/aleph/vm/orchestrator/vm_registry.py
+++ b/src/aleph/vm/orchestrator/vm_registry.py
@@ -1,0 +1,50 @@
+"""Agent-side registry of VMs the agent knows about.
+
+An in-memory cache for messages, keyed by vm_hash. The agent owns this; the
+supervisor (hypervisor) never sees it. It replaces the vestigial
+``pool.message_cache``. For now it is populated on create; a later iteration
+rehydrates it from the agent DB on startup and, eventually, from the network
+(scheduler plan + Aleph messages). See the design doc, sections 3 and 9.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aleph_message.models import ExecutableContent, ItemHash
+
+
+@dataclass
+class AgentVmRecord:
+    """What the agent remembers about one VM: the (updated) message and the
+    original message it was derived from. Used by agent-only consumers such as
+    operator-API owner-auth, billing, and update-watching."""
+
+    message: ExecutableContent
+    original: ExecutableContent
+
+
+class AgentVmRegistry:
+    """In-memory cache of AgentVmRecord, keyed by vm_hash."""
+
+    def __init__(self) -> None:
+        self._records: dict[ItemHash, AgentVmRecord] = {}
+
+    def record(
+        self, vm_hash: ItemHash, *, message: ExecutableContent, original: ExecutableContent
+    ) -> AgentVmRecord:
+        record = AgentVmRecord(message=message, original=original)
+        self._records[vm_hash] = record
+        return record
+
+    def get(self, vm_hash: ItemHash) -> AgentVmRecord | None:
+        return self._records.get(vm_hash)
+
+    def forget(self, vm_hash: ItemHash) -> None:
+        self._records.pop(vm_hash, None)
+
+    def __contains__(self, vm_hash: object) -> bool:
+        return vm_hash in self._records
+
+    def __len__(self) -> int:
+        return len(self._records)

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -9,13 +9,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import psutil
-from aleph_message.models import (
-    Chain,
-    InstanceContent,
-    ItemHash,
-    Payment,
-    PaymentType,
-)
+from aleph_message.models import Chain, InstanceContent, ItemHash, Payment, PaymentType
 
 from aleph.vm.conf import settings
 from aleph.vm.controllers.configuration import (

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -11,7 +11,6 @@ from typing import Any
 import psutil
 from aleph_message.models import (
     Chain,
-    ExecutableMessage,
     InstanceContent,
     ItemHash,
     Payment,
@@ -62,7 +61,6 @@ class VmPool:
     """
 
     executions: dict[ItemHash, VmExecution]
-    message_cache: dict[str, ExecutableMessage]
     network: Network | None
     snapshot_manager: SnapshotManager | None = None
     systemd_manager: SystemDManager
@@ -75,7 +73,6 @@ class VmPool:
 
     def __init__(self):
         self.executions = {}
-        self.message_cache = {}
         self.reservations = {}
         self.gpus = []
         self._draining = False

--- a/tests/supervisor/test_agent_vm_registry.py
+++ b/tests/supervisor/test_agent_vm_registry.py
@@ -1,0 +1,39 @@
+"""AgentVmRegistry: the agent-side message cache keyed by vm_hash."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from aleph_message.models import ItemHash
+
+from aleph.vm.orchestrator.vm_registry import AgentVmRecord, AgentVmRegistry
+
+_HASH = ItemHash("deadbeef" * 8)
+
+
+def test_record_and_get():
+    registry = AgentVmRegistry()
+    message, original = MagicMock(), MagicMock()
+
+    record = registry.record(_HASH, message=message, original=original)
+
+    assert record == AgentVmRecord(message=message, original=original)
+    assert registry.get(_HASH) is record
+    assert _HASH in registry
+    assert len(registry) == 1
+
+
+def test_get_unknown_returns_none():
+    assert AgentVmRegistry().get(_HASH) is None
+    assert _HASH not in AgentVmRegistry()
+
+
+def test_forget_is_idempotent():
+    registry = AgentVmRegistry()
+    registry.record(_HASH, message=MagicMock(), original=MagicMock())
+
+    registry.forget(_HASH)
+    assert registry.get(_HASH) is None
+    assert _HASH not in registry
+
+    registry.forget(_HASH)  # forgetting an unknown hash must not raise

--- a/tests/supervisor/test_supervisor_run_helpers.py
+++ b/tests/supervisor/test_supervisor_run_helpers.py
@@ -1,0 +1,50 @@
+"""Unit tests for the run.py create-path helpers (no pool, no I/O)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aleph_message.models import ItemHash
+
+from aleph.vm.orchestrator import run as run_module
+from aleph.vm.supervisor.types import Protocol, VmId
+
+_HASH = ItemHash("deadbeef" * 8)
+_VM_ID = VmId(str(_HASH))
+
+
+@pytest.mark.asyncio
+async def test_resolve_port_forwards_always_forces_ssh(monkeypatch):
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+    content = SimpleNamespace(address="0xabc")
+
+    forwards = await run_module.resolve_port_forwards(_VM_ID, content)
+
+    assert (22, Protocol.TCP) in {(f.vm_port, f.protocol) for f in forwards}
+    assert all(f.host_port == 0 and f.vm_id == _VM_ID for f in forwards)
+
+
+@pytest.mark.asyncio
+async def test_resolve_port_forwards_reads_settings(monkeypatch):
+    payload = {str(_HASH): {"ports": {"80": {"tcp": True, "udp": False}, "53": {"tcp": False, "udp": True}}}}
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value=payload))
+    content = SimpleNamespace(address="0xabc")
+
+    pairs = {(f.vm_port, f.protocol) for f in await run_module.resolve_port_forwards(_VM_ID, content)}
+
+    assert (80, Protocol.TCP) in pairs
+    assert (53, Protocol.UDP) in pairs
+    assert (80, Protocol.UDP) not in pairs
+    assert (22, Protocol.TCP) in pairs  # SSH still forced
+
+
+@pytest.mark.asyncio
+async def test_resolve_port_forwards_tolerates_settings_error(monkeypatch):
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(side_effect=RuntimeError("boom")))
+    content = SimpleNamespace(address="0xabc")
+
+    forwards = await run_module.resolve_port_forwards(_VM_ID, content)
+
+    assert [(f.vm_port, f.protocol) for f in forwards] == [(22, Protocol.TCP)]

--- a/tests/supervisor/test_supervisor_run_helpers.py
+++ b/tests/supervisor/test_supervisor_run_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -9,7 +10,7 @@ import pytest
 from aleph_message.models import ItemHash
 
 from aleph.vm.orchestrator import run as run_module
-from aleph.vm.supervisor.types import Protocol, VmId
+from aleph.vm.supervisor.types import Protocol, VmId, VmStatus
 
 _HASH = ItemHash("deadbeef" * 8)
 _VM_ID = VmId(str(_HASH))
@@ -48,3 +49,34 @@ async def test_resolve_port_forwards_tolerates_settings_error(monkeypatch):
     forwards = await run_module.resolve_port_forwards(_VM_ID, content)
 
     assert [(f.vm_port, f.protocol) for f in forwards] == [(22, Protocol.TCP)]
+
+
+@pytest.mark.asyncio
+async def test_wait_until_running_returns_on_running(monkeypatch):
+    booting = SimpleNamespace(status=VmStatus.BOOTING)
+    running = SimpleNamespace(status=VmStatus.RUNNING)
+    supervisor = SimpleNamespace(get_vm=AsyncMock(side_effect=[booting, running]))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+
+    info = await run_module._wait_until_running(supervisor, _VM_ID, timeout=10, interval=0)
+
+    assert info.status is VmStatus.RUNNING
+    assert supervisor.get_vm.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_wait_until_running_raises_on_terminal_status(monkeypatch):
+    supervisor = SimpleNamespace(get_vm=AsyncMock(return_value=SimpleNamespace(status=VmStatus.FAILED)))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+
+    with pytest.raises(RuntimeError):
+        await run_module._wait_until_running(supervisor, _VM_ID, timeout=10, interval=0)
+
+
+@pytest.mark.asyncio
+async def test_wait_until_running_times_out(monkeypatch):
+    supervisor = SimpleNamespace(get_vm=AsyncMock(return_value=SimpleNamespace(status=VmStatus.BOOTING)))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+
+    with pytest.raises(asyncio.TimeoutError):
+        await run_module._wait_until_running(supervisor, _VM_ID, timeout=0, interval=0)

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -135,9 +135,7 @@ async def test_eligible_instance_timeout_tears_down(monkeypatch):
     pool = SimpleNamespace(executions={}, create_a_vm=AsyncMock())
 
     with pytest.raises(asyncio.TimeoutError):
-        await run_module.create_vm_execution(
-            _HASH, pool, supervisor=supervisor, registry=registry, persistent=True
-        )
+        await run_module.create_vm_execution(_HASH, pool, supervisor=supervisor, registry=registry, persistent=True)
 
     supervisor.delete_vm.assert_awaited_once_with(VmId(str(_HASH)))
     assert registry.get(_HASH) is None  # forgotten on failure
@@ -162,9 +160,7 @@ async def test_eligible_instance_port_forward_failure_tears_down(monkeypatch):
     pool = SimpleNamespace(executions={}, create_a_vm=AsyncMock())
 
     with pytest.raises(RuntimeError, match="nftables boom"):
-        await run_module.create_vm_execution(
-            _HASH, pool, supervisor=supervisor, registry=registry, persistent=True
-        )
+        await run_module.create_vm_execution(_HASH, pool, supervisor=supervisor, registry=registry, persistent=True)
 
     supervisor.delete_vm.assert_awaited_once_with(VmId(str(_HASH)))
     assert registry.get(_HASH) is None  # forgotten on failure

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -17,6 +17,7 @@ from aleph_message.models.execution.environment import (
 )
 from test_supervisor_translate import _make_qemu_instance_message
 
+from aleph.vm.models import MessageSpec
 from aleph.vm.orchestrator import run as run_module
 from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.supervisor.types import (
@@ -110,6 +111,10 @@ async def test_eligible_instance_routed_through_supervisor(monkeypatch):
     assert supervisor.add_port_forward.await_count >= 1
     # The execution is read back from the pool once for start_persistent_vm.
     assert execution is created
+    # PR 1 boundary: the message-free execution is re-sourced as message-driven
+    # so the operator API (owner-auth, billing) keeps reading execution.message
+    # until those consumers move to the registry.
+    assert execution.spec == MessageSpec(message=content, original=original_content)
     supervisor.delete_vm.assert_not_awaited()
 
 

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -1,7 +1,8 @@
-"""run.create_vm_execution routes eligible QEMU instances through the spec."""
+"""run.create_vm_execution routes eligible QEMU instances through the Supervisor."""
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -16,8 +17,8 @@ from aleph_message.models.execution.environment import (
 )
 from test_supervisor_translate import _make_qemu_instance_message
 
-from aleph.vm.models import MessageSpec
 from aleph.vm.orchestrator import run as run_module
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.supervisor.types import (
     Backend,
     CreateVmSpec,
@@ -26,6 +27,8 @@ from aleph.vm.supervisor.types import (
     DiskSpec,
     NetworkConfig,
     VmId,
+    VmInfo,
+    VmStatus,
 )
 
 _HASH = ItemHash("deadbeef" * 8)
@@ -55,83 +58,138 @@ def _spec() -> CreateVmSpec:
     )
 
 
+def _info(status: VmStatus = VmStatus.RUNNING) -> VmInfo:
+    return VmInfo(
+        vm_id=VmId(str(_HASH)),
+        status=status,
+        ipv4="",
+        ipv6="",
+        uptime_secs=0,
+        backend=Backend.QEMU,
+        numa_node=None,
+        status_message="",
+    )
+
+
+def _fake_supervisor(*, create_status: VmStatus = VmStatus.RUNNING, get_status: VmStatus = VmStatus.RUNNING):
+    return SimpleNamespace(
+        create_vm=AsyncMock(return_value=_info(create_status)),
+        get_vm=AsyncMock(return_value=_info(get_status)),
+        add_port_forward=AsyncMock(),
+        delete_vm=AsyncMock(),
+    )
+
+
 @pytest.mark.asyncio
-async def test_eligible_instance_routed_through_spec(monkeypatch):
+async def test_eligible_instance_routed_through_supervisor(monkeypatch):
     content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
     original_content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
     message = MagicMock(content=content)
     original_message = MagicMock(content=original_content)
     monkeypatch.setattr(run_module, "load_updated_message", AsyncMock(return_value=(message, original_message)))
-
     spec = _spec()
     monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(return_value=spec))
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
 
-    created = SimpleNamespace(spec=None, is_instance=True)
-    created.fetch_port_redirect_config_and_setup = AsyncMock()
-    pool = SimpleNamespace(
-        message_cache={},
-        create_vm_from_spec=AsyncMock(return_value=created),
-        create_a_vm=AsyncMock(),
+    supervisor = _fake_supervisor()
+    registry = AgentVmRegistry()
+    created = SimpleNamespace()
+    pool = SimpleNamespace(executions={_HASH: created}, create_a_vm=AsyncMock())
+
+    execution = await run_module.create_vm_execution(
+        _HASH, pool, supervisor=supervisor, registry=registry, persistent=True
     )
 
-    execution = await run_module.create_vm_execution(_HASH, pool, persistent=True)
-
-    run_module.build_create_vm_spec.assert_awaited_once()
-    pool.create_vm_from_spec.assert_awaited_once_with(spec)
+    supervisor.create_vm.assert_awaited_once_with(spec)
     pool.create_a_vm.assert_not_awaited()
-    # Agent re-sourced the execution as message-driven for its own consumers.
-    assert execution.spec == MessageSpec(message=content, original=original_content)
-    created.fetch_port_redirect_config_and_setup.assert_awaited_once()
+    # The message is recorded in the agent registry, not on the execution.
+    assert registry.get(_HASH).message is content
+    assert registry.get(_HASH).original is original_content
+    # SSH port-forward applied through the abstraction.
+    assert supervisor.add_port_forward.await_count >= 1
+    # The execution is read back from the pool once for start_persistent_vm.
+    assert execution is created
+    supervisor.delete_vm.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_ineligible_firecracker_falls_back_to_legacy(monkeypatch):
-    content = _make_qemu_instance_message(hypervisor=HypervisorType.firecracker)
+async def test_eligible_instance_timeout_tears_down(monkeypatch):
+    content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
     message = MagicMock(content=content)
-    original_message = MagicMock(content=_make_qemu_instance_message())
-    monkeypatch.setattr(run_module, "load_updated_message", AsyncMock(return_value=(message, original_message)))
-    monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock())
-
-    legacy = SimpleNamespace()
-    pool = SimpleNamespace(
-        message_cache={},
-        create_vm_from_spec=AsyncMock(),
-        create_a_vm=AsyncMock(return_value=legacy),
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
     )
+    monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(return_value=_spec()))
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(run_module, "_START_POLL_TIMEOUT_SECONDS", 0)
 
-    execution = await run_module.create_vm_execution(_HASH, pool, persistent=False)
+    supervisor = _fake_supervisor(get_status=VmStatus.BOOTING)  # never RUNNING
+    registry = AgentVmRegistry()
+    pool = SimpleNamespace(executions={}, create_a_vm=AsyncMock())
 
-    pool.create_a_vm.assert_awaited_once()
-    pool.create_vm_from_spec.assert_not_awaited()
-    run_module.build_create_vm_spec.assert_not_awaited()
-    assert execution is legacy
+    with pytest.raises(asyncio.TimeoutError):
+        await run_module.create_vm_execution(
+            _HASH, pool, supervisor=supervisor, registry=registry, persistent=True
+        )
+
+    supervisor.delete_vm.assert_awaited_once_with(VmId(str(_HASH)))
+    assert registry.get(_HASH) is None  # forgotten on failure
+
+
+@pytest.mark.asyncio
+async def test_eligible_instance_port_forward_failure_tears_down(monkeypatch):
+    # Readiness succeeds but applying a port forward fails: the other failure
+    # source in the same try block must trigger the same teardown.
+    content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
+    message = MagicMock(content=content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
+    )
+    monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(return_value=_spec()))
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+
+    supervisor = _fake_supervisor()  # get_vm reports RUNNING immediately
+    supervisor.add_port_forward = AsyncMock(side_effect=RuntimeError("nftables boom"))
+    registry = AgentVmRegistry()
+    pool = SimpleNamespace(executions={}, create_a_vm=AsyncMock())
+
+    with pytest.raises(RuntimeError, match="nftables boom"):
+        await run_module.create_vm_execution(
+            _HASH, pool, supervisor=supervisor, registry=registry, persistent=True
+        )
+
+    supervisor.delete_vm.assert_awaited_once_with(VmId(str(_HASH)))
+    assert registry.get(_HASH) is None  # forgotten on failure
 
 
 async def _assert_routed_to_legacy(monkeypatch, content) -> None:
-    """Assert an ineligible message takes create_a_vm and never touches the spec path."""
+    """An ineligible message takes create_a_vm, never touches the spec path, and is still recorded."""
     message = MagicMock(content=content)
     original_message = MagicMock(content=_make_qemu_instance_message())
     monkeypatch.setattr(run_module, "load_updated_message", AsyncMock(return_value=(message, original_message)))
     monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock())
 
+    supervisor = _fake_supervisor()
+    registry = AgentVmRegistry()
     legacy = SimpleNamespace()
-    pool = SimpleNamespace(
-        message_cache={},
-        create_vm_from_spec=AsyncMock(),
-        create_a_vm=AsyncMock(return_value=legacy),
+    pool = SimpleNamespace(executions={}, create_a_vm=AsyncMock(return_value=legacy))
+
+    execution = await run_module.create_vm_execution(
+        _HASH, pool, supervisor=supervisor, registry=registry, persistent=False
     )
 
-    execution = await run_module.create_vm_execution(_HASH, pool, persistent=False)
-
     pool.create_a_vm.assert_awaited_once()
-    pool.create_vm_from_spec.assert_not_awaited()
+    supervisor.create_vm.assert_not_awaited()
     run_module.build_create_vm_spec.assert_not_awaited()
     assert execution is legacy
+    assert registry.get(_HASH) is not None  # legacy path records the message too
 
 
 @pytest.mark.asyncio
 async def test_non_instance_falls_back_to_legacy(monkeypatch):
-    # A program (non-instance) message is never spec-eligible.
     await _assert_routed_to_legacy(monkeypatch, MagicMock(spec=ProgramContent))
 
 

--- a/tests/supervisor/views/test_operator.py
+++ b/tests/supervisor/views/test_operator.py
@@ -843,8 +843,13 @@ async def test_operator_reinstall(aiohttp_client, mocker):
     assert fake_volume.path_on_host.unlink.call_count == 1
     # Readonly volume was NOT deleted
     assert fake_readonly_volume.path_on_host.unlink.call_count == 0
-    # VM was started again
-    mock_create_vm.assert_called_once_with(vm_hash=vm_hash, pool=fake_vm_pool)
+    # VM was started again, routed through the app-wide supervisor + registry
+    mock_create_vm.assert_called_once_with(
+        vm_hash=vm_hash,
+        pool=fake_vm_pool,
+        supervisor=app["supervisor"],
+        registry=app["vm_registry"],
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Phase 0 of the aleph-cvm backport: the agent's **create path** now goes through the message-agnostic `Supervisor` abstraction instead of reaching into `VmPool` directly. The supervisor creates VMs from a `CreateVmSpec` and never sees an Aleph message; the agent owns messages via a new agent-side `AgentVmRegistry` (which replaces the vestigial `pool.message_cache`).

Stacked on #957.

### What changes
- **`AgentVmRegistry`** (`orchestrator/vm_registry.py`): in-memory, agent-side cache of the messages the agent knows about (kept as a DB-backed cache conceptually; later it will be rebuilt from the scheduler plan + Aleph messages). Replaces `pool.message_cache`.
- **`create_vm_execution`** routes spec-eligible instances through `Supervisor.create_vm(spec)`, records the message in the registry, polls `get_vm` until `RUNNING`, and applies port forwards through `Supervisor.add_port_forward` (agent resolves the policy via `resolve_port_forwards`, the supervisor owns the mechanism). Tears the VM down on readiness/port-forward failure.
- **App wiring**: `setup_webapp` constructs the app-wide `InProcessSupervisor` + `AgentVmRegistry`; every create/start call site (operator reboot/reinstall/restore, allocation views, CLI) threads them through. Program paths build them locally (they always take the legacy create path, which never touches the supervisor).
- **PR-1 boundary** (documented): the operator endpoints, billing and update-watching still read owner identity off `execution.message`, so the spec-created execution is re-sourced as message-driven until those consumers move to the registry in a later PR. `start_persistent_vm` still drives the `VmExecution` for the pre-existing check / expiry-cancel.

Design doc and implementation plan are included under `docs/plans/`.

### Notable review fix
The initial create-path rewrite dropped the line that keeps the execution message-driven, which would have 500'd owner-auth on every spec-eligible instance (operator tests mock `execution.message` and never drive the create path, so it slipped through). Restored with a regression test (`31772d2a`).

## Test Plan
- [x] Full suite: only the 8 known environmental failures (root/network/binary), 552 passed
- [x] mypy union-attr gates: `src/aleph/vm/` = 2, `controllers/` = 0
- [x] mypy on touched modules: no new errors (net -4 vs base)
- [x] ruff + isort: clean (no new findings)
- [x] New unit tests: `AgentVmRegistry`, `resolve_port_forwards`, `_wait_until_running`, create-path routing (incl. timeout + port-forward-failure teardown, message-driven re-sourcing)
- [ ] Manual: create an instance and hit an owner-authed operator endpoint (reboot) to confirm auth still resolves