### PR TITLE
feat(auth): source authorized allocation signers from settings aggregate

### DIFF
--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -15,7 +15,7 @@ from aleph_message.models import Chain
 from aleph_message.models.execution.environment import HypervisorType
 from dotenv import load_dotenv
 from eth_utils import is_checksum_address
-from pydantic import Field, HttpUrl, field_validator
+from pydantic import Field, HttpUrl, ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from aleph.vm.orchestrator.chain import STREAM_CHAINS
@@ -114,15 +114,15 @@ def obtain_dns_ips(dns_resolver: DnsResolver, network_interface: str) -> list[st
 
 
 class Settings(BaseSettings):
-    @field_validator("AUTHORIZED_ALLOCATION_SIGNERS")
+    @field_validator("AUTHORIZED_ALLOCATION_SIGNERS", "DEFAULT_ALLOCATION_SIGNERS")
     @classmethod
-    def _check_authorized_signers(cls, value: list[str]) -> list[str]:
+    def _check_authorized_signers(cls, value: list[str], info: ValidationInfo) -> list[str]:
         for addr in value:
             if not is_checksum_address(addr):
                 msg = (
-                    f"AUTHORIZED_ALLOCATION_SIGNERS contains an invalid or "
-                    f"non-checksummed ETH address: {addr!r}. Use the checksum "
-                    f"form (mixed case, EIP-55) to catch typos."
+                    f"{info.field_name} contains an invalid or non-checksummed "
+                    f"ETH address: {addr!r}. Use the checksum form (mixed case, "
+                    f"EIP-55) to catch typos."
                 )
                 raise ValueError(msg)
         return value
@@ -362,12 +362,31 @@ class Settings(BaseSettings):
     schedulers migrate to AUTHORIZED_ALLOCATION_SIGNERS / Aleph-EIP191-V1."""
 
     AUTHORIZED_ALLOCATION_SIGNERS: list[str] = []
-    """ETH addresses authorized to sign requests to scheduler-only endpoints
-    (Aleph-EIP191-V1 scheme). Empty list disables the signature path; only the
-    legacy ALLOCATION_TOKEN_HASH path is active.
+    """Local override of the ETH addresses authorized to sign requests to
+    scheduler-only endpoints (Aleph-EIP191-V1 scheme).
+
+    When non-empty, this list is used verbatim and both the settings aggregate
+    and DEFAULT_ALLOCATION_SIGNERS are ignored — giving operators an immediate,
+    network-independent way to rotate or revoke a scheduler key. When empty (the
+    default), signers are resolved from the network, then the built-in default.
+    See aleph.vm.orchestrator.utils.get_authorized_allocation_signers for the
+    full precedence (override > aggregate > default).
 
     Each entry must be a checksummed ETH address (e.g. 0xAbC...). Validated at
     startup; invalid entries fail with a clear error.
+    """
+
+    DEFAULT_ALLOCATION_SIGNERS: list[str] = ["0x2937f62e5F81A88e921f883f8fE56ceCf4A4A44A"]
+    """Built-in fallback scheduler signer(s) for the Aleph-EIP191-V1 path, used
+    only when there is no local AUTHORIZED_ALLOCATION_SIGNERS override and the
+    settings aggregate provides no signers (unfetchable, or its
+    `authorized_allocation_signers` key is absent/empty).
+
+    Ships with the official scheduler address so a fresh CRN trusts it with zero
+    configuration on day one and stays reachable if the aggregate is down. A
+    non-empty aggregate list takes precedence, so the foundation can rotate the
+    scheduler key network-wide without a CRN redeploy. Same checksum-address
+    validation as AUTHORIZED_ALLOCATION_SIGNERS.
     """
 
     ALLOCATION_SIGNATURE_MAX_AGE_SECONDS: int = 300

--- a/src/aleph/vm/orchestrator/utils.py
+++ b/src/aleph/vm/orchestrator/utils.py
@@ -14,6 +14,8 @@ class AggregateSettingsDict(TypedDict):
     compatible_gpus: list[Any]
     community_wallet_address: str
     community_wallet_timestamp: int
+    # Optional in practice (older aggregates omit it); accessed via .get().
+    authorized_allocation_signers: list[str]
 
 
 PRICE_PRECISION = 18
@@ -80,6 +82,38 @@ async def is_after_community_wallet_start(dt: datetime | None = None) -> bool:
 
 def format_cost(v: Decimal | str, p: int = PRICE_PRECISION) -> Decimal:
     return Decimal(v).quantize(Decimal(1) / Decimal(10**p), ROUND_FLOOR)
+
+
+async def get_authorized_allocation_signers() -> set[str]:
+    """Effective allow-list of ETH addresses for the Aleph-EIP191-V1 scheduler
+    auth path, lowercased for case-insensitive comparison against the recovered
+    signer. Resolved with precedence: local override > settings aggregate >
+    built-in default.
+
+    1. ``settings.AUTHORIZED_ALLOCATION_SIGNERS`` (local override): if non-empty,
+       used verbatim and nothing else is consulted. This gives operators an
+       immediate, network-independent rotation/revocation path — they can add a
+       new scheduler key or drop a compromised one without waiting for the
+       aggregate's owner key to publish an update.
+    2. The network settings aggregate's ``authorized_allocation_signers`` key:
+       used when non-empty, so the foundation can rotate the scheduler key
+       network-wide (a non-empty list replaces the built-in default below).
+    3. ``settings.DEFAULT_ALLOCATION_SIGNERS`` (built-in): the fallback used when
+       the override is unset and the aggregate yields no signers (unfetchable, or
+       the key is absent/empty). Ships with the official scheduler so a fresh CRN
+       works on day one and stays reachable if the aggregate is down. An empty
+       aggregate list is treated as "no opinion" and falls back here rather than
+       authorizing no one, so a stray empty publication can't brick scheduling.
+    """
+    local = settings.AUTHORIZED_ALLOCATION_SIGNERS
+    if local:
+        return {addr.lower() for addr in local}
+    aggregate = await get_aggregate_settings()
+    if aggregate:
+        signers = aggregate.get("authorized_allocation_signers") or []
+        if signers:
+            return {addr.lower() for addr in signers}
+    return {addr.lower() for addr in settings.DEFAULT_ALLOCATION_SIGNERS}
 
 
 def get_compatible_gpus() -> list[Any]:

--- a/src/aleph/vm/orchestrator/views/allocation_auth.py
+++ b/src/aleph/vm/orchestrator/views/allocation_auth.py
@@ -19,6 +19,7 @@ from eth_account import Account
 from eth_account.messages import encode_defunct
 
 from aleph.vm.conf import settings
+from aleph.vm.orchestrator.utils import get_authorized_allocation_signers
 
 logger = logging.getLogger(__name__)
 
@@ -175,7 +176,7 @@ async def _verify_aleph_signature(request: web.Request, auth_header: str) -> boo
             encode_defunct(payload_bytes),
             signature=bytes.fromhex(sig_hex),
         )
