### PR TITLE
Message-free supervisor: agent-side expiry facility

### DIFF
--- a/docs/plans/2026-06-08-supervisor-expiry-design.md
+++ b/docs/plans/2026-06-08-supervisor-expiry-design.md
@@ -1,0 +1,195 @@
+# Wire agent onto Supervisor: agent-side expiry facility
+
+**Status:** Design / spec (approved 2026-06-08)
+**Owner:** Olivier Desenfans
+**Series:** Message-free supervisor, Phase 0 residual cleanup. First of the
+residual PRs that finish detaching the agent from `VmExecution` before the
+Phase 1 process split.
+**Stacked on:** PR 3 read views (`od/wire-supervisor-read-views`, #967), itself
+on `dev`.
+
+## 1. Context
+
+Idle teardown for on-demand programs ("expiry") is agent policy: keep a microVM
+warm for `REUSE_TIMEOUT` seconds after a request, then reap it. Today the timer
+lives on `VmExecution` (`stop_after_timeout` / `expire` / `cancel_expiration` /
+`expire_task`), the god-object Phase 0 is splitting into an agent-side
+`Execution` and a hypervisor-side `Vm`. The timer is therefore on the wrong side
+of the future boundary, and the agent reaches it by holding the `VmExecution`
+instance.
+
+The same coupling shows up on the hypervisor side: `VmPool` itself calls
+`cancel_expiration()` in four places, all "do not expire a VM I am handing back
+for reuse." Those calls exist only because the timer is a method on the
+execution. The pool has no business knowing about an agent idle policy.
+
+This PR lifts expiry into an agent-owned facility keyed by `vm_id`, acting
+through the `Supervisor` abstraction, and removes the expiry members from both
+`VmExecution` and `VmPool`. When microVM creation later moves behind the
+supervisor (Phase 1), nothing in the idle path needs a `VmExecution` anymore.
+
+This is one of three residual cleanups (the others, shipped separately, are
+update-watching and the pre-existing-VM state check that together let
+`create_vm_execution` stop reading `pool.executions[vm_hash]` back).
+
+## 2. Goals / non-goals
+
+**Goals**
+- An `ExpiryManager` agent facility that owns idle timers, decoupled from
+  `VmExecution` and `VmPool`.
+- All three expiry touch-points migrated: the `run.py` idle-teardown
+  `finally:` blocks, `start_persistent_vm`'s cancel, and the `operate_expire`
+  operator endpoint.
+- `VmExecution` and `VmPool` lose every expiry member and call.
+- No observable behavior change: data volumes preserved, same warm-then-reap
+  semantics, same "do not expire while serving a request" guarantee.
+
+**Non-goals**
+- Update-watching (`watch_for_updates` / `cancel_update` / `update_task`):
+  separate PR. The `start_watching_for_updates` calls next to the migrated
+  expiry calls stay in place.
+- The `pool.executions[vm_hash]` readback at `run.py:223`: separate PR.
+- Owner-auth migration. `operate_expire` keeps its execution-based auth check
+  (`is_sender_authorized(sender, execution.message)`); only the timer mechanism
+  changes.
+- Any `stop_vm` addition to the contract. Expiry reaps via the existing
+  `delete_vm`.
+
+## 3. Behavior parity (the backward-compat contract)
+
+The reaping action on fire is `supervisor.delete_vm(vm_id, wipe=False)`. This is
+behavior-preserving in two ways that were explicitly checked:
+
+1. **Volumes are preserved.** `delete_vm(wipe=False)` never calls
+   `erase_volumes()`; volume erasure is gated entirely behind `wipe=True`
+   (`inprocess.py:243`). A microVM's persistent data volume survives an idle
+   reap, exactly as today. The expiry path always passes `wipe=False`.
+2. **Forgetting is not new.** `create_a_vm` always schedules
+   `_schedule_forget_on_stop` (`pool.py:398`), so today's
+   `expire()` -> `stop()` -> `stop_event` set -> `_forget_task` -> `forget_vm`
+   already removes the VM from the pool after idle, asynchronously.
+   `delete_vm(wipe=False)` performs the same stop + forget, synchronously.
+
+The "do not expire while serving a request" guarantee is preserved by moving the
+cancel-on-reuse from the pool to the agent: when the agent picks up a running VM
+to serve a request it calls `expiry.cancel(vm_id)`, and re-arms with
+`expiry.schedule(vm_id, REUSE_TIMEOUT)` in the `finally:` block. This is the same
+cancel-then-rearm the pool's `get_running_vm` + the execution's
+`stop_after_timeout` did together.
+
+## 4. The unit: `ExpiryManager`
+
+New module `src/aleph/vm/orchestrator/expiry.py`.
+
+```python
+class ExpiryManager:
+    """Agent-owned idle-teardown timers, keyed by vm_id.
+
+    One purpose (own the timers), one dependency (the Supervisor). Independently
+    testable with a fake supervisor.
+    """
+
+    def __init__(self, supervisor: Supervisor) -> None: ...
+
+    def schedule(self, vm_id: VmId, timeout: float) -> None:
+        """Arm (or re-arm, extending) the idle timer for vm_id."""
+
+    def cancel(self, vm_id: VmId) -> bool:
+        """Cancel a pending timer. Returns whether one existed."""
+
+    async def cancel_all(self) -> None:
+        """Cancel every pending timer (shutdown cleanup)."""
+
+    async def _expire(self, vm_id: VmId, timeout: float) -> None:
+        """Sleep, then reap via supervisor.delete_vm; tolerate already-gone."""
+```
+
+- State: `_tasks: dict[VmId, asyncio.Task]`.
+- `schedule` cancels any existing task for `vm_id` before creating the new one
+  (re-arm extends the window, matching `stop_after_timeout`).
+- `_expire` sleeps `timeout`, calls `await self.supervisor.delete_vm(vm_id)`
+  swallowing `VmNotFoundError` (the VM was already torn down through another
+  path), and removes itself from `_tasks` in a `finally`.
+- Keyed by `VmId` (= `str(vm_hash)`, the id the supervisor reports), so the
+  agent uses one consistent key against both the registry and the manager.
+
+## 5. Wiring
+
+- `supervisor.py` (where `app["supervisor"]` is built, ~line 168):
+  `app["expiry"] = ExpiryManager(app["supervisor"])`.
+- `tasks.py` (~line 257, where `Reactor(pubsub, pool)` is built next to
+  `app["supervisor"]` / `app["vm_registry"]`): pass `app["expiry"]` into the
+  `Reactor`, which threads it to `run_code_on_event`.
+- `run_code_on_request` reads `request.app["expiry"]`.
+- `cli.py` one-shot `check` (`run_code_on_event` at ~line 238) constructs a
+  throwaway `ExpiryManager(InProcessSupervisor(pool))`; the process exits after
+  the single run, so a long-lived manager is unnecessary there.
+
+In-process the supervisor is a stateless wrapper over the pool, so any
+`InProcessSupervisor` over the same pool reaps correctly; only the
+`ExpiryManager` itself must be long-lived.
+
+## 6. Call-site migration
+
+**On-demand idle path** (`run_code_on_request`, `run_code_on_event`):
+- On picking up a running VM for reuse: `expiry.cancel(vm_id)`.
+- Reuse `finally:` branch: `execution.stop_after_timeout(REUSE_TIMEOUT)` ->
+  `expiry.schedule(vm_id, REUSE_TIMEOUT)`. (`start_watching_for_updates` stays.)
+- Non-reuse `finally:` branch: `await execution.stop(); pool.forget_vm(...)` ->
+  `await supervisor.delete_vm(vm_id)`.
+
+**`start_persistent_vm`** (`run.py:496`):
+- `execution.cancel_expiration()` -> `expiry.cancel(vm_id)`.
+
+**`operate_expire`** (`operator.py:412`):
+- Drop the `execution.persistent = False` hack (only needed because
+  `stop_after_timeout` no-ops for persistent VMs; scheduling `delete_vm`
+  directly does not need de-persisting).
+- `execution.stop_after_timeout(timeout)` -> `expiry.schedule(vm_id, timeout)`.
+- Auth check unchanged (still fetches the execution for `is_sender_authorized`).
+
+**Tidy cancel on external teardown:** `operate_stop` / the delete and erase
+operator endpoints call `expiry.cancel(vm_id)` so a manual teardown clears any
+pending timer. `_expire`'s `VmNotFoundError` swallow is the safety net; this is
+just hygiene.
+
+## 7. Removals (the decoupling)
+
+**`VmExecution`** (`models.py`):
+- Delete `stop_after_timeout`, `expire`, `cancel_expiration`, and the
+  `expire_task` field.
+- Drop the `self.cancel_expiration()` call inside `stop()` (~line 841). The
+  agent now owns timer cancellation. (`cancel_update()` stays: update-watching
+  is the next PR.)
+
+**`VmPool`** (`pool.py`):
+- Remove all four `cancel_expiration()` calls: `create_a_vm:327`,
+  `create_vm_from_spec:418`, `get_running_or_starting_vm:482`,
+  `get_running_vm:491`.
+- Fix the two "Disables the VM expiration task" docstrings on `get_running_vm`
+  / `get_running_or_starting_vm` (they now just return a running VM or None).
+- `get_running_or_starting_vm` has no `src/` callers; left otherwise as-is to
+  keep this PR scoped (dead-code removal is unrelated).
+
+## 8. Testing
+
+- New `tests/supervisor/test_expiry.py` against a fake supervisor:
+  - `schedule` fires `delete_vm(vm_id, wipe=False)` after the timeout.
+  - re-`schedule` replaces the pending timer (extends, does not double-fire).
+  - `cancel` returns `True`/`False` and prevents the fire.
+  - `_expire` swallows `VmNotFoundError`.
+  - `cancel_all` clears everything.
+- Update `tests/supervisor/views/test_operator.py:198`: it asserts
+  `execution.expire.call_count == 1`; rewrite to assert the `operate_expire`
+  endpoint schedules on the `ExpiryManager` instead.
+- The existing run/request tests must keep passing (warm-then-reap parity).
+
+## 9. Done criteria
+
+- `grep -rn "stop_after_timeout\|cancel_expiration\|expire_task" src/` returns
+  nothing.
+- `VmPool` contains no expiry references.
+- The idle path reaps via `supervisor.delete_vm(vm_id, wipe=False)`; volumes
+  survive; warm-then-reap and "no expiry while serving a request" hold.
+- `operate_expire` drives the `ExpiryManager`; its persistent-flag hack is gone.
+- mypy / format / isort gates green; full suite at baseline.

--- a/docs/plans/2026-06-08-supervisor-expiry-plan.md
+++ b/docs/plans/2026-06-08-supervisor-expiry-plan.md
@@ -1,0 +1,705 @@
+# Agent-side expiry facility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lift idle-teardown ("expiry") off `VmExecution` into an agent-owned `ExpiryManager` that reaps through `Supervisor.delete_vm`, and remove every expiry member from `VmExecution` and `VmPool`.
+
+**Architecture:** A new `ExpiryManager` (one purpose: own idle timers; one dependency: the `Supervisor`) keyed by `VmId`. It is constructed as an app singleton, threaded into the request path via `request.app["expiry"]` and into the reactor path via the `Reactor`. All three expiry touch-points (the `run.py` idle `finally:` blocks, `start_persistent_vm`, `operate_expire`) migrate to it, then the dead expiry code is deleted from the model and pool.
+
+**Tech Stack:** Python 3.10+, asyncio, aiohttp, pytest + pytest-asyncio.
+
+**Spec:** `docs/plans/2026-06-08-supervisor-expiry-design.md`.
+
+---
+
+## Environment setup (controller does once, before Task 1)
+
+Worktree already created: `.worktrees/wire-supervisor-expiry` on branch
+`od/wire-supervisor-expiry` (based on the #967 read-views tip).
+
+Test venv (dbus-python and other system packages cannot build locally; chain
+system site-packages):
+
+```bash
+cd /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-expiry
+python3 -m venv --system-site-packages .testvenv
+echo "$PWD/src" > .testvenv/lib/python3*/site-packages/_local_aleph.pth
+.testvenv/bin/python -m pip install -q pytest pytest-asyncio pytest-aiohttp pytest-mock
+```
+
+Run tests as `.testvenv/bin/python -m pytest <paths> -v`.
+
+Known baseline (neither set blocks): the ~8 environmental-only failures
+(root / network / qemu) in `test_execution.py` / `test_instance.py` /
+`test_interfaces.py`, and the order-dependent DB-init errors in
+`test_port_mappings.py` when run as a subset.
+
+---
+
+## File structure
+
+- Create: `src/aleph/vm/orchestrator/expiry.py` (the `ExpiryManager`).
+- Create: `tests/supervisor/test_expiry.py` (unit tests).
+- Modify: `src/aleph/vm/orchestrator/supervisor.py` (`app["expiry"]`).
+- Modify: `src/aleph/vm/orchestrator/run.py` (both `run_code_on_*`, `start_persistent_vm`).
+- Modify: `src/aleph/vm/orchestrator/reactor.py` (thread expiry/supervisor).
+- Modify: `src/aleph/vm/orchestrator/tasks.py` (build `Reactor` with deps).
+- Modify: `src/aleph/vm/orchestrator/cli.py` (bench `FakeRequest`, one-shot call).
+- Modify: `src/aleph/vm/orchestrator/views/operator.py` (`operate_expire`, tidy cancels).
+- Modify: `src/aleph/vm/orchestrator/views/__init__.py` (`start_persistent_vm` callers).
+- Modify: `src/aleph/vm/models.py` (delete expiry members).
+- Modify: `src/aleph/vm/pool.py` (delete four `cancel_expiration` calls).
+- Modify: `tests/supervisor/views/test_operator.py` (expiry assertion).
+
+---
+
+### Task 1: The `ExpiryManager` unit
+
+**Files:**
+- Create: `src/aleph/vm/orchestrator/expiry.py`
+- Test: `tests/supervisor/test_expiry.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/supervisor/test_expiry.py`:
+
+```python
+import asyncio
+
+import pytest
+
+from aleph.vm.orchestrator.expiry import ExpiryManager
+from aleph.vm.supervisor.errors import VmNotFoundError
+from aleph.vm.supervisor.types import VmId
+
+
+class FakeSupervisor:
+    def __init__(self, *, raise_not_found: bool = False):
+        self.deleted: list[tuple[str, bool]] = []
+        self.raise_not_found = raise_not_found
+
+    async def delete_vm(self, vm_id: VmId, wipe: bool = False) -> None:
+        self.deleted.append((str(vm_id), wipe))
+        if self.raise_not_found:
+            raise VmNotFoundError(str(vm_id))
+
+
+@pytest.mark.asyncio
+async def test_schedule_reaps_after_timeout():
+    sup = FakeSupervisor()
+    expiry = ExpiryManager(sup)
+    vm_id = VmId("vm-a")
+
+    expiry.schedule(vm_id, 0.01)
+    await asyncio.sleep(0.05)
+
+    assert sup.deleted == [("vm-a", False)]
+    assert expiry.cancel(vm_id) is False  # task removed itself after firing
+
+
+@pytest.mark.asyncio
+async def test_cancel_prevents_reap():
+    sup = FakeSupervisor()
+    expiry = ExpiryManager(sup)
+    vm_id = VmId("vm-a")
+
+    expiry.schedule(vm_id, 0.05)
+    assert expiry.cancel(vm_id) is True
+    await asyncio.sleep(0.1)
+
+    assert sup.deleted == []
+    assert expiry.cancel(vm_id) is False
+
+
+@pytest.mark.asyncio
+async def test_reschedule_replaces_pending_timer():
+    sup = FakeSupervisor()
+    expiry = ExpiryManager(sup)
+    vm_id = VmId("vm-a")
+
+    expiry.schedule(vm_id, 0.2)
+    expiry.schedule(vm_id, 0.01)  # re-arm shorter
+    await asyncio.sleep(0.1)
+
+    assert sup.deleted == [("vm-a", False)]  # fired once, on the second timer
+
+
+@pytest.mark.asyncio
+async def test_expire_swallows_vm_not_found():
+    sup = FakeSupervisor(raise_not_found=True)
+    expiry = ExpiryManager(sup)
+    vm_id = VmId("vm-gone")
+
+    expiry.schedule(vm_id, 0.01)
+    await asyncio.sleep(0.05)  # must not raise
+
+    assert sup.deleted == [("vm-gone", False)]
+    assert expiry.cancel(vm_id) is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_clears_every_timer():
+    sup = FakeSupervisor()
+    expiry = ExpiryManager(sup)
+
+    expiry.schedule(VmId("vm-a"), 0.05)
+    expiry.schedule(VmId("vm-b"), 0.05)
+    await expiry.cancel_all()
+    await asyncio.sleep(0.1)
+
+    assert sup.deleted == []
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `.testvenv/bin/python -m pytest tests/supervisor/test_expiry.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'aleph.vm.orchestrator.expiry'`.
+
+- [ ] **Step 3: Implement `ExpiryManager`**
+
+Create `src/aleph/vm/orchestrator/expiry.py`:
+
+```python
+import asyncio
+import logging
+
+from aleph.vm.supervisor.abc import Supervisor
+from aleph.vm.supervisor.errors import VmNotFoundError
+from aleph.vm.supervisor.types import VmId
+
+logger = logging.getLogger(__name__)
+
+
+class ExpiryManager:
+    """Agent-owned idle-teardown timers, keyed by vm_id.
+
+    One purpose (own the timers), one dependency (the Supervisor). Replaces the
+    expiry methods that used to live on VmExecution, so the idle policy no
+    longer needs a VmExecution instance.
+    """
+
+    def __init__(self, supervisor: Supervisor) -> None:
+        self.supervisor = supervisor
+        self._tasks: dict[VmId, asyncio.Task] = {}
+
+    def schedule(self, vm_id: VmId, timeout: float) -> None:
+        """Arm (or re-arm, extending) the idle timer for vm_id."""
+        self.cancel(vm_id)
+        self._tasks[vm_id] = asyncio.create_task(self._expire(vm_id, timeout), name=f"expire {vm_id}")
+
+    def cancel(self, vm_id: VmId) -> bool:
+        """Cancel a pending timer. Returns whether one existed."""
+        task = self._tasks.pop(vm_id, None)
+        if task is None:
+            return False
+        task.cancel()
+        return True
+
+    async def cancel_all(self) -> None:
+        """Cancel every pending timer (shutdown cleanup)."""
+        for vm_id in list(self._tasks):
+            self.cancel(vm_id)
+
+    async def _expire(self, vm_id: VmId, timeout: float) -> None:
+        try:
+            await asyncio.sleep(timeout)
+            logger.info("Idle timeout reached for %s, reaping", vm_id)
+            await self.supervisor.delete_vm(vm_id)
+        except VmNotFoundError:
+            logger.debug("Expiry: VM %s already gone", vm_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Expiry of %s failed", vm_id)
+        finally:
+            # Only drop our own entry: a concurrent re-schedule may have already
+            # replaced it with a new task under the same key.
+            if self._tasks.get(vm_id) is asyncio.current_task():
+                del self._tasks[vm_id]
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `.testvenv/bin/python -m pytest tests/supervisor/test_expiry.py -v`
+Expected: all 5 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/aleph/vm/orchestrator/expiry.py tests/supervisor/test_expiry.py
+git commit -m "feat(expiry): agent-owned ExpiryManager keyed by vm_id"
+```
+
+---
+
+### Task 2: App wiring + `run_code_on_request` migration + CLI bench
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/supervisor.py:168` (add `app["expiry"]`)
+- Modify: `src/aleph/vm/orchestrator/run.py` (`run_code_on_request`)
+- Modify: `src/aleph/vm/orchestrator/cli.py` (`FakeRequest`, `benchmark`)
+
+- [ ] **Step 1: Add the app singleton**
+
+In `src/aleph/vm/orchestrator/supervisor.py`, add the import near the other
+orchestrator imports:
+
+```python
+from aleph.vm.orchestrator.expiry import ExpiryManager
+```
+
+And in `setup_webapp`, right after the `app["supervisor"]` line (currently
+line 168):
+
+```python
+    app["supervisor"] = InProcessSupervisor(pool)
+    app["expiry"] = ExpiryManager(app["supervisor"])
+    app["vm_registry"] = AgentVmRegistry()
+```
+
+- [ ] **Step 2: Migrate `run_code_on_request`**
+
+In `src/aleph/vm/orchestrator/run.py`, at the top of `run_code_on_request`
+(after the docstring), resolve the deps and cancel any pending timer for the VM
+being served:
+
+```python
+async def run_code_on_request(vm_hash: ItemHash, path: str, pool: VmPool, request: web.Request) -> web.Response:
+    """
+    Execute the code corresponding to the 'code id' in the path.
+    """
+    supervisor: Supervisor = request.app["supervisor"]
+    expiry: ExpiryManager = request.app["expiry"]
+    vm_id = VmId(str(vm_hash))
+    expiry.cancel(vm_id)  # do not reap a VM we are about to serve
+
+    execution: VmExecution | None = pool.get_running_vm(vm_hash=vm_hash)
+```
+
+Replace the `finally:` block (currently lines 392-399):
+
+```python
+    finally:
+        if settings.REUSE_TIMEOUT > 0:
+            if settings.WATCH_FOR_UPDATES:
+                execution.start_watching_for_updates(pubsub=request.app["pubsub"])
+            expiry.schedule(vm_id, settings.REUSE_TIMEOUT)
+        else:
+            await supervisor.delete_vm(vm_id)
+```
+
+Add the import for `ExpiryManager` at the top of `run.py` (with the other
+`aleph.vm.orchestrator` imports):
+
+```python
+from aleph.vm.orchestrator.expiry import ExpiryManager
+```
+
+(`Supervisor` and `VmId` are already imported in `run.py`.)
+
+- [ ] **Step 3: Give the CLI bench an app with the singletons**
+
+In `src/aleph/vm/orchestrator/cli.py`, add `app` to the `FakeRequest` field
+list (class around line 159):
+
+```python
+class FakeRequest:
+    headers: dict[str, str]
+    raw_headers: list[tuple[bytes, bytes]]
+    match_info: dict
+    method: str
+    query_string: str
+    read: Callable
+    app: dict
+```
+
+In `benchmark`, after `pool = VmPool()` / `await pool.setup()`, wire the app
+dict (add imports for `InProcessSupervisor` and `ExpiryManager` at the top of
+`cli.py` if absent):
+
+```python
+    bench_supervisor = InProcessSupervisor(pool)
+    fake_request.app = {
+        "supervisor": bench_supervisor,
+        "expiry": ExpiryManager(bench_supervisor),
+        "pubsub": PubSub(),
+    }
+```
+
+- [ ] **Step 4: Run the affected tests**
+
+Run: `.testvenv/bin/python -m pytest tests/supervisor/ -k "request or run or executions" -v`
+Expected: PASS (warm-then-reap parity preserved; new app key present).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/aleph/vm/orchestrator/supervisor.py src/aleph/vm/orchestrator/run.py src/aleph/vm/orchestrator/cli.py
+git commit -m "refactor(expiry): run_code_on_request drives the ExpiryManager"
+```
+
+---
+
+### Task 3: `run_code_on_event` migration (reactor path)
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/run.py` (`run_code_on_event`)
+- Modify: `src/aleph/vm/orchestrator/reactor.py` (`Reactor` carries deps)
+- Modify: `src/aleph/vm/orchestrator/tasks.py:257` (build `Reactor` with deps)
+- Modify: `src/aleph/vm/orchestrator/cli.py` (one-shot `run_code_on_event` call)
+
+- [ ] **Step 1: Change `run_code_on_event` signature and body**
+
+In `src/aleph/vm/orchestrator/run.py`, update the signature and the local-build
+block (the reactor has no request, so deps are passed in; reuse the passed
+supervisor instead of building a throwaway one):
+
+```python
+async def run_code_on_event(
+    vm_hash: ItemHash,
+    event,
+    pubsub: PubSub,
+    pool: VmPool,
+    *,
+    supervisor: Supervisor,
+    expiry: ExpiryManager,
+):
+    """
+    Execute code in response to an event.
+    """
+    vm_id = VmId(str(vm_hash))
+    expiry.cancel(vm_id)  # do not reap a VM we are about to serve
+
+    execution: VmExecution | None = pool.get_running_vm(vm_hash=vm_hash)
+
+    if not execution:
+        # programs use the legacy create path; the reactor has no agent
+        # registry singleton, so build a local one for the create follow-up.
+        registry = AgentVmRegistry()
+        execution = await create_vm_execution_or_raise_http_error(
+            vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry
+        )
+```
+
+Replace the `finally:` block (currently lines 449-455):
+
+```python
+    finally:
+        if settings.REUSE_TIMEOUT > 0:
+            if settings.WATCH_FOR_UPDATES:
+                execution.start_watching_for_updates(pubsub=pubsub)
+            expiry.schedule(vm_id, settings.REUSE_TIMEOUT)
+        else:
+            await supervisor.delete_vm(vm_id)
+```
+
+(`InProcessSupervisor` may now be an unused import in `run.py` if nothing else
+uses it; check and remove only if so.)
+
+- [ ] **Step 2: Carry the deps on the `Reactor`**
+
+In `src/aleph/vm/orchestrator/reactor.py`, add imports and constructor params:
+
+```python
+from aleph.vm.orchestrator.expiry import ExpiryManager
+from aleph.vm.supervisor.abc import Supervisor
+
+
+class Reactor:
+    pubsub: PubSub
+    pool: VmPool
+    supervisor: Supervisor
+    expiry: ExpiryManager
+    listeners: list[AlephMessage]
+
+    def __init__(self, pubsub: PubSub, pool: VmPool, supervisor: Supervisor, expiry: ExpiryManager):
+        self.pubsub = pubsub
+        self.pool = pool
+        self.supervisor = supervisor
+        self.expiry = expiry
+        self.listeners = []
+```
+
+And the `trigger` call site:
+
+```python
+                    coroutines.append(
+                        run_code_on_event(
+                            vm_hash, event, self.pubsub, pool=self.pool,
+                            supervisor=self.supervisor, expiry=self.expiry,
+                        )
+                    )
+```
+
+- [ ] **Step 3: Build the `Reactor` with deps**
+
+In `src/aleph/vm/orchestrator/tasks.py`, `start_watch_for_messages_task`
+(line 257), pass the app singletons:
+
+```python
+    supervisor = app["supervisor"]
+    registry = app["vm_registry"]
+    reactor = Reactor(pubsub, pool, supervisor, app["expiry"])
+```
+
+- [ ] **Step 4: Update the one-shot CLI call**
+
+In `src/aleph/vm/orchestrator/cli.py`, the `run_code_on_event` call in
+`benchmark` (line 238) reuses the bench supervisor built in Task 2:
+
+```python
+    result = await run_code_on_event(
+        vm_hash=ref, event=None, pubsub=PubSub(), pool=pool,
+        supervisor=bench_supervisor, expiry=fake_request.app["expiry"],
+    )
+```
+
+- [ ] **Step 5: Run the affected tests**
+
+Run: `.testvenv/bin/python -m pytest tests/supervisor/ -k "reactor or event or run" -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/aleph/vm/orchestrator/run.py src/aleph/vm/orchestrator/reactor.py src/aleph/vm/orchestrator/tasks.py src/aleph/vm/orchestrator/cli.py
+git commit -m "refactor(expiry): reactor path drives the ExpiryManager"
+```
+
+---
+
+### Task 4: `start_persistent_vm` + `operate_expire` migration
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/run.py` (`start_persistent_vm`)
+- Modify: `src/aleph/vm/orchestrator/views/__init__.py` (3 callers + `cli.py` caller)
+- Modify: `src/aleph/vm/orchestrator/cli.py` (`start_instance` caller)
+- Modify: `src/aleph/vm/orchestrator/views/operator.py` (`operate_expire`, tidy cancels)
+- Test: `tests/supervisor/views/test_operator.py`
+
+- [ ] **Step 1: Add `expiry` to `start_persistent_vm` and swap the cancel**
+
+In `src/aleph/vm/orchestrator/run.py`:
+
+```python
+async def start_persistent_vm(
+    vm_hash: ItemHash,
+    pubsub: PubSub | None,
+    pool: VmPool,
+    *,
+    supervisor: Supervisor,
+    registry: AgentVmRegistry,
+    expiry: ExpiryManager,
+) -> VmExecution:
+```
+
+Replace `execution.cancel_expiration()` (line 496) with:
+
+```python
+    # If the VM was already running in lambda mode, it should not expire
+    # as long as it is also scheduled as long-running
+    expiry.cancel(VmId(str(vm_hash)))
+```
+
+- [ ] **Step 2: Update `start_persistent_vm` callers**
+
+In `src/aleph/vm/orchestrator/views/__init__.py`, the three calls (lines ~599,
+~613, ~998) each gain `expiry=request.app["expiry"]`, e.g.:
+
+```python
+                await start_persistent_vm(
+                    vm_hash, pubsub, pool,
+                    supervisor=supervisor, registry=registry, expiry=request.app["expiry"],
+                )
+```
+
+(Apply the same `expiry=request.app["expiry"]` addition to all three call
+sites; `instance_item_hash` / `item_hash` is the first arg at the other two.)
+
+In `src/aleph/vm/orchestrator/cli.py`, `start_instance` (line 246) builds a
+throwaway:
+
+```python
+async def start_instance(item_hash: ItemHash, pubsub: PubSub | None, pool) -> VmExecution:
+    """Run an instance from an InstanceMessage."""
+    supervisor = InProcessSupervisor(pool)
+    registry = AgentVmRegistry()
+    expiry = ExpiryManager(supervisor)
+    return await start_persistent_vm(
+        item_hash, pubsub, pool, supervisor=supervisor, registry=registry, expiry=expiry
+    )
+```
+
+- [ ] **Step 3: Migrate `operate_expire`**
+
+In `src/aleph/vm/orchestrator/views/operator.py`, rewrite the action lines of
+`operate_expire` (currently `execution.persistent = False` /
+`execution.stop_after_timeout(timeout=timeout)`):
+
+```python
+        logger.info(f"Expiring in {timeout} seconds: {execution.vm_hash}")
+        expiry: ExpiryManager = request.app["expiry"]
+        expiry.schedule(VmId(str(vm_hash)), timeout)
+
+        return web.Response(status=200, body=f"Expiring VM with ref {vm_hash} in {timeout} seconds")
+```
+
+Add the import near the other orchestrator imports in `operator.py`:
+
+```python
+from aleph.vm.orchestrator.expiry import ExpiryManager
+```
+
+In `operate_stop` and the delete/erase operator endpoints, after the
+`supervisor.delete_vm(...)` call, clear any pending timer:
+
+```python
+                request.app["expiry"].cancel(vm_id)
+```
+
+(Use the `vm_id` already resolved in each handler; in `operate_stop` it is the
+`vm_id` passed to `delete_vm`.)
+
+- [ ] **Step 4: Update the operator expiry test**
+
+In `tests/supervisor/views/test_operator.py`, the test currently asserts
+`fake_vm_pool["executions"][vm_hash].expire.call_count == 1` (line 198).
+`operate_expire` no longer touches the execution; it schedules on the app's
+`ExpiryManager`. Replace the assertion so the test installs a spy expiry and
+checks it was scheduled. Before `setup_webapp`, build the app with a spy:
+
+```python
+    app = setup_webapp(pool=fake_vm_pool)
+    scheduled: list[tuple[str, float]] = []
+    app["expiry"].schedule = lambda vm_id, timeout: scheduled.append((str(vm_id), timeout))
+    client: TestClient = await aiohttp_client(app)
+```
+
+And replace the final assertion:
+
+```python
+    assert response.status == 200, await response.text()
+    assert scheduled == [(vm_hash, 1.0)]
+```
+
+- [ ] **Step 5: Run the affected tests**
+
+Run: `.testvenv/bin/python -m pytest tests/supervisor/views/test_operator.py -v`
+Expected: PASS (including the rewritten expire test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/aleph/vm/orchestrator/run.py src/aleph/vm/orchestrator/views/__init__.py src/aleph/vm/orchestrator/views/operator.py src/aleph/vm/orchestrator/cli.py tests/supervisor/views/test_operator.py
+git commit -m "refactor(expiry): start_persistent_vm and operate_expire drive the ExpiryManager"
+```
+
+---
+
+### Task 5: Remove the dead expiry code from `VmExecution` and `VmPool`
+
+**Files:**
+- Modify: `src/aleph/vm/models.py`
+- Modify: `src/aleph/vm/pool.py`
+
+- [ ] **Step 1: Delete the model members**
+
+In `src/aleph/vm/models.py`:
+- Delete the `expire_task: asyncio.Task | None = None` field (line 142).
+- Delete the `stop_after_timeout` method (lines 785-796).
+- Delete the `expire` method (lines 798-804).
+- Delete the `cancel_expiration` method (lines 806-811).
+- In `stop()`, delete the `self.cancel_expiration()` line (line 841). Leave the
+  adjacent `self.cancel_update()` line in place (update-watching is a later PR).
+
+- [ ] **Step 2: Delete the pool calls and fix docstrings**
+
+In `src/aleph/vm/pool.py`, remove these `cancel_expiration` calls:
+- `create_a_vm` (line 327): drop `current_execution.cancel_expiration()`; the
+  reuse branch becomes just `return current_execution`.
+- `create_vm_from_spec` (line 418): drop `current_execution.cancel_expiration()`;
+  becomes `return current_execution`.
+- `get_running_or_starting_vm` (line 482): drop the call.
+- `get_running_vm` (line 491): drop the call.
+
+Fix the now-stale docstrings on `get_running_vm` and
+`get_running_or_starting_vm` (both currently `"""Return a running VM or None.
+Disables the VM expiration task."""`) to:
+
+```python
+        """Return a running VM or None."""
+```
+
+- [ ] **Step 3: Verify no references remain**
+
+Run: `grep -rn "stop_after_timeout\|cancel_expiration\|expire_task\|\.expire(" src/`
+Expected: no output.
+
+- [ ] **Step 4: Run the model/pool tests**
+
+Run: `.testvenv/bin/python -m pytest tests/supervisor/ tests/test_pool.py -v`
+Expected: PASS (env-only failures from the baseline excepted).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/aleph/vm/models.py src/aleph/vm/pool.py
+git commit -m "refactor(expiry): drop expiry members from VmExecution and VmPool"
+```
+
+---
+
+### Task 6: Gates and full suite
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Type check the touched modules**
+
+Run:
+```bash
+.testvenv/bin/python -m mypy src/aleph/vm/orchestrator/expiry.py src/aleph/vm/orchestrator/run.py src/aleph/vm/orchestrator/reactor.py src/aleph/vm/orchestrator/views/ src/aleph/vm/models.py src/aleph/vm/pool.py --ignore-missing-imports
+```
+Expected: no NEW errors against the branch baseline.
+
+- [ ] **Step 2: Format and import gates**
+
+Run:
+```bash
+uvx ruff@0.4.6 format --diff .
+uvx isort@5.13.2 --check-only --profile black src tests examples
+```
+Expected: clean. If `ruff format` reports diffs on touched files, apply
+`uvx ruff@0.4.6 format <file>` and `git commit -m "style: ruff format"`.
+
+- [ ] **Step 3: Done-criteria grep**
+
+Run: `grep -rn "stop_after_timeout\|cancel_expiration\|expire_task" src/`
+Expected: empty. And `grep -rn "cancel_expiration\|expire" src/aleph/vm/pool.py`
+returns nothing.
+
+- [ ] **Step 4: Full suite**
+
+Run: `.testvenv/bin/python -m pytest tests/ -q`
+Expected: at baseline (the documented env-only failures only).
+
+- [ ] **Step 5: Final commit (if any format fixes pending)**
+
+```bash
+git add -A
+git commit -m "test(expiry): gates green, full suite at baseline" || echo "nothing to commit"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: ExpiryManager (Task 1); wiring (Tasks 2-3); all three
+  touch-points (Tasks 2-4); removals from model + pool (Task 5); volume-safe
+  reap via `delete_vm(wipe=False)` (Task 1 test + Tasks 2-3); tests (Tasks 1,
+  4); gates (Task 6).
+- The cancel-on-reuse (`expiry.cancel(vm_id)` at the top of both `run_code_on_*`)
+  preserves the "no expiry while serving a request" guarantee the pool's
+  `get_running_vm` cancel used to give.
+- `cancel_all` is implemented and unit-tested; not yet wired into a shutdown
+  hook (no current hook reaches the agent singletons cleanly). Left available;
+  wiring it is out of scope per the spec.

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import logging
 import uuid
-from asyncio import Task
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -139,7 +138,6 @@ class VmExecution:
     runs_done_event: asyncio.Event
     stop_pending_lock: asyncio.Lock
     stop_event: asyncio.Event
-    expire_task: asyncio.Task | None = None
     update_task: asyncio.Task | None = None
     init_task: asyncio.Task | None
     _forget_task: asyncio.Task | None = None
@@ -782,34 +780,6 @@ class VmExecution:
         assert self.vm, "The VM attribute has to be set before calling wait_for_init()"
         await self.vm.wait_for_init()
 
-    def stop_after_timeout(self, timeout: float = 5.0) -> Task | None:
-        if self.persistent:
-            logger.debug("VM marked as long running. Ignoring timeout.")
-            return None
-
-        if self.expire_task:
-            logger.debug("VM already has a timeout. Extending it.")
-            self.expire_task.cancel()
-
-        vm_id: str = str(self.vm.vm_id if self.vm else None)
-        self.expire_task = create_task_log_exceptions(self.expire(timeout), name=f"expire {vm_id}")
-        return self.expire_task
-
-    async def expire(self, timeout: float) -> None:
-        """Coroutine that will stop the VM after 'timeout' seconds."""
-        await asyncio.sleep(timeout)
-        assert self.times.started_at
-        if self.times.stopping_at or self.times.stopped_at:
-            return
-        await self.stop()
-
-    def cancel_expiration(self) -> bool:
-        if self.expire_task:
-            self.expire_task.cancel()
-            return True
-        else:
-            return False
-
     def cancel_update(self) -> bool:
         if self.update_task:
             self.update_task.cancel()
@@ -838,7 +808,6 @@ class VmExecution:
             await self.vm.teardown()
 
             self.times.stopped_at = datetime.now(tz=timezone.utc)
-            self.cancel_expiration()
             self.cancel_update()
 
             if self.vm.support_snapshot and self.snapshot_manager:

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -244,8 +244,12 @@ async def benchmark(runs: int):
     logger.info(bench)
 
     result = await run_code_on_event(
-        vm_hash=ref, event=None, pubsub=PubSub(), pool=pool,
-        supervisor=bench_supervisor, expiry=fake_request.app["expiry"],
+        vm_hash=ref,
+        event=None,
+        pubsub=PubSub(),
+        pool=pool,
+        supervisor=bench_supervisor,
+        expiry=fake_request.app["expiry"],
     )
     print("Event result", result)
 
@@ -255,9 +259,7 @@ async def start_instance(item_hash: ItemHash, pubsub: PubSub | None, pool) -> Vm
     supervisor = InProcessSupervisor(pool)
     registry = AgentVmRegistry()
     expiry = ExpiryManager(supervisor)
-    return await start_persistent_vm(
-        item_hash, pubsub, pool, supervisor=supervisor, registry=registry, expiry=expiry
-    )
+    return await start_persistent_vm(item_hash, pubsub, pool, supervisor=supervisor, registry=registry, expiry=expiry)
 
 
 async def run_instances(instances: list[ItemHash]) -> None:

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -243,7 +243,10 @@ async def benchmark(runs: int):
     logger.info(f"BENCHMARK: n={len(bench)} avg={mean(bench):03f} min={min(bench):03f} max={max(bench):03f}")
     logger.info(bench)
 
-    result = await run_code_on_event(vm_hash=ref, event=None, pubsub=PubSub(), pool=pool)
+    result = await run_code_on_event(
+        vm_hash=ref, event=None, pubsub=PubSub(), pool=pool,
+        supervisor=bench_supervisor, expiry=fake_request.app["expiry"],
+    )
     print("Event result", result)
 
 

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from aleph.vm.conf import ALLOW_DEVELOPER_SSH_KEYS, make_db_url, settings
 from aleph.vm.models import VmExecution
+from aleph.vm.orchestrator.expiry import ExpiryManager
 from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.pool import VmPool
 from aleph.vm.supervisor.inprocess import InProcessSupervisor
@@ -157,6 +158,7 @@ def parse_args(args):
 
 
 class FakeRequest:
+    app: dict
     headers: dict[str, str]
     raw_headers: list[tuple[bytes, bytes]]
     match_info: dict
@@ -192,6 +194,12 @@ async def benchmark(runs: int):
     loop = asyncio.get_event_loop()
     pool = VmPool()
     await pool.setup()
+    bench_supervisor = InProcessSupervisor(pool)
+    fake_request.app = {
+        "supervisor": bench_supervisor,
+        "expiry": ExpiryManager(bench_supervisor),
+        "pubsub": PubSub(),
+    }
 
     # Does not make sense in benchmarks
     settings.WATCH_FOR_MESSAGES = False

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -254,7 +254,10 @@ async def start_instance(item_hash: ItemHash, pubsub: PubSub | None, pool) -> Vm
     """Run an instance from an InstanceMessage."""
     supervisor = InProcessSupervisor(pool)
     registry = AgentVmRegistry()
-    return await start_persistent_vm(item_hash, pubsub, pool, supervisor=supervisor, registry=registry)
+    expiry = ExpiryManager(supervisor)
+    return await start_persistent_vm(
+        item_hash, pubsub, pool, supervisor=supervisor, registry=registry, expiry=expiry
+    )
 
 
 async def run_instances(instances: list[ItemHash]) -> None:

--- a/src/aleph/vm/orchestrator/expiry.py
+++ b/src/aleph/vm/orchestrator/expiry.py
@@ -1,0 +1,56 @@
+import asyncio
+import logging
+
+from aleph.vm.supervisor.abc import Supervisor
+from aleph.vm.supervisor.errors import VmNotFoundError
+from aleph.vm.supervisor.types import VmId
+
+logger = logging.getLogger(__name__)
+
+
+class ExpiryManager:
+    """Agent-owned idle-teardown timers, keyed by vm_id.
+
+    One purpose (own the timers), one dependency (the Supervisor). Replaces the
+    expiry methods that used to live on VmExecution, so the idle policy no
+    longer needs a VmExecution instance.
+    """
+
+    def __init__(self, supervisor: Supervisor) -> None:
+        self.supervisor = supervisor
+        self._tasks: dict[VmId, asyncio.Task] = {}
+
+    def schedule(self, vm_id: VmId, timeout: float) -> None:
+        """Arm (or re-arm, extending) the idle timer for vm_id."""
+        self.cancel(vm_id)
+        self._tasks[vm_id] = asyncio.create_task(self._expire(vm_id, timeout), name=f"expire {vm_id}")
+
+    def cancel(self, vm_id: VmId) -> bool:
+        """Cancel a pending timer. Returns whether one existed."""
+        task = self._tasks.pop(vm_id, None)
+        if task is None:
+            return False
+        task.cancel()
+        return True
+
+    async def cancel_all(self) -> None:
+        """Cancel every pending timer (shutdown cleanup)."""
+        for vm_id in list(self._tasks):
+            self.cancel(vm_id)
+
+    async def _expire(self, vm_id: VmId, timeout: float) -> None:
+        try:
+            await asyncio.sleep(timeout)
+            logger.info("Idle timeout reached for %s, reaping", vm_id)
+            await self.supervisor.delete_vm(vm_id)
+        except VmNotFoundError:
+            logger.debug("Expiry: VM %s already gone", vm_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Expiry of %s failed", vm_id)
+        finally:
+            # Only drop our own entry: a concurrent re-schedule may have already
+            # replaced it with a new task under the same key.
+            if self._tasks.get(vm_id) is asyncio.current_task():
+                del self._tasks[vm_id]

--- a/src/aleph/vm/orchestrator/reactor.py
+++ b/src/aleph/vm/orchestrator/reactor.py
@@ -71,8 +71,12 @@ class Reactor:
                     # Register the listener in the list of coroutines to run asynchronously:
                     coroutines.append(
                         run_code_on_event(
-                            vm_hash, event, self.pubsub, pool=self.pool,
-                            supervisor=self.supervisor, expiry=self.expiry,
+                            vm_hash,
+                            event,
+                            self.pubsub,
+                            pool=self.pool,
+                            supervisor=self.supervisor,
+                            expiry=self.expiry,
                         )
                     )
                     break

--- a/src/aleph/vm/orchestrator/reactor.py
+++ b/src/aleph/vm/orchestrator/reactor.py
@@ -4,7 +4,9 @@ from collections.abc import Coroutine
 from aleph_message.models import AlephMessage
 from aleph_message.models.execution.environment import Subscription
 
+from aleph.vm.orchestrator.expiry import ExpiryManager
 from aleph.vm.pool import VmPool
+from aleph.vm.supervisor.abc import Supervisor
 from aleph.vm.utils import create_task_log_exceptions
 
 from .pubsub import PubSub
@@ -41,11 +43,15 @@ def subscription_matches(subscription: Subscription, message: AlephMessage) -> b
 class Reactor:
     pubsub: PubSub
     pool: VmPool
+    supervisor: Supervisor
+    expiry: ExpiryManager
     listeners: list[AlephMessage]
 
-    def __init__(self, pubsub: PubSub, pool: VmPool):
+    def __init__(self, pubsub: PubSub, pool: VmPool, supervisor: Supervisor, expiry: ExpiryManager):
         self.pubsub = pubsub
         self.pool = pool
+        self.supervisor = supervisor
+        self.expiry = expiry
         self.listeners = []
 
     async def trigger(self, message: AlephMessage):
@@ -63,7 +69,12 @@ class Reactor:
                     vm_hash = listener.item_hash
                     event = message.model_dump_json()
                     # Register the listener in the list of coroutines to run asynchronously:
-                    coroutines.append(run_code_on_event(vm_hash, event, self.pubsub, pool=self.pool))
+                    coroutines.append(
+                        run_code_on_event(
+                            vm_hash, event, self.pubsub, pool=self.pool,
+                            supervisor=self.supervisor, expiry=self.expiry,
+                        )
+                    )
                     break
 
         # Call all listeners asynchronously from the event loop:

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -398,7 +398,9 @@ async def run_code_on_request(vm_hash: ItemHash, path: str, pool: VmPool, reques
         if settings.REUSE_TIMEOUT > 0:
             if settings.WATCH_FOR_UPDATES:
                 execution.start_watching_for_updates(pubsub=request.app["pubsub"])
-            expiry.schedule(vm_id, settings.REUSE_TIMEOUT)
+            # Persistent executions are long-running by design: never idle-reap them.
+            if not execution.persistent:
+                expiry.schedule(vm_id, settings.REUSE_TIMEOUT)
         else:
             await supervisor.delete_vm(vm_id)
 
@@ -463,7 +465,9 @@ async def run_code_on_event(
         if settings.REUSE_TIMEOUT > 0:
             if settings.WATCH_FOR_UPDATES:
                 execution.start_watching_for_updates(pubsub=pubsub)
-            expiry.schedule(vm_id, settings.REUSE_TIMEOUT)
+            # Persistent executions are long-running by design: never idle-reap them.
+            if not execution.persistent:
+                expiry.schedule(vm_id, settings.REUSE_TIMEOUT)
         else:
             await supervisor.delete_vm(vm_id)
 

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -475,6 +475,7 @@ async def start_persistent_vm(
     *,
     supervisor: Supervisor,
     registry: AgentVmRegistry,
+    expiry: ExpiryManager,
 ) -> VmExecution:
     execution: VmExecution | None = pool.executions.get(vm_hash)
     if execution:
@@ -506,7 +507,7 @@ async def start_persistent_vm(
 
     # If the VM was already running in lambda mode, it should not expire
     # as long as it is also scheduled as long-running
-    execution.cancel_expiration()
+    expiry.cancel(VmId(str(vm_hash)))
 
     if pubsub and settings.WATCH_FOR_UPDATES:
         execution.start_watching_for_updates(pubsub=pubsub)

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -24,6 +24,7 @@ from aleph.vm.controllers.firecracker.program import (
 )
 from aleph.vm.hypervisors.firecracker.microvm import MicroVMFailedInitError
 from aleph.vm.models import MessageSpec, VmExecution
+from aleph.vm.orchestrator.expiry import ExpiryManager
 from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.pool import VmPool
 from aleph.vm.resources import InsufficientResourcesError
@@ -288,6 +289,10 @@ async def run_code_on_request(vm_hash: ItemHash, path: str, pool: VmPool, reques
     """
     Execute the code corresponding to the 'code id' in the path.
     """
+    supervisor: Supervisor = request.app["supervisor"]
+    expiry: ExpiryManager = request.app["expiry"]
+    vm_id = VmId(str(vm_hash))
+    expiry.cancel(vm_id)  # do not reap a VM we are about to serve
 
     execution: VmExecution | None = pool.get_running_vm(vm_hash=vm_hash)
 
@@ -393,10 +398,9 @@ async def run_code_on_request(vm_hash: ItemHash, path: str, pool: VmPool, reques
         if settings.REUSE_TIMEOUT > 0:
             if settings.WATCH_FOR_UPDATES:
                 execution.start_watching_for_updates(pubsub=request.app["pubsub"])
-            _ = execution.stop_after_timeout(timeout=settings.REUSE_TIMEOUT)
+            expiry.schedule(vm_id, settings.REUSE_TIMEOUT)
         else:
-            await execution.stop()
-            pool.forget_vm(execution.vm_hash)
+            await supervisor.delete_vm(vm_id)
 
 
 async def run_code_on_event(vm_hash: ItemHash, event, pubsub: PubSub, pool: VmPool):

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -403,17 +403,26 @@ async def run_code_on_request(vm_hash: ItemHash, path: str, pool: VmPool, reques
             await supervisor.delete_vm(vm_id)
 
 
-async def run_code_on_event(vm_hash: ItemHash, event, pubsub: PubSub, pool: VmPool):
+async def run_code_on_event(
+    vm_hash: ItemHash,
+    event,
+    pubsub: PubSub,
+    pool: VmPool,
+    *,
+    supervisor: Supervisor,
+    expiry: ExpiryManager,
+):
     """
     Execute code in response to an event.
     """
+    vm_id = VmId(str(vm_hash))
+    expiry.cancel(vm_id)  # do not reap a VM we are about to serve
 
     execution: VmExecution | None = pool.get_running_vm(vm_hash=vm_hash)
 
     if not execution:
-        # See run_code_on_request: programs use the legacy path; build the
-        # supervisor/registry locally since the reactor has no app singletons.
-        supervisor = InProcessSupervisor(pool)
+        # programs use the legacy create path; the reactor has no agent
+        # registry singleton, so build a local one for the create follow-up.
         registry = AgentVmRegistry()
         execution = await create_vm_execution_or_raise_http_error(
             vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry
@@ -454,9 +463,9 @@ async def run_code_on_event(vm_hash: ItemHash, event, pubsub: PubSub, pool: VmPo
         if settings.REUSE_TIMEOUT > 0:
             if settings.WATCH_FOR_UPDATES:
                 execution.start_watching_for_updates(pubsub=pubsub)
-            _ = execution.stop_after_timeout(timeout=settings.REUSE_TIMEOUT)
+            expiry.schedule(vm_id, settings.REUSE_TIMEOUT)
         else:
-            await execution.stop()
+            await supervisor.delete_vm(vm_id)
 
 
 async def start_persistent_vm(

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -269,6 +269,13 @@ async def stop_all_vms(app: web.Application):
         logger.exception("Error stopping VMs during shutdown")
 
 
+async def stop_expiry_manager(app: web.Application) -> None:
+    """on_cleanup hook: cancel any pending idle-teardown timers."""
+    expiry = app.get("expiry")
+    if expiry is not None:
+        await expiry.cancel_all()
+
+
 async def _run_migration_reaper(app: web.Application) -> None:
     """on_startup hook: clean up orphan migration files left from a prior supervisor run."""
     pool = app.get("vm_pool")
@@ -334,6 +341,7 @@ def run():
             app.on_cleanup.append(stop_watch_for_messages_task)
             app.on_cleanup.append(stop_balances_monitoring_task)
 
+        app.on_cleanup.append(stop_expiry_manager)
         app.on_cleanup.append(stop_all_vms)
 
         from aleph.vm.orchestrator.http import close_session, reset_session

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -18,6 +18,7 @@ from aiohttp_cors import ResourceOptions, setup
 
 from aleph.vm.conf import settings
 from aleph.vm.migration.reaper import reap_orphan_migration_files
+from aleph.vm.orchestrator.expiry import ExpiryManager
 from aleph.vm.orchestrator.vm_registry import AgentVmRegistry, rehydrate_registry
 from aleph.vm.pool import VmPool
 from aleph.vm.sevclient import SevClient
@@ -166,6 +167,7 @@ def setup_webapp(pool: VmPool | None):
     app.on_response_prepare.append(on_prepare_server_version)
     app["vm_pool"] = pool
     app["supervisor"] = InProcessSupervisor(pool)
+    app["expiry"] = ExpiryManager(app["supervisor"])
     app["vm_registry"] = AgentVmRegistry()
     app["backup_state"] = BackupState()
     cors = setup(

--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -254,7 +254,7 @@ async def start_watch_for_messages_task(app: web.Application):
     pool: VmPool = app["vm_pool"]
     supervisor = app["supervisor"]
     registry = app["vm_registry"]
-    reactor = Reactor(pubsub, pool)
+    reactor = Reactor(pubsub, pool, supervisor, app["expiry"])
 
     # Register an hardcoded initial program
     # TODO: Register all programs with subscriptions

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -570,6 +570,7 @@ async def update_allocations(request: web.Request):
     pool: VmPool = request.app["vm_pool"]
     supervisor = request.app["supervisor"]
     registry = request.app["vm_registry"]
+    expiry = request.app["expiry"]
 
     async with allocation_lock:
         logger.debug("Got allocation_lock, updating allocations")
@@ -619,7 +620,7 @@ async def update_allocations(request: web.Request):
             try:
                 logger.info(f"Starting long running VM '{vm_hash}'")
                 vm_hash = ItemHash(vm_hash)
-                await start_persistent_vm(vm_hash, pubsub, pool, supervisor=supervisor, registry=registry)
+                await start_persistent_vm(vm_hash, pubsub, pool, supervisor=supervisor, registry=registry, expiry=expiry)
             except vm_creation_exceptions as error:
                 logger.exception("Error while starting VM '%s': %s", vm_hash, error)
                 scheduling_errors[vm_hash] = error
@@ -633,7 +634,7 @@ async def update_allocations(request: web.Request):
             logger.info(f"Starting instance '{instance_hash}'")
             instance_item_hash = ItemHash(instance_hash)
             try:
-                await start_persistent_vm(instance_item_hash, pubsub, pool, supervisor=supervisor, registry=registry)
+                await start_persistent_vm(instance_item_hash, pubsub, pool, supervisor=supervisor, registry=registry, expiry=expiry)
             except vm_creation_exceptions as error:
                 logger.exception("Error while starting VM '%s': %s", instance_hash, error)
                 scheduling_errors[instance_item_hash] = error
@@ -885,6 +886,7 @@ async def notify_allocation(request: web.Request):
     pool: VmPool = request.app["vm_pool"]
     supervisor = request.app["supervisor"]
     registry = request.app["vm_registry"]
+    expiry = request.app["expiry"]
 
     # Capacity admission control: refuse the allocation early (before payment
     # validation) if accepting it would push the host above its memory, vCPU,
@@ -1018,7 +1020,7 @@ async def notify_allocation(request: web.Request):
     scheduling_errors: dict[ItemHash, Exception] = {}
     try:
         logger.info(f"Starting persistent vm {item_hash} from notify_allocation")
-        await start_persistent_vm(item_hash, pubsub, pool, supervisor=supervisor, registry=registry)
+        await start_persistent_vm(item_hash, pubsub, pool, supervisor=supervisor, registry=registry, expiry=expiry)
         successful = True
         await pool.update_domain_mapping()
     except vm_creation_exceptions as error:

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -620,7 +620,9 @@ async def update_allocations(request: web.Request):
             try:
                 logger.info(f"Starting long running VM '{vm_hash}'")
                 vm_hash = ItemHash(vm_hash)
-                await start_persistent_vm(vm_hash, pubsub, pool, supervisor=supervisor, registry=registry, expiry=expiry)
+                await start_persistent_vm(
+                    vm_hash, pubsub, pool, supervisor=supervisor, registry=registry, expiry=expiry
+                )
             except vm_creation_exceptions as error:
                 logger.exception("Error while starting VM '%s': %s", vm_hash, error)
                 scheduling_errors[vm_hash] = error
@@ -634,7 +636,9 @@ async def update_allocations(request: web.Request):
             logger.info(f"Starting instance '{instance_hash}'")
             instance_item_hash = ItemHash(instance_hash)
             try:
-                await start_persistent_vm(instance_item_hash, pubsub, pool, supervisor=supervisor, registry=registry, expiry=expiry)
+                await start_persistent_vm(
+                    instance_item_hash, pubsub, pool, supervisor=supervisor, registry=registry, expiry=expiry
+                )
             except vm_creation_exceptions as error:
                 logger.exception("Error while starting VM '%s': %s", instance_hash, error)
                 scheduling_errors[instance_item_hash] = error

--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -44,6 +44,7 @@ from aleph.vm.models import VmExecution
 from aleph.vm.orchestrator import metrics
 from aleph.vm.orchestrator.cache import AsyncTTLCache
 from aleph.vm.orchestrator.custom_logs import set_vm_for_logging
+from aleph.vm.orchestrator.expiry import ExpiryManager
 from aleph.vm.orchestrator.http import get_session
 from aleph.vm.orchestrator.run import create_vm_execution_or_raise_http_error
 from aleph.vm.orchestrator.views.authentication import (
@@ -429,8 +430,8 @@ async def operate_expire(request: web.Request, authenticated_sender: str) -> web
             return web.Response(status=403, body="Unauthorized sender")
 
         logger.info(f"Expiring in {timeout} seconds: {execution.vm_hash}")
-        execution.persistent = False
-        execution.stop_after_timeout(timeout=timeout)
+        expiry: ExpiryManager = request.app["expiry"]
+        expiry.schedule(VmId(str(vm_hash)), timeout)
 
         return web.Response(status=200, body=f"Expiring VM with ref {vm_hash} in {timeout} seconds")
 
@@ -506,6 +507,7 @@ async def operate_stop(request: web.Request, authenticated_sender: str) -> web.R
             if info.status in (VmStatus.RUNNING, VmStatus.BOOTING):
                 logger.info(f"Stopping {vm_hash}")
                 await supervisor.delete_vm(vm_id)
+                request.app["expiry"].cancel(vm_id)
                 return web.Response(status=200, body=f"Stopped VM with ref {vm_hash}")
         except VmNotFoundError:
             raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_hash}") from None
@@ -534,6 +536,7 @@ async def operate_reboot(request: web.Request, authenticated_sender: str) -> web
                     await supervisor.reboot_vm(vm_id)
                 else:
                     await supervisor.delete_vm(vm_id)
+                    request.app["expiry"].cancel(vm_id)
                     await create_vm_execution_or_raise_http_error(
                         vm_hash=vm_hash,
                         pool=request.app["vm_pool"],
@@ -636,6 +639,7 @@ async def operate_erase(request: web.Request, authenticated_sender: str) -> web.
         supervisor: Supervisor = request.app["supervisor"]
         try:
             await supervisor.delete_vm(VmId(str(vm_hash)), wipe=True)
+            request.app["expiry"].cancel(VmId(str(vm_hash)))
         except VmNotFoundError:
             raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_hash}") from None
         request.app["vm_registry"].forget(vm_hash)

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -324,7 +324,6 @@ class VmPool:
             current_execution = self.executions.get(vm_hash)
             if current_execution:
                 if current_execution.is_running and not current_execution.is_stopping:
-                    current_execution.cancel_expiration()
                     return current_execution
 
             # Check if there are sufficient resources available before creating the VM
@@ -415,7 +414,6 @@ class VmPool:
         async with self.creation_lock:
             current_execution = self.executions.get(vm_hash)
             if current_execution and current_execution.is_running and not current_execution.is_stopping:
-                current_execution.cancel_expiration()
                 return current_execution
 
             execution = VmExecution.from_spec(
@@ -476,19 +474,17 @@ class VmPool:
         raise ValueError(msg)
 
     def get_running_or_starting_vm(self, vm_hash: ItemHash) -> VmExecution | None:
-        """Return a running VM or None. Disables the VM expiration task."""
+        """Return a running VM or None."""
         execution = self.executions.get(vm_hash)
         if execution and execution.is_running and not execution.is_stopping:
-            execution.cancel_expiration()
             return execution
         else:
             return None
 
     def get_running_vm(self, vm_hash: ItemHash) -> VmExecution | None:
-        """Return a running VM or None. Disables the VM expiration task."""
+        """Return a running VM or None."""
         execution = self.executions.get(vm_hash)
         if execution and execution.is_running and not execution.is_stopping:
-            execution.cancel_expiration()
             return execution
         else:
             return None

--- a/src/aleph/vm/supervisor/inprocess.py
+++ b/src/aleph/vm/supervisor/inprocess.py
@@ -238,7 +238,10 @@ class InProcessSupervisor(Supervisor):
             execution = self._require(vm_id)
             await self.pool.stop_vm(vm_id)
             if execution.vm_hash in self.pool.executions:
-                logger.warning("VM %s was not removed from pool after stop; forgetting it now", vm_id)
+                # Routine: the pool's _schedule_forget_on_stop task has usually
+                # not run yet by the time stop_vm returns, so delete_vm wins
+                # this race on most reaps.
+                logger.debug("VM %s was not removed from pool after stop; forgetting it now", vm_id)
                 self.pool.forget_vm(vm_id)
             if wipe:
                 # Mirrors the old operate_erase semantics exactly: persisted

--- a/tests/supervisor/test_expiry.py
+++ b/tests/supervisor/test_expiry.py
@@ -6,6 +6,10 @@ from aleph.vm.orchestrator.expiry import ExpiryManager
 from aleph.vm.supervisor.errors import VmNotFoundError
 from aleph.vm.supervisor.types import VmId
 
+# Cap on every wait for a timer that is expected to fire: generous enough for a
+# loaded CI worker, only ever reached on an actual failure.
+WAIT_TIMEOUT = 5.0
+
 
 class FakeSupervisor:
     def __init__(self, *, raise_not_found: bool = False):
@@ -24,8 +28,8 @@ async def test_schedule_reaps_after_timeout():
     expiry = ExpiryManager(sup)
     vm_id = VmId("vm-a")
 
-    expiry.schedule(vm_id, 0.01)
-    await asyncio.sleep(0.05)
+    expiry.schedule(vm_id, 0.001)
+    await asyncio.wait_for(expiry._tasks[vm_id], timeout=WAIT_TIMEOUT)
 
     assert sup.deleted == [("vm-a", False)]
     assert expiry.cancel(vm_id) is False  # task removed itself after firing
@@ -37,10 +41,12 @@ async def test_cancel_prevents_reap():
     expiry = ExpiryManager(sup)
     vm_id = VmId("vm-a")
 
-    expiry.schedule(vm_id, 0.05)
+    expiry.schedule(vm_id, 60)
+    task = expiry._tasks[vm_id]
     assert expiry.cancel(vm_id) is True
-    await asyncio.sleep(0.1)
+    await asyncio.gather(task, return_exceptions=True)
 
+    assert task.cancelled()
     assert sup.deleted == []
     assert expiry.cancel(vm_id) is False
 
@@ -51,10 +57,16 @@ async def test_reschedule_replaces_pending_timer():
     expiry = ExpiryManager(sup)
     vm_id = VmId("vm-a")
 
-    expiry.schedule(vm_id, 0.2)
-    expiry.schedule(vm_id, 0.01)  # re-arm shorter
-    await asyncio.sleep(0.1)
+    expiry.schedule(vm_id, 60)
+    first = expiry._tasks[vm_id]
+    expiry.schedule(vm_id, 0.001)  # re-arm shorter
+    second = expiry._tasks[vm_id]
+    assert first is not second
 
+    await asyncio.wait_for(second, timeout=WAIT_TIMEOUT)
+    await asyncio.gather(first, return_exceptions=True)
+
+    assert first.cancelled()
     assert sup.deleted == [("vm-a", False)]  # fired once, on the second timer
 
 
@@ -64,8 +76,9 @@ async def test_expire_swallows_vm_not_found():
     expiry = ExpiryManager(sup)
     vm_id = VmId("vm-gone")
 
-    expiry.schedule(vm_id, 0.01)
-    await asyncio.sleep(0.05)  # must not raise
+    expiry.schedule(vm_id, 0.001)
+    # Awaiting the task directly also surfaces any exception _expire let through.
+    await asyncio.wait_for(expiry._tasks[vm_id], timeout=WAIT_TIMEOUT)
 
     assert sup.deleted == [("vm-gone", False)]
     assert expiry.cancel(vm_id) is False
@@ -76,9 +89,12 @@ async def test_cancel_all_clears_every_timer():
     sup = FakeSupervisor()
     expiry = ExpiryManager(sup)
 
-    expiry.schedule(VmId("vm-a"), 0.05)
-    expiry.schedule(VmId("vm-b"), 0.05)
+    expiry.schedule(VmId("vm-a"), 60)
+    expiry.schedule(VmId("vm-b"), 60)
+    tasks = list(expiry._tasks.values())
     await expiry.cancel_all()
-    await asyncio.sleep(0.1)
+    await asyncio.gather(*tasks, return_exceptions=True)
 
+    assert all(task.cancelled() for task in tasks)
     assert sup.deleted == []
+    assert not expiry._tasks

--- a/tests/supervisor/test_expiry.py
+++ b/tests/supervisor/test_expiry.py
@@ -1,0 +1,84 @@
+import asyncio
+
+import pytest
+
+from aleph.vm.orchestrator.expiry import ExpiryManager
+from aleph.vm.supervisor.errors import VmNotFoundError
+from aleph.vm.supervisor.types import VmId
+
+
+class FakeSupervisor:
+    def __init__(self, *, raise_not_found: bool = False):
+        self.deleted: list[tuple[str, bool]] = []
+        self.raise_not_found = raise_not_found
+
+    async def delete_vm(self, vm_id: VmId, wipe: bool = False) -> None:
+        self.deleted.append((str(vm_id), wipe))
+        if self.raise_not_found:
+            raise VmNotFoundError(str(vm_id))
+
+
+@pytest.mark.asyncio
+async def test_schedule_reaps_after_timeout():
+    sup = FakeSupervisor()
+    expiry = ExpiryManager(sup)
+    vm_id = VmId("vm-a")
+
+    expiry.schedule(vm_id, 0.01)
+    await asyncio.sleep(0.05)
+
+    assert sup.deleted == [("vm-a", False)]
+    assert expiry.cancel(vm_id) is False  # task removed itself after firing
+
+
+@pytest.mark.asyncio
+async def test_cancel_prevents_reap():
+    sup = FakeSupervisor()
+    expiry = ExpiryManager(sup)
+    vm_id = VmId("vm-a")
+
+    expiry.schedule(vm_id, 0.05)
+    assert expiry.cancel(vm_id) is True
+    await asyncio.sleep(0.1)
+
+    assert sup.deleted == []
+    assert expiry.cancel(vm_id) is False
+
+
+@pytest.mark.asyncio
+async def test_reschedule_replaces_pending_timer():
+    sup = FakeSupervisor()
+    expiry = ExpiryManager(sup)
+    vm_id = VmId("vm-a")
+
+    expiry.schedule(vm_id, 0.2)
+    expiry.schedule(vm_id, 0.01)  # re-arm shorter
+    await asyncio.sleep(0.1)
+
+    assert sup.deleted == [("vm-a", False)]  # fired once, on the second timer
+
+
+@pytest.mark.asyncio
+async def test_expire_swallows_vm_not_found():
+    sup = FakeSupervisor(raise_not_found=True)
+    expiry = ExpiryManager(sup)
+    vm_id = VmId("vm-gone")
+
+    expiry.schedule(vm_id, 0.01)
+    await asyncio.sleep(0.05)  # must not raise
+
+    assert sup.deleted == [("vm-gone", False)]
+    assert expiry.cancel(vm_id) is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_clears_every_timer():
+    sup = FakeSupervisor()
+    expiry = ExpiryManager(sup)
+
+    expiry.schedule(VmId("vm-a"), 0.05)
+    expiry.schedule(VmId("vm-b"), 0.05)
+    await expiry.cancel_all()
+    await asyncio.sleep(0.1)
+
+    assert sup.deleted == []

--- a/tests/supervisor/test_run_idle_teardown.py
+++ b/tests/supervisor/test_run_idle_teardown.py
@@ -1,0 +1,131 @@
+"""Idle-teardown behavior of the run_code_on_* paths.
+
+The expiry guard these tests pin down: serving a request must re-arm the idle
+timer for on-demand executions only. Persistent executions (instances and
+persistent programs) are long-running by design and must never be idle-reaped
+— the guard that used to live inside VmExecution.stop_after_timeout.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import msgpack
+import pytest
+from aleph_message.models import ItemHash
+
+from aleph.vm.conf import settings
+from aleph.vm.orchestrator.run import run_code_on_event, run_code_on_request
+from aleph.vm.supervisor.types import VmId
+
+VM_HASH = ItemHash(settings.FAKE_INSTANCE_ID)
+REUSE_TIMEOUT = 42.0
+
+
+class SpyExpiry:
+    def __init__(self):
+        self.scheduled: list[tuple[str, float]] = []
+        self.cancelled: list[str] = []
+
+    def schedule(self, vm_id: VmId, timeout: float) -> None:
+        self.scheduled.append((str(vm_id), timeout))
+
+    def cancel(self, vm_id: VmId) -> bool:
+        self.cancelled.append(str(vm_id))
+        return False
+
+
+class FakeExecution:
+    def __init__(self, *, persistent: bool, result: dict):
+        self.persistent = persistent
+        self.vm_hash = VM_HASH
+        self.vm_id = 3
+        self.has_resources = True
+        self.message = SimpleNamespace(code=SimpleNamespace(ref="code-ref"))
+        self._result_raw = msgpack.dumps(result)
+
+    async def becomes_ready(self) -> None:
+        pass
+
+    async def run_code(self, scope: dict) -> bytes:
+        return self._result_raw
+
+
+class FakePool:
+    def __init__(self, execution: FakeExecution):
+        self._execution = execution
+
+    def get_running_vm(self, vm_hash: ItemHash) -> FakeExecution:
+        assert vm_hash == VM_HASH
+        return self._execution
+
+
+class FakeRequest:
+    method = "GET"
+    query_string = ""
+    raw_headers: list[tuple[bytes, bytes]] = []
+
+    def __init__(self, app: dict):
+        self.app = app
+
+    async def read(self) -> bytes:
+        return b""
+
+
+@pytest.fixture
+def reuse_settings(monkeypatch):
+    monkeypatch.setattr(settings, "REUSE_TIMEOUT", REUSE_TIMEOUT)
+    monkeypatch.setattr(settings, "WATCH_FOR_UPDATES", False)
+
+
+def _request_fakes(*, persistent: bool):
+    execution = FakeExecution(
+        persistent=persistent,
+        result={"headers": {"headers": [[b"content-type", b"text/plain"]], "status": 200}, "body": {"body": b"ok"}},
+    )
+    expiry = SpyExpiry()
+    request = FakeRequest(app={"supervisor": None, "expiry": expiry, "pubsub": None})
+    return execution, expiry, request
+
+
+@pytest.mark.asyncio
+async def test_request_rearms_idle_timer_for_on_demand_vm(reuse_settings):
+    execution, expiry, request = _request_fakes(persistent=False)
+
+    response = await run_code_on_request(VM_HASH, "/", FakePool(execution), request)
+
+    assert response.status == 200
+    assert expiry.cancelled == [str(VM_HASH)]
+    assert expiry.scheduled == [(str(VM_HASH), REUSE_TIMEOUT)]
+
+
+@pytest.mark.asyncio
+async def test_request_never_schedules_expiry_for_persistent_vm(reuse_settings):
+    execution, expiry, request = _request_fakes(persistent=True)
+
+    response = await run_code_on_request(VM_HASH, "/", FakePool(execution), request)
+
+    assert response.status == 200
+    assert expiry.scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_event_rearms_idle_timer_for_on_demand_vm(reuse_settings):
+    execution = FakeExecution(persistent=False, result={"body": "ok"})
+    expiry = SpyExpiry()
+
+    result = await run_code_on_event(VM_HASH, None, None, FakePool(execution), supervisor=None, expiry=expiry)
+
+    assert result == "ok"
+    assert expiry.cancelled == [str(VM_HASH)]
+    assert expiry.scheduled == [(str(VM_HASH), REUSE_TIMEOUT)]
+
+
+@pytest.mark.asyncio
+async def test_event_never_schedules_expiry_for_persistent_vm(reuse_settings):
+    execution = FakeExecution(persistent=True, result={"body": "ok"})
+    expiry = SpyExpiry()
+
+    result = await run_code_on_event(VM_HASH, None, None, FakePool(execution), supervisor=None, expiry=expiry)
+
+    assert result == "ok"
+    assert expiry.scheduled == []


### PR DESCRIPTION
## What

Lifts idle-teardown ("expiry") of on-demand VMs off the `VmExecution` god-object into a new agent-owned `ExpiryManager`, and removes every expiry member from `VmExecution` and `VmPool`. First of the Phase-0 residual cleanups in the message-free supervisor series.

Design: `docs/plans/2026-06-08-supervisor-expiry-design.md`
Plan: `docs/plans/2026-06-08-supervisor-expiry-plan.md`

## Why

Idle teardown is agent policy, but it lived as methods on `VmExecution` (the object being split into an agent `Execution` and a hypervisor `Vm`). The pool also reached into it (`cancel_expiration` in four places). This decouples it so that when microVM creation moves behind the Supervisor in Phase 1, nothing in the idle path needs a `VmExecution`.

## How

- New `ExpiryManager` (`orchestrator/expiry.py`): timers keyed by `vm_id`, reaping via `Supervisor.delete_vm(vm_id)` (`wipe=False`, so data volumes are preserved). Built as `app["expiry"]`, threaded into the request path (`run_code_on_request`) and the reactor path (`run_code_on_event` via `Reactor`); cancelled on shutdown via `on_cleanup`.
- `run_code_on_*` cancel any pending timer when reusing a running VM and re-arm in `finally` (preserves "no expiry while serving a request").
- `start_persistent_vm` and `operate_expire` drive the manager; teardown endpoints (`operate_stop`/reboot/erase) cancel pending timers.
- `VmExecution` loses `stop_after_timeout`/`expire`/`cancel_expiration`/`expire_task`; `VmPool` loses all four `cancel_expiration` calls.

## Behavior parity

`delete_vm(wipe=False)` does not erase volumes, and `create_a_vm` already auto-forgets on stop, so the reap matches today's behavior (volumes survive, VM forgotten after idle).

## Notes / follow-ups

- `operate_expire` has a pre-existing dead route (path lacks `{timeout}` but the handler reads `match_info["timeout"]`, so it always 400s). This PR only swaps the timer mechanism and intentionally leaves the route bug and the skipped `test_operator_expire` as-is. Fixing the route is a separate follow-up.
- Update-watching (`watch_for_updates`) and the `pool.executions[vm_hash]` readback at `run.py` are the other two Phase-0 residuals, shipped separately.

## Stacking

Stacked on #967 (`od/wire-supervisor-read-views`). Base this PR on that branch; rebase onto `dev` once #967 merges.
