### PR TITLE
fix(supervisor): stop destroying confidential VMs awaiting owner initialization

### DIFF
--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -339,6 +339,21 @@ class VmExecution:
         return True if getattr(self.message.environment, "trusted_execution", None) else False
 
     @property
+    def is_awaiting_confidential_init(self) -> bool:
+        """The confidential VM is created but waiting for its owner to upload the
+        session certificates and start it via /control/machine/{ref}/confidential/initialize.
+
+        The controller service is only started at that point, so the execution is
+        neither starting nor running. It must not be treated as a dead execution:
+        only the owner can start it, the orchestrator cannot."""
+        return (
+            self.is_confidential
+            and self.persistent
+            and bool(self.times.started_at and not self.times.stopping_at)
+            and not self.is_running
+        )
+
+    @property
     def hypervisor(self) -> HypervisorType:
         if self.is_program:
             return HypervisorType.firecracker

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -278,6 +278,10 @@ async def start_persistent_vm(vm_hash: ItemHash, pubsub: PubSub | None, pool: Vm
             logger.info(f"{vm_hash} is stopping, waiting for complete stop before restarting")
             await execution.stop_event.wait()
             execution = None
+        elif execution.is_awaiting_confidential_init:
+            # Stopping and recreating the execution here would loop forever:
+            # only the owner can start it by uploading the session certificates.
+            logger.info(f"{vm_hash} is waiting for its owner to initialize the confidential session")
         else:
             logger.info(f"{vm_hash} unknown execution state, stopping the vm")
             if execution.vm:

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -269,6 +269,9 @@ async def list_executions_v2(request: web.Request) -> web.Response:
                 ),
                 "status": execution.times,
                 "running": running_states.get(item_hash, False),
+                # Confidential VMs are only started once their owner uploads the
+                # session certificates: not running, but not dead either.
+                "awaiting_confidential_init": execution.is_awaiting_confidential_init,
                 "vm_type": VmType.from_message_content(execution.message).name,
             }
             for item_hash, execution in pool.executions.items()

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -221,6 +221,18 @@ def _get_executions_running_states(pool: VmPool) -> dict[ItemHash, bool]:
     return running_states
 
 
+def _is_listable_awaiting_confidential_init(execution: VmExecution) -> bool:
+    """Whether a confidential VM waiting for its owner belongs in the executions list.
+
+    The scheduler re-allocates any planned VM absent from the list, so a waiting
+    confidential VM must be listed or it gets re-allocated forever. Consumers
+    require the networking fields, so only list it once its tap interface exists.
+    """
+    return (
+        execution.is_awaiting_confidential_init and execution.vm is not None and execution.vm.tap_interface is not None
+    )
+
+
 @cors_allow_all
 async def list_executions(request: web.Request) -> web.Response:
     pool: VmPool = request.app["vm_pool"]
@@ -236,9 +248,10 @@ async def list_executions(request: web.Request) -> web.Response:
                     "ipv6": execution.vm.tap_interface.ipv6_network,
                 },
                 "vm_type": VmType.from_message_content(execution.message).name,
+                "awaiting_confidential_init": execution.is_awaiting_confidential_init,
             }
             for item_hash, execution in pool.executions.items()
-            if running_states.get(item_hash, False)
+            if running_states.get(item_hash, False) or _is_listable_awaiting_confidential_init(execution)
         },
         dumps=dumps_for_json,
     )

