### PR TITLE
Message-free supervisor: agent-side update-watching + execution-free start_persistent_vm

### DIFF
--- a/docs/plans/2026-06-09-supervisor-update-watching-design.md
+++ b/docs/plans/2026-06-09-supervisor-update-watching-design.md
@@ -226,7 +226,7 @@ one the create path records into.
   (alongside the `supervisor`/`expiry` it already took), passes them into
   `run_code_on_event`.
 - `tasks.py` (`start_watch_for_messages_task`): construct
-  `Reactor(pubsub, pool, supervisor, app["expiry"], app["vm_registry"], app["update_watcher"])`.
+  `Reactor(pubsub, pool, supervisor, app["expiry"], app["update_watcher"], app["vm_registry"])`.
 - Lifecycle endpoints (`views/operator.py`): add `update_watcher.cancel(vm_id)`
   next to every existing `expiry.cancel(vm_id)` (stop / reboot / erase).
 - `update_allocations` / `notify_allocation` (`views/__init__.py`): pass

--- a/docs/plans/2026-06-09-supervisor-update-watching-design.md
+++ b/docs/plans/2026-06-09-supervisor-update-watching-design.md
@@ -1,0 +1,287 @@
+# Agent-side update-watching + `start_persistent_vm` execution decoupling
+
+**Status:** design
+**Date:** 2026-06-09
+**Series:** message-free supervisor (Phase-0 residual cleanup, after #969 expiry)
+**Stacks on:** `od/wire-supervisor-expiry` (#969)
+
+## 1. Goal
+
+Lift update-watching ("re-deploy on message update") off the `VmExecution`
+god-object into an agent-owned `UpdateWatcher`, and make `start_persistent_vm`
+execution-free by moving its pre-existing-VM check onto `supervisor.get_vm`.
+
+This is the second half of the design doc's future-work item *"Migrate
+expiry-cancel and update-watching off `VmExecution`"* — expiry shipped in #969;
+this PR does update-watching and the residual `start_persistent_vm`
+`pool.executions` read it named.
+
+## 2. Background
+
+The message-free-supervisor effort splits the current `VmExecution` god-object
+into an agent-side concept (knows the message, owner, billing, expiry,
+update-watching — backed by the `AgentVmRegistry` + agent DB) and a
+hypervisor-side `Vm` (process, networking, status — behind the `Supervisor`
+boundary). The agent *owns* messages; the goal is to get message-derived policy
+off the **hypervisor object**, not off the agent.
+
+Update-watching is agent policy: it subscribes to the Aleph messages referenced
+by a VM's deployment (code / runtime / data / volumes) and, when any is updated,
+stops the VM so the next request redeploys it. Today it lives as
+`VmExecution.watch_for_updates` / `start_watching_for_updates` / `update_task` /
+`cancel_update`, exactly parallel to where expiry lived before #969.
+
+### What #969 established (the template)
+
+- `ExpiryManager` (`orchestrator/expiry.py`): agent-owned timers keyed by
+  `vm_id`, one dependency (`Supervisor`), reaping via
+  `supervisor.delete_vm(vm_id)` (`wipe=False`). Built as `app["expiry"]`,
+  threaded into the request path, the reactor (via `Reactor.__init__`),
+  `start_persistent_vm`, and the lifecycle endpoints; `cancel_all()` on
+  `on_cleanup`.
+- Concurrency discipline: the per-VM task removes only its **own** dict entry in
+  `finally` (current-task identity check), swallows `VmNotFoundError`, re-raises
+  `CancelledError`.
+
+### Confirmed facts that shape this design
+
+- **`app["pubsub"]` is created late** — in `tasks.py` (`start_watch_for_messages_task`),
+  not in `setup_webapp` where the supervisor/expiry singletons are built. The
+  watcher therefore cannot hold pubsub from construction; pubsub is passed
+  per-`watch()` call (as `ExpiryManager.schedule` takes the timeout per call).
+- **Both `create_vm_execution` branches already record to the registry** — the
+  spec/instance path and the legacy/program path. Every agent-created VM already
+  has its `original` message in the registry, keyed by `vm_hash`. A
+  registry-backed watcher needs **no registry-population change**.
+- **`create_vm_execution` already waits-until-running** on the spec path
+  (`_wait_until_running`). `start_persistent_vm` can use
+  `_wait_until_running(supervisor, vm_id)` in place of
+  `execution.becomes_ready()`, so it can become fully execution-free.
+- **`WATCH_FOR_UPDATES` defaults `True`** — this path is live in production.
+- **The reactor builds a throwaway local `AgentVmRegistry`** in
+  `run_code_on_event` today. A registry-backed watcher requires the reactor to
+  use the app registry singleton instead (a small correctness improvement: one
+  registry, not two).
+
+## 3. Scope
+
+### In scope
+
+1. New agent-owned `UpdateWatcher` facility; remove the update machinery from
+   `VmExecution`.
+2. `start_persistent_vm` execution-free: pre-existing-VM check via
+   `supervisor.get_vm` (kills the residual `pool.executions.get(vm_hash)` read),
+   readiness via `_wait_until_running`, update-watching via the watcher; returns
+   `None`.
+3. Wiring symmetric with expiry across request path, reactor, lifecycle
+   endpoints, shutdown, and `cli.py`.
+4. The reactor adopts the app `vm_registry` singleton (drops the local one).
+
+### Out of scope (explicit residuals, unchanged)
+
+- **The `create_vm_execution` save() readback** (`pool.executions[vm_hash]` →
+  `execution.save()`). `save()` persists the full `ExecutionRecord` (message,
+  timings, vcpus/memory/gpus, mapped_ports, cpu/io counters) — the agent's
+  billing/rehydration record. Moving that onto an agent-owned persistence path
+  is deferred (decision 2026-06-09): the `VmExecution` survives this PR anyway,
+  and a parallel persistence path carries rehydration round-trip risk for the
+  sake of one readback line. It migrates when the rest of the agent's
+  record-persistence leaves the execution.
+- **Operator owner-auth's `execution.message` reads** (~10 sites in
+  `operator.py`). Owner-auth stays exactly as-is; migrating it to read
+  `registry.get(vm_hash).message` is separate agent plumbing, not this PR.
+
+## 4. Components
+
+### 4.1 `UpdateWatcher` (`src/aleph/vm/orchestrator/update_watcher.py`)
+
+Agent-owned update-subscription tasks keyed by `vm_id`. Subscription-driven
+counterpart to `ExpiryManager`.
+
+**Dependencies:** `Supervisor` + `AgentVmRegistry`.
+
+**State:** `_tasks: dict[VmId, asyncio.Task]`.
+
+**API:**
+
+- `watch(vm_id: VmId, vm_hash: ItemHash, pubsub: PubSub) -> None`
+  Look up the record in the registry. If absent or its `original` is not a
+  watchable message → **no-op** (preserves today's behavior: spec-built /
+  reattached executions, which have no Aleph message to watch, don't schedule a
+  task). Otherwise cancel any existing task for `vm_id` and spawn `_watch`.
+- `cancel(vm_id: VmId) -> bool` — cancel a pending task; return whether one
+  existed.
+- `cancel_all() -> None` — cancel every task (shutdown cleanup).
+
+**`_watch(vm_id, refs, pubsub)`:**
+
+```
+try:
+    await pubsub.msubscribe(*refs)        # blocks until a referenced msg updates
+    logger.info("Update received for %s, reaping", vm_id)
+    await self.supervisor.delete_vm(vm_id)   # wipe=False
+except VmNotFoundError:
+    logger.debug("Update-watch: VM %s already gone", vm_id)
+except asyncio.CancelledError:
+    raise
+except Exception:
+    logger.exception("Update-watch of %s failed", vm_id)
+finally:
+    if self._tasks.get(vm_id) is asyncio.current_task():
+        del self._tasks[vm_id]
+```
+
+**Ref extraction** (moved verbatim from `VmExecution.watch_for_updates`, off the
+execution): given `original` and whether it is an instance,
+
+- instance → the `ref` of each volume that has one;
+- program → `code.ref`, `runtime.ref`, `data.ref` (if present), plus volume
+  refs.
+
+The instance-vs-program decision uses the message type (the same signal
+`VmExecution.is_instance` carries), determined from the registry record — not
+from a `VmExecution`.
+
+**Why depend on the registry rather than take `original` explicitly:** the
+registry is the agent's message store; an agent-owned update facility reading it
+is coherent and keeps the 3 call sites trivial (`watch(vm_id, vm_hash, pubsub)`).
+The alternative (pass `original` per call) re-spreads the message read across
+call sites that would each fetch it from the registry anyway.
+
+### 4.2 `VmExecution` removals (`src/aleph/vm/models.py`)
+
+Delete `watch_for_updates`, `start_watching_for_updates`, `update_task`,
+`cancel_update`, and the `self.cancel_update()` call inside `stop()`. The
+ref-extraction logic relocates to `UpdateWatcher`.
+
+### 4.3 `start_persistent_vm` (`src/aleph/vm/orchestrator/run.py`)
+
+Becomes execution-free. New shape:
+
+```
+async def start_persistent_vm(vm_hash, pubsub, pool, *, supervisor, registry,
+                              expiry, update_watcher) -> None:
+    vm_id = VmId(str(vm_hash))
+    try:
+        info = await supervisor.get_vm(vm_id)
+    except VmNotFoundError:
+        info = None
+
+    if info is not None:
+        if info.status == VmStatus.RUNNING:
+            pass                                      # already up
+        elif info.status in (VmStatus.DEFINED, VmStatus.BOOTING):
+            await _wait_until_running(supervisor, vm_id)
+        elif info.status == VmStatus.STOPPING:
+            await _wait_until_gone(supervisor, vm_id)   # poll get_vm -> NotFound
+            info = None
+        else:                                         # STOPPED / FAILED
+            await supervisor.delete_vm(vm_id)
+            info = None
+
+    if info is None:
+        logger.info("Starting persistent virtual machine with id: %s", vm_hash)
+        await create_vm_execution(vm_hash=vm_hash, pool=pool,
+                                  supervisor=supervisor, registry=registry,
+                                  persistent=True)
+        await _wait_until_running(supervisor, vm_id)
+
+    expiry.cancel(vm_id)        # scheduled long-running: must not idle-expire
+    if pubsub and settings.WATCH_FOR_UPDATES:
+        update_watcher.watch(vm_id, vm_hash, pubsub)
+```
+
+Notes:
+
+- The "stopping → wait for full stop, then recreate" branch previously awaited
+  `execution.stop_event`; with no execution it polls `get_vm` until
+  `VmNotFoundError`. Same outcome (recreate once stopped), different mechanism.
+  `_wait_until_gone` is a small helper alongside `_wait_until_running`.
+- `create_vm_execution` still returns a `VmExecution` (it does the deferred
+  save() readback internally and `run_code_on_request` still consumes its
+  return). `start_persistent_vm` ignores it and returns `None`.
+- `VmStatus` members (`supervisor/types.py`): `DEFINED`, `BOOTING`, `RUNNING`,
+  `STOPPING`, `STOPPED`, `FAILED`. `get_vm` raises `VmNotFoundError` when the VM
+  is absent (the `info = None` path above).
+
+### 4.4 Request + reactor paths (`run.py`)
+
+In `run_code_on_request` and `run_code_on_event`, replace
+`execution.start_watching_for_updates(pubsub=...)` with
+`update_watcher.watch(vm_id, vm_hash, pubsub)`. Both already receive
+`supervisor`/`expiry`; they additionally receive `update_watcher`. The
+non-reuse teardown branches that already `expiry.cancel(...)` /
+`supervisor.delete_vm(...)` also `update_watcher.cancel(vm_id)`.
+
+`run_code_on_event` stops building a local `AgentVmRegistry`: the `Reactor`
+passes the app registry through, so the registry the watcher reads is the same
+one the create path records into.
+
+## 5. Wiring (symmetric with expiry)
+
+- `setup_webapp` (`supervisor.py`): `app["update_watcher"] =
+  UpdateWatcher(app["supervisor"], app["vm_registry"])` (built after
+  `vm_registry`).
+- `Reactor.__init__` (`reactor.py`): gains `registry` and `update_watcher`
+  (alongside the `supervisor`/`expiry` it already took), passes them into
+  `run_code_on_event`.
+- `tasks.py` (`start_watch_for_messages_task`): construct
+  `Reactor(pubsub, pool, supervisor, app["expiry"], app["vm_registry"], app["update_watcher"])`.
+- Lifecycle endpoints (`views/operator.py`): add `update_watcher.cancel(vm_id)`
+  next to every existing `expiry.cancel(vm_id)` (stop / reboot / erase).
+- `update_allocations` / `notify_allocation` (`views/__init__.py`): pass
+  `update_watcher` into `start_persistent_vm`.
+- Shutdown (`supervisor.py` `run()`): `app.on_cleanup.append(stop_update_watcher)`
+  where `stop_update_watcher` calls `cancel_all()` (mirrors
+  `stop_expiry_manager`), ordered before `stop_all_vms`.
+- `cli.py`: `benchmark` builds an `UpdateWatcher` into the fake app dict and
+  passes it to `run_code_on_event`; `start_instance` passes one into
+  `start_persistent_vm`.
+
+## 6. Behavior parity
+
+- Reap-on-update is unchanged: subscribe to the same refs, then stop the VM.
+  `delete_vm(wipe=False)` == the old `stop()` (volumes preserved, VM forgotten),
+  matching #969's expiry reap.
+- The no-op for spec-built / reattached (non-message) VMs is preserved: today
+  `start_watching_for_updates` returns early when the spec is not a
+  `MessageSpec`; the watcher no-ops when the registry has no watchable `original`.
+- `start_persistent_vm`'s state machine preserves the running / starting /
+  stopping / unknown / absent outcomes; only the stopping-wait mechanism changes
+  (poll vs `stop_event`).
+
+## 7. Testing
+
+- `tests/supervisor/test_update_watcher.py` (mirrors `test_expiry.py`, with a
+  `FakePubSub` whose `msubscribe` is awaitable and controllable):
+  reaps-on-update; `cancel` prevents reap; re-`watch` replaces the pending task;
+  `VmNotFoundError` swallowed; **no-op when the vm is unrecorded / not
+  watchable**; `cancel_all` clears every task.
+- `start_persistent_vm` precheck-state tests against a fake supervisor:
+  absent → create; `RUNNING` → no recreate; `BOOTING` → waits; `STOPPING` →
+  waits-gone then recreates; terminal → deletes then recreates.
+- A `VmExecution` test asserting the update API (`start_watching_for_updates`
+  etc.) is gone.
+- Full suite: no new failures vs the #969 base (the 10 pre-existing
+  environment failures excluded).
+
+## 8. Risks
+
+- **Reactor registry switch.** Moving the reactor onto the app registry changes
+  which registry the reactor's create records into. Mitigation: the app registry
+  is the correct shared one; the local registry was a throwaway that nothing
+  read across calls.
+- **`get_vm` status coverage.** The precheck maps every `VmStatus` member
+  explicitly (`RUNNING` / `DEFINED` / `BOOTING` / `STOPPING`); `STOPPED` and
+  `FAILED` fall into the terminal `else` (delete + recreate). No status is left
+  unhandled.
+- **`msubscribe` test ergonomics.** The watcher blocks on `pubsub.msubscribe`;
+  tests drive it with a fake pubsub that resolves on demand. Same pattern as the
+  expiry timer tests, with an awaitable in place of `asyncio.sleep`.
+
+## 9. Out-of-scope residuals after this PR
+
+- `create_vm_execution` save() readback (#1) — agent-owned `ExecutionRecord`
+  persistence.
+- Operator owner-auth reads of `execution.message` → registry.
+- `operate_expire`'s pre-existing dead route (carried from #969).

--- a/docs/plans/2026-06-09-supervisor-update-watching-plan.md
+++ b/docs/plans/2026-06-09-supervisor-update-watching-plan.md
@@ -1,0 +1,942 @@
+# Agent-side Update-Watching + Execution-Free `start_persistent_vm` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lift update-watching off the `VmExecution` god-object into an agent-owned `UpdateWatcher`, and make `start_persistent_vm` execution-free by moving its pre-existing-VM check onto `supervisor.get_vm`.
+
+**Architecture:** New `UpdateWatcher` (mirror of `ExpiryManager` from #969) holds update-subscription tasks keyed by `vm_id`, reads each VM's message from the `AgentVmRegistry`, subscribes to its code/runtime/data/volume refs via `PubSub.msubscribe`, and reaps via `supervisor.delete_vm` on update. Wired symmetrically with expiry across the request path, reactor, lifecycle endpoints, and shutdown. `start_persistent_vm` drops its `pool.executions` read in favour of `get_vm` + `_wait_until_running`.
+
+**Tech Stack:** Python 3, asyncio, aiohttp, pytest / pytest-asyncio. Design doc: `docs/plans/2026-06-09-supervisor-update-watching-design.md`.
+
+**Stacks on:** `od/wire-supervisor-expiry` (#969).
+
+---
+
+## Environment note (test command)
+
+This worktree has no local `.testvenv`. Run tests through the shared interpreter with this worktree's `src` on the path:
+
+```bash
+PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -m pytest <args>
+```
+
+In the steps below, `pytest` is shorthand for exactly that invocation. Every `git`/`pytest` command runs from the worktree root `/home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-expiry`. All bash here needs `dangerouslyDisableSandbox: true`.
+
+## File structure
+
+- **Create** `src/aleph/vm/orchestrator/update_watcher.py` — the `UpdateWatcher` class + the `update_refs(original)` pure helper. Sole responsibility: own update-subscription tasks and translate a message into its watch refs.
+- **Create** `tests/supervisor/test_update_watcher.py` — unit tests for the watcher and `update_refs`.
+- **Modify** `src/aleph/vm/models.py` — delete the update machinery from `VmExecution`.
+- **Modify** `src/aleph/vm/orchestrator/run.py` — request/reactor paths use the watcher; `start_persistent_vm` execution-free; add `_wait_until_gone`.
+- **Modify** `src/aleph/vm/orchestrator/reactor.py` — `Reactor` gains `registry` + `update_watcher`.
+- **Modify** `src/aleph/vm/orchestrator/tasks.py` — construct `Reactor` with the new args.
+- **Modify** `src/aleph/vm/orchestrator/supervisor.py` — build `app["update_watcher"]`; `stop_update_watcher` cleanup hook.
+- **Modify** `src/aleph/vm/orchestrator/views/operator.py` — `update_watcher.cancel` on stop/reboot/erase.
+- **Modify** `src/aleph/vm/orchestrator/views/__init__.py` — pass `update_watcher` into `start_persistent_vm`.
+- **Modify** `src/aleph/vm/orchestrator/cli.py` — benchmark + `start_instance` build/pass an `UpdateWatcher`.
+- **Modify** `tests/supervisor/test_execution.py` (or a new `test_models_no_update_api.py`) — assert the update API is gone from `VmExecution`.
+
+---
+
+## Task 1: `UpdateWatcher` facility + `update_refs`
+
+**Files:**
+- Create: `src/aleph/vm/orchestrator/update_watcher.py`
+- Test: `tests/supervisor/test_update_watcher.py`
+
+Reference shape: `src/aleph/vm/orchestrator/expiry.py` (the `ExpiryManager` from #969). The watcher mirrors its `cancel`/`cancel_all`/`finally`-cleanup discipline, but is subscription-driven and **idempotent** (a live watch is not restarted — preserving the old `if not self.update_task` behaviour).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/supervisor/test_update_watcher.py`:
+
+```python
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+from aleph_message.models import InstanceContent
+
+from aleph.vm.orchestrator.update_watcher import UpdateWatcher, update_refs
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor.errors import VmNotFoundError
+from aleph.vm.supervisor.types import VmId
+from aleph.vm.utils import get_message_executable_content
+
+# Import the existing instance-message builder (instance branch of update_refs).
+from test_supervisor_translate import _make_qemu_instance_message
+
+
+def _program_content():
+    # examples/program_message_from_aleph.json is a full message envelope; the
+    # helper wants the bare content dict.
+    with open("examples/program_message_from_aleph.json") as fd:
+        return get_message_executable_content(json.load(fd)["content"])
+
+
+class FakeSupervisor:
+    def __init__(self, *, raise_not_found: bool = False):
+        self.deleted: list[tuple[str, bool]] = []
+        self.raise_not_found = raise_not_found
+
+    async def delete_vm(self, vm_id: VmId, wipe: bool = False) -> None:
+        self.deleted.append((str(vm_id), wipe))
+        if self.raise_not_found:
+            raise VmNotFoundError(str(vm_id))
+
+
+class FakePubSub:
+    """msubscribe blocks until the test triggers it, recording the keys."""
+
+    def __init__(self):
+        self.event = asyncio.Event()
+        self.subscribed: tuple | None = None
+
+    async def msubscribe(self, *keys):
+        self.subscribed = tuple(k for k in keys if k is not None)
+        await self.event.wait()
+
+    def trigger(self):
+        self.event.set()
+
+
+def _registry_with(vm_hash: str, original):
+    registry = AgentVmRegistry()
+    registry.record(vm_hash, message=original, original=original, persistent=False)
+    return registry
+
+
+_HASH = "a" * 64
+
+
+def test_update_refs_instance_uses_volume_refs():
+    content = _make_qemu_instance_message()  # volumes=[]
+    assert update_refs(content) == []
+
+
+def test_update_refs_program_uses_code_runtime_data():
+    content = _program_content()
+    refs = update_refs(content)
+    assert content.code.ref in refs
+    assert content.runtime.ref in refs
+
+
+def test_update_refs_program_branch_type():
+    # A program message is not an InstanceContent: exercises the else-branch.
+    assert not isinstance(_program_content(), InstanceContent)
+
+
+@pytest.mark.asyncio
+async def test_watch_reaps_on_update():
+    sup, pubsub = FakeSupervisor(), FakePubSub()
+    registry = _registry_with(_HASH, _make_qemu_instance_message())
+    watcher = UpdateWatcher(sup, registry)
+    vm_id = VmId(_HASH)
+
+    watcher.watch(vm_id, _HASH, pubsub)
+    await asyncio.sleep(0)          # let the task reach msubscribe
+    pubsub.trigger()
+    await asyncio.sleep(0.02)
+
+    assert sup.deleted == [(_HASH, False)]
+    assert watcher.cancel(vm_id) is False  # task removed itself after firing
+
+
+@pytest.mark.asyncio
+async def test_cancel_prevents_reap():
+    sup, pubsub = FakeSupervisor(), FakePubSub()
+    registry = _registry_with(_HASH, _make_qemu_instance_message())
+    watcher = UpdateWatcher(sup, registry)
+    vm_id = VmId(_HASH)
+
+    watcher.watch(vm_id, _HASH, pubsub)
+    await asyncio.sleep(0)
+    assert watcher.cancel(vm_id) is True
+    pubsub.trigger()
+    await asyncio.sleep(0.02)
+
+    assert sup.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_watch_is_idempotent_keeps_existing_subscription():
+    sup, pubsub1, pubsub2 = FakeSupervisor(), FakePubSub(), FakePubSub()
+    registry = _registry_with(_HASH, _make_qemu_instance_message())
+    watcher = UpdateWatcher(sup, registry)
+    vm_id = VmId(_HASH)
+
+    watcher.watch(vm_id, _HASH, pubsub1)
+    await asyncio.sleep(0)
+    watcher.watch(vm_id, _HASH, pubsub2)  # second call must NOT restart
+    await asyncio.sleep(0)
+
+    assert pubsub1.subscribed is not None   # first subscription is live
+    assert pubsub2.subscribed is None       # second was a no-op
+
+
+@pytest.mark.asyncio
+async def test_watch_noop_when_unrecorded():
+    sup, pubsub = FakeSupervisor(), FakePubSub()
+    watcher = UpdateWatcher(sup, AgentVmRegistry())  # empty registry
+    vm_id = VmId(_HASH)
+
+    watcher.watch(vm_id, _HASH, pubsub)
+    await asyncio.sleep(0.01)
+
+    assert watcher.cancel(vm_id) is False   # nothing scheduled
+    assert pubsub.subscribed is None
+
+
+@pytest.mark.asyncio
+async def test_watch_swallows_vm_not_found():
+    sup = FakeSupervisor(raise_not_found=True)
+    pubsub = FakePubSub()
+    registry = _registry_with(_HASH, _make_qemu_instance_message())
+    watcher = UpdateWatcher(sup, registry)
+    vm_id = VmId(_HASH)
+
+    watcher.watch(vm_id, _HASH, pubsub)
+    await asyncio.sleep(0)
+    pubsub.trigger()
+    await asyncio.sleep(0.02)               # must not raise
+
+    assert sup.deleted == [(_HASH, False)]
+    assert watcher.cancel(vm_id) is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_clears_every_watch():
+    sup = FakeSupervisor()
+    registry = AgentVmRegistry()
+    registry.record("a" * 64, message=_make_qemu_instance_message(),
+                    original=_make_qemu_instance_message(), persistent=False)
+    registry.record("b" * 64, message=_make_qemu_instance_message(),
+                    original=_make_qemu_instance_message(), persistent=False)
+    watcher = UpdateWatcher(sup, registry)
+    watcher.watch(VmId("a" * 64), "a" * 64, FakePubSub())
+    watcher.watch(VmId("b" * 64), "b" * 64, FakePubSub())
+    await asyncio.sleep(0)
+
+    await watcher.cancel_all()
+    await asyncio.sleep(0.02)
+
+    assert sup.deleted == []
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/supervisor/test_update_watcher.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'aleph.vm.orchestrator.update_watcher'`.
+
+- [ ] **Step 3: Implement `update_watcher.py`**
+
+Create `src/aleph/vm/orchestrator/update_watcher.py`:
+
+```python
+import asyncio
+import logging
+
+from aleph_message.models import ExecutableContent, InstanceContent, ItemHash
+
+from aleph.vm.orchestrator.pubsub import PubSub
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor.abc import Supervisor
+from aleph.vm.supervisor.errors import VmNotFoundError
+from aleph.vm.supervisor.types import VmId
+
+logger = logging.getLogger(__name__)
+
+
+def update_refs(original: ExecutableContent) -> list[str]:
+    """The Aleph message refs whose update should redeploy the VM.
+
+    Moved verbatim from VmExecution.watch_for_updates: instances watch their
+    volume refs; programs also watch code / runtime / data.
+    """
+    volume_refs = [volume.ref for volume in (original.volumes or []) if hasattr(volume, "ref")]
+    if isinstance(original, InstanceContent):
+        return volume_refs
+    data_ref = [original.data.ref] if original.data else []
+    return [original.code.ref, original.runtime.ref, *data_ref, *volume_refs]
+
+
+class UpdateWatcher:
+    """Agent-owned 'redeploy on message update' subscriptions, keyed by vm_id.
+
+    Subscription-driven counterpart to ExpiryManager. One dependency pair: the
+    Supervisor (to reap) and the AgentVmRegistry (to read the watched message).
+    Replaces the update methods that used to live on VmExecution.
+    """
+
+    def __init__(self, supervisor: Supervisor, registry: AgentVmRegistry) -> None:
+        self.supervisor = supervisor
+        self.registry = registry
+        self._tasks: dict[VmId, asyncio.Task] = {}
+
+    def watch(self, vm_id: VmId, vm_hash: ItemHash, pubsub: PubSub) -> None:
+        """Start watching for updates to vm_hash, unless already watching it.
+
+        Idempotent: a live subscription is kept (matches the old
+        ``if not self.update_task`` guard). No-op when the agent has no record
+        of the VM (e.g. nothing to watch)."""
+        existing = self._tasks.get(vm_id)
+        if existing is not None and not existing.done():
+            return
+        record = self.registry.get(vm_hash)
+        if record is None:
+            return
+        refs = update_refs(record.original)
+        self._tasks[vm_id] = asyncio.create_task(self._watch(vm_id, refs, pubsub), name=f"watch {vm_id}")
+
+    def cancel(self, vm_id: VmId) -> bool:
+        """Cancel a pending watch. Returns whether one existed."""
+        task = self._tasks.pop(vm_id, None)
+        if task is None:
+            return False
+        task.cancel()
+        return True
+
+    async def cancel_all(self) -> None:
+        """Cancel every pending watch (shutdown cleanup)."""
+        for vm_id in list(self._tasks):
+            self.cancel(vm_id)
+
+    async def _watch(self, vm_id: VmId, refs: list[str], pubsub: PubSub) -> None:
+        try:
+            await pubsub.msubscribe(*refs)
+            logger.info("Update received for %s, reaping", vm_id)
+            await self.supervisor.delete_vm(vm_id)
+        except VmNotFoundError:
+            logger.debug("Update-watch: VM %s already gone", vm_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Update-watch of %s failed", vm_id)
+        finally:
+            # Only drop our own entry: a concurrent re-watch may have replaced it.
+            if self._tasks.get(vm_id) is asyncio.current_task():
+                del self._tasks[vm_id]
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/supervisor/test_update_watcher.py -q`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/aleph/vm/orchestrator/update_watcher.py tests/supervisor/test_update_watcher.py
+git commit -m "feat(update-watch): agent-owned UpdateWatcher keyed by vm_id"
+```
+
+---
+
+## Task 2: App wiring (`app["update_watcher"]` + shutdown)
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/supervisor.py`
+
+Reference the expiry wiring already in this file: `app["expiry"] = ExpiryManager(app["supervisor"])` and `stop_expiry_manager`.
+
+- [ ] **Step 1: Add the import and construct the watcher**
+
+In `src/aleph/vm/orchestrator/supervisor.py`, next to the existing expiry import:
+
+```python
+from aleph.vm.orchestrator.expiry import ExpiryManager
+from aleph.vm.orchestrator.update_watcher import UpdateWatcher
+```
+
+In `setup_webapp`, immediately after the `vm_registry` line (the watcher needs the registry):
+
+```python
+    app["expiry"] = ExpiryManager(app["supervisor"])
+    app["vm_registry"] = AgentVmRegistry()
+    app["update_watcher"] = UpdateWatcher(app["supervisor"], app["vm_registry"])
+```
+
+- [ ] **Step 2: Add the shutdown hook**
+
+After `stop_expiry_manager` in the same file:
+
+```python
+async def stop_update_watcher(app: web.Application) -> None:
+    """on_cleanup hook: cancel any pending update-watch subscriptions."""
+    update_watcher = app.get("update_watcher")
+    if update_watcher is not None:
+        await update_watcher.cancel_all()
+```
+
+In `run()`, register it next to `stop_expiry_manager` (before `stop_all_vms`):
+
+```python
+        app.on_cleanup.append(stop_expiry_manager)
+        app.on_cleanup.append(stop_update_watcher)
+        app.on_cleanup.append(stop_all_vms)
+```
+
+- [ ] **Step 3: Verify the app still builds**
+
+Run: `pytest tests/supervisor/test_views.py -q -k system_usage`
+Expected: the pre-existing environment failures only (no new import/collection errors). Confirm the module imports:
+
+Run: `PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -c "import aleph.vm.orchestrator.supervisor"`
+Expected: no output (clean import).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/aleph/vm/orchestrator/supervisor.py
+git commit -m "feat(update-watch): build app[\"update_watcher\"] and cancel it on shutdown"
+```
+
+---
+
+## Task 3: Request + reactor paths use the watcher
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/run.py` (`run_code_on_request`, `run_code_on_event`)
+- Modify: `src/aleph/vm/orchestrator/reactor.py`
+- Modify: `src/aleph/vm/orchestrator/tasks.py`
+- Modify: `src/aleph/vm/orchestrator/cli.py` (`benchmark`)
+
+- [ ] **Step 1: `run_code_on_request` — pull the watcher and use it**
+
+In `run_code_on_request` (after the existing `expiry = request.app["expiry"]` lines):
+
+```python
+    supervisor: Supervisor = request.app["supervisor"]
+    expiry: ExpiryManager = request.app["expiry"]
+    update_watcher: UpdateWatcher = request.app["update_watcher"]
+    vm_id = VmId(str(vm_hash))
+    expiry.cancel(vm_id)  # do not reap a VM we are about to serve
+```
+
+(Update the imports at the top of `run.py`:)
+
+```python
+from aleph.vm.orchestrator.expiry import ExpiryManager
+from aleph.vm.orchestrator.update_watcher import UpdateWatcher
+```
+
+In the `finally` block of `run_code_on_request`, replace the `start_watching_for_updates` call and add a cancel on the teardown branch:
+
+```python
+    finally:
+        if settings.REUSE_TIMEOUT > 0:
+            if settings.WATCH_FOR_UPDATES:
+                update_watcher.watch(vm_id, vm_hash, request.app["pubsub"])
+            expiry.schedule(vm_id, settings.REUSE_TIMEOUT)
+        else:
+            update_watcher.cancel(vm_id)
+            await supervisor.delete_vm(vm_id)
+```
+
+Note: update-watch is **not** cancelled at the top of the request (unlike expiry). An update that fires mid-serve must still redeploy; `delete_vm` → `stop_vm` waits for the in-flight run, matching the old `stop()` semantics.
+
+- [ ] **Step 2: `run_code_on_event` — accept and use the watcher**
+
+Change the signature to take `update_watcher`, drop the local registry, and use the passed registry:
+
+```python
+async def run_code_on_event(
+    vm_hash: ItemHash,
+    event,
+    pubsub: PubSub,
+    pool: VmPool,
+    *,
+    supervisor: Supervisor,
+    expiry: ExpiryManager,
+    update_watcher: UpdateWatcher,
+    registry: AgentVmRegistry,
+):
+    """
+    Execute code in response to an event.
+    """
+    vm_id = VmId(str(vm_hash))
+    expiry.cancel(vm_id)  # do not reap a VM we are about to serve
+
+    execution: VmExecution | None = pool.get_running_vm(vm_hash=vm_hash)
+
+    if not execution:
+        # programs use the legacy create path; the registry is the agent's
+        # shared known-VM store (so the watcher reads the same record).
+        execution = await create_vm_execution_or_raise_http_error(
+            vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry
+        )
+```
+
+In its trailing reuse/teardown block:
+
+```python
+        if settings.REUSE_TIMEOUT > 0:
+            if settings.WATCH_FOR_UPDATES:
+                update_watcher.watch(vm_id, vm_hash, pubsub)
+            expiry.schedule(vm_id, settings.REUSE_TIMEOUT)
+        else:
+            update_watcher.cancel(vm_id)
+            await supervisor.delete_vm(vm_id)
+```
+
+- [ ] **Step 3: `Reactor` carries the registry + watcher**
+
+In `src/aleph/vm/orchestrator/reactor.py`:
+
+```python
+from aleph.vm.orchestrator.expiry import ExpiryManager
+from aleph.vm.orchestrator.update_watcher import UpdateWatcher
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
+from aleph.vm.pool import VmPool
+from aleph.vm.supervisor.abc import Supervisor
+```
+
+```python
+class Reactor:
+    pubsub: PubSub
+    pool: VmPool
+    supervisor: Supervisor
+    expiry: ExpiryManager
+    update_watcher: UpdateWatcher
+    registry: AgentVmRegistry
+    listeners: list[AlephMessage]
+
+    def __init__(
+        self,
+        pubsub: PubSub,
+        pool: VmPool,
+        supervisor: Supervisor,
+        expiry: ExpiryManager,
+        update_watcher: UpdateWatcher,
+        registry: AgentVmRegistry,
+    ):
+        self.pubsub = pubsub
+        self.pool = pool
+        self.supervisor = supervisor
+        self.expiry = expiry
+        self.update_watcher = update_watcher
+        self.registry = registry
+        self.listeners = []
+```
+
+In `Reactor.trigger`, pass them through:
+
+```python
+                    coroutines.append(
+                        run_code_on_event(
+                            vm_hash,
+                            event,
+                            self.pubsub,
+                            pool=self.pool,
+                            supervisor=self.supervisor,
+                            expiry=self.expiry,
+                            update_watcher=self.update_watcher,
+                            registry=self.registry,
+                        )
+                    )
+```
+
+- [ ] **Step 4: `tasks.py` constructs the Reactor with the new args**
+
+In `src/aleph/vm/orchestrator/tasks.py`, `start_watch_for_messages_task`:
+
+```python
+    reactor = Reactor(pubsub, pool, supervisor, app["expiry"], app["update_watcher"], registry)
+```
+
+(`registry` is already bound there as `registry = app["vm_registry"]`.)
+
+- [ ] **Step 5: `cli.py benchmark` passes the watcher**
+
+In `src/aleph/vm/orchestrator/cli.py`:
+
+```python
+from aleph.vm.orchestrator.update_watcher import UpdateWatcher
+```
+
+In `benchmark`, where the fake app dict and `bench_supervisor` are built:
+
+```python
+    bench_supervisor = InProcessSupervisor(pool)
+    bench_registry = AgentVmRegistry()
+    bench_update_watcher = UpdateWatcher(bench_supervisor, bench_registry)
+    fake_request.app = {
+        "supervisor": bench_supervisor,
+        "expiry": ExpiryManager(bench_supervisor),
+        "update_watcher": bench_update_watcher,
+        "vm_registry": bench_registry,
+        "pubsub": PubSub(),
+    }
+```
+
+And the `run_code_on_event` call:
+
+```python
+    result = await run_code_on_event(
+        vm_hash=ref,
+        event=None,
+        pubsub=PubSub(),
+        pool=pool,
+        supervisor=bench_supervisor,
+        expiry=fake_request.app["expiry"],
+        update_watcher=bench_update_watcher,
+        registry=bench_registry,
+    )
+```
+
+- [ ] **Step 6: Run the affected suites**
+
+Run: `pytest tests/supervisor/test_supervisor_run_routing.py -q`
+Expected: PASS (the routing tests exercise `run_code_on_event`; update any that construct `run_code_on_event`/`Reactor` directly to pass `update_watcher` + `registry`).
+
+Run: `pytest tests/supervisor/test_update_watcher.py -q`
+Expected: PASS (unchanged).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/aleph/vm/orchestrator/run.py src/aleph/vm/orchestrator/reactor.py \
+        src/aleph/vm/orchestrator/tasks.py src/aleph/vm/orchestrator/cli.py
+git commit -m "feat(update-watch): request and reactor paths drive UpdateWatcher; reactor adopts the app registry"
+```
+
+---
+
+## Task 4: Execution-free `start_persistent_vm` + lifecycle cancels
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/run.py` (`start_persistent_vm`, new `_wait_until_gone`)
+- Modify: `src/aleph/vm/orchestrator/views/__init__.py` (`update_allocations`, `notify_allocation`)
+- Modify: `src/aleph/vm/orchestrator/views/operator.py` (`operate_stop`, `operate_reboot`, `operate_erase`)
+- Modify: `src/aleph/vm/orchestrator/cli.py` (`start_instance`)
+- Test: `tests/supervisor/test_supervisor_run_routing.py` (new `start_persistent_vm` precheck tests)
+
+- [ ] **Step 1: Write the failing precheck tests**
+
+Add to `tests/supervisor/test_supervisor_run_routing.py` (it already has `_info`, `_fake_supervisor`, `_HASH`, and imports `run_module`, `VmStatus`). These drive `start_persistent_vm` against a fake supervisor and assert create-vs-reuse based on `get_vm` status:
+
+```python
+@pytest.mark.asyncio
+async def test_start_persistent_reuses_running(monkeypatch):
+    sup = _fake_supervisor(get_status=VmStatus.RUNNING)
+    created = AsyncMock()
+    monkeypatch.setattr(run_module, "create_vm_execution", created)
+    monkeypatch.setattr(run_module, "_wait_until_running", AsyncMock())
+
+    result = await run_module.start_persistent_vm(
+        ItemHash(_HASH), None, MagicMock(),
+        supervisor=sup, registry=AgentVmRegistry(),
+        expiry=MagicMock(), update_watcher=MagicMock(),
+    )
+    assert result is None
+    created.assert_not_awaited()  # already running -> no create
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_creates_when_absent(monkeypatch):
+    sup = _fake_supervisor()
+    sup.get_vm = AsyncMock(side_effect=VmNotFoundError(_HASH))
+    created = AsyncMock()
+    monkeypatch.setattr(run_module, "create_vm_execution", created)
+    monkeypatch.setattr(run_module, "_wait_until_running", AsyncMock())
+
+    await run_module.start_persistent_vm(
+        ItemHash(_HASH), None, MagicMock(),
+        supervisor=sup, registry=AgentVmRegistry(),
+        expiry=MagicMock(), update_watcher=MagicMock(),
+    )
+    created.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_recreates_after_terminal(monkeypatch):
+    sup = _fake_supervisor(get_status=VmStatus.STOPPED)
+    created = AsyncMock()
+    monkeypatch.setattr(run_module, "create_vm_execution", created)
+    monkeypatch.setattr(run_module, "_wait_until_running", AsyncMock())
+
+    await run_module.start_persistent_vm(
+        ItemHash(_HASH), None, MagicMock(),
+        supervisor=sup, registry=AgentVmRegistry(),
+        expiry=MagicMock(), update_watcher=MagicMock(),
+    )
+    sup.delete_vm.assert_awaited_once()  # terminal -> delete then recreate
+    created.assert_awaited_once()
+```
+
+Ensure these imports are present at the top of the test file (add any missing):
+`from unittest.mock import AsyncMock, MagicMock`, `from aleph.vm.orchestrator.vm_registry import AgentVmRegistry`, `from aleph.vm.supervisor.errors import VmNotFoundError`. `_fake_supervisor` must expose `delete_vm`/`get_vm` as `AsyncMock`s — if the existing helper does not, extend it so `delete_vm = AsyncMock()` and `get_vm = AsyncMock(return_value=_info(get_status))`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/supervisor/test_supervisor_run_routing.py -q -k start_persistent`
+Expected: FAIL — `start_persistent_vm` still takes the old signature (no `update_watcher`) and reads `pool.executions`.
+
+- [ ] **Step 3: Add `_wait_until_gone` and rewrite `start_persistent_vm`**
+
+In `src/aleph/vm/orchestrator/run.py`, add next to `_wait_until_running`:
+
+```python
+async def _wait_until_gone(
+    supervisor: Supervisor,
+    vm_id: VmId,
+    *,
+    timeout: float | None = None,
+    interval: float | None = None,
+) -> None:
+    """Poll get_vm until the VM is gone (VmNotFoundError)."""
+    if timeout is None:
+        timeout = _START_POLL_TIMEOUT_SECONDS
+    if interval is None:
+        interval = _START_POLL_INTERVAL_SECONDS
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        try:
+            await supervisor.get_vm(vm_id)
+        except VmNotFoundError:
+            return
+        if asyncio.get_running_loop().time() >= deadline:
+            msg = f"VM {vm_id} did not stop within {timeout}s"
+            raise asyncio.TimeoutError(msg)
+        await asyncio.sleep(interval)
+```
+
+(Mirrors `_wait_until_running`'s clock and timeout-raise exactly.)
+
+Rewrite `start_persistent_vm`:
+
+```python
+async def start_persistent_vm(
+    vm_hash: ItemHash,
+    pubsub: PubSub | None,
+    pool: VmPool,
+    *,
+    supervisor: Supervisor,
+    registry: AgentVmRegistry,
+    expiry: ExpiryManager,
+    update_watcher: UpdateWatcher,
+) -> None:
+    vm_id = VmId(str(vm_hash))
+    try:
+        info: VmInfo | None = await supervisor.get_vm(vm_id)
+    except VmNotFoundError:
+        info = None
+
+    if info is not None:
+        if info.status == VmStatus.RUNNING:
+            logger.info(f"{vm_hash} is already running")
+        elif info.status in (VmStatus.DEFINED, VmStatus.BOOTING):
+            logger.info(f"{vm_hash} is already starting")
+            await _wait_until_running(supervisor, vm_id)
+        elif info.status == VmStatus.STOPPING:
+            logger.info(f"{vm_hash} is stopping, waiting before restart")
+            await _wait_until_gone(supervisor, vm_id)
+            info = None
+        else:  # STOPPED / FAILED
+            logger.info(f"{vm_hash} in terminal state {info.status}, recreating")
+            await supervisor.delete_vm(vm_id)
+            info = None
+
+    if info is None:
+        logger.info(f"Starting persistent virtual machine with id: {vm_hash}")
+        await create_vm_execution(
+            vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry, persistent=True
+        )
+        await _wait_until_running(supervisor, vm_id)
+
+    # Scheduled long-running: it must not idle-expire.
+    expiry.cancel(vm_id)
+
+    if pubsub and settings.WATCH_FOR_UPDATES:
+        update_watcher.watch(vm_id, vm_hash, pubsub)
+```
+
+Ensure `VmInfo` and `VmStatus` are imported in `run.py`:
+
+```python
+from aleph.vm.supervisor.types import VmId, VmInfo, VmStatus
+```
+
+- [ ] **Step 4: Run the precheck tests**
+
+Run: `pytest tests/supervisor/test_supervisor_run_routing.py -q -k start_persistent`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Update `start_persistent_vm` callers**
+
+In `src/aleph/vm/orchestrator/views/__init__.py`, all three call sites (two in `update_allocations`, one in `notify_allocation`) gain `update_watcher`. First bind it next to the existing `expiry = request.app["expiry"]`:
+
+```python
+    expiry = request.app["expiry"]
+    update_watcher = request.app["update_watcher"]
+```
+
+Then each call:
+
+```python
+        await start_persistent_vm(
+            vm_hash, pubsub, pool, supervisor=supervisor, registry=registry,
+            expiry=expiry, update_watcher=update_watcher,
+        )
+```
+
+(Apply the same `update_watcher=update_watcher` addition to the `instance_item_hash` and `notify_allocation` calls.)
+
+In `src/aleph/vm/orchestrator/cli.py`, `start_instance`:
+
+```python
+async def start_instance(item_hash: ItemHash, pubsub: PubSub | None, pool) -> VmExecution:
+    """Run an instance from an InstanceMessage."""
+    supervisor = InProcessSupervisor(pool)
+    registry = AgentVmRegistry()
+    expiry = ExpiryManager(supervisor)
+    update_watcher = UpdateWatcher(supervisor, registry)
+    return await start_persistent_vm(
+        item_hash, pubsub, pool, supervisor=supervisor, registry=registry,
+        expiry=expiry, update_watcher=update_watcher,
+    )
+```
+
+Note: `start_persistent_vm` now returns `None`. If `start_instance`'s return value is consumed anywhere, change its annotation to `-> None` and drop the `return`/use; verify with:
+
+Run: `PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -c "import aleph.vm.orchestrator.cli"`
+Expected: clean import. (`run_instances` ignores the value today; if mypy/flake flags the `-> VmExecution` annotation, change it to `-> None`.)
+
+- [ ] **Step 6: Lifecycle endpoints cancel the watcher**
+
+In `src/aleph/vm/orchestrator/views/operator.py`, add `request.app["update_watcher"].cancel(vm_id)` next to every existing `request.app["expiry"].cancel(vm_id)`:
+
+`operate_stop` (after the existing expiry cancel):
+```python
+                await supervisor.delete_vm(vm_id)
+                request.app["expiry"].cancel(vm_id)
+                request.app["update_watcher"].cancel(vm_id)
+                return web.Response(status=200, body=f"Stopped VM with ref {vm_hash}")
+```
+
+`operate_reboot` (the delete-then-recreate branch):
+```python
+                    await supervisor.delete_vm(vm_id)
+                    request.app["expiry"].cancel(vm_id)
+                    request.app["update_watcher"].cancel(vm_id)
+```
+
+`operate_erase`:
+```python
+            await supervisor.delete_vm(VmId(str(vm_hash)), wipe=True)
+            request.app["expiry"].cancel(VmId(str(vm_hash)))
+            request.app["update_watcher"].cancel(VmId(str(vm_hash)))
+```
+
+- [ ] **Step 7: Run the views + routing suites**
+
+Run: `pytest tests/supervisor/test_supervisor_run_routing.py tests/supervisor/test_views.py -q`
+Expected: no new failures vs the #969 base (the 10 pre-existing environment failures only).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/aleph/vm/orchestrator/run.py src/aleph/vm/orchestrator/views/__init__.py \
+        src/aleph/vm/orchestrator/views/operator.py src/aleph/vm/orchestrator/cli.py \
+        tests/supervisor/test_supervisor_run_routing.py
+git commit -m "refactor(update-watch): execution-free start_persistent_vm via get_vm; lifecycle endpoints cancel the watcher"
+```
+
+---
+
+## Task 5: Remove the dead update machinery from `VmExecution`
+
+**Files:**
+- Modify: `src/aleph/vm/models.py`
+- Test: `tests/supervisor/test_execution.py`
+
+By now nothing calls `start_watching_for_updates` / `watch_for_updates` / `cancel_update` (Tasks 3–4 removed every caller).
+
+- [ ] **Step 1: Confirm there are no remaining callers**
+
+Run:
+```bash
+grep -rn "start_watching_for_updates\|watch_for_updates\|cancel_update\|update_task" src/ tests/
+```
+Expected: only the definitions in `src/aleph/vm/models.py` (and any tests asserting their absence you are about to add). If a caller remains, migrate it before deleting.
+
+- [ ] **Step 2: Write the failing "API is gone" test**
+
+Append to `tests/supervisor/test_execution.py`:
+
+```python
+def test_vm_execution_has_no_update_watch_api():
+    # Update-watching moved to the agent-side UpdateWatcher (design 2026-06-09).
+    from aleph.vm.models import VmExecution
+
+    for gone in ("start_watching_for_updates", "watch_for_updates", "cancel_update"):
+        assert not hasattr(VmExecution, gone), f"{gone} should be removed from VmExecution"
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `pytest tests/supervisor/test_execution.py -q -k no_update_watch_api`
+Expected: FAIL (the methods still exist).
+
+- [ ] **Step 4: Delete the update machinery**
+
+In `src/aleph/vm/models.py`:
+- Remove the `update_task: asyncio.Task | None = None` field.
+- Remove `start_watching_for_updates`, `watch_for_updates`, and `cancel_update` methods.
+- Remove the `self.cancel_update()` call inside `stop()`.
+- If `Task`/`PubSub` imports become unused after this and the expiry removal in #969, drop them. Verify with the import check below.
+
+- [ ] **Step 5: Run the test + import check**
+
+Run: `pytest tests/supervisor/test_execution.py -q -k no_update_watch_api`
+Expected: PASS.
+
+Run: `PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -c "import aleph.vm.models"`
+Expected: clean import (no unused-import crash; if `ruff` flags unused imports, remove them).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/aleph/vm/models.py tests/supervisor/test_execution.py
+git commit -m "refactor(update-watch): drop update-watching members from VmExecution"
+```
+
+---
+
+## Task 6: Whole-branch checks + style gates
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full supervisor + orchestrator test set**
+
+Run: `pytest tests/supervisor -q`
+Expected: no new failures vs the #969 base. Confirm by comparing the failing-set to the known 10 pre-existing environment failures (`/var/lib/aleph` perms). Any failure outside that set must be fixed before proceeding.
+
+- [ ] **Step 2: Style gates (must match CI exactly)**
+
+```bash
+uvx ruff@0.4.6 format --diff src/aleph/vm/orchestrator/update_watcher.py \
+    src/aleph/vm/orchestrator/run.py src/aleph/vm/orchestrator/reactor.py \
+    src/aleph/vm/orchestrator/tasks.py src/aleph/vm/orchestrator/cli.py \
+    src/aleph/vm/orchestrator/supervisor.py src/aleph/vm/orchestrator/views/__init__.py \
+    src/aleph/vm/orchestrator/views/operator.py src/aleph/vm/models.py \
+    tests/supervisor/test_update_watcher.py
+uvx isort==5.13.2 --check-only --profile black src/aleph/vm/orchestrator/update_watcher.py
+```
+Expected: no diff. Apply `ruff format` / `isort` (without `--check`/`--diff`) if either reports changes, then re-commit. Remove any `uv.lock` that `uvx` regenerates (`git rm --cached uv.lock` if it appears — it is not tracked).
+
+- [ ] **Step 3: Final commit (only if the gates changed files)**
+
+```bash
+git add -A
+git commit -m "style(update-watch): ruff/isort formatting"
+```
+
+---
+
+## Out-of-scope residuals after this PR (do NOT touch)
+
+- The `create_vm_execution` save() readback (`pool.executions[vm_hash]` → `execution.save()`) — deferred agent-owned `ExecutionRecord` persistence.
+- Operator owner-auth's `execution.message` reads (~10 sites in `operator.py`).
+- `operate_expire`'s pre-existing dead route (carried from #969).

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -58,7 +58,6 @@ from aleph.vm.orchestrator.metrics import (
     save_port_mappings,
     save_record,
 )
-from aleph.vm.orchestrator.pubsub import PubSub
 from aleph.vm.orchestrator.vm import AlephFirecrackerInstance
 from aleph.vm.resources import GpuDevice, HostGPU
 from aleph.vm.supervisor.types import Backend, CreateVmSpec
@@ -138,7 +137,6 @@ class VmExecution:
     runs_done_event: asyncio.Event
     stop_pending_lock: asyncio.Lock
     stop_event: asyncio.Event
-    update_task: asyncio.Task | None = None
     init_task: asyncio.Task | None
     _forget_task: asyncio.Task | None = None
 
@@ -780,13 +778,6 @@ class VmExecution:
         assert self.vm, "The VM attribute has to be set before calling wait_for_init()"
         await self.vm.wait_for_init()
 
-    def cancel_update(self) -> bool:
-        if self.update_task:
-            self.update_task.cancel()
-            return True
-        else:
-            return False
-
     async def stop(self) -> None:
         """Stop the VM and release resources"""
         assert self.vm, "The VM attribute has to be set before calling stop()"
@@ -808,43 +799,11 @@ class VmExecution:
             await self.vm.teardown()
 
             self.times.stopped_at = datetime.now(tz=timezone.utc)
-            self.cancel_update()
 
             if self.vm.support_snapshot and self.snapshot_manager:
                 await self.snapshot_manager.stop_for(self.vm_hash)
             self.stop_event.set()
             logger.info("%s stopped", self)
-
-    def start_watching_for_updates(self, pubsub: PubSub):
-        if not isinstance(self.spec, MessageSpec):
-            # Message-free (spec-built / reattached) executions have no Aleph
-            # message to watch for updates. After a reboot the agent re-fetches
-            # the allocation and re-establishes watching; the supervisor's own
-            # reattach does not. No-op rather than scheduling a task that fails.
-            return
-        if not self.update_task:
-            self.update_task = create_task_log_exceptions(self.watch_for_updates(pubsub=pubsub))
-
-    async def watch_for_updates(self, pubsub: PubSub):
-        # Message-only entrypoint. start_watching_for_updates already no-ops for
-        # spec-built / reattached executions, so reaching here with one is a
-        # programming error: fail loud rather than silently watching nothing.
-        if not isinstance(self.spec, MessageSpec):
-            raise TypeError("watch_for_updates is message-only; spec-built executions have no message to update")
-        original = self.spec.original
-        if self.is_instance:
-            await pubsub.msubscribe(
-                *(volume.ref for volume in (original.volumes or []) if hasattr(volume, "ref")),
-            )
-        else:
-            await pubsub.msubscribe(
-                original.code.ref,
-                original.runtime.ref,
-                original.data.ref if original.data else None,
-                *(volume.ref for volume in (original.volumes or []) if hasattr(volume, "ref")),
-            )
-        logger.debug("Update received, stopping VM...")
-        await self.stop()
 
     async def all_runs_complete(self):
         """Wait for all runs to complete. Used in self.stop() to prevent interrupting a request."""

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -62,7 +62,7 @@ from aleph.vm.orchestrator.vm import AlephFirecrackerInstance
 from aleph.vm.resources import GpuDevice, HostGPU
 from aleph.vm.supervisor.types import Backend, CreateVmSpec
 from aleph.vm.systemd import SystemDManager
-from aleph.vm.utils import create_task_log_exceptions, dumps_for_json
+from aleph.vm.utils import dumps_for_json
 from aleph.vm.utils.aggregate import get_user_settings
 
 SUPPORTED_PROTOCOL_FOR_REDIRECT = ["udp", "tcp"]

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from aleph.vm.conf import ALLOW_DEVELOPER_SSH_KEYS, make_db_url, settings
 from aleph.vm.models import VmExecution
 from aleph.vm.orchestrator.expiry import ExpiryManager
+from aleph.vm.orchestrator.update_watcher import UpdateWatcher
 from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.pool import VmPool
 from aleph.vm.supervisor.inprocess import InProcessSupervisor
@@ -195,9 +196,13 @@ async def benchmark(runs: int):
     pool = VmPool()
     await pool.setup()
     bench_supervisor = InProcessSupervisor(pool)
+    bench_registry = AgentVmRegistry()
+    bench_update_watcher = UpdateWatcher(bench_supervisor, bench_registry)
     fake_request.app = {
         "supervisor": bench_supervisor,
         "expiry": ExpiryManager(bench_supervisor),
+        "update_watcher": bench_update_watcher,
+        "vm_registry": bench_registry,
         "pubsub": PubSub(),
     }
 
@@ -250,6 +255,8 @@ async def benchmark(runs: int):
         pool=pool,
         supervisor=bench_supervisor,
         expiry=fake_request.app["expiry"],
+        update_watcher=bench_update_watcher,
+        registry=bench_registry,
     )
     print("Event result", result)
 

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -197,13 +197,16 @@ async def benchmark(runs: int):
     bench_supervisor = InProcessSupervisor(pool)
     bench_registry = AgentVmRegistry()
     bench_update_watcher = UpdateWatcher(bench_supervisor, bench_registry)
+    bench_expiry = ExpiryManager(bench_supervisor)
     fake_request.app = {
         "supervisor": bench_supervisor,
-        "expiry": ExpiryManager(bench_supervisor),
+        "expiry": bench_expiry,
         "update_watcher": bench_update_watcher,
         "vm_registry": bench_registry,
         "pubsub": PubSub(),
     }
+    bench_expiry.on_reaped = bench_update_watcher.cancel
+    bench_update_watcher.on_reaped = bench_expiry.cancel
 
     # Does not make sense in benchmarks
     settings.WATCH_FOR_MESSAGES = False
@@ -266,6 +269,8 @@ async def start_instance(item_hash: ItemHash, pubsub: PubSub | None, pool) -> No
     registry = AgentVmRegistry()
     expiry = ExpiryManager(supervisor)
     update_watcher = UpdateWatcher(supervisor, registry)
+    expiry.on_reaped = update_watcher.cancel
+    update_watcher.on_reaped = expiry.cancel
     await start_persistent_vm(
         item_hash,
         pubsub,

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -18,7 +18,6 @@ from aleph_message.models import ItemHash
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from aleph.vm.conf import ALLOW_DEVELOPER_SSH_KEYS, make_db_url, settings
-from aleph.vm.models import VmExecution
 from aleph.vm.orchestrator.expiry import ExpiryManager
 from aleph.vm.orchestrator.update_watcher import UpdateWatcher
 from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
@@ -261,12 +260,21 @@ async def benchmark(runs: int):
     print("Event result", result)
 
 
-async def start_instance(item_hash: ItemHash, pubsub: PubSub | None, pool) -> VmExecution:
+async def start_instance(item_hash: ItemHash, pubsub: PubSub | None, pool) -> None:
     """Run an instance from an InstanceMessage."""
     supervisor = InProcessSupervisor(pool)
     registry = AgentVmRegistry()
     expiry = ExpiryManager(supervisor)
-    return await start_persistent_vm(item_hash, pubsub, pool, supervisor=supervisor, registry=registry, expiry=expiry)
+    update_watcher = UpdateWatcher(supervisor, registry)
+    await start_persistent_vm(
+        item_hash,
+        pubsub,
+        pool,
+        supervisor=supervisor,
+        registry=registry,
+        expiry=expiry,
+        update_watcher=update_watcher,
+    )
 
 
 async def run_instances(instances: list[ItemHash]) -> None:

--- a/src/aleph/vm/orchestrator/expiry.py
+++ b/src/aleph/vm/orchestrator/expiry.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from collections.abc import Callable
 
 from aleph.vm.supervisor.abc import Supervisor
 from aleph.vm.supervisor.errors import VmNotFoundError
@@ -19,6 +20,7 @@ class ExpiryManager:
     def __init__(self, supervisor: Supervisor) -> None:
         self.supervisor = supervisor
         self._tasks: dict[VmId, asyncio.Task] = {}
+        self.on_reaped: Callable[[VmId], object] | None = None
 
     def schedule(self, vm_id: VmId, timeout: float) -> None:
         """Arm (or re-arm, extending) the idle timer for vm_id."""
@@ -39,12 +41,15 @@ class ExpiryManager:
             self.cancel(vm_id)
 
     async def _expire(self, vm_id: VmId, timeout: float) -> None:
+        reaped = False
         try:
             await asyncio.sleep(timeout)
             logger.info("Idle timeout reached for %s, reaping", vm_id)
             await self.supervisor.delete_vm(vm_id)
+            reaped = True
         except VmNotFoundError:
             logger.debug("Expiry: VM %s already gone", vm_id)
+            reaped = True
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -54,3 +59,7 @@ class ExpiryManager:
             # replaced it with a new task under the same key.
             if self._tasks.get(vm_id) is asyncio.current_task():
                 del self._tasks[vm_id]
+            # Cancel the sibling idle-teardown timer (the update watcher) for the
+            # same VM: once reaped, its subscription would otherwise leak.
+            if reaped and self.on_reaped is not None:
+                self.on_reaped(vm_id)

--- a/src/aleph/vm/orchestrator/reactor.py
+++ b/src/aleph/vm/orchestrator/reactor.py
@@ -5,6 +5,8 @@ from aleph_message.models import AlephMessage
 from aleph_message.models.execution.environment import Subscription
 
 from aleph.vm.orchestrator.expiry import ExpiryManager
+from aleph.vm.orchestrator.update_watcher import UpdateWatcher
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.pool import VmPool
 from aleph.vm.supervisor.abc import Supervisor
 from aleph.vm.utils import create_task_log_exceptions
@@ -45,13 +47,25 @@ class Reactor:
     pool: VmPool
     supervisor: Supervisor
     expiry: ExpiryManager
+    update_watcher: UpdateWatcher
+    registry: AgentVmRegistry
     listeners: list[AlephMessage]
 
-    def __init__(self, pubsub: PubSub, pool: VmPool, supervisor: Supervisor, expiry: ExpiryManager):
+    def __init__(
+        self,
+        pubsub: PubSub,
+        pool: VmPool,
+        supervisor: Supervisor,
+        expiry: ExpiryManager,
+        update_watcher: UpdateWatcher,
+        registry: AgentVmRegistry,
+    ):
         self.pubsub = pubsub
         self.pool = pool
         self.supervisor = supervisor
         self.expiry = expiry
+        self.update_watcher = update_watcher
+        self.registry = registry
         self.listeners = []
 
     async def trigger(self, message: AlephMessage):
@@ -77,6 +91,8 @@ class Reactor:
                             pool=self.pool,
                             supervisor=self.supervisor,
                             expiry=self.expiry,
+                            update_watcher=self.update_watcher,
+                            registry=self.registry,
                         )
                     )
                     break

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -30,6 +30,7 @@ from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.pool import VmPool
 from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.supervisor.abc import Supervisor
+from aleph.vm.supervisor.errors import VmNotFoundError
 from aleph.vm.supervisor.translate import build_create_vm_spec
 from aleph.vm.supervisor.types import (
     GuestPort,
@@ -177,6 +178,30 @@ async def _wait_until_running(
             raise RuntimeError(msg)
         if asyncio.get_running_loop().time() >= deadline:
             msg = f"VM {vm_id} did not reach RUNNING within {timeout}s"
+            raise asyncio.TimeoutError(msg)
+        await asyncio.sleep(interval)
+
+
+async def _wait_until_gone(
+    supervisor: Supervisor,
+    vm_id: VmId,
+    *,
+    timeout: float | None = None,
+    interval: float | None = None,
+) -> None:
+    """Poll get_vm until the VM is gone (VmNotFoundError)."""
+    if timeout is None:
+        timeout = _START_POLL_TIMEOUT_SECONDS
+    if interval is None:
+        interval = _START_POLL_INTERVAL_SECONDS
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        try:
+            await supervisor.get_vm(vm_id)
+        except VmNotFoundError:
+            return
+        if asyncio.get_running_loop().time() >= deadline:
+            msg = f"VM {vm_id} did not stop within {timeout}s"
             raise asyncio.TimeoutError(msg)
         await asyncio.sleep(interval)
 
@@ -482,40 +507,39 @@ async def start_persistent_vm(
     supervisor: Supervisor,
     registry: AgentVmRegistry,
     expiry: ExpiryManager,
-) -> VmExecution:
-    execution: VmExecution | None = pool.executions.get(vm_hash)
-    if execution:
-        if execution.is_running:
+    update_watcher: UpdateWatcher,
+) -> None:
+    vm_id = VmId(str(vm_hash))
+    try:
+        info: VmInfo | None = await supervisor.get_vm(vm_id)
+    except VmNotFoundError:
+        info = None
+
+    if info is not None:
+        if info.status == VmStatus.RUNNING:
             logger.info(f"{vm_hash} is already running")
-        elif execution.is_starting:
+        elif info.status in (VmStatus.DEFINED, VmStatus.BOOTING):
             logger.info(f"{vm_hash} is already starting")
-        elif execution.is_stopping:
-            logger.info(f"{vm_hash} is stopping, waiting for complete stop before restarting")
-            await execution.stop_event.wait()
-            execution = None
-        else:
-            logger.info(f"{vm_hash} unknown execution state, stopping the vm")
-            if execution.vm:
-                await execution.stop()
-            else:
-                if execution._forget_task:
-                    execution._forget_task.cancel()
-                pool.forget_vm(vm_hash)
-            execution = None
+            await _wait_until_running(supervisor, vm_id)
+        elif info.status == VmStatus.STOPPING:
+            logger.info(f"{vm_hash} is stopping, waiting before restart")
+            await _wait_until_gone(supervisor, vm_id)
+            info = None
+        else:  # STOPPED / FAILED
+            logger.info(f"{vm_hash} in terminal state {info.status}, recreating")
+            await supervisor.delete_vm(vm_id)
+            info = None
 
-    if not execution:
+    if info is None:
         logger.info(f"Starting persistent virtual machine with id: {vm_hash}")
-        execution = await create_vm_execution(
-            vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry, persistent=True
-        )
+        await create_vm_execution(vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry, persistent=True)
+        # create_vm_execution blocks until RUNNING in-process today; this re-poll
+        # is the explicit readiness barrier (and stays correct if a future
+        # out-of-process create returns before the VM is RUNNING).
+        await _wait_until_running(supervisor, vm_id)
 
-    await execution.becomes_ready()
-
-    # If the VM was already running in lambda mode, it should not expire
-    # as long as it is also scheduled as long-running
-    expiry.cancel(VmId(str(vm_hash)))
+    # Scheduled long-running: it must not idle-expire.
+    expiry.cancel(vm_id)
 
     if pubsub and settings.WATCH_FOR_UPDATES:
-        execution.start_watching_for_updates(pubsub=pubsub)
-
-    return execution
+        update_watcher.watch(vm_id, vm_hash, pubsub)

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -25,11 +25,11 @@ from aleph.vm.controllers.firecracker.program import (
 from aleph.vm.hypervisors.firecracker.microvm import MicroVMFailedInitError
 from aleph.vm.models import MessageSpec, VmExecution
 from aleph.vm.orchestrator.expiry import ExpiryManager
+from aleph.vm.orchestrator.update_watcher import UpdateWatcher
 from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.pool import VmPool
 from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.supervisor.abc import Supervisor
-from aleph.vm.supervisor.inprocess import InProcessSupervisor
 from aleph.vm.supervisor.translate import build_create_vm_spec
 from aleph.vm.supervisor.types import (
     GuestPort,
@@ -291,6 +291,7 @@ async def run_code_on_request(vm_hash: ItemHash, path: str, pool: VmPool, reques
     """
     supervisor: Supervisor = request.app["supervisor"]
     expiry: ExpiryManager = request.app["expiry"]
+    update_watcher: UpdateWatcher = request.app["update_watcher"]
     vm_id = VmId(str(vm_hash))
     expiry.cancel(vm_id)  # do not reap a VM we are about to serve
 
@@ -305,11 +306,9 @@ async def run_code_on_request(vm_hash: ItemHash, path: str, pool: VmPool, reques
 
     if not execution:
         # Programs always take the legacy create path (they are never spec-eligible),
-        # which ignores the supervisor; the registry is the agent's own message cache.
-        # Construct them locally: this entry point also serves the standalone benchmark
-        # where there is no app-wide singleton to draw from.
-        supervisor = InProcessSupervisor(pool)
-        registry = AgentVmRegistry()
+        # which ignores the supervisor. Use the app-wide registry so the agent's
+        # update-watcher (which reads app["vm_registry"]) sees the record it creates.
+        registry = request.app["vm_registry"]
         execution = await create_vm_execution_or_raise_http_error(
             vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry
         )
@@ -397,11 +396,12 @@ async def run_code_on_request(vm_hash: ItemHash, path: str, pool: VmPool, reques
     finally:
         if settings.REUSE_TIMEOUT > 0:
             if settings.WATCH_FOR_UPDATES:
-                execution.start_watching_for_updates(pubsub=request.app["pubsub"])
+                update_watcher.watch(vm_id, vm_hash, request.app["pubsub"])
             # Persistent executions are long-running by design: never idle-reap them.
             if not execution.persistent:
                 expiry.schedule(vm_id, settings.REUSE_TIMEOUT)
         else:
+            update_watcher.cancel(vm_id)
             await supervisor.delete_vm(vm_id)
 
 
@@ -413,6 +413,8 @@ async def run_code_on_event(
     *,
     supervisor: Supervisor,
     expiry: ExpiryManager,
+    update_watcher: UpdateWatcher,
+    registry: AgentVmRegistry,
 ):
     """
     Execute code in response to an event.
@@ -423,9 +425,8 @@ async def run_code_on_event(
     execution: VmExecution | None = pool.get_running_vm(vm_hash=vm_hash)
 
     if not execution:
-        # programs use the legacy create path; the reactor has no agent
-        # registry singleton, so build a local one for the create follow-up.
-        registry = AgentVmRegistry()
+        # programs use the legacy create path; the registry is the agent's
+        # shared known-VM store (so the watcher reads the same record).
         execution = await create_vm_execution_or_raise_http_error(
             vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry
         )
@@ -464,11 +465,12 @@ async def run_code_on_event(
     finally:
         if settings.REUSE_TIMEOUT > 0:
             if settings.WATCH_FOR_UPDATES:
-                execution.start_watching_for_updates(pubsub=pubsub)
+                update_watcher.watch(vm_id, vm_hash, pubsub)
             # Persistent executions are long-running by design: never idle-reap them.
             if not execution.persistent:
                 expiry.schedule(vm_id, settings.REUSE_TIMEOUT)
         else:
+            update_watcher.cancel(vm_id)
             await supervisor.delete_vm(vm_id)
 
 

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -171,6 +171,10 @@ def setup_webapp(pool: VmPool | None):
     app["expiry"] = ExpiryManager(app["supervisor"])
     app["vm_registry"] = AgentVmRegistry()
     app["update_watcher"] = UpdateWatcher(app["supervisor"], app["vm_registry"])
+    # Each idle-teardown facility cancels the other's timer when it reaps a VM,
+    # so an expired or updated VM never leaks the sibling's pending task.
+    app["expiry"].on_reaped = app["update_watcher"].cancel
+    app["update_watcher"].on_reaped = app["expiry"].cancel
     app["backup_state"] = BackupState()
     cors = setup(
         app,

--- a/src/aleph/vm/orchestrator/supervisor.py
+++ b/src/aleph/vm/orchestrator/supervisor.py
@@ -19,6 +19,7 @@ from aiohttp_cors import ResourceOptions, setup
 from aleph.vm.conf import settings
 from aleph.vm.migration.reaper import reap_orphan_migration_files
 from aleph.vm.orchestrator.expiry import ExpiryManager
+from aleph.vm.orchestrator.update_watcher import UpdateWatcher
 from aleph.vm.orchestrator.vm_registry import AgentVmRegistry, rehydrate_registry
 from aleph.vm.pool import VmPool
 from aleph.vm.sevclient import SevClient
@@ -169,6 +170,7 @@ def setup_webapp(pool: VmPool | None):
     app["supervisor"] = InProcessSupervisor(pool)
     app["expiry"] = ExpiryManager(app["supervisor"])
     app["vm_registry"] = AgentVmRegistry()
+    app["update_watcher"] = UpdateWatcher(app["supervisor"], app["vm_registry"])
     app["backup_state"] = BackupState()
     cors = setup(
         app,
@@ -276,6 +278,13 @@ async def stop_expiry_manager(app: web.Application) -> None:
         await expiry.cancel_all()
 
 
+async def stop_update_watcher(app: web.Application) -> None:
+    """on_cleanup hook: cancel any pending update-watch subscriptions."""
+    update_watcher = app.get("update_watcher")
+    if update_watcher is not None:
+        await update_watcher.cancel_all()
+
+
 async def _run_migration_reaper(app: web.Application) -> None:
     """on_startup hook: clean up orphan migration files left from a prior supervisor run."""
     pool = app.get("vm_pool")
@@ -342,6 +351,7 @@ def run():
             app.on_cleanup.append(stop_balances_monitoring_task)
 
         app.on_cleanup.append(stop_expiry_manager)
+        app.on_cleanup.append(stop_update_watcher)
         app.on_cleanup.append(stop_all_vms)
 
         from aleph.vm.orchestrator.http import close_session, reset_session

--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -254,7 +254,7 @@ async def start_watch_for_messages_task(app: web.Application):
     pool: VmPool = app["vm_pool"]
     supervisor = app["supervisor"]
     registry = app["vm_registry"]
-    reactor = Reactor(pubsub, pool, supervisor, app["expiry"])
+    reactor = Reactor(pubsub, pool, supervisor, app["expiry"], app["update_watcher"], registry)
 
     # Register an hardcoded initial program
     # TODO: Register all programs with subscriptions

--- a/src/aleph/vm/orchestrator/update_watcher.py
+++ b/src/aleph/vm/orchestrator/update_watcher.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from collections.abc import Callable
 
 from aleph_message.models import ExecutableContent, InstanceContent, ItemHash
 
@@ -37,6 +38,7 @@ class UpdateWatcher:
         self.supervisor = supervisor
         self.registry = registry
         self._tasks: dict[VmId, asyncio.Task] = {}
+        self.on_reaped: Callable[[VmId], object] | None = None
 
     def watch(self, vm_id: VmId, vm_hash: ItemHash, pubsub: PubSub) -> None:
         """Start watching for updates to vm_hash, unless already watching it.
@@ -67,12 +69,15 @@ class UpdateWatcher:
             self.cancel(vm_id)
 
     async def _watch(self, vm_id: VmId, refs: list[str], pubsub: PubSub) -> None:
+        reaped = False
         try:
             await pubsub.msubscribe(*refs)
             logger.info("Update received for %s, reaping", vm_id)
             await self.supervisor.delete_vm(vm_id)
+            reaped = True
         except VmNotFoundError:
             logger.debug("Update-watch: VM %s already gone", vm_id)
+            reaped = True
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -81,3 +86,7 @@ class UpdateWatcher:
             # Only drop our own entry: a concurrent re-watch may have replaced it.
             if self._tasks.get(vm_id) is asyncio.current_task():
                 del self._tasks[vm_id]
+            # Cancel the sibling idle-teardown timer (the expiry manager) for the
+            # same VM once it has been reaped.
+            if reaped and self.on_reaped is not None:
+                self.on_reaped(vm_id)

--- a/src/aleph/vm/orchestrator/update_watcher.py
+++ b/src/aleph/vm/orchestrator/update_watcher.py
@@ -1,0 +1,83 @@
+import asyncio
+import logging
+
+from aleph_message.models import ExecutableContent, InstanceContent, ItemHash
+
+from aleph.vm.orchestrator.pubsub import PubSub
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor.abc import Supervisor
+from aleph.vm.supervisor.errors import VmNotFoundError
+from aleph.vm.supervisor.types import VmId
+
+logger = logging.getLogger(__name__)
+
+
+def update_refs(original: ExecutableContent) -> list[str]:
+    """The Aleph message refs whose update should redeploy the VM.
+
+    Adapted from VmExecution.watch_for_updates: instances watch their
+    volume refs; programs also watch code / runtime / data.
+    """
+    volume_refs = [volume.ref for volume in (original.volumes or []) if hasattr(volume, "ref")]
+    if isinstance(original, InstanceContent):
+        return volume_refs
+    data_ref = [original.data.ref] if original.data else []
+    return [original.code.ref, original.runtime.ref, *data_ref, *volume_refs]
+
+
+class UpdateWatcher:
+    """Agent-owned 'redeploy on message update' subscriptions, keyed by vm_id.
+
+    Subscription-driven counterpart to ExpiryManager. One dependency pair: the
+    Supervisor (to reap) and the AgentVmRegistry (to read the watched message).
+    Replaces the update methods that used to live on VmExecution.
+    """
+
+    def __init__(self, supervisor: Supervisor, registry: AgentVmRegistry) -> None:
+        self.supervisor = supervisor
+        self.registry = registry
+        self._tasks: dict[VmId, asyncio.Task] = {}
+
+    def watch(self, vm_id: VmId, vm_hash: ItemHash, pubsub: PubSub) -> None:
+        """Start watching for updates to vm_hash, unless already watching it.
+
+        Idempotent: a live subscription is kept (matches the old
+        ``if not self.update_task`` guard). No-op when the agent has no record
+        of the VM (e.g. nothing to watch)."""
+        existing = self._tasks.get(vm_id)
+        if existing is not None and not existing.done():
+            return
+        record = self.registry.get(vm_hash)
+        if record is None:
+            return
+        refs = update_refs(record.original)
+        self._tasks[vm_id] = asyncio.create_task(self._watch(vm_id, refs, pubsub), name=f"watch {vm_id}")
+
+    def cancel(self, vm_id: VmId) -> bool:
+        """Cancel a pending watch. Returns whether one existed."""
+        task = self._tasks.pop(vm_id, None)
+        if task is None:
+            return False
+        task.cancel()
+        return True
+
+    async def cancel_all(self) -> None:
+        """Cancel every pending watch (shutdown cleanup)."""
+        for vm_id in list(self._tasks):
+            self.cancel(vm_id)
+
+    async def _watch(self, vm_id: VmId, refs: list[str], pubsub: PubSub) -> None:
+        try:
+            await pubsub.msubscribe(*refs)
+            logger.info("Update received for %s, reaping", vm_id)
+            await self.supervisor.delete_vm(vm_id)
+        except VmNotFoundError:
+            logger.debug("Update-watch: VM %s already gone", vm_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Update-watch of %s failed", vm_id)
+        finally:
+            # Only drop our own entry: a concurrent re-watch may have replaced it.
+            if self._tasks.get(vm_id) is asyncio.current_task():
+                del self._tasks[vm_id]

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -571,6 +571,7 @@ async def update_allocations(request: web.Request):
     supervisor = request.app["supervisor"]
     registry = request.app["vm_registry"]
     expiry = request.app["expiry"]
+    update_watcher = request.app["update_watcher"]
 
     async with allocation_lock:
         logger.debug("Got allocation_lock, updating allocations")
@@ -621,7 +622,13 @@ async def update_allocations(request: web.Request):
                 logger.info(f"Starting long running VM '{vm_hash}'")
                 vm_hash = ItemHash(vm_hash)
                 await start_persistent_vm(
-                    vm_hash, pubsub, pool, supervisor=supervisor, registry=registry, expiry=expiry
+                    vm_hash,
+                    pubsub,
+                    pool,
+                    supervisor=supervisor,
+                    registry=registry,
+                    expiry=expiry,
+                    update_watcher=update_watcher,
                 )
             except vm_creation_exceptions as error:
                 logger.exception("Error while starting VM '%s': %s", vm_hash, error)
@@ -637,7 +644,13 @@ async def update_allocations(request: web.Request):
             instance_item_hash = ItemHash(instance_hash)
             try:
                 await start_persistent_vm(
-                    instance_item_hash, pubsub, pool, supervisor=supervisor, registry=registry, expiry=expiry
+                    instance_item_hash,
+                    pubsub,
+                    pool,
+                    supervisor=supervisor,
+                    registry=registry,
+                    expiry=expiry,
+                    update_watcher=update_watcher,
                 )
             except vm_creation_exceptions as error:
                 logger.exception("Error while starting VM '%s': %s", instance_hash, error)
@@ -891,6 +904,7 @@ async def notify_allocation(request: web.Request):
     supervisor = request.app["supervisor"]
     registry = request.app["vm_registry"]
     expiry = request.app["expiry"]
+    update_watcher = request.app["update_watcher"]
 
     # Capacity admission control: refuse the allocation early (before payment
     # validation) if accepting it would push the host above its memory, vCPU,
@@ -1024,7 +1038,15 @@ async def notify_allocation(request: web.Request):
     scheduling_errors: dict[ItemHash, Exception] = {}
     try:
         logger.info(f"Starting persistent vm {item_hash} from notify_allocation")
-        await start_persistent_vm(item_hash, pubsub, pool, supervisor=supervisor, registry=registry, expiry=expiry)
+        await start_persistent_vm(
+            item_hash,
+            pubsub,
+            pool,
+            supervisor=supervisor,
+            registry=registry,
+            expiry=expiry,
+            update_watcher=update_watcher,
+        )
         successful = True
         await pool.update_domain_mapping()
     except vm_creation_exceptions as error:

--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -432,6 +432,8 @@ async def operate_expire(request: web.Request, authenticated_sender: str) -> web
         logger.info(f"Expiring in {timeout} seconds: {execution.vm_hash}")
         expiry: ExpiryManager = request.app["expiry"]
         expiry.schedule(VmId(str(vm_hash)), timeout)
+        # Deliberately leave the update watcher armed: the VM keeps running until
+        # the timer fires, so an update during the window should still redeploy it.
 
         return web.Response(status=200, body=f"Expiring VM with ref {vm_hash} in {timeout} seconds")
 
@@ -508,6 +510,7 @@ async def operate_stop(request: web.Request, authenticated_sender: str) -> web.R
                 logger.info(f"Stopping {vm_hash}")
                 await supervisor.delete_vm(vm_id)
                 request.app["expiry"].cancel(vm_id)
+                request.app["update_watcher"].cancel(vm_id)
                 return web.Response(status=200, body=f"Stopped VM with ref {vm_hash}")
         except VmNotFoundError:
             raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_hash}") from None
@@ -537,6 +540,7 @@ async def operate_reboot(request: web.Request, authenticated_sender: str) -> web
                 else:
                     await supervisor.delete_vm(vm_id)
                     request.app["expiry"].cancel(vm_id)
+                    request.app["update_watcher"].cancel(vm_id)
                     await create_vm_execution_or_raise_http_error(
                         vm_hash=vm_hash,
                         pool=request.app["vm_pool"],
@@ -640,6 +644,7 @@ async def operate_erase(request: web.Request, authenticated_sender: str) -> web.
         try:
             await supervisor.delete_vm(VmId(str(vm_hash)), wipe=True)
             request.app["expiry"].cancel(VmId(str(vm_hash)))
+            request.app["update_watcher"].cancel(VmId(str(vm_hash)))
         except VmNotFoundError:
             raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_hash}") from None
         request.app["vm_registry"].forget(vm_hash)

--- a/tests/supervisor/test_execution.py
+++ b/tests/supervisor/test_execution.py
@@ -318,3 +318,11 @@ async def test_create_execution_legacy():
     Create a new VM execution based on the legacy FastAPI check and ensure that it starts properly.
     """
     await test_create_execution_online(vm_hash=settings.LEGACY_CHECK_FASTAPI_VM_ID)
+
+
+def test_vm_execution_has_no_update_watch_api():
+    # Update-watching moved to the agent-side UpdateWatcher (design 2026-06-09).
+    from aleph.vm.models import VmExecution
+
+    for gone in ("start_watching_for_updates", "watch_for_updates", "cancel_update"):
+        assert not hasattr(VmExecution, gone), f"{gone} should be removed from VmExecution"

--- a/tests/supervisor/test_expiry.py
+++ b/tests/supervisor/test_expiry.py
@@ -98,3 +98,32 @@ async def test_cancel_all_clears_every_timer():
     assert all(task.cancelled() for task in tasks)
     assert sup.deleted == []
     assert not expiry._tasks
+
+
+@pytest.mark.asyncio
+async def test_expiry_on_reaped_called_after_reap():
+    sup = FakeSupervisor()
+    expiry = ExpiryManager(sup)
+    reaped: list = []
+    expiry.on_reaped = reaped.append
+    vm_id = VmId("vm-a")
+
+    expiry.schedule(vm_id, 0.01)
+    await asyncio.sleep(0.05)
+
+    assert reaped == [vm_id]
+
+
+@pytest.mark.asyncio
+async def test_expiry_on_reaped_not_called_on_cancel():
+    sup = FakeSupervisor()
+    expiry = ExpiryManager(sup)
+    reaped: list = []
+    expiry.on_reaped = reaped.append
+    vm_id = VmId("vm-a")
+
+    expiry.schedule(vm_id, 0.05)
+    expiry.cancel(vm_id)
+    await asyncio.sleep(0.1)
+
+    assert reaped == []

--- a/tests/supervisor/test_run_idle_teardown.py
+++ b/tests/supervisor/test_run_idle_teardown.py
@@ -83,7 +83,7 @@ def _request_fakes(*, persistent: bool):
         result={"headers": {"headers": [[b"content-type", b"text/plain"]], "status": 200}, "body": {"body": b"ok"}},
     )
     expiry = SpyExpiry()
-    request = FakeRequest(app={"supervisor": None, "expiry": expiry, "pubsub": None})
+    request = FakeRequest(app={"supervisor": None, "expiry": expiry, "pubsub": None, "update_watcher": None})
     return execution, expiry, request
 
 
@@ -113,7 +113,9 @@ async def test_event_rearms_idle_timer_for_on_demand_vm(reuse_settings):
     execution = FakeExecution(persistent=False, result={"body": "ok"})
     expiry = SpyExpiry()
 
-    result = await run_code_on_event(VM_HASH, None, None, FakePool(execution), supervisor=None, expiry=expiry)
+    result = await run_code_on_event(
+        VM_HASH, None, None, FakePool(execution), supervisor=None, expiry=expiry, update_watcher=None, registry=None
+    )
 
     assert result == "ok"
     assert expiry.cancelled == [str(VM_HASH)]
@@ -125,7 +127,9 @@ async def test_event_never_schedules_expiry_for_persistent_vm(reuse_settings):
     execution = FakeExecution(persistent=True, result={"body": "ok"})
     expiry = SpyExpiry()
 
-    result = await run_code_on_event(VM_HASH, None, None, FakePool(execution), supervisor=None, expiry=expiry)
+    result = await run_code_on_event(
+        VM_HASH, None, None, FakePool(execution), supervisor=None, expiry=expiry, update_watcher=None, registry=None
+    )
 
     assert result == "ok"
     assert expiry.scheduled == []

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -303,3 +303,22 @@ async def test_start_persistent_waits_gone_then_recreates_when_stopping(monkeypa
     )
     waited_gone.assert_awaited_once()  # STOPPING -> wait until gone
     created.assert_awaited_once()  # then recreate
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_arms_update_watch(monkeypatch):
+    sup = _fake_supervisor(get_status=VmStatus.RUNNING)
+    monkeypatch.setattr(run_module, "_wait_until_running", AsyncMock())
+    watcher = MagicMock()
+    pubsub = MagicMock()  # truthy -> WATCH_FOR_UPDATES default True -> watch armed
+
+    await run_module.start_persistent_vm(
+        ItemHash(_HASH),
+        pubsub,
+        MagicMock(),
+        supervisor=sup,
+        registry=AgentVmRegistry(),
+        expiry=MagicMock(),
+        update_watcher=watcher,
+    )
+    watcher.watch.assert_called_once()

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -20,6 +20,7 @@ from test_supervisor_translate import _make_qemu_instance_message
 from aleph.vm.models import MessageSpec
 from aleph.vm.orchestrator import run as run_module
 from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor.errors import VmNotFoundError
 from aleph.vm.supervisor.types import (
     Backend,
     CreateVmSpec,
@@ -220,3 +221,85 @@ async def test_gpu_instance_falls_back_to_legacy(monkeypatch):
         }
     )
     await _assert_routed_to_legacy(monkeypatch, content)
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_reuses_running(monkeypatch):
+    sup = _fake_supervisor(get_status=VmStatus.RUNNING)
+    created = AsyncMock()
+    monkeypatch.setattr(run_module, "create_vm_execution", created)
+    monkeypatch.setattr(run_module, "_wait_until_running", AsyncMock())
+
+    result = await run_module.start_persistent_vm(
+        ItemHash(_HASH),
+        None,
+        MagicMock(),
+        supervisor=sup,
+        registry=AgentVmRegistry(),
+        expiry=MagicMock(),
+        update_watcher=MagicMock(),
+    )
+    assert result is None
+    created.assert_not_awaited()  # already running -> no create
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_creates_when_absent(monkeypatch):
+    sup = _fake_supervisor()
+    sup.get_vm = AsyncMock(side_effect=VmNotFoundError(_HASH))
+    created = AsyncMock()
+    monkeypatch.setattr(run_module, "create_vm_execution", created)
+    monkeypatch.setattr(run_module, "_wait_until_running", AsyncMock())
+
+    await run_module.start_persistent_vm(
+        ItemHash(_HASH),
+        None,
+        MagicMock(),
+        supervisor=sup,
+        registry=AgentVmRegistry(),
+        expiry=MagicMock(),
+        update_watcher=MagicMock(),
+    )
+    created.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_recreates_after_terminal(monkeypatch):
+    sup = _fake_supervisor(get_status=VmStatus.STOPPED)
+    created = AsyncMock()
+    monkeypatch.setattr(run_module, "create_vm_execution", created)
+    monkeypatch.setattr(run_module, "_wait_until_running", AsyncMock())
+
+    await run_module.start_persistent_vm(
+        ItemHash(_HASH),
+        None,
+        MagicMock(),
+        supervisor=sup,
+        registry=AgentVmRegistry(),
+        expiry=MagicMock(),
+        update_watcher=MagicMock(),
+    )
+    sup.delete_vm.assert_awaited_once()  # terminal -> delete then recreate
+    created.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_waits_gone_then_recreates_when_stopping(monkeypatch):
+    sup = _fake_supervisor(get_status=VmStatus.STOPPING)
+    waited_gone = AsyncMock()
+    created = AsyncMock()
+    monkeypatch.setattr(run_module, "_wait_until_gone", waited_gone)
+    monkeypatch.setattr(run_module, "create_vm_execution", created)
+    monkeypatch.setattr(run_module, "_wait_until_running", AsyncMock())
+
+    await run_module.start_persistent_vm(
+        ItemHash(_HASH),
+        None,
+        MagicMock(),
+        supervisor=sup,
+        registry=AgentVmRegistry(),
+        expiry=MagicMock(),
+        update_watcher=MagicMock(),
+    )
+    waited_gone.assert_awaited_once()  # STOPPING -> wait until gone
+    created.assert_awaited_once()  # then recreate

--- a/tests/supervisor/test_supervisor_spec_execution.py
+++ b/tests/supervisor/test_supervisor_spec_execution.py
@@ -134,14 +134,3 @@ async def test_start_skips_configure_and_save_for_spec(monkeypatch):
     systemd.enable_and_start.assert_awaited_once_with(execution.controller_service)
     save_record.assert_not_awaited()  # spec path keeps no DB record
     assert execution.ready_event.is_set()
-
-
-def test_start_watching_for_updates_is_noop_without_message():
-    # A message-free (spec-built / reattached) execution has no Aleph message to
-    # watch; start_watching_for_updates must no-op, not schedule a task that
-    # would crash on `self.original` being None.
-    execution = VmExecution.from_spec(make_spec(), snapshot_manager=None, systemd_manager=None)
-
-    execution.start_watching_for_updates(pubsub=object())  # type: ignore[arg-type]
-
-    assert execution.update_task is None

--- a/tests/supervisor/test_update_watcher.py
+++ b/tests/supervisor/test_update_watcher.py
@@ -193,3 +193,58 @@ async def test_watch_again_after_completion_rewatches():
     assert pubsub2.subscribed is not None
     watcher.cancel(vm_id)
     await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_expiry_reap_cancels_update_watch():
+    # Regression: an idle-expired VM must not leak its update-watch subscription.
+    from aleph.vm.orchestrator.expiry import ExpiryManager
+
+    sup = FakeSupervisor()
+    registry = _registry_with(_HASH, _make_qemu_instance_message())
+    watcher = UpdateWatcher(sup, registry)
+    expiry = ExpiryManager(sup)
+    expiry.on_reaped = watcher.cancel
+    watcher.on_reaped = expiry.cancel
+    vm_id = VmId(_HASH)
+
+    watcher.watch(vm_id, _HASH, FakePubSub())
+    expiry.schedule(vm_id, 0.01)
+    await asyncio.sleep(0.05)  # expiry fires, reaps, cancels the watch
+
+    assert sup.deleted == [(_HASH, False)]  # expiry reaped
+    assert watcher.cancel(vm_id) is False  # the watch was cancelled (gone)
+
+
+@pytest.mark.asyncio
+async def test_update_watch_on_reaped_called_after_reap():
+    sup, pubsub = FakeSupervisor(), FakePubSub()
+    registry = _registry_with(_HASH, _make_qemu_instance_message())
+    watcher = UpdateWatcher(sup, registry)
+    reaped: list = []
+    watcher.on_reaped = reaped.append
+    vm_id = VmId(_HASH)
+
+    watcher.watch(vm_id, _HASH, pubsub)
+    await asyncio.sleep(0)
+    pubsub.trigger()
+    await asyncio.sleep(0.02)
+
+    assert reaped == [vm_id]
+
+
+@pytest.mark.asyncio
+async def test_update_watch_on_reaped_not_called_on_cancel():
+    sup, pubsub = FakeSupervisor(), FakePubSub()
+    registry = _registry_with(_HASH, _make_qemu_instance_message())
+    watcher = UpdateWatcher(sup, registry)
+    reaped: list = []
+    watcher.on_reaped = reaped.append
+    vm_id = VmId(_HASH)
+
+    watcher.watch(vm_id, _HASH, pubsub)
+    await asyncio.sleep(0)
+    watcher.cancel(vm_id)
+    await asyncio.sleep(0.02)
+
+    assert reaped == []  # cancellation is not a reap

--- a/tests/supervisor/test_update_watcher.py
+++ b/tests/supervisor/test_update_watcher.py
@@ -1,0 +1,195 @@
+import asyncio
+import json
+
+import pytest
+
+# Import the existing instance-message builder (instance branch of update_refs).
+from test_supervisor_translate import _make_qemu_instance_message
+
+from aleph.vm.orchestrator.update_watcher import UpdateWatcher, update_refs
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor.errors import VmNotFoundError
+from aleph.vm.supervisor.types import VmId
+from aleph.vm.utils import get_message_executable_content
+
+
+def _program_content():
+    # examples/program_message_from_aleph.json is a full message envelope; the
+    # helper wants the bare content dict.
+    with open("examples/program_message_from_aleph.json") as fd:
+        return get_message_executable_content(json.load(fd)["content"])
+
+
+class FakeSupervisor:
+    def __init__(self, *, raise_not_found: bool = False):
+        self.deleted: list[tuple[str, bool]] = []
+        self.raise_not_found = raise_not_found
+
+    async def delete_vm(self, vm_id: VmId, wipe: bool = False) -> None:
+        self.deleted.append((str(vm_id), wipe))
+        if self.raise_not_found:
+            raise VmNotFoundError(str(vm_id))
+
+
+class FakePubSub:
+    """msubscribe blocks until the test triggers it, recording the keys."""
+
+    def __init__(self):
+        self.event = asyncio.Event()
+        self.subscribed: tuple | None = None
+
+    async def msubscribe(self, *keys):
+        self.subscribed = tuple(k for k in keys if k is not None)
+        await self.event.wait()
+
+    def trigger(self):
+        self.event.set()
+
+
+def _registry_with(vm_hash: str, original):
+    registry = AgentVmRegistry()
+    registry.record(vm_hash, message=original, original=original, persistent=False)
+    return registry
+
+
+_HASH = "a" * 64
+
+
+def test_update_refs_instance_uses_volume_refs():
+    content = _make_qemu_instance_message()  # volumes=[]
+    assert update_refs(content) == []
+
+
+def test_update_refs_program_uses_code_runtime_data():
+    content = _program_content()
+    refs = update_refs(content)
+    assert content.code.ref in refs
+    assert content.runtime.ref in refs
+
+
+@pytest.mark.asyncio
+async def test_watch_reaps_on_update():
+    sup, pubsub = FakeSupervisor(), FakePubSub()
+    registry = _registry_with(_HASH, _make_qemu_instance_message())
+    watcher = UpdateWatcher(sup, registry)
+    vm_id = VmId(_HASH)
+
+    watcher.watch(vm_id, _HASH, pubsub)
+    await asyncio.sleep(0)  # let the task reach msubscribe
+    pubsub.trigger()
+    await asyncio.sleep(0.02)
+
+    assert sup.deleted == [(_HASH, False)]
+    assert watcher.cancel(vm_id) is False  # task removed itself after firing
+
+
+@pytest.mark.asyncio
+async def test_cancel_prevents_reap():
+    sup, pubsub = FakeSupervisor(), FakePubSub()
+    registry = _registry_with(_HASH, _make_qemu_instance_message())
+    watcher = UpdateWatcher(sup, registry)
+    vm_id = VmId(_HASH)
+
+    watcher.watch(vm_id, _HASH, pubsub)
+    await asyncio.sleep(0)
+    assert watcher.cancel(vm_id) is True
+    pubsub.trigger()
+    await asyncio.sleep(0.02)
+
+    assert sup.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_watch_is_idempotent_keeps_existing_subscription():
+    sup, pubsub1, pubsub2 = FakeSupervisor(), FakePubSub(), FakePubSub()
+    registry = _registry_with(_HASH, _make_qemu_instance_message())
+    watcher = UpdateWatcher(sup, registry)
+    vm_id = VmId(_HASH)
+
+    watcher.watch(vm_id, _HASH, pubsub1)
+    await asyncio.sleep(0)
+    watcher.watch(vm_id, _HASH, pubsub2)  # second call must NOT restart
+    await asyncio.sleep(0)
+
+    assert pubsub1.subscribed is not None  # first subscription is live
+    assert pubsub2.subscribed is None  # second was a no-op
+
+    watcher.cancel(vm_id)
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_watch_noop_when_unrecorded():
+    sup, pubsub = FakeSupervisor(), FakePubSub()
+    watcher = UpdateWatcher(sup, AgentVmRegistry())  # empty registry
+    vm_id = VmId(_HASH)
+
+    watcher.watch(vm_id, _HASH, pubsub)
+    await asyncio.sleep(0.01)
+
+    assert watcher.cancel(vm_id) is False  # nothing scheduled
+    assert pubsub.subscribed is None
+
+
+@pytest.mark.asyncio
+async def test_watch_swallows_vm_not_found():
+    sup = FakeSupervisor(raise_not_found=True)
+    pubsub = FakePubSub()
+    registry = _registry_with(_HASH, _make_qemu_instance_message())
+    watcher = UpdateWatcher(sup, registry)
+    vm_id = VmId(_HASH)
+
+    watcher.watch(vm_id, _HASH, pubsub)
+    await asyncio.sleep(0)
+    pubsub.trigger()
+    await asyncio.sleep(0.02)  # must not raise
+
+    assert sup.deleted == [(_HASH, False)]
+    assert watcher.cancel(vm_id) is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_clears_every_watch():
+    sup = FakeSupervisor()
+    registry = AgentVmRegistry()
+    registry.record(
+        "a" * 64,
+        message=_make_qemu_instance_message(),
+        original=_make_qemu_instance_message(),
+        persistent=False,
+    )
+    registry.record(
+        "b" * 64,
+        message=_make_qemu_instance_message(),
+        original=_make_qemu_instance_message(),
+        persistent=False,
+    )
+    watcher = UpdateWatcher(sup, registry)
+    watcher.watch(VmId("a" * 64), "a" * 64, FakePubSub())
+    watcher.watch(VmId("b" * 64), "b" * 64, FakePubSub())
+    await asyncio.sleep(0)
+
+    await watcher.cancel_all()
+    await asyncio.sleep(0.02)
+
+    assert sup.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_watch_again_after_completion_rewatches():
+    sup, pubsub1, pubsub2 = FakeSupervisor(), FakePubSub(), FakePubSub()
+    registry = _registry_with(_HASH, _make_qemu_instance_message())
+    watcher = UpdateWatcher(sup, registry)
+    vm_id = VmId(_HASH)
+
+    watcher.watch(vm_id, _HASH, pubsub1)
+    await asyncio.sleep(0)
+    pubsub1.trigger()  # fires -> deletes -> task completes
+    await asyncio.sleep(0.02)
+    assert sup.deleted == [(_HASH, False)]
+
+    watcher.watch(vm_id, _HASH, pubsub2)  # prior task done -> a new watch starts
+    await asyncio.sleep(0)
+    assert pubsub2.subscribed is not None
+    watcher.cancel(vm_id)
+    await asyncio.sleep(0)


### PR DESCRIPTION
Second of the Phase-0 residual cleanups in the message-free supervisor series (after #969 expiry). Lifts **update-watching** ("redeploy a VM when its Aleph message updates") off the `VmExecution` god-object into a new agent-owned `UpdateWatcher`, and makes `start_persistent_vm` **execution-free**.

Design: `docs/plans/2026-06-09-supervisor-update-watching-design.md`
Plan: `docs/plans/2026-06-09-supervisor-update-watching-plan.md`

## Why

Update-watching is agent policy (it subscribes to the deployment's code/runtime/data/volume refs and stops the VM on update), but it lived as methods on `VmExecution` — the object being split into an agent `Execution` and a hypervisor `Vm`. This is the exact mirror of what #969 did for idle-expiry. With it gone, the idle/update paths no longer need a `VmExecution`, and `start_persistent_vm` stops reaching into `pool.executions`.

## What

- **New `UpdateWatcher`** (`orchestrator/update_watcher.py`): subscription tasks keyed by `vm_id`, reading each VM's message from the `AgentVmRegistry` and reaping via `Supervisor.delete_vm(wipe=False)` on update. Subscription-driven counterpart to `ExpiryManager`, with the same concurrency discipline (current-task identity check, `VmNotFoundError` swallow, `CancelledError` re-raise). `watch()` is **idempotent** (a live subscription is not restarted — preserves the old `if not self.update_task` guard).
- **`start_persistent_vm` is now execution-free**: the pre-existing-VM check runs through `supervisor.get_vm` (a `VmStatus` state machine: `RUNNING`→reuse, `DEFINED`/`BOOTING`→`_wait_until_running`, `STOPPING`→`_wait_until_gone`→recreate, `STOPPED`/`FAILED`→`delete_vm`→recreate, absent→create), readiness via `_wait_until_running`, update via the watcher. Returns `None` (callers already ignore the return). This kills the residual `pool.executions.get(vm_hash)` read the design doc named.
- **`VmExecution` loses** `watch_for_updates` / `start_watching_for_updates` / `update_task` / `cancel_update` (and the `cancel_update()` call in `stop()`); the ref-extraction logic relocates to `UpdateWatcher`.
- **Wiring symmetric with expiry**: `app["update_watcher"]` built in `setup_webapp`; threaded into the request path, the reactor (which now also adopts the shared `app["vm_registry"]` instead of a throwaway local one), and `start_persistent_vm`; `update_watcher.cancel` added next to every `expiry.cancel` in stop/reboot/erase; `cancel_all()` on shutdown; `cli.py` benchmark/`start_instance` updated.

## Behavior parity

- Reap-on-update is unchanged: subscribe to the same refs, then stop the VM (volumes preserved, VM forgotten — matches the old `stop()` and #969's expiry reap).
- The no-op for message-less (spec-built/reattached) VMs is preserved (the watcher no-ops when the registry has no record). Reattached persistent VMs are now *also* watched after a restart (rehydration repopulates the registry), a small improvement over the old execution-based no-op.

## Two issues caught in review (worth calling out)

1. **On-demand programs kept their watch.** `run_code_on_request` was building a throwaway local `AgentVmRegistry` for program creates, so the app-level watcher would never see the record. Fixed to use `request.app["vm_registry"]` (every caller — HTTP views + benchmark — has the app singletons), so on-demand programs remain update-watched.
2. **Sibling-timer leak on reap.** Removing `cancel_update()` from `VmExecution.stop()` broke the linkage where an expiry-reap used to also tear down the update-watch. The agent now has two idle-teardown facilities reaping the same VM, so each is given an `on_reaped` hook cross-wired to the other's `cancel` — an expired VM no longer leaks its pending `msubscribe` task, and vice-versa. Regression-tested (`test_expiry_reap_cancels_update_watch`).

## Residuals (explicitly out of scope, documented in the design doc §3)

- The `create_vm_execution` `save()` readback (`pool.executions[vm_hash]` → `execution.save()`) — the agent's `ExecutionRecord` persistence; deferred to when the rest of the agent's record-persistence leaves the execution.
- Operator owner-auth's `execution.message` reads (~10 sites) — these stay; owner-auth is agent policy and simply reads the agent's own message store. (Migrating them to read the registry is separate plumbing.)

## Tests

`UpdateWatcher` unit tests mirror `test_expiry.py` (reap-on-update, cancel, idempotent-no-restart, re-watch-after-completion, no-op-when-unrecorded, `VmNotFoundError` swallow, `cancel_all`, `on_reaped`); `start_persistent_vm` precheck-state tests (running/booting/stopping/absent/terminal); a `VmExecution`-API-gone test; the sibling-cancel regression test. Full supervisor suite shows no new failures vs the #969 base (the pre-existing `/var/cache/aleph` environment failures are identical to the dev baseline). ruff-format / isort gates green.

## Stacking

Stacked on #969 (`od/wire-supervisor-expiry`). Base this PR on that branch; retarget to `dev` once #969 merges.