-        authorized = {a.lower() for a in settings.AUTHORIZED_ALLOCATION_SIGNERS}
+        authorized = await get_authorized_allocation_signers()
         if recovered.lower() not in authorized:
             return False
 
@@ -243,30 +244,33 @@ async def authenticate_api_request(request: web.Request) -> bool:
 
 
 def log_allocation_auth_config() -> None:
-    """Emit a one-shot warning at supervisor boot if the legacy token path is
-    the only auth method configured. Operators see the deprecation notice
-    exactly once per process lifetime — not flooded per-request."""
+    """Summarize the allocation-auth configuration once at supervisor boot, so
+    operators see the deprecation notice exactly once per process lifetime —
+    not flooded per-request.
+
+    Note this can only report the *local* configuration: the aggregate-sourced
+    signer list (used when no local override is set) is fetched lazily at
+    request time, so its contents aren't known here."""
     has_signers = bool(settings.AUTHORIZED_ALLOCATION_SIGNERS)
     has_legacy = bool(settings.ALLOCATION_TOKEN_HASH)
     if has_signers:
         logger.info(
-            "Allocation auth: Aleph-EIP191-V1 enabled with %d authorized signer(s)",
+            "Allocation auth: Aleph-EIP191-V1 enabled with %d locally-configured "
+            "signer(s) (overrides the settings aggregate)",
             len(settings.AUTHORIZED_ALLOCATION_SIGNERS),
         )
-        if has_legacy:
-            logger.warning(
-                "Allocation auth: legacy X-Auth-Signature path is still enabled "
-                "(ALLOCATION_TOKEN_HASH is set). Remove it once all schedulers "
-                "have migrated to Aleph-EIP191-V1.",
-            )
-    elif has_legacy:
-        logger.warning(
-            "Allocation auth: only the legacy X-Auth-Signature path is configured. "
-            "Set AUTHORIZED_ALLOCATION_SIGNERS to enable Aleph-EIP191-V1 (recommended).",
-        )
     else:
+        logger.info(
+            "Allocation auth: no local AUTHORIZED_ALLOCATION_SIGNERS override set; "
+            "Aleph-EIP191-V1 signers are sourced from the network settings aggregate, "
+            "falling back to %d built-in default signer(s).",
+            len(settings.DEFAULT_ALLOCATION_SIGNERS),
+        )
+    if has_legacy:
         logger.warning(
-            "Allocation auth: no auth method configured — all scheduler " "endpoints will reject requests with 401.",
+            "Allocation auth: legacy X-Auth-Signature path is still enabled "
+            "(ALLOCATION_TOKEN_HASH is set). Remove it once all schedulers "
+            "have migrated to Aleph-EIP191-V1.",
         )
 
 

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -12,6 +12,8 @@ from eth_account.messages import encode_defunct
 from pydantic import ValidationError
 
 from aleph.vm.conf import Settings, settings
+from aleph.vm.orchestrator import utils as orchestrator_utils
+from aleph.vm.orchestrator.utils import get_authorized_allocation_signers
 from aleph.vm.orchestrator.views import allocation_auth
 from aleph.vm.orchestrator.views.allocation_auth import (
     MAX_SIGNED_REQUEST_BODY_BYTES,
@@ -20,6 +22,33 @@ from aleph.vm.orchestrator.views.allocation_auth import (
     _verify_aleph_signature,
     log_allocation_auth_config,
 )
+
+
+@pytest.fixture(autouse=True)
+def stub_settings_aggregate(monkeypatch):
+    """Default the settings-aggregate fetch to "unavailable" so tests never hit
+    the network. Fail-closed: with no local signers, the aggregate path
+    authorizes nobody unless a test explicitly provides one via
+    `set_aggregate_signers`."""
+
+    async def _none():
+        return None
+
+    monkeypatch.setattr(orchestrator_utils, "get_aggregate_settings", _none)
+
+
+@pytest.fixture
+def set_aggregate_signers(monkeypatch):
+    """Return a callable that makes the settings aggregate report the given
+    list of authorized signer addresses."""
+
+    def _apply(addresses):
+        async def _aggregate():
+            return {"authorized_allocation_signers": list(addresses)}
+
+        monkeypatch.setattr(orchestrator_utils, "get_aggregate_settings", _aggregate)
+
+    return _apply
 
 
 def test_authorized_signers_default_empty():
@@ -641,24 +670,31 @@ def test_log_allocation_auth_config_both_enabled_warns(caplog, monkeypatch):
     assert any("legacy X-Auth-Signature path is still enabled" in m for m in warnings)
 
 
-def test_log_allocation_auth_config_legacy_only_warns(caplog, monkeypatch):
-    """No signers, legacy hash only → warning prompts operator to migrate."""
+def test_log_allocation_auth_config_legacy_still_enabled_warns(caplog, monkeypatch):
+    """No local override + legacy hash → warning to remove the legacy path.
+
+    The signature path is not "disabled" here: with no local override signers
+    are sourced from the settings aggregate, so the only thing worth warning
+    about is the still-enabled legacy token."""
     monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
     monkeypatch.setattr(settings, "ALLOCATION_TOKEN_HASH", sha256(b"test").hexdigest())
 
-    with caplog.at_level("WARNING", logger="aleph.vm.orchestrator.views.allocation_auth"):
+    with caplog.at_level("INFO", logger="aleph.vm.orchestrator.views.allocation_auth"):
         log_allocation_auth_config()
-    assert any("only the legacy X-Auth-Signature path is configured" in r.message for r in caplog.records)
+    assert any("legacy X-Auth-Signature path is still enabled" in r.message for r in caplog.records)
 
 
-def test_log_allocation_auth_config_nothing_configured_warns(caplog, monkeypatch):
-    """No signers and no legacy hash → warning that all scheduler calls will 401."""
+def test_log_allocation_auth_config_aggregate_sourced_when_local_empty(caplog, monkeypatch):
+    """No local override and no legacy hash → signers come from the settings
+    aggregate (the default for a stock CRN); this is not a misconfiguration, so
+    no warning is emitted."""
     monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
     monkeypatch.setattr(settings, "ALLOCATION_TOKEN_HASH", "")
 
-    with caplog.at_level("WARNING", logger="aleph.vm.orchestrator.views.allocation_auth"):
+    with caplog.at_level("INFO", logger="aleph.vm.orchestrator.views.allocation_auth"):
         log_allocation_auth_config()
-    assert any("no auth method configured" in r.message for r in caplog.records)
+    assert any("settings aggregate" in r.message for r in caplog.records)
+    assert not [r for r in caplog.records if r.levelname == "WARNING"]
 
 
 # --- M3: iat window boundary behavior ---
@@ -844,3 +880,157 @@ async def test_verify_per_signer_dedup_is_independent(mock_request, monkeypatch)
     # Replaying A's exact request is still rejected — for A.
     request_a2 = mock_request(headers={"Authorization": auth_a}, body=b"{}")
     assert await _verify_aleph_signature(request_a2, auth_a) is False
+
+
+# --- Authorized-signer resolution: local override > aggregate > baked-in default ---
+
+
+def test_default_allocation_signers_includes_scheduler():
+    """The package ships with the official scheduler address as the built-in
+    default, so a fresh CRN trusts it with zero configuration even before the
+    settings aggregate is reachable."""
+    assert "0x2937f62e5F81A88e921f883f8fE56ceCf4A4A44A" in settings.DEFAULT_ALLOCATION_SIGNERS
+
+
+@pytest.mark.asyncio
+async def test_signers_local_overrides_aggregate(monkeypatch, set_aggregate_signers):
+    """A non-empty local list is used verbatim; the aggregate is not consulted."""
+    local = Account.create()
+    aggregate_only = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [local.address])
+    set_aggregate_signers([aggregate_only.address])
+
+    resolved = await get_authorized_allocation_signers()
+
+    assert resolved == {local.address.lower()}
+    assert aggregate_only.address.lower() not in resolved
+
+
+@pytest.mark.asyncio
+async def test_signers_from_aggregate_when_local_empty(monkeypatch, set_aggregate_signers):
+    """With no local override, signers come from the settings aggregate."""
+    aggregate_signer = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
+    set_aggregate_signers([aggregate_signer.address])
+
+    resolved = await get_authorized_allocation_signers()
+
+    assert resolved == {aggregate_signer.address.lower()}
+
+
+@pytest.mark.asyncio
+async def test_signers_aggregate_overrides_default(monkeypatch, set_aggregate_signers):
+    """A non-empty aggregate list replaces the baked-in default, so rotation via
+    the aggregate takes effect and a superseded default key can be dropped."""
+    aggregate_signer = Account.create()
+    default_signer = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
+    monkeypatch.setattr(settings, "DEFAULT_ALLOCATION_SIGNERS", [default_signer.address])
+    set_aggregate_signers([aggregate_signer.address])
+
+    resolved = await get_authorized_allocation_signers()
+
+    assert resolved == {aggregate_signer.address.lower()}
+    assert default_signer.address.lower() not in resolved
+
+
+@pytest.mark.asyncio
+async def test_signers_fall_back_to_default_when_aggregate_unavailable(monkeypatch):
+    """Local empty + aggregate unfetchable → the baked-in default scheduler is
+    used, so a stock CRN keeps accepting the official scheduler even when the
+    aggregate can't be fetched. (The autouse stub makes the fetch return None.)"""
+    default_signer = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
+    monkeypatch.setattr(settings, "DEFAULT_ALLOCATION_SIGNERS", [default_signer.address])
+
+    assert await get_authorized_allocation_signers() == {default_signer.address.lower()}
+
+
+@pytest.mark.asyncio
+async def test_signers_fall_back_to_default_when_aggregate_omits_key(monkeypatch):
+    """Local empty + aggregate fetched but without the signer key → default."""
+    default_signer = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
+    monkeypatch.setattr(settings, "DEFAULT_ALLOCATION_SIGNERS", [default_signer.address])
+
+    async def _aggregate_without_key():
+        return {"compatible_gpus": []}
+
+    monkeypatch.setattr(orchestrator_utils, "get_aggregate_settings", _aggregate_without_key)
+
+    assert await get_authorized_allocation_signers() == {default_signer.address.lower()}
+
+
+@pytest.mark.asyncio
+async def test_signers_empty_aggregate_list_falls_back_to_default(monkeypatch, set_aggregate_signers):
+    """An empty aggregate list is treated as "no opinion" and falls back to the
+    default — publishing an empty list cannot silently brick scheduling."""
+    default_signer = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
+    monkeypatch.setattr(settings, "DEFAULT_ALLOCATION_SIGNERS", [default_signer.address])
+    set_aggregate_signers([])
+
+    assert await get_authorized_allocation_signers() == {default_signer.address.lower()}
+
+
+@pytest.mark.asyncio
+async def test_verify_accepts_signer_from_aggregate(mock_request, monkeypatch, set_aggregate_signers):
+    """A request signed by an aggregate-listed signer verifies when no local override is set."""
+    signer = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
+    set_aggregate_signers([signer.address])
+
+    payload_bytes = make_signed_payload(body=b"{}")
+    auth = make_auth_header(signer, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+
+    assert await _verify_aleph_signature(request, auth) is True
+
+
+@pytest.mark.asyncio
+async def test_verify_accepts_default_signer_when_aggregate_unavailable(mock_request, monkeypatch):
+    """A request signed by the baked-in default scheduler verifies when local is
+    empty and the aggregate is unavailable — the zero-config day-one path."""
+    default_signer = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
+    monkeypatch.setattr(settings, "DEFAULT_ALLOCATION_SIGNERS", [default_signer.address])
+
+    payload_bytes = make_signed_payload(body=b"{}")
+    auth = make_auth_header(default_signer, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+
+    assert await _verify_aleph_signature(request, auth) is True
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_aggregate_signer_when_local_override_set(
+    mock_request, monkeypatch, set_aggregate_signers
+):
+    """Override semantics: a local list shadows the aggregate entirely, so an
+    aggregate-only signer is rejected once any local signer is configured."""
+    aggregate_signer = Account.create()
+    other_local = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [other_local.address])
+    set_aggregate_signers([aggregate_signer.address])
+
+    payload_bytes = make_signed_payload(body=b"{}")
+    auth = make_auth_header(aggregate_signer, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+
+    assert await _verify_aleph_signature(request, auth) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_unknown_signer_via_default_fallback(mock_request, monkeypatch):
+    """On the default-fallback path (local empty, aggregate down), a signer that
+    is neither in the aggregate nor the baked-in default is still rejected."""
+    default_signer = Account.create()
+    unknown = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
+    monkeypatch.setattr(settings, "DEFAULT_ALLOCATION_SIGNERS", [default_signer.address])
+
+    payload_bytes = make_signed_payload(body=b"{}")
+    auth = make_auth_header(unknown, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=b"{}")
+
+    assert await _verify_aleph_signature(request, auth) is False


### PR DESCRIPTION
## Summary

The Aleph-EIP191-V1 scheduler auth path previously read its authorized-signer allow-list only from `settings.AUTHORIZED_ALLOCATION_SIGNERS`, which defaulted to empty — so the signature path was effectively off until each operator configured it by hand.

This introduces a new resolver, `get_authorized_allocation_signers()`, that resolves signers through **three layers** (precedence: override > aggregate > default):

| Layer | Source | Wins when |
|-------|--------|-----------|
| 1. Override | `AUTHORIZED_ALLOCATION_SIGNERS` (env/config) | non-empty → used alone, nothing else consulted |
| 2. Network | settings aggregate `authorized_allocation_signers` | override empty **and** aggregate lists ≥1 signer |
| 3. Default | `DEFAULT_ALLOCATION_SIGNERS` (built-in) | override empty **and** aggregate yields nothing |

### Why
- **Zero-config day one / outage resilience** — `DEFAULT_ALLOCATION_SIGNERS` ships with the official scheduler address, so a fresh CRN trusts it without configuration and stays reachable if the aggregate is unfetchable.
- **Network rotation** — the foundation publishing a non-empty list to the aggregate replaces the default network-wide, no CRN redeploy.
- **Operator fast rotation** — the env override shadows everything instantly, independent of the aggregate's owner key being available.

### Notes
- An **empty aggregate list** is treated as "no opinion" and falls back to the default rather than authorizing nobody, so a stray empty publication can't brick scheduling globally.
- The boot-time auth summary log now reflects aggregate-sourcing (with a built-in default) when no local override is set.
- The private key matching the shipped default address must live on the scheduler.

## Test plan
- 70/70 tests pass in `tests/supervisor/views/test_allocation_auth.py`, including new coverage for all three layers, override shadowing, default fallback, empty-aggregate fallback, and end-to-end accept/reject.
- `ruff format --check`, `isort --check-only`, and `mypy` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