--- a/tests/supervisor/test_run.py
+++ b/tests/supervisor/test_run.py
@@ -1,0 +1,119 @@
+from datetime import datetime, timezone
+
+import pytest
+from aleph_message.models import InstanceContent, ItemHash
+
+from aleph.vm.models import VmExecution
+from aleph.vm.orchestrator.run import start_persistent_vm
+
+VM_HASH = ItemHash("decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca")
+FIRMWARE_HASH = "facefacefacefacefacefacefacefacefacefacefacefacefacefacefaceface"
+
+
+@pytest.fixture()
+def instance_content() -> dict:
+    return {
+        "address": "0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9",
+        "time": 1713874241.800818,
+        "allow_amend": False,
+        "metadata": None,
+        "authorized_keys": None,
+        "variables": None,
+        "environment": {"reproducible": False, "internet": True, "aleph_api": True, "shared_cache": False},
+        "resources": {"vcpus": 1, "memory": 256, "seconds": 30, "published_ports": None},
+        "payment": {"type": "hold", "chain": "ETH"},
+        "requirements": None,
+        "replaces": None,
+        "rootfs": {
+            "parent": {"ref": "63f07193e6ee9d207b7d1fcf8286f9aee34e6f12f101d2ec77c1229f92964696"},
+            "ref": "63f07193e6ee9d207b7d1fcf8286f9aee34e6f12f101d2ec77c1229f92964696",
+            "use_latest": True,
+            "comment": "",
+            "persistence": "host",
+            "size_mib": 1000,
+        },
+    }
+
+
+@pytest.fixture()
+def confidential_instance_content(instance_content) -> dict:
+    instance_content["environment"]["hypervisor"] = "qemu"
+    instance_content["environment"]["trusted_execution"] = {"policy": 1, "firmware": FIRMWARE_HASH}
+    return instance_content
+
+
+def make_execution(content: dict, mocker, *, controller_active: bool = False) -> VmExecution:
+    """Build a persistent execution whose systemd controller state is mocked."""
+    message = InstanceContent.model_validate(content)
+    systemd_manager = mocker.Mock(is_service_active=mocker.Mock(return_value=controller_active))
+    return VmExecution(
+        vm_hash=VM_HASH,
+        message=message,
+        original=message,
+        snapshot_manager=None,
+        systemd_manager=systemd_manager,
+        persistent=True,
+    )
+
+
+def mark_started(execution: VmExecution) -> None:
+    """Put the execution in the state left by VmExecution.start()."""
+    execution.times.starting_at = datetime.now(tz=timezone.utc)
+    execution.times.started_at = datetime.now(tz=timezone.utc)
+    execution.ready_event.set()
+
+
+def test_confidential_instance_awaits_init_after_start(confidential_instance_content, mocker):
+    """A confidential VM created but not yet initialized by its owner must be
+    reported as awaiting its confidential initialization, not as some unknown state."""
+    execution = make_execution(confidential_instance_content, mocker)
+    mark_started(execution)
+
+    assert execution.is_running is False
+    assert execution.is_awaiting_confidential_init is True
+
+
+def test_confidential_instance_not_awaiting_init_once_controller_runs(confidential_instance_content, mocker):
+    """Once the owner initialized the VM (controller service active), it is running."""
+    execution = make_execution(confidential_instance_content, mocker, controller_active=True)
+    mark_started(execution)
+
+    assert execution.is_running is True
+    assert execution.is_awaiting_confidential_init is False
+
+
+def test_confidential_instance_not_awaiting_init_when_stopping(confidential_instance_content, mocker):
+    execution = make_execution(confidential_instance_content, mocker)
+    mark_started(execution)
+    execution.times.stopping_at = datetime.now(tz=timezone.utc)
+
+    assert execution.is_awaiting_confidential_init is False
+
+
+def test_non_confidential_instance_never_awaits_init(instance_content, mocker):
+    execution = make_execution(instance_content, mocker)
+    mark_started(execution)
+
+    assert execution.is_awaiting_confidential_init is False
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_vm_keeps_confidential_instance_awaiting_init(confidential_instance_content, mocker):
+    """An allocation for a confidential VM waiting for its owner's session must not
+    stop and recreate it (it would loop forever: the VM can only start once the
+    owner uploads the session certificates via /confidential/initialize)."""
+    execution = make_execution(confidential_instance_content, mocker)
+    mark_started(execution)
+    execution.vm = mocker.Mock()
+
+    stop_mock = mocker.patch.object(execution, "stop", new=mocker.AsyncMock())
+    create_mock = mocker.patch("aleph.vm.orchestrator.run.create_vm_execution", new=mocker.AsyncMock())
+
+    pool = mocker.Mock(executions={VM_HASH: execution})
+
+    result = await start_persistent_vm(VM_HASH, pubsub=None, pool=pool)
+
+    assert result is execution
+    stop_mock.assert_not_called()
+    create_mock.assert_not_called()
+    pool.forget_vm.assert_not_called()

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -457,6 +457,115 @@ async def test_v2_executions_list_confidential_awaiting_init(
 
 
 @pytest.mark.asyncio
+async def test_v1_executions_list_includes_confidential_awaiting_init(
+    aiohttp_client, mocker, mock_app_with_pool, mock_instance_content
+):
+    """The scheduler reads /about/executions/list and re-allocates any planned VM
+    missing from it. A confidential VM waiting for its owner must be listed, else
+    the scheduler re-POSTs allocations forever and keeps reporting it missing."""
+    from ipaddress import IPv4Network, IPv6Network
+
+    web_app = await mock_app_with_pool
+    pool = web_app["vm_pool"]
+
+    content = deepcopy(mock_instance_content)
+    content["environment"]["hypervisor"] = "qemu"
+    content["environment"]["trusted_execution"] = {
+        "policy": 1,
+        "firmware": "facefacefacefacefacefacefacefacefacefacefacefacefacefacefaceface",
+    }
+    message = InstanceContent.model_validate(content)
+
+    vm_hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
+    systemd_manager = mocker.Mock(
+        is_service_active=mocker.Mock(return_value=False),
+        get_services_active_states=mocker.Mock(return_value={}),
+    )
+    execution = VmExecution(
+        vm_hash=vm_hash,
+        message=message,
+        original=message,
+        persistent=True,
+        snapshot_manager=None,
+        systemd_manager=systemd_manager,
+    )
+    execution.times.starting_at = execution.times.defined_at
+    execution.times.started_at = execution.times.defined_at
+    execution.vm = mocker.Mock(
+        tap_interface=mocker.Mock(
+            ip_network=IPv4Network("172.16.3.0/24"),
+            ipv6_network=IPv6Network("fc00:1:2:3::/64"),
+        )
+    )
+
+    pool.executions = {vm_hash: execution}
+    pool.systemd_manager = systemd_manager
+
+    client = await aiohttp_client(web_app)
+    response: web.Response = await client.get(
+        "/about/executions/list",
+    )
+    assert response.status == 200
+    resp = await response.json()
+    assert resp == {
+        vm_hash: {
+            "networking": {
+                "ipv4": "172.16.3.0/24",
+                "ipv6": "fc00:1:2:3::/64",
+            },
+            "vm_type": "instance",
+            "awaiting_confidential_init": True,
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_v1_executions_list_excludes_awaiting_init_without_network(
+    aiohttp_client, mocker, mock_app_with_pool, mock_instance_content
+):
+    """Entries without networking would break strict consumers of the v1 schema
+    (the scheduler requires networking.ipv4/ipv6), so an awaiting-init VM whose
+    tap interface is not set up must stay out of the list."""
+    web_app = await mock_app_with_pool
+    pool = web_app["vm_pool"]
+
+    content = deepcopy(mock_instance_content)
+    content["environment"]["hypervisor"] = "qemu"
+    content["environment"]["trusted_execution"] = {
+        "policy": 1,
+        "firmware": "facefacefacefacefacefacefacefacefacefacefacefacefacefacefaceface",
+    }
+    message = InstanceContent.model_validate(content)
+
+    vm_hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
+    systemd_manager = mocker.Mock(
+        is_service_active=mocker.Mock(return_value=False),
+        get_services_active_states=mocker.Mock(return_value={}),
+    )
+    execution = VmExecution(
+        vm_hash=vm_hash,
+        message=message,
+        original=message,
+        persistent=True,
+        snapshot_manager=None,
+        systemd_manager=systemd_manager,
+    )
+    execution.times.starting_at = execution.times.defined_at
+    execution.times.started_at = execution.times.defined_at
+    execution.vm = mocker.Mock(tap_interface=None)
+
+    pool.executions = {vm_hash: execution}
+    pool.systemd_manager = systemd_manager
+
+    client = await aiohttp_client(web_app)
+    response: web.Response = await client.get(
+        "/about/executions/list",
+    )
+    assert response.status == 200
+    assert await response.json() == {}
+
+
+@pytest.mark.asyncio
 async def test_v2_executions_list_vm_network(aiohttp_client, mocker, mock_app_with_pool, mock_instance_content):
     "Test locally but do not create"
     web_app = await mock_app_with_pool

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -404,9 +404,56 @@ async def test_v2_executions_list_one_vm(aiohttp_client, mock_app_with_pool, moc
                 "stopped_at": None,
             },
             "running": False,
+            "awaiting_confidential_init": False,
             "vm_type": "instance",
         }
     }
+
+
+@pytest.mark.asyncio
+async def test_v2_executions_list_confidential_awaiting_init(
+    aiohttp_client, mocker, mock_app_with_pool, mock_instance_content
+):
+    """A confidential VM waiting for its owner to initialize it must be distinguishable
+    from a dead VM in the executions list, so the scheduler and console can report it."""
+    web_app = await mock_app_with_pool
+    pool = web_app["vm_pool"]
+
+    content = deepcopy(mock_instance_content)
+    content["environment"]["hypervisor"] = "qemu"
+    content["environment"]["trusted_execution"] = {
+        "policy": 1,
+        "firmware": "facefacefacefacefacefacefacefacefacefacefacefacefacefacefaceface",
+    }
+    message = InstanceContent.model_validate(content)
+
+    vm_hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
+    systemd_manager = mocker.Mock(
+        is_service_active=mocker.Mock(return_value=False),
+        get_services_active_states=mocker.Mock(return_value={}),
+    )
+    execution = VmExecution(
+        vm_hash=vm_hash,
+        message=message,
+        original=message,
+        persistent=True,
+        snapshot_manager=None,
+        systemd_manager=systemd_manager,
+    )
+    execution.times.starting_at = execution.times.defined_at
+    execution.times.started_at = execution.times.defined_at
+
+    pool.executions = {vm_hash: execution}
+    pool.systemd_manager = systemd_manager
+
+    client = await aiohttp_client(web_app)
+    response: web.Response = await client.get(
+        "/v2/about/executions/list",
+    )
+    assert response.status == 200
+    resp = await response.json()
+    assert resp[vm_hash]["running"] is False
+    assert resp[vm_hash]["awaiting_confidential_init"] is True
 
 
 @pytest.mark.asyncio
@@ -480,6 +527,7 @@ async def test_v2_executions_list_vm_network(aiohttp_client, mocker, mock_app_wi
                 "stopped_at": None,
             },
             "running": False,
+            "awaiting_confidential_init": False,
             "vm_type": "instance",
         }
     }


