### PR TITLE
fix: stop event loop stalls in monitor_payments D-Bus sweep

### DIFF
--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -271,9 +271,9 @@ async def start_persistent_vm(vm_hash: ItemHash, pubsub: PubSub | None, pool: Vm
     execution: VmExecution | None = pool.executions.get(vm_hash)
     if execution:
         if execution.is_running:
-            logger.info(f"{vm_hash} is already running")
+            logger.debug(f"{vm_hash} is already running")
         elif execution.is_starting:
-            logger.info(f"{vm_hash} is already starting")
+            logger.debug(f"{vm_hash} is already starting")
         elif execution.is_stopping:
             logger.info(f"{vm_hash} is stopping, waiting for complete stop before restarting")
             await execution.stop_event.wait()

--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -334,8 +334,27 @@ async def check_payment(pool: VmPool):
             # Status is healthy — reset any previous strikes
             _terminal_strike_count.pop(str(vm_hash), None)
 
+    # Snapshot the active state of every persistent VM's controller
+    # service via a single batched D-Bus ListUnits() call, run off the
+    # event loop. Without this, get_executions_by_address would hit
+    # is_service_active per VM (each round-trip blocks the loop), and
+    # with dozens of VMs the loop stalls for tens of seconds, visible
+    # to clients as multi-second TTFB on unrelated HTTP requests.
+    persistent_services = [
+        execution.controller_service for execution in pool.executions.values() if execution.persistent
+    ]
+    if persistent_services and pool.systemd_manager:
+        running_states = await asyncio.to_thread(
+            pool.systemd_manager.get_services_active_states,
+            persistent_services,
+        )
+    else:
+        running_states = {}
+
     # Check if the balance held in the wallet is sufficient holder tier resources (Not do it yet)
-    for execution_address, chains in pool.get_executions_by_address(payment_type=PaymentType.hold).items():
+    for execution_address, chains in pool.get_executions_by_address(
+        payment_type=PaymentType.hold, running_states=running_states
+    ).items():
         for chain, executions in chains.items():
             executions = [execution for execution in executions if execution.is_confidential]
             if not executions:
@@ -359,7 +378,9 @@ async def check_payment(pool: VmPool):
         logger.error("Monitor payment ERROR: No community wallet set. Cannot check community payment")
 
     # Check if the credit balance held in the wallet is sufficient credit tier resources (Not do it yet)
-    for execution_address, chains in pool.get_executions_by_address(payment_type=PaymentType.credit).items():
+    for execution_address, chains in pool.get_executions_by_address(
+        payment_type=PaymentType.credit, running_states=running_states
+    ).items():
         for chain, executions in chains.items():
             executions = [execution for execution in executions]
             if not executions:
@@ -379,7 +400,9 @@ async def check_payment(pool: VmPool):
                 required_credits = await compute_required_credit_balance(executions)
 
     # Check if the balance held in the wallet is sufficient stream tier resources
-    for execution_address, chains in pool.get_executions_by_address(payment_type=PaymentType.superfluid).items():
+    for execution_address, chains in pool.get_executions_by_address(
+        payment_type=PaymentType.superfluid, running_states=running_states
+    ).items():
         for chain, executions in chains.items():
             try:
                 stream = await get_stream(

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -551,7 +551,9 @@ async def update_allocations(request: web.Request):
         # Schedule the start of persistent VMs:
         for vm_hash in allocation.persistent_vms:
             try:
-                logger.info(f"Starting long running VM '{vm_hash}'")
+                # start_persistent_vm logs at INFO when it actually starts
+                # a VM; firing an unconditional log here just adds noise
+                # when the scheduler re-pushes the full allocation list.
                 vm_hash = ItemHash(vm_hash)
                 await start_persistent_vm(vm_hash, pubsub, pool)
             except vm_creation_exceptions as error:
@@ -564,7 +566,6 @@ async def update_allocations(request: web.Request):
 
         # Schedule the start of instances:
         for instance_hash in allocation.instances:
-            logger.info(f"Starting instance '{instance_hash}'")
             instance_item_hash = ItemHash(instance_hash)
             try:
                 await start_persistent_vm(instance_item_hash, pubsub, pool)

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -816,20 +816,37 @@ class VmPool:
                 available_gpus.append(gpu)
         return available_gpus
 
-    def get_executions_by_address(self, payment_type: PaymentType) -> dict[str, dict[str, list[VmExecution]]]:
-        """Return all executions of the given type, grouped by sender and by chain."""
+    def get_executions_by_address(
+        self,
+        payment_type: PaymentType,
+        running_states: dict[str, bool] | None = None,
+    ) -> dict[str, dict[str, list[VmExecution]]]:
+        """Return all executions of the given type, grouped by sender and by chain.
+
+        Args:
+            payment_type: Filter to this payment type.
+            running_states: Optional pre-computed mapping of
+                controller_service name -> active state, e.g. the result
+                of ``SystemDManager.get_services_active_states()``. When
+                provided, persistent executions are filtered by this map
+                instead of via the per-VM ``is_running`` property, which
+                otherwise issues a D-Bus round-trip per execution and
+                blocks the event loop.
+        """
         executions_by_address: dict[str, dict[str, list[VmExecution]]] = {}
         for vm_hash, execution in self.executions.items():
             if execution.vm_hash in (settings.CHECK_FASTAPI_VM_ID, settings.LEGACY_CHECK_FASTAPI_VM_ID):
                 # Ignore Diagnostic VM execution
                 continue
 
-            if not execution.is_running:
+            if running_states is not None and execution.persistent:
+                is_active = running_states.get(execution.controller_service, False)
+            else:
+                is_active = execution.is_running
+            if not is_active:
                 # Ignore the execution that is stopping or not running anymore
                 continue
-            if execution.vm_hash == settings.CHECK_FASTAPI_VM_ID:
-                # Ignore Diagnostic VM execution
-                continue
+
             execution_payment = (
                 execution.message.payment
                 if execution.message.payment

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -832,6 +832,15 @@ class VmPool:
                 instead of via the per-VM ``is_running`` property, which
                 otherwise issues a D-Bus round-trip per execution and
                 blocks the event loop.
+
+                Semantic note: the per-VM path also checked
+                ``is_service_enabled`` before reading the active state;
+                the batch path reads ActiveState only. Aleph-VM
+                controller services are always enabled via
+                ``EnableUnitFiles`` before ``StartUnit`` (see
+                ``SystemDManager.enable_and_start``), so the gap is
+                immaterial in practice; the same batch shortcut is
+                already used by ``load_persistent_executions``.
         """
         executions_by_address: dict[str, dict[str, list[VmExecution]]] = {}
         for vm_hash, execution in self.executions.items():

--- a/src/aleph/vm/systemd.py
+++ b/src/aleph/vm/systemd.py
@@ -17,6 +17,22 @@ class SystemDManagerError(Exception):
     pass
 
 
+_NO_SUCH_UNIT = "org.freedesktop.systemd1.NoSuchUnit"
+
+
+def _log_dbus_lookup_error(service: str, error: DBusException) -> None:
+    """Log a unit lookup error at the right severity.
+
+    NoSuchUnit is a routine outcome (instance was stopped or never
+    loaded) and should not pollute ERROR logs. Other DBusExceptions
+    are real and worth surfacing.
+    """
+    if error.get_dbus_name() == _NO_SUCH_UNIT:
+        logger.debug("Service %s not loaded", service)
+    else:
+        logger.error("D-Bus lookup failed for %s: %s", service, error)
+
+
 class SystemDManager:
     """SystemD Manager class.
 
@@ -44,17 +60,24 @@ class SystemDManager:
         raise DBusException(msg)
 
     def _ensure_connection(self) -> None:
-        """Ensure D-Bus connection is active, reconnect if necessary."""
+        """Ensure D-Bus connection is active, reconnect if necessary.
+
+        Uses ``get_is_connected()`` as a cheap local check. The previous
+        implementation called ``ListUnits()`` here as a "test": that
+        enumerates every loaded systemd unit on the host over D-Bus and
+        ran ahead of every operation, turning a per-VM ``is_service_active``
+        sweep into N full host enumerations and stalling the event loop
+        for tens of seconds. Real call failures still trigger reconnect
+        via the per-method ``DBusException`` handlers.
+        """
+        if self._bus is None or self._manager is None:
+            self._connect()
+            return
         try:
-            if self._bus is None or self._manager is None:
+            if not self._bus.get_is_connected():
                 self._connect()
-                return
-            self._bus.get_is_connected()
-            # Try a simple operation to test the connection
-            if self._manager is not None:
-                self._manager.ListUnits()
         except (DBusException, AttributeError):
-            logger.info("D-Bus connection lost, attempting to reconnect...")
+            logger.info("D-Bus connection lost, reconnecting")
             self._connect()
 
     def _get_manager(self) -> Interface:
@@ -153,7 +176,7 @@ class SystemDManager:
                 )
             )
         except DBusException as error:
-            logger.error("Failed to get active state for %s: %s", service, error)
+            _log_dbus_lookup_error(service, error)
             return "unknown"
 
     def is_service_active(self, service: str) -> bool:
@@ -171,7 +194,7 @@ class SystemDManager:
             active_state = unit_properties.Get("org.freedesktop.systemd1.Unit", "ActiveState")
             return active_state == "active"
         except DBusException as error:
-            logger.error(error)
+            _log_dbus_lookup_error(service, error)
             return False
 
     def get_services_active_states(self, services: list[str]) -> dict[str, bool]:

--- a/src/aleph/vm/systemd.py
+++ b/src/aleph/vm/systemd.py
@@ -67,8 +67,14 @@ class SystemDManager:
         enumerates every loaded systemd unit on the host over D-Bus and
         ran ahead of every operation, turning a per-VM ``is_service_active``
         sweep into N full host enumerations and stalling the event loop
-        for tens of seconds. Real call failures still trigger reconnect
-        via the per-method ``DBusException`` handlers.
+        for tens of seconds.
+
+        Note: ``get_is_connected()`` is a local library-level flag and
+        does not round-trip to the D-Bus daemon, so it cannot detect a
+        hung or unresponsive daemon. Real call failures still trigger
+        reconnect via the per-method ``DBusException`` handlers; this
+        check exists only to short-circuit the obvious "bus closed"
+        case before issuing the actual call.
         """
         if self._bus is None or self._manager is None:
             self._connect()

--- a/tests/supervisor/test_checkpayment.py
+++ b/tests/supervisor/test_checkpayment.py
@@ -308,3 +308,84 @@ async def test_removed_message_status(mocker, fake_instance_content):
     await check_payment(pool=pool)
     mock_stop_vm.assert_called_once_with(hash)
     mock_forget_vm.assert_called_once_with(hash)
+
+
+@pytest.mark.asyncio
+async def test_persistent_vm_uses_batched_running_states(mocker, fake_instance_content):
+    """check_payment batches systemd state lookups for persistent VMs.
+
+    Verifies that the asyncio.to_thread + get_services_active_states
+    path is taken (single batched D-Bus call) instead of the per-VM
+    is_running property, and that the returned dict drives the filter
+    in get_executions_by_address.
+    """
+    mocker.patch.object(settings, "ALLOW_VM_NETWORKING", False)
+    mocker.patch.object(settings, "PAYMENT_RECEIVER_ADDRESS", "0xD39C335404a78E0BDCf6D50F29B86EFd57924288")
+    mock_community_wallet_address = "0x23C7A99d7AbebeD245d044685F1893aeA4b5Da90"
+    mocker.patch(
+        "aleph.vm.orchestrator.tasks.get_community_wallet_address",
+        return_value=mock_community_wallet_address,
+    )
+    mocker.patch("aleph.vm.orchestrator.tasks.is_after_community_wallet_start", return_value=True)
+    mocker.patch("aleph.vm.orchestrator.tasks.get_stream", return_value=400, autospec=True)
+    mocker.patch("aleph.vm.orchestrator.tasks.get_message_status", return_value=MessageStatus.PROCESSED)
+
+    async def compute_required_flow(executions):
+        return 500 * len(executions)
+
+    mocker.patch("aleph.vm.orchestrator.tasks.compute_required_flow", compute_required_flow)
+
+    message = InstanceContent.model_validate(fake_instance_content)
+    hash_active = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadec0"
+    hash_inactive = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadec1"
+
+    mocker.patch.object(VmExecution, "stop", new=mocker.AsyncMock(return_value=False))
+
+    systemd_manager = mocker.Mock()
+    systemd_manager.get_services_active_states = mocker.Mock(
+        return_value={
+            f"aleph-vm-controller@{hash_active}.service": True,
+            f"aleph-vm-controller@{hash_inactive}.service": False,
+        }
+    )
+
+    pool = VmPool()
+    pool.systemd_manager = systemd_manager
+
+    active_execution = VmExecution(
+        vm_hash=hash_active,
+        message=message,
+        original=message,
+        persistent=True,
+        snapshot_manager=None,
+        systemd_manager=systemd_manager,
+    )
+    inactive_execution = VmExecution(
+        vm_hash=hash_inactive,
+        message=message,
+        original=message,
+        persistent=True,
+        snapshot_manager=None,
+        systemd_manager=systemd_manager,
+    )
+    pool.executions = {hash_active: active_execution, hash_inactive: inactive_execution}
+
+    await check_payment(pool=pool)
+
+    systemd_manager.get_services_active_states.assert_called_once()
+    queried_services = set(systemd_manager.get_services_active_states.call_args.args[0])
+    assert queried_services == {
+        f"aleph-vm-controller@{hash_active}.service",
+        f"aleph-vm-controller@{hash_inactive}.service",
+    }
+
+    by_sender = pool.get_executions_by_address(
+        payment_type=PaymentType.superfluid,
+        running_states={
+            f"aleph-vm-controller@{hash_active}.service": True,
+            f"aleph-vm-controller@{hash_inactive}.service": False,
+        },
+    )
+    listed = [e for chains in by_sender.values() for executions in chains.values() for e in executions]
+    assert active_execution in listed
+    assert inactive_execution not in listed


### PR DESCRIPTION
  monitor_payments => check_payment iterates executions and reads
  execution.is_running per VM, which goes through is_service_active.
  Two layered problems made this serialize the asyncio event loop
  for tens of seconds at a time on CRNs with many VMs:

  - _ensure_connection ran ListUnits() before every operation as a "connection test", enumerating every loaded systemd unit on the host over D-Bus. Replaced with the cheap get_is_connected() bool check; real call failures still fall through to the per-method DBusException handlers.
  - Each is_running access issued its own D-Bus round-trips, synchronously, on the event loop thread. Batch the lookup once via SystemDManager.get_services_active_states (already present, one ListUnits per batch) wrapped in asyncio.to_thread, and pass the result down through get_executions_by_address.