### PR DESCRIPTION
## Problem

Reported by a user: confidential VM `c3ab0d76…` is allocated by the scheduler to a CRN (coco0.leviathan.so, 1.12.0) but never comes up. The scheduler POSTs `/control/allocations` every minute as expected, yet the VM stays "missing" forever. A second confidential VM on the same node (`e95a0b05…`) is stuck in the identical state.

## Root cause

A confidential VM execution is created with its controller service deliberately left inactive: it can only start once its owner uploads the session certificates via `/control/machine/{ref}/confidential/initialize` (the CRN cannot have the disk secret).

In that waiting state all three state properties are False:

| Property | Value | Why |
|---|---|---|
| `is_starting` | False | `times.started_at` is set by `start()` |
| `is_running` | False | persistent ⇒ systemd check; controller never started |
| `is_stopping` | False | no `stopping_at` |

Two failure loops feed each other:

1. **Node side:** every allocation POST falls into the `"unknown execution state, stopping the vm"` branch of `start_persistent_vm()` and **stops and recreates the execution that was legitimately waiting for its owner**, racing the owner's initialization handshake:

```
11:19:36 Starting instance 'c3ab0d76…'
11:19:36 c3ab0d76… unknown execution state, stopping the vm
11:19:37 <VMExecution AlephQemuConfidentialInstance c3ab0d76…> stopped
11:19:37 Starting persistent virtual machine with id: c3ab0d76…
```

2. **Scheduler side:** the scheduler reads `/about/executions/list` and only uses the keys (`executions.into_keys()` → `running_vms`; re-POSTs whenever `planned_vms != running_vms`). That list filters to *running* VMs, so the waiting VM never appears → the scheduler re-allocates every cycle and reports the VM as `missing`, forever.

## Fix

- Add `VmExecution.is_awaiting_confidential_init`: confidential + persistent + started + not stopping + controller not active.
- `start_persistent_vm()` leaves such executions untouched instead of stopping and recreating them.
- `/about/executions/list` (read by the scheduler) now includes awaiting-init confidential VMs, with an `awaiting_confidential_init` flag on all entries. This makes the scheduler observe the VM, ending the re-allocation storm and the permanent `missing` status. Entries are only added once the tap interface exists: the scheduler deserializes values into a struct with **required** `networking.ipv4`/`ipv6` fields, and one entry without them would fail the whole node poll.
- `/v2/about/executions/list` exposes `awaiting_confidential_init` as well so consumers can distinguish "waiting for its owner" from a dead VM.

Note: with this change the scheduler will count a waiting confidential VM as observed even though the guest is not booted until its owner initializes it. That is the intent — re-allocating cannot start it, only the owner can — but consoles reading scheduler state will show it as placed rather than missing until they consume the new flag.

## Tests

- `tests/supervisor/test_run.py` (new): property semantics (awaiting / running / stopping / non-confidential) and `start_persistent_vm` keeping the awaiting execution (no `stop()`, no recreate, no `forget_vm`).
- `tests/supervisor/test_views.py`: v1 list includes an awaiting-init VM (full payload incl. networking) and excludes it while the tap interface is missing; v2 list reports `awaiting_confidential_init: true`; existing list tests updated for the new field.

All tests written first and verified to fail on the previous behavior.
