### PR TITLE
Message-free supervisor: operator owner-auth reads the agent registry

### DIFF
--- a/docs/plans/2026-06-09-supervisor-owner-auth-registry-design.md
+++ b/docs/plans/2026-06-09-supervisor-owner-auth-registry-design.md
@@ -1,0 +1,192 @@
+# Operator owner-auth reads the agent registry
+
+**Status:** design
+**Date:** 2026-06-09
+**Series:** message-free supervisor (Phase-0 residual cleanup, after #969 expiry, #970 update-watching)
+**Stacks on:** `od/wire-supervisor-update-watch` (#970)
+
+## 1. Goal
+
+Stop operator endpoints from reading owner identity off the hypervisor pool
+(`pool.executions[vm_hash].message`). After this PR, `execution.message` is read
+**nowhere** in `orchestrator/views/operator.py`; owner-auth consults the agent
+registry — the agent's own message store — exactly like the already-migrated
+`operate_stop` / `operate_reboot` / `operate_erase`.
+
+This is the last of the design docs' named owner-auth residual: *"Operator
+owner-auth's `execution.message` reads (~10 sites in `operator.py`) → registry."*
+
+## 2. Background
+
+The message-free-supervisor effort splits the `VmExecution` god-object into an
+agent-side concept (message, owner, billing, expiry, update-watching — backed by
+the `AgentVmRegistry` + agent DB) and a hypervisor-side `Vm` (process,
+networking, status — behind the `Supervisor` boundary). The agent *owns*
+messages; the goal is to get message-derived policy off the **hypervisor
+object**, not off the agent.
+
+Owner-authorization is agent policy: an operator request is authorized iff the
+authenticated sender is the message owner or a delegate. The message it reads is
+the agent's own — so it should come from the agent registry, not from a reach
+through `pool.executions` into the hypervisor object's `spec.message`.
+
+### What is already migrated (the template)
+
+`operate_stop`, `operate_reboot`, and `operate_erase` already read
+`record.message` via the `get_agent_record_or_404(request, vm_hash)` helper
+(registry-only, 404 on miss). The logs endpoints use `_logs_auth_message`
+(registry first, DB fallback). This PR finishes the same migration for the
+remaining endpoints.
+
+```python
+def get_agent_record_or_404(request: web.Request, vm_hash: ItemHash) -> AgentVmRecord:
+    """Owner identity now comes from the agent registry, not the execution."""
+    record = request.app["vm_registry"].get(vm_hash)
+    if record is None:
+        raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_hash}")
+    return record
+```
+
+`AgentVmRecord.message` is an `ExecutableContent` — the same type
+`is_sender_authorized(authenticated_sender, message)` and the incidental
+`message.rootfs.size_mib` reads already expect.
+
+## 3. Scope
+
+### In scope
+
+The remaining `execution.message` reads in `operator.py` — nine functions (one
+auth read each), plus two additional `execution.message.rootfs.size_mib` content
+reads inside `_do_restore` — in three shapes.
+
+**① Delete (dead code).** `authenticate_websocket_for_vm_or_403` (def at
+line 380) reads `execution.message` but has **zero callers** repo-wide
+(`grep -rn` across `src/` and `tests/` finds only the definition). Remove the
+function (YAGNI) rather than migrate its read. It takes `execution: VmExecution`
+as a parameter, so removing it also drops a `VmExecution` dependency from the
+module's surface.
+
+**② Become execution-free.** These endpoints use the execution *only* for the
+auth check; the `get_execution_or_404` lookup is removed entirely and the auth
+message comes from the registry:
+
+- `operate_expire` — otherwise needed only `execution.vm_hash`, which equals the
+  `vm_hash` already in scope.
+- `operate_backup_status` — otherwise uses only `request.app["backup_state"]`.
+- `operate_backup_delete` — otherwise uses only the backup directory on disk.
+
+**③ Auth-only swap.** These genuinely need the execution for the hypervisor
+operation (`execution.vm`, `execution.is_running`, `execution.vm.resources`,
+`rootfs_path`). The execution lookup stays; only the *message read* moves to the
+registry:
+
+- `operate_confidential_initialize` (uses `execution.is_running`,
+  `execution.is_confidential`, `execution.vm`)
+- `operate_confidential_measurement` (`QemuVmClient(execution.vm)`)
+- `operate_confidential_inject_secret` (`QemuVmClient(execution.vm)`)
+- `operate_backup` (`execution.is_running`, `execution.vm`)
+- `_do_restore` (`execution.vm`, `execution.vm.resources.rootfs_path`) — plus its
+  **two** `execution.message.rootfs.size_mib` content reads, which become
+  `record.message.rootfs.size_mib` (restore is QEMU-instance-only, guarded by an
+  `isinstance(execution.vm, AlephQemuInstance | AlephQemuConfidentialInstance)`
+  check, so `.rootfs` is present on the message exactly as before).
+
+### Out of scope (explicit residuals, unchanged)
+
+- **`execution.vm` / `execution.is_running` direct reads in `operator.py`.**
+  These are hypervisor-object access that bypasses the `Supervisor` boundary —
+  Phase-1 work, not message-coupling. The ③ endpoints keep them.
+- **The `create_vm_execution` `save()` readback.** Still deferred (decision
+  2026-06-09): agent-owned `ExecutionRecord` persistence.
+- **The `VmExecution.message` property itself.** Stays — the hypervisor object's
+  own QEMU/Firecracker config build reads `self.spec.message`. This PR removes
+  *operator.py's* reads of it, not the property.
+
+## 4. The migration pattern
+
+Per the `operate_stop` precedent, registry-auth runs first, then (for ③) the
+execution lookup for the hypervisor op:
+
+```python
+# ② execution-free:
+record = get_agent_record_or_404(request, vm_hash)
+if not await is_sender_authorized(authenticated_sender, record.message):
+    return web.Response(status=403, body="Unauthorized sender")
+# ... endpoint body uses no execution ...
+
+# ③ auth-only swap:
+record = get_agent_record_or_404(request, vm_hash)
+if not await is_sender_authorized(authenticated_sender, record.message):
+    return web.Response(status=403, body="Unauthorized sender")
+execution = get_execution_or_404(vm_hash, pool=pool)   # for execution.vm
+# ... endpoint body uses execution.vm / is_running / resources ...
+```
+
+### Behavior nuance (deliberate)
+
+For the ③ endpoints the auth check now runs **before** the running-VM lookup
+(previously `get_execution_or_404` ran first). Consequences:
+
+- **Unauthorized** request against a **known-but-stopped** VM: now **403**
+  (registry has the record) instead of the previous **404** (no running
+  execution). This matches the already-migrated endpoints and is arguably more
+  correct — authorization precedes VM-state disclosure.
+- **Unknown** VM (no registry record): **404**, preserved — `get_agent_record_or_404`
+  raises 404 on a registry miss.
+- **Authorized** request against a stopped VM: still reaches
+  `get_execution_or_404`, which still returns **404** when there is no running
+  execution. Unchanged for authorized callers.
+
+This is the design decision approved 2026-06-09: accept the 403-before-404
+ordering for consistency with the migrated endpoints, rather than preserving the
+exact current ordering by keeping execution-lookup-first.
+
+### Minor cleanup folded in
+
+`get_execution_or_404` carries a stale `# TODO: Check if this should be
+execution.message.address or execution.message.content.address?` comment — it
+referred to the auth read this PR removes. Delete the comment. The helper itself
+stays (the ③ endpoints use it for `execution.vm`).
+
+## 5. Components / files touched
+
+- `src/aleph/vm/orchestrator/views/operator.py` — the nine migrations, the dead
+  function deletion, the stale-TODO removal. Imports: drop `VmExecution` if it
+  becomes unused after deleting `authenticate_websocket_for_vm_or_403` (verify;
+  `get_execution_or_404` is annotated `-> VmExecution`, so the import likely
+  stays — confirm during implementation).
+- Tests (below).
+
+No wiring changes: `app["vm_registry"]` and `get_agent_record_or_404` already
+exist and are used by the migrated endpoints.
+
+## 6. Testing
+
+For each migrated endpoint:
+
+- **Authorized** sender (matching `record.message.address`) → request proceeds
+  (past auth; the hypervisor-side outcome may still be a 4xx for non-running VMs,
+  asserted as today).
+- **Unauthorized** sender → **403**.
+- **Registry miss** (`vm_registry.get` returns `None`) → **404**.
+
+Tests stub `request.app["vm_registry"]` with a record whose `message.address` is
+the owner. Reuse the existing operator-view test harness.
+
+Cross-cutting guards:
+
+- A test asserting `execution.message` appears **nowhere** in `operator.py`
+  (source scan), locking in the migration.
+- Confirm the dead-function deletion breaks no imports or route registrations
+  (`authenticate_websocket_for_vm_or_403` is referenced only at its definition).
+
+Existing operator tests for the migrated endpoints must continue to pass
+(authorized-path behavior is unchanged).
+
+## 7. Out-of-scope residuals after this PR
+
+- `execution.vm` / `execution.is_running` direct hypervisor reads in operator.py
+  (Phase-1 Supervisor-boundary work).
+- `create_vm_execution` save() readback — agent-owned `ExecutionRecord`
+  persistence.
+- Recreate-agent-state-from-network (demote DB from authority to cache).

--- a/docs/plans/2026-06-09-supervisor-owner-auth-registry-plan.md
+++ b/docs/plans/2026-06-09-supervisor-owner-auth-registry-plan.md
@@ -1,0 +1,833 @@
+# Operator owner-auth → agent registry — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make operator owner-authorization read the message from the agent registry instead of the hypervisor pool, so `execution.message` is read nowhere in `orchestrator/views/operator.py`.
+
+**Architecture:** Mechanical migration of 9 functions in one file. Three shapes: delete one dead function; make three endpoints execution-free (they used the execution only for auth); for five endpoints that genuinely need `execution.vm`, keep the execution lookup but move the *auth message read* ahead of it, sourced from `get_agent_record_or_404(request, vm_hash)`. Established precedent: `operate_stop`/`operate_reboot`/`operate_erase` already do exactly this.
+
+**Tech Stack:** Python 3, aiohttp, pytest / pytest-asyncio, `mocker` (pytest-mock).
+
+**Design doc:** `docs/plans/2026-06-09-supervisor-owner-auth-registry-design.md`
+
+**Branch:** `od/wire-supervisor-owner-auth` (stacked on #970 `od/wire-supervisor-update-watch`).
+
+---
+
+## Environment notes (read before running anything)
+
+- **Every `Bash` command needs `dangerouslyDisableSandbox: true`** (the repo's seccomp profile blocks sandboxed exec with `apply-seccomp ... Permission denied`).
+- **This worktree has no local venv.** Run tests with the sibling worktree's venv:
+  ```bash
+  cd /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-expiry
+  PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -m pytest <args>
+  ```
+- **Style gates (CI):**
+  ```bash
+  uvx ruff@0.4.6 format --diff src/aleph/vm/orchestrator/views/operator.py tests/supervisor/views/test_operator.py
+  uvx isort==5.13.2 --check-only --profile black src/aleph/vm/orchestrator/views/operator.py tests/supervisor/views/test_operator.py
+  ```
+  `uvx` writes an untracked `uv.lock` — **never `git add` it.**
+- **Pre-existing environmental failures:** the full `tests/supervisor` suite has ~50 failed + 4 errors on `/var/cache/aleph`, `/var/lib/aleph`, and pyroute2 netlink — identical to the `origin/dev` baseline. Judge regressions against that baseline, not against zero. Run the targeted test file `tests/supervisor/views/test_operator.py` (which does not hit those paths) for fast iteration.
+- **No `Co-Authored-By` trailer in commits.**
+
+## Shared facts (true for every task)
+
+- File under change: `src/aleph/vm/orchestrator/views/operator.py`.
+- Test file: `tests/supervisor/views/test_operator.py`.
+- The helper already exists (do not add it):
+  ```python
+  def get_agent_record_or_404(request: web.Request, vm_hash: ItemHash) -> AgentVmRecord:
+      """Owner identity now comes from the agent registry, not the execution."""
+      record = request.app["vm_registry"].get(vm_hash)
+      if record is None:
+          raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_hash}")
+      return record
+  ```
+- `AgentVmRecord.message` is an `ExecutableContent` — the same type `is_sender_authorized(sender, message)` and `message.rootfs.size_mib` already consume.
+- **Registry-seeding pattern for tests** (from the existing `test_operator_stop`):
+  ```python
+  vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+  instance_message = await get_message(ref=vm_hash)
+  app["vm_registry"].record(
+      vm_hash,
+      message=instance_message.content,
+      original=instance_message.content,
+      persistent=True,
+  )
+  ```
+- **Why the new tests are red on current code:** they seed the *registry* and leave `pool.executions` **empty**. Current code calls `get_execution_or_404` first → 404 on the empty pool. After migration, auth reads the registry → the assertion (403, or a past-auth body) holds. That is the red→green signal.
+- `is_sender_authorized` is patched in tests as `aleph.vm.orchestrator.views.operator.is_sender_authorized` to avoid the delegation/network path (matches the existing `test_operator_confidential_initialize_not_authorized`).
+
+---
+
+## Task 1: Delete the dead websocket-auth function and the stale TODO
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/views/operator.py` (delete `authenticate_websocket_for_vm_or_403` def; delete one comment line in `get_execution_or_404`)
+- Test: `tests/supervisor/views/test_operator.py`
+
+`authenticate_websocket_for_vm_or_403` (def at ~line 380) has **zero callers** repo-wide (verified: `grep -rn authenticate_websocket_for_vm_or_403 src/ tests/` returns only the definition). It reads `execution.message`. Remove it (YAGNI). Removing it does not orphan any import: `authenticate_websocket_message` is still used by the websocket-logs handler, `is_sender_authorized` is used throughout, and `VmExecution` is still used by `get_execution_or_404`'s annotation.
+
+- [ ] **Step 1: Write the failing guard test**
+
+Add at the end of `tests/supervisor/views/test_operator.py`:
+
+```python
+def test_dead_websocket_auth_helper_is_removed():
+    """authenticate_websocket_for_vm_or_403 had no callers; it must be gone."""
+    from aleph.vm.orchestrator.views import operator
+
+    assert not hasattr(operator, "authenticate_websocket_for_vm_or_403")
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run:
+```bash
+PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -m pytest tests/supervisor/views/test_operator.py::test_dead_websocket_auth_helper_is_removed -v
+```
+Expected: FAIL (`assert not True` — the function still exists).
+
+- [ ] **Step 3: Delete the function**
+
+Remove the entire `authenticate_websocket_for_vm_or_403` definition (from its `async def authenticate_websocket_for_vm_or_403(...)` line through its final `raise web.HTTPForbidden(body="Unauthorized sender")`, including the two blank lines that precede it down to one separating blank line). The current body to delete:
+
+```python
+async def authenticate_websocket_for_vm_or_403(execution: VmExecution, vm_hash: ItemHash, ws: web.WebSocketResponse):
+    """Authenticate a websocket connection.
+
+    Web browsers do not allow setting headers in WebSocket requests, so the authentication
+    relies on the first message sent by the client.
+    """
+    try:
+        first_message = await ws.receive_json()
+    except TypeError as error:
+        logging.exception(error)
+        await ws.send_json({"status": "failed", "reason": str(error)})
+        raise web.HTTPForbidden(body="Invalid auth package")
+    credentials = first_message["auth"]
+
+    try:
+        authenticated_sender = await authenticate_websocket_message(credentials)
+
+        if await is_sender_authorized(authenticated_sender, execution.message):
+            logger.debug(f"Accepted request to access logs by {authenticated_sender} on {vm_hash}")
+            return True
+    except Exception as error:
+        # Error occurred (invalid auth packet or other
+        await ws.send_json({"status": "failed", "reason": str(error)})
+        raise web.HTTPForbidden(body="Unauthorized sender")
+
+    # Auth was valid but not the correct user
+    logger.debug(f"Denied request to access logs by {authenticated_sender} on {vm_hash}")
+    await ws.send_json({"status": "failed", "reason": "unauthorized sender"})
+    raise web.HTTPForbidden(body="Unauthorized sender")
+```
+
+- [ ] **Step 4: Delete the stale TODO comment in `get_execution_or_404`**
+
+In `get_execution_or_404`, remove the line:
+```python
+    # TODO: Check if this should be execution.message.address or execution.message.content.address?
+```
+so the function becomes:
+```python
+def get_execution_or_404(ref: ItemHash, pool: VmPool) -> VmExecution:
+    """Return the execution corresponding to the ref or raise an HTTP 404 error."""
+    execution = pool.executions.get(ref)
+    if execution:
+        return execution
+    else:
+        raise web.HTTPNotFound(body=f"No virtual machine with ref {ref}")
+```
+
+- [ ] **Step 5: Run the guard test + a smoke import**
+
+Run:
+```bash
+PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -m pytest tests/supervisor/views/test_operator.py -q
+```
+Expected: the new test PASSES and no previously-passing operator test regresses (collection succeeds — proves no import broke).
+
+- [ ] **Step 6: Style + commit**
+
+```bash
+uvx ruff@0.4.6 format --diff src/aleph/vm/orchestrator/views/operator.py tests/supervisor/views/test_operator.py
+uvx isort==5.13.2 --check-only --profile black src/aleph/vm/orchestrator/views/operator.py tests/supervisor/views/test_operator.py
+git add src/aleph/vm/orchestrator/views/operator.py tests/supervisor/views/test_operator.py
+git commit -m "refactor(owner-auth): delete dead authenticate_websocket_for_vm_or_403 and stale TODO"
+```
+
+---
+
+## Task 2: Make the three execution-free endpoints registry-authorized
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/views/operator.py` (`operate_expire`, `operate_backup_status`, `operate_backup_delete`)
+- Test: `tests/supervisor/views/test_operator.py`
+
+These three use the execution **only** for the auth check. Drop `get_execution_or_404` and the now-unused `pool` local; authorize from the registry.
+
+> **`operate_expire` caveat:** its route `/control/machine/{ref}/expire` carries no `{timeout}` segment, but the handler reads `request.match_info["timeout"]` → `KeyError` → always `400` *before* reaching auth. This routing bug is the known out-of-scope residual (design §7). We still migrate its auth read (so `execution.message` leaves the file) but **do not** add an HTTP happy-path test for it — it cannot return 200. We delete the misleading `@pytest.mark.skip()` test that asserted a non-existent `.expire()` call.
+
+### 2a — `operate_backup_status` and `operate_backup_delete`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/supervisor/views/test_operator.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_operator_backup_status_authorized_reads_registry(aiohttp_client, mocker, tmp_path):
+    """Authorized backup-status reaches the backup logic with an empty pool."""
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    fake_vm_pool = mocker.AsyncMock(executions={})
+
+    mocker.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value=instance_message.sender,
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.is_sender_authorized",
+        return_value=True,
+    )
+    # get_backup_directory() mkdirs under settings.EXECUTION_ROOT (a /var path);
+    # patch the operator-local name to a tmp dir to avoid the environment's
+    # /var PermissionError.
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.get_backup_directory",
+        return_value=tmp_path,
+    )
+    app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    client: TestClient = await aiohttp_client(app)
+    response = await client.get(f"/control/machine/{vm_hash}/backup")
+    # Past auth: no backup exists, so the backup logic returns its own 404.
+    assert response.status == 404, await response.text()
+    assert "No backup found" in await response.text()
+
+
+@pytest.mark.asyncio
+async def test_operator_backup_status_unauthorized_reads_registry(aiohttp_client, mocker):
+    """Backup-status authorizes against the registry, not the pool."""
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    fake_vm_pool = mocker.AsyncMock(executions={})
+
+    mocker.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value="0xstranger",
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.is_sender_authorized",
+        return_value=False,
+    )
+    app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    client: TestClient = await aiohttp_client(app)
+    response = await client.get(f"/control/machine/{vm_hash}/backup")
+    assert response.status == 403, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_operator_backup_delete_authorized_reads_registry(aiohttp_client, mocker, tmp_path):
+    """Authorized backup-delete reaches the delete logic with an empty pool."""
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    fake_vm_pool = mocker.AsyncMock(executions={})
+
+    mocker.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value=instance_message.sender,
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.is_sender_authorized",
+        return_value=True,
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.get_backup_directory",
+        return_value=tmp_path,
+    )
+    app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    client: TestClient = await aiohttp_client(app)
+    response = await client.delete(f"/control/machine/{vm_hash}/backup/{vm_hash}aa")
+    # Past auth: no such backup file, so the delete logic returns its own 404.
+    assert response.status == 404, await response.text()
+    assert "not found" in await response.text()
+```
+
+(The `backup_id` `f"{vm_hash}aa"` satisfies `_validate_backup_id`, which requires the id to start with the vm_hash.)
+
+- [ ] **Step 2: Run, verify they fail**
+
+Run:
+```bash
+PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -m pytest tests/supervisor/views/test_operator.py -k "backup_status or backup_delete" -v
+```
+Expected: the three new tests FAIL — current code hits `get_execution_or_404` on the empty pool and returns `404 "No virtual machine with ref ..."` (the authorized tests expected a different 404 body; the unauthorized test expected 403).
+
+- [ ] **Step 3: Migrate `operate_backup_status`**
+
+Replace its current head:
+```python
+    with set_vm_for_logging(vm_hash=vm_hash):
+        pool: VmPool = request.app["vm_pool"]
+        execution = get_execution_or_404(vm_hash, pool=pool)
+
+        if not await is_sender_authorized(authenticated_sender, execution.message):
+            return web.Response(status=403, body="Unauthorized sender")
+```
+with:
+```python
+    with set_vm_for_logging(vm_hash=vm_hash):
+        record = get_agent_record_or_404(request, vm_hash)
+        if not await is_sender_authorized(authenticated_sender, record.message):
+            return web.Response(status=403, body="Unauthorized sender")
+```
+
+- [ ] **Step 4: Migrate `operate_backup_delete`**
+
+Replace its current head:
+```python
+    with set_vm_for_logging(vm_hash=vm_hash):
+        pool: VmPool = request.app["vm_pool"]
+        execution = get_execution_or_404(vm_hash, pool=pool)
+
+        if not await is_sender_authorized(authenticated_sender, execution.message):
+            return web.Response(status=403, body="Unauthorized sender")
+```
+with:
+```python
+    with set_vm_for_logging(vm_hash=vm_hash):
+        record = get_agent_record_or_404(request, vm_hash)
+        if not await is_sender_authorized(authenticated_sender, record.message):
+            return web.Response(status=403, body="Unauthorized sender")
+```
+
+- [ ] **Step 5: Run the three tests, verify they pass**
+
+Run:
+```bash
+PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -m pytest tests/supervisor/views/test_operator.py -k "backup_status or backup_delete" -v
+```
+Expected: PASS.
+
+### 2b — `operate_expire`
+
+- [ ] **Step 6: Delete the obsolete skipped test**
+
+Remove the entire `test_operator_expire` function (the `@pytest.mark.asyncio` / `@pytest.mark.skip()` decorated test that asserts `fake_vm_pool["executions"][vm_hash].expire.call_count == 1`). It tests behavior that never existed and the endpoint is a known-broken route.
+
+- [ ] **Step 7: Migrate `operate_expire`'s auth read**
+
+Replace:
+```python
+        pool: VmPool = request.app["vm_pool"]
+        execution = get_execution_or_404(vm_hash, pool=pool)
+
+        if not await is_sender_authorized(authenticated_sender, execution.message):
+            return web.Response(status=403, body="Unauthorized sender")
+
+        logger.info(f"Expiring in {timeout} seconds: {execution.vm_hash}")
+```
+with:
+```python
+        record = get_agent_record_or_404(request, vm_hash)
+        if not await is_sender_authorized(authenticated_sender, record.message):
+            return web.Response(status=403, body="Unauthorized sender")
+
+        logger.info(f"Expiring in {timeout} seconds: {vm_hash}")
+```
+(`execution.vm_hash` was equal to `vm_hash`; use `vm_hash` directly.)
+
+- [ ] **Step 8: Verify the targeted file still collects and passes**
+
+Run:
+```bash
+PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -m pytest tests/supervisor/views/test_operator.py -q
+```
+Expected: PASS (the removed skipped test is gone; nothing else regresses).
+
+- [ ] **Step 9: Style + commit**
+
+```bash
+uvx ruff@0.4.6 format --diff src/aleph/vm/orchestrator/views/operator.py tests/supervisor/views/test_operator.py
+uvx isort==5.13.2 --check-only --profile black src/aleph/vm/orchestrator/views/operator.py tests/supervisor/views/test_operator.py
+git add src/aleph/vm/orchestrator/views/operator.py tests/supervisor/views/test_operator.py
+git commit -m "refactor(owner-auth): authorize expire/backup-status/backup-delete from the registry"
+```
+
+---
+
+## Task 3: Migrate the five auth-only-swap endpoints
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/views/operator.py` (`operate_confidential_initialize`, `operate_confidential_measurement`, `operate_confidential_inject_secret`, `operate_backup`, `_do_restore`)
+- Test: `tests/supervisor/views/test_operator.py`
+
+These keep the `get_execution_or_404` lookup (they need `execution.vm` / `is_running` / `resources`), but the **auth message** moves to the registry and runs **before** the execution lookup. Pattern:
+
+```python
+record = get_agent_record_or_404(request, vm_hash)
+if not await is_sender_authorized(authenticated_sender, record.message):
+    return web.Response(status=403, body="Unauthorized sender")
+execution = get_execution_or_404(vm_hash, pool=pool)   # still needed for execution.vm
+```
+
+### 3a — Update the four existing `confidential_initialize` tests to seed the registry
+
+After migration these endpoints authorize from `app["vm_registry"]`; the existing tests seed only `pool.executions`, so without a registry record they would now 404 before auth. Add the registry seed to each.
+
+- [ ] **Step 1: Update `test_operator_confidential_initialize_not_authorized`**
+
+This test uses a `FakeVmPool`/`FakeExecution` and patches `is_sender_authorized` → False, expecting 403. Add a registry record so auth is reached. Replace the body from `with mock.patch(... authenticate_jwk ...)` onward so it seeds the registry on the constructed `app`:
+
+```python
+@pytest.mark.asyncio
+async def test_operator_confidential_initialize_not_authorized(aiohttp_client):
+    """Rejects when the sender is not authorized; auth message comes from the registry."""
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.ENABLE_CONFIDENTIAL_COMPUTING = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+
+    class FakeExecution:
+        message = None
+        is_running: bool = True
+        is_confidential: bool = False
+
+    class FakeVmPool:
+        def __init__(self):
+            self.executions = {settings.FAKE_INSTANCE_ID: FakeExecution()}
+
+    with mock.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value="",
+    ):
+        with mock.patch(
+            "aleph.vm.orchestrator.views.operator.is_sender_authorized",
+            return_value=False,
+        ) as is_sender_authorized_mock:
+            app = setup_webapp(pool=FakeVmPool())
+            app["vm_registry"].record(
+                vm_hash,
+                message=instance_message.content,
+                original=instance_message.content,
+                persistent=True,
+            )
+            client = await aiohttp_client(app)
+            response = await client.post(
+                f"/control/machine/{settings.FAKE_INSTANCE_ID}/confidential/initialize",
+            )
+            assert response.status == 403
+            assert await response.text() == "Unauthorized sender"
+            is_sender_authorized_mock.assert_called_once()
+```
+
+- [ ] **Step 2: Seed the registry in the three remaining confidential tests**
+
+In each of `test_operator_confidential_initialize_already_running`, `test_operator_confidential_initialize_not_confidential`, and `test_operator_confidential_initialize` (the authorized one), add — immediately after `app = setup_webapp(pool=fake_vm_pool)` — the seed:
+
+```python
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+```
+
+All three already define `vm_hash` and `instance_message = await get_message(ref=vm_hash)` and set the execution's `message=instance_message.content`, so the registry message matches what they expect.
+
+- [ ] **Step 3: Run them, verify they now fail against current code**
+
+Run:
+```bash
+PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -m pytest tests/supervisor/views/test_operator.py -k confidential_initialize -v
+```
+Expected: the authorized cases still pass (they seed both pool and registry; current code reads the pool and the message matches), but `test_operator_confidential_initialize_not_authorized` is the red signal — after the test edit it seeds the registry; **current** code still authorizes from `execution.message` (which is `None` on `FakeExecution`) → `is_sender_authorized(None)` patched to False → 403, so it may already pass. If all four pass here, that is acceptable: they are migration-safety tests, and Step 5 proves the migration keeps them green. Proceed.
+
+> Note for the implementer: the genuine red→green proof for the ③ endpoints is the empty-pool 403 tests in Steps 6–9 below, not the confidential-init edits (which exist to keep already-covered paths green through the migration).
+
+### 3b — New empty-pool 403 tests (the red→green proof for ③)
+
+- [ ] **Step 4: Add the four 403 tests**
+
+Add to `tests/supervisor/views/test_operator.py`. Each seeds the registry, leaves the pool empty, patches `is_sender_authorized` → False, and expects 403. On current code each returns 404 (empty pool, execution-first) — red.
+
+```python
+@pytest.mark.asyncio
+async def test_operator_confidential_measurement_unauthorized_reads_registry(aiohttp_client, mocker):
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.ENABLE_CONFIDENTIAL_COMPUTING = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    fake_vm_pool = mocker.AsyncMock(executions={})
+
+    mocker.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value="0xstranger",
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.is_sender_authorized",
+        return_value=False,
+    )
+    app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    client: TestClient = await aiohttp_client(app)
+    response = await client.get(f"/control/machine/{vm_hash}/confidential/measurement")
+    assert response.status == 403, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_operator_confidential_inject_secret_unauthorized_reads_registry(aiohttp_client, mocker):
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.ENABLE_CONFIDENTIAL_COMPUTING = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    fake_vm_pool = mocker.AsyncMock(executions={})
+
+    mocker.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value="0xstranger",
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.is_sender_authorized",
+        return_value=False,
+    )
+    app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    client: TestClient = await aiohttp_client(app)
+    # InjectSecretParams (packet_header, secret) is validated before auth, so the
+    # body must be schema-valid for the request to reach the registry-auth check.
+    response = await client.post(
+        f"/control/machine/{vm_hash}/confidential/inject_secret",
+        json={"packet_header": "aGVhZGVy", "secret": "c2VjcmV0"},
+    )
+    assert response.status == 403, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_operator_backup_unauthorized_reads_registry(aiohttp_client, mocker):
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    fake_vm_pool = mocker.AsyncMock(executions={})
+
+    mocker.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value="0xstranger",
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.is_sender_authorized",
+        return_value=False,
+    )
+    app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    client: TestClient = await aiohttp_client(app)
+    response = await client.post(f"/control/machine/{vm_hash}/backup")
+    assert response.status == 403, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_operator_restore_unauthorized_reads_registry(aiohttp_client, mocker):
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    fake_vm_pool = mocker.AsyncMock(executions={})
+
+    mocker.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value="0xstranger",
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.is_sender_authorized",
+        return_value=False,
+    )
+    app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    client: TestClient = await aiohttp_client(app)
+    # operate_restore acquires the per-VM backup lock then delegates to _do_restore,
+    # whose first act (after migration) is the registry-auth check — before any body
+    # parsing — so an empty JSON body is fine for the 403 path.
+    response = await client.post(
+        f"/control/machine/{vm_hash}/restore",
+        json={},
+    )
+    assert response.status == 403, await response.text()
+```
+
+- [ ] **Step 5: Run, verify the four new tests fail**
+
+Run:
+```bash
+PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -m pytest tests/supervisor/views/test_operator.py -k "measurement_unauthorized or inject_secret_unauthorized or backup_unauthorized or restore_unauthorized" -v
+```
+Expected: FAIL — current code returns 404 (empty pool) where the tests expect 403.
+
+### 3c — Apply the migration to the five endpoints
+
+- [ ] **Step 6: Migrate `operate_confidential_initialize`**
+
+Replace:
+```python
+        pool: VmPool = request.app["vm_pool"]
+        logger.debug(f"Iterating through running executions... {pool.executions}")
+        execution = get_execution_or_404(vm_hash, pool=pool)
+
+        if not await is_sender_authorized(authenticated_sender, execution.message):
+            return web.Response(status=403, body="Unauthorized sender")
+```
+with:
+```python
+        pool: VmPool = request.app["vm_pool"]
+        record = get_agent_record_or_404(request, vm_hash)
+        if not await is_sender_authorized(authenticated_sender, record.message):
+            return web.Response(status=403, body="Unauthorized sender")
+
+        logger.debug(f"Iterating through running executions... {pool.executions}")
+        execution = get_execution_or_404(vm_hash, pool=pool)
+```
+
+- [ ] **Step 7: Migrate `operate_confidential_measurement`**
+
+Replace:
+```python
+        pool: VmPool = request.app["vm_pool"]
+        execution = get_execution_or_404(vm_hash, pool=pool)
+
+        if not await is_sender_authorized(authenticated_sender, execution.message):
+            return web.Response(status=403, body="Unauthorized sender")
+```
+with:
+```python
+        pool: VmPool = request.app["vm_pool"]
+        record = get_agent_record_or_404(request, vm_hash)
+        if not await is_sender_authorized(authenticated_sender, record.message):
+            return web.Response(status=403, body="Unauthorized sender")
+
+        execution = get_execution_or_404(vm_hash, pool=pool)
+```
+
+- [ ] **Step 8: Migrate `operate_confidential_inject_secret`**
+
+Replace:
+```python
+        pool: VmPool = request.app["vm_pool"]
+        execution = get_execution_or_404(vm_hash, pool=pool)
+        if not await is_sender_authorized(authenticated_sender, execution.message):
+            return web.Response(status=403, body="Unauthorized sender")
+```
+with:
+```python
+        pool: VmPool = request.app["vm_pool"]
+        record = get_agent_record_or_404(request, vm_hash)
+        if not await is_sender_authorized(authenticated_sender, record.message):
+            return web.Response(status=403, body="Unauthorized sender")
+
+        execution = get_execution_or_404(vm_hash, pool=pool)
+```
+
+- [ ] **Step 9: Migrate `operate_backup`**
+
+Replace:
+```python
+            pool: VmPool = request.app["vm_pool"]
+            execution = get_execution_or_404(vm_hash, pool=pool)
+
+            if not await is_sender_authorized(authenticated_sender, execution.message):
+                return web.Response(status=403, body="Unauthorized sender")
+```
+with:
+```python
+            pool: VmPool = request.app["vm_pool"]
+            record = get_agent_record_or_404(request, vm_hash)
+            if not await is_sender_authorized(authenticated_sender, record.message):
+                return web.Response(status=403, body="Unauthorized sender")
+
+            execution = get_execution_or_404(vm_hash, pool=pool)
+```
+
+- [ ] **Step 10: Migrate `_do_restore` (auth read + two rootfs reads)**
+
+Replace:
+```python
+            pool: VmPool = request.app["vm_pool"]
+            execution = get_execution_or_404(vm_hash, pool=pool)
+
+            if not await is_sender_authorized(authenticated_sender, execution.message):
+                return web.Response(status=403, body="Unauthorized sender")
+```
+with:
+```python
+            pool: VmPool = request.app["vm_pool"]
+            record = get_agent_record_or_404(request, vm_hash)
+            if not await is_sender_authorized(authenticated_sender, record.message):
+                return web.Response(status=403, body="Unauthorized sender")
+
+            execution = get_execution_or_404(vm_hash, pool=pool)
+```
+Then replace **both** occurrences of:
+```python
+            max_upload = execution.message.rootfs.size_mib * 1024 * 1024
+```
+and
+```python
+            max_size = execution.message.rootfs.size_mib * 1024 * 1024
+```
+with the registry-sourced reads:
+```python
+            max_upload = record.message.rootfs.size_mib * 1024 * 1024
+```
+and
+```python
+            max_size = record.message.rootfs.size_mib * 1024 * 1024
+```
+
+- [ ] **Step 11: Run the ③ tests, verify green**
+
+Run:
+```bash
+PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -m pytest tests/supervisor/views/test_operator.py -k "confidential or backup or restore" -v
+```
+Expected: the four new 403 tests PASS; the four confidential-init tests still PASS.
+
+- [ ] **Step 12: Style + commit**
+
+```bash
+uvx ruff@0.4.6 format --diff src/aleph/vm/orchestrator/views/operator.py tests/supervisor/views/test_operator.py
+uvx isort==5.13.2 --check-only --profile black src/aleph/vm/orchestrator/views/operator.py tests/supervisor/views/test_operator.py
+git add src/aleph/vm/orchestrator/views/operator.py tests/supervisor/views/test_operator.py
+git commit -m "refactor(owner-auth): authorize confidential/backup/restore endpoints from the registry"
+```
+
+---
+
+## Task 4: Lock the invariant and verify the whole file
+
+**Files:**
+- Test: `tests/supervisor/views/test_operator.py`
+
+- [ ] **Step 1: Write the source-scan guard test**
+
+Add to `tests/supervisor/views/test_operator.py`:
+
+```python
+def test_operator_module_does_not_read_execution_message():
+    """Owner-auth and content reads must come from the registry, not the pool execution."""
+    import inspect
+
+    from aleph.vm.orchestrator.views import operator
+
+    source = inspect.getsource(operator)
+    assert "execution.message" not in source, (
+        "operator.py must not read `execution.message`; authorize from the agent "
+        "registry (get_agent_record_or_404 -> record.message) instead."
+    )
+```
+
+- [ ] **Step 2: Run it, verify it passes**
+
+Run:
+```bash
+PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -m pytest tests/supervisor/views/test_operator.py::test_operator_module_does_not_read_execution_message -v
+```
+Expected: PASS (all `execution.message` reads migrated in Tasks 1–3). If it fails, the failure message names the invariant — find the remaining `execution.message` and migrate it per the Task 3 pattern.
+
+- [ ] **Step 3: Run the full operator test file**
+
+Run:
+```bash
+PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -m pytest tests/supervisor/views/test_operator.py -q
+```
+Expected: all pass (no `/var/cache/aleph`-class failures in this file).
+
+- [ ] **Step 4: Baseline check on the broader supervisor suite**
+
+Run:
+```bash
+PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -m pytest tests/supervisor -q 2>&1 | tail -20
+```
+Expected: the failing/error set is the pre-existing environmental baseline (~50 failed + 4 errors on `/var/cache/aleph`, `/var/lib/aleph`, pyroute2) and **no new failures** attributable to this change. If unsure whether a failure is new, diff the failing-test names against `origin/dev` for the same file set.
+
+- [ ] **Step 5: Final style gate + commit**
+
+```bash
+uvx ruff@0.4.6 format --diff src/aleph/vm/orchestrator/views/operator.py tests/supervisor/views/test_operator.py
+uvx isort==5.13.2 --check-only --profile black src/aleph/vm/orchestrator/views/operator.py tests/supervisor/views/test_operator.py
+git add tests/supervisor/views/test_operator.py
+git commit -m "test(owner-auth): guard that operator.py never reads execution.message"
+```
+
+---
+
+## Done criteria
+
+- `execution.message` appears nowhere in `operator.py` (guard test green).
+- `authenticate_websocket_for_vm_or_403` deleted; no import or route broke.
+- Three endpoints (`operate_expire`, `operate_backup_status`, `operate_backup_delete`) are execution-free for auth; five (`operate_confidential_initialize`, `operate_confidential_measurement`, `operate_confidential_inject_secret`, `operate_backup`, `_do_restore`) authorize from the registry before their (retained) execution lookup.
+- `tests/supervisor/views/test_operator.py` passes; broader suite matches the `origin/dev` environmental baseline with no new failures.
+- Style gates clean; no `uv.lock` staged; no `Co-Authored-By` trailer.
+
+## Out of scope (residuals after this PR — design §7)
+
+- `execution.vm` / `execution.is_running` direct hypervisor reads in `operator.py` (Phase-1 Supervisor boundary).
+- `operate_expire`'s broken route (no `{timeout}` segment) — known dead route, auth migrated but routing unchanged.
+- `create_vm_execution` `save()` readback.

--- a/docs/plans/2026-06-09-supervisor-owner-auth-registry-plan.md
+++ b/docs/plans/2026-06-09-supervisor-owner-auth-registry-plan.md
@@ -17,18 +17,29 @@
 ## Environment notes (read before running anything)
 
 - **Every `Bash` command needs `dangerouslyDisableSandbox: true`** (the repo's seccomp profile blocks sandboxed exec with `apply-seccomp ... Permission denied`).
-- **This worktree has no local venv.** Run tests with the sibling worktree's venv:
+- **This worktree has no local venv.** Run tests with the sibling worktree's venv,
+  **and redirect the cache/execution roots to writable tmp dirs** — otherwise
+  `settings.setup()` does `os.makedirs("/var/cache/aleph", ...)` and raises
+  `PermissionError` in this sandbox (the messages are read from a bundled
+  `examples/instance_message_from_aleph.json`, so redirecting the cache is safe):
   ```bash
   cd /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-expiry
-  PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python -m pytest <args>
+  mkdir -p "$TMPDIR/alephcache" "$TMPDIR/alephlib"
+  ALEPH_VM_CACHE_ROOT="$TMPDIR/alephcache" ALEPH_VM_EXECUTION_ROOT="$TMPDIR/alephlib" \
+    PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python \
+    -m pytest <args> -p no:warnings
   ```
+  With these overrides the whole `tests/supervisor/views/test_operator.py` file is
+  green (40 passed, 1 skipped before this work). Use this exact invocation for all
+  test runs below (the bare `PYTHONPATH=src ... pytest` shown in later steps assumes
+  these two env vars are also set).
 - **Style gates (CI):**
   ```bash
   uvx ruff@0.4.6 format --diff src/aleph/vm/orchestrator/views/operator.py tests/supervisor/views/test_operator.py
   uvx isort==5.13.2 --check-only --profile black src/aleph/vm/orchestrator/views/operator.py tests/supervisor/views/test_operator.py
   ```
   `uvx` writes an untracked `uv.lock` — **never `git add` it.**
-- **Pre-existing environmental failures:** the full `tests/supervisor` suite has ~50 failed + 4 errors on `/var/cache/aleph`, `/var/lib/aleph`, and pyroute2 netlink — identical to the `origin/dev` baseline. Judge regressions against that baseline, not against zero. Run the targeted test file `tests/supervisor/views/test_operator.py` (which does not hit those paths) for fast iteration.
+- **Pre-existing environmental failures:** without the `ALEPH_VM_*` overrides above, the full `tests/supervisor` suite has ~50 failed + 4 errors on `/var/cache/aleph`, `/var/lib/aleph`, and pyroute2 netlink — identical to the `origin/dev` baseline. The overrides fix the `/var/cache` and `/var/lib` class for `test_operator.py`; pyroute2/netlink failures elsewhere remain environmental. Iterate on `tests/supervisor/views/test_operator.py` with the overrides for a clean green signal.
 - **No `Co-Authored-By` trailer in commits.**
 
 ## Shared facts (true for every task)

--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -391,13 +391,11 @@ async def operate_expire(request: web.Request, authenticated_sender: str) -> web
         if not 0 < timeout < timedelta(days=10).total_seconds():
             return web.HTTPBadRequest(body="Invalid timeout duration")
 
-        pool: VmPool = request.app["vm_pool"]
-        execution = get_execution_or_404(vm_hash, pool=pool)
-
-        if not await is_sender_authorized(authenticated_sender, execution.message):
+        record = get_agent_record_or_404(request, vm_hash)
+        if not await is_sender_authorized(authenticated_sender, record.message):
             return web.Response(status=403, body="Unauthorized sender")
 
-        logger.info(f"Expiring in {timeout} seconds: {execution.vm_hash}")
+        logger.info(f"Expiring in {timeout} seconds: {vm_hash}")
         expiry: ExpiryManager = request.app["expiry"]
         expiry.schedule(VmId(str(vm_hash)), timeout)
         # Deliberately leave the update watcher armed: the VM keeps running until
@@ -954,10 +952,8 @@ async def operate_backup_status(request: web.Request, authenticated_sender: str)
     vm_hash = get_itemhash_or_400(request.match_info)
 
     with set_vm_for_logging(vm_hash=vm_hash):
-        pool: VmPool = request.app["vm_pool"]
-        execution = get_execution_or_404(vm_hash, pool=pool)
-
-        if not await is_sender_authorized(authenticated_sender, execution.message):
+        record = get_agent_record_or_404(request, vm_hash)
+        if not await is_sender_authorized(authenticated_sender, record.message):
             return web.Response(status=403, body="Unauthorized sender")
 
         vm_hash_str = str(vm_hash)
@@ -1069,10 +1065,8 @@ async def operate_backup_delete(
     backup_id = _validate_backup_id(request.match_info.get("backup_id", ""), vm_hash)
 
     with set_vm_for_logging(vm_hash=vm_hash):
-        pool: VmPool = request.app["vm_pool"]
-        execution = get_execution_or_404(vm_hash, pool=pool)
-
-        if not await is_sender_authorized(authenticated_sender, execution.message):
+        record = get_agent_record_or_404(request, vm_hash)
+        if not await is_sender_authorized(authenticated_sender, record.message):
             return web.Response(status=403, body="Unauthorized sender")
 
         destination_dir = get_backup_directory()

--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -168,7 +168,6 @@ def get_itemhash_or_400(match_info: UrlMappingMatchInfo) -> ItemHash:
 
 def get_execution_or_404(ref: ItemHash, pool: VmPool) -> VmExecution:
     """Return the execution corresponding to the ref or raise an HTTP 404 error."""
-    # TODO: Check if this should be execution.message.address or execution.message.content.address?
     execution = pool.executions.get(ref)
     if execution:
         return execution
@@ -375,37 +374,6 @@ async def operate_logs_json(request: web.Request, authenticated_sender: str) -> 
         await response.write(b"]")
         await response.write_eof()
         return response
-
-
-async def authenticate_websocket_for_vm_or_403(execution: VmExecution, vm_hash: ItemHash, ws: web.WebSocketResponse):
-    """Authenticate a websocket connection.
-
-    Web browsers do not allow setting headers in WebSocket requests, so the authentication
-    relies on the first message sent by the client.
-    """
-    try:
-        first_message = await ws.receive_json()
-    except TypeError as error:
-        logging.exception(error)
-        await ws.send_json({"status": "failed", "reason": str(error)})
-        raise web.HTTPForbidden(body="Invalid auth package")
-    credentials = first_message["auth"]
-
-    try:
-        authenticated_sender = await authenticate_websocket_message(credentials)
-
-        if await is_sender_authorized(authenticated_sender, execution.message):
-            logger.debug(f"Accepted request to access logs by {authenticated_sender} on {vm_hash}")
-            return True
-    except Exception as error:
-        # Error occurred (invalid auth packet or other
-        await ws.send_json({"status": "failed", "reason": str(error)})
-        raise web.HTTPForbidden(body="Unauthorized sender")
-
-    # Auth was valid but not the correct user
-    logger.debug(f"Denied request to access logs by {authenticated_sender} on {vm_hash}")
-    await ws.send_json({"status": "failed", "reason": "unauthorized sender"})
-    raise web.HTTPForbidden(body="Unauthorized sender")
 
 
 @cors_allow_all

--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -411,11 +411,12 @@ async def operate_confidential_initialize(request: web.Request, authenticated_se
     vm_hash = get_itemhash_or_400(request.match_info)
     with set_vm_for_logging(vm_hash=vm_hash):
         pool: VmPool = request.app["vm_pool"]
+        record = get_agent_record_or_404(request, vm_hash)
+        if not await is_sender_authorized(authenticated_sender, record.message):
+            return web.Response(status=403, body="Unauthorized sender")
+
         logger.debug(f"Iterating through running executions... {pool.executions}")
         execution = get_execution_or_404(vm_hash, pool=pool)
-
-        if not await is_sender_authorized(authenticated_sender, execution.message):
-            return web.Response(status=403, body="Unauthorized sender")
 
         if execution.is_running:
             return web.json_response(
@@ -528,10 +529,11 @@ async def operate_confidential_measurement(request: web.Request, authenticated_s
     vm_hash = get_itemhash_or_400(request.match_info)
     with set_vm_for_logging(vm_hash=vm_hash):
         pool: VmPool = request.app["vm_pool"]
-        execution = get_execution_or_404(vm_hash, pool=pool)
-
-        if not await is_sender_authorized(authenticated_sender, execution.message):
+        record = get_agent_record_or_404(request, vm_hash)
+        if not await is_sender_authorized(authenticated_sender, record.message):
             return web.Response(status=403, body="Unauthorized sender")
+
+        execution = get_execution_or_404(vm_hash, pool=pool)
 
         if not execution.is_running:
             raise web.HTTPForbidden(body="Operation not running")
@@ -573,9 +575,11 @@ async def operate_confidential_inject_secret(request: web.Request, authenticated
     vm_hash = get_itemhash_or_400(request.match_info)
     with set_vm_for_logging(vm_hash=vm_hash):
         pool: VmPool = request.app["vm_pool"]
-        execution = get_execution_or_404(vm_hash, pool=pool)
-        if not await is_sender_authorized(authenticated_sender, execution.message):
+        record = get_agent_record_or_404(request, vm_hash)
+        if not await is_sender_authorized(authenticated_sender, record.message):
             return web.Response(status=403, body="Unauthorized sender")
+
+        execution = get_execution_or_404(vm_hash, pool=pool)
 
         # if not execution.is_running:
         #     raise web.HTTPForbidden(body="Operation not running")
@@ -839,10 +843,11 @@ async def operate_backup(request: web.Request, authenticated_sender: str) -> web
     with set_vm_for_logging(vm_hash=vm_hash):
         try:
             pool: VmPool = request.app["vm_pool"]
-            execution = get_execution_or_404(vm_hash, pool=pool)
-
-            if not await is_sender_authorized(authenticated_sender, execution.message):
+            record = get_agent_record_or_404(request, vm_hash)
+            if not await is_sender_authorized(authenticated_sender, record.message):
                 return web.Response(status=403, body="Unauthorized sender")
+
+            execution = get_execution_or_404(vm_hash, pool=pool)
 
             if not execution.is_running:
                 return web.HTTPBadRequest(body="VM must be running to create backup")
@@ -1176,10 +1181,11 @@ async def _do_restore(
     with set_vm_for_logging(vm_hash=vm_hash):
         try:
             pool: VmPool = request.app["vm_pool"]
-            execution = get_execution_or_404(vm_hash, pool=pool)
-
-            if not await is_sender_authorized(authenticated_sender, execution.message):
+            record = get_agent_record_or_404(request, vm_hash)
+            if not await is_sender_authorized(authenticated_sender, record.message):
                 return web.Response(status=403, body="Unauthorized sender")
+
+            execution = get_execution_or_404(vm_hash, pool=pool)
 
             if not isinstance(execution.vm, AlephQemuInstance | AlephQemuConfidentialInstance):
                 return web.HTTPBadRequest(body="Restore only supported for QEMU VMs")
@@ -1190,7 +1196,7 @@ async def _do_restore(
             current_rootfs = Path(execution.vm.resources.rootfs_path)
             backup_dir = get_backup_directory()
 
-            max_upload = execution.message.rootfs.size_mib * 1024 * 1024
+            max_upload = record.message.rootfs.size_mib * 1024 * 1024
             if request.content_length and request.content_length > max_upload:
                 return web.HTTPRequestEntityTooLarge(
                     max_size=max_upload,
@@ -1220,7 +1226,7 @@ async def _do_restore(
                     body="Uploaded file is not a valid QCOW2 disk image",
                 )
 
-            max_size = execution.message.rootfs.size_mib * 1024 * 1024
+            max_size = record.message.rootfs.size_mib * 1024 * 1024
             if new_size > max_size:
                 return web.HTTPBadRequest(
                     body=f"New rootfs virtual size ({new_size} bytes) exceeds "

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -1129,12 +1129,14 @@ async def test_restore_rejects_invalid_image_format(mocker, tmp_path):
     vm_hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
 
     execution = mocker.Mock()
-    execution.message.rootfs.size_mib = 1000
     execution.is_running = False
     execution.vm = mocker.Mock()
     # Make the AlephQemuInstance isinstance check pass.
     execution.vm.__class__ = AlephQemuInstance
     execution.vm.resources.rootfs_path = str(tmp_path / "rootfs.qcow2")
+
+    record = mocker.Mock()
+    record.message.rootfs.size_mib = 1000
 
     mocker.patch.object(operator, "get_execution_or_404", return_value=execution)
     mocker.patch.object(operator, "is_sender_authorized", new=mocker.AsyncMock(return_value=True))
@@ -1152,7 +1154,10 @@ async def test_restore_rejects_invalid_image_format(mocker, tmp_path):
     )
 
     request = mocker.Mock()
-    request.app = {"vm_pool": mocker.Mock()}
+    request.app = {
+        "vm_pool": mocker.Mock(),
+        "vm_registry": mocker.Mock(get=mocker.Mock(return_value=record)),
+    }
     request.content_length = None
     request.content_type = "multipart/form-data"
 

--- a/tests/supervisor/views/test_operator.py
+++ b/tests/supervisor/views/test_operator.py
@@ -2037,3 +2037,16 @@ async def test_operator_restore_unauthorized_reads_registry(aiohttp_client, mock
         json={},
     )
     assert response.status == 403, await response.text()
+
+
+def test_operator_module_does_not_read_execution_message():
+    """Owner-auth and content reads must come from the registry, not the pool execution."""
+    import inspect
+
+    from aleph.vm.orchestrator.views import operator
+
+    source = inspect.getsource(operator)
+    assert "execution.message" not in source, (
+        "operator.py must not read `execution.message`; authorize from the agent "
+        "registry (get_agent_record_or_404 -> record.message) instead."
+    )

--- a/tests/supervisor/views/test_operator.py
+++ b/tests/supervisor/views/test_operator.py
@@ -83,22 +83,18 @@ def _clear_caches():
 
 @pytest.mark.asyncio
 async def test_operator_confidential_initialize_not_authorized(aiohttp_client):
-    """Test that the confidential initialize endpoint rejects if the sender is not the good one. Auth needed"""
-
+    """Rejects when the sender is not authorized; auth message comes from the registry."""
     settings.ENABLE_QEMU_SUPPORT = True
     settings.ENABLE_CONFIDENTIAL_COMPUTING = True
     settings.setup()
 
-    class FakeExecution:
-        message = None
-        is_running: bool = True
-        is_confidential: bool = False
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
 
     class FakeVmPool:
-        executions: dict[ItemHash, FakeExecution] = {}
-
-        def __init__(self):
-            self.executions[settings.FAKE_INSTANCE_ID] = FakeExecution()
+        # The 403 is returned at the registry-auth check, before the pool is read,
+        # so an empty pool is sufficient.
+        executions: dict = {}
 
     with mock.patch(
         "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
@@ -109,6 +105,12 @@ async def test_operator_confidential_initialize_not_authorized(aiohttp_client):
             return_value=False,
         ) as is_sender_authorized_mock:
             app = setup_webapp(pool=FakeVmPool())
+            app["vm_registry"].record(
+                vm_hash,
+                message=instance_message.content,
+                original=instance_message.content,
+                persistent=True,
+            )
             client = await aiohttp_client(app)
             response = await client.post(
                 f"/control/machine/{settings.FAKE_INSTANCE_ID}/confidential/initialize",
@@ -146,6 +148,12 @@ async def test_operator_confidential_initialize_already_running(aiohttp_client, 
         return_value=instance_message.sender,
     )
     app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
     client: TestClient = await aiohttp_client(app)
     response = await client.post(
         f"/control/machine/{vm_hash}/confidential/initialize",
@@ -222,6 +230,12 @@ async def test_operator_confidential_initialize_not_confidential(aiohttp_client,
         return_value=instance_message.sender,
     )
     app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
     client: TestClient = await aiohttp_client(app)
     response = await client.post(
         f"/control/machine/{vm_hash}/confidential/initialize",
@@ -272,6 +286,12 @@ async def test_operator_confidential_initialize(aiohttp_client, mocker):
             return_value=instance_message.sender,
         ):
             app = setup_webapp(pool=FakeVmPool())
+            app["vm_registry"].record(
+                vm_hash,
+                message=instance_message.content,
+                original=instance_message.content,
+                persistent=True,
+            )
             client = await aiohttp_client(app)
             response = await client.post(
                 f"/control/machine/{vm_hash}/confidential/initialize",
@@ -1888,3 +1908,132 @@ def test_dead_websocket_auth_helper_is_removed():
     from aleph.vm.orchestrator.views import operator
 
     assert not hasattr(operator, "authenticate_websocket_for_vm_or_403")
+
+
+@pytest.mark.asyncio
+async def test_operator_confidential_measurement_unauthorized_reads_registry(aiohttp_client, mocker):
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.ENABLE_CONFIDENTIAL_COMPUTING = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    fake_vm_pool = mocker.AsyncMock(executions={})
+
+    mocker.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value="0xstranger",
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.is_sender_authorized",
+        return_value=False,
+    )
+    app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    client: TestClient = await aiohttp_client(app)
+    response = await client.get(f"/control/machine/{vm_hash}/confidential/measurement")
+    assert response.status == 403, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_operator_confidential_inject_secret_unauthorized_reads_registry(aiohttp_client, mocker):
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.ENABLE_CONFIDENTIAL_COMPUTING = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    fake_vm_pool = mocker.AsyncMock(executions={})
+
+    mocker.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value="0xstranger",
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.is_sender_authorized",
+        return_value=False,
+    )
+    app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    client: TestClient = await aiohttp_client(app)
+    # InjectSecretParams (packet_header, secret) is validated before auth, so the
+    # body must be schema-valid for the request to reach the registry-auth check.
+    response = await client.post(
+        f"/control/machine/{vm_hash}/confidential/inject_secret",
+        json={"packet_header": "aGVhZGVy", "secret": "c2VjcmV0"},
+    )
+    assert response.status == 403, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_operator_backup_unauthorized_reads_registry(aiohttp_client, mocker):
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    fake_vm_pool = mocker.AsyncMock(executions={})
+
+    mocker.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value="0xstranger",
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.is_sender_authorized",
+        return_value=False,
+    )
+    app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    client: TestClient = await aiohttp_client(app)
+    response = await client.post(f"/control/machine/{vm_hash}/backup")
+    assert response.status == 403, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_operator_restore_unauthorized_reads_registry(aiohttp_client, mocker):
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    fake_vm_pool = mocker.AsyncMock(executions={})
+
+    mocker.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value="0xstranger",
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.is_sender_authorized",
+        return_value=False,
+    )
+    app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    client: TestClient = await aiohttp_client(app)
+    # operate_restore acquires the per-VM backup lock then delegates to _do_restore,
+    # whose first act (after migration) is the registry-auth check — before any body
+    # parsing — so an empty JSON body is fine for the 403 path.
+    response = await client.post(
+        f"/control/machine/{vm_hash}/restore",
+        json={},
+    )
+    assert response.status == 403, await response.text()

--- a/tests/supervisor/views/test_operator.py
+++ b/tests/supervisor/views/test_operator.py
@@ -1814,3 +1814,10 @@ async def test_operate_update_skips_reconcile_when_not_running(aiohttp_client, m
     data = await response.json()
     assert data["msg"] == "VM not starting yet"
     reconcile_mock.assert_not_awaited()
+
+
+def test_dead_websocket_auth_helper_is_removed():
+    """authenticate_websocket_for_vm_or_403 had no callers; it must be gone."""
+    from aleph.vm.orchestrator.views import operator
+
+    assert not hasattr(operator, "authenticate_websocket_for_vm_or_403")

--- a/tests/supervisor/views/test_operator.py
+++ b/tests/supervisor/views/test_operator.py
@@ -160,45 +160,6 @@ async def test_operator_confidential_initialize_already_running(aiohttp_client, 
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip()
-async def test_operator_expire(aiohttp_client, mocker):
-    """Test that the expires endpoint work. SPOILER it doesn't"""
-
-    settings.ENABLE_QEMU_SUPPORT = True
-    settings.ENABLE_CONFIDENTIAL_COMPUTING = True
-    settings.setup()
-
-    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
-    instance_message = await get_message(ref=vm_hash)
-
-    fake_vm_pool = mocker.Mock(
-        executions={
-            vm_hash: mocker.Mock(
-                vm_hash=vm_hash,
-                message=instance_message.content,
-                is_confidential=False,
-                is_running=False,
-            ),
-        },
-    )
-
-    # Disable auth
-    mocker.patch(
-        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
-        return_value=instance_message.sender,
-    )
-    app = setup_webapp(pool=fake_vm_pool)
-    client: TestClient = await aiohttp_client(app)
-    response = await client.post(
-        f"/control/machine/{vm_hash}/expire",
-        data={"timeout": 1},
-        # json={"timeout": 1},
-    )
-    assert response.status == 200, await response.text()
-    assert fake_vm_pool["executions"][vm_hash].expire.call_count == 1
-
-
-@pytest.mark.asyncio
 async def test_operator_stop(aiohttp_client, mocker):
     """Test that the stop endpoint drives the supervisor, not the pool directly."""
 
@@ -799,6 +760,112 @@ async def test_operator_erase_with_delegation(aiohttp_client, mocker):
     fake_sup.delete_vm.assert_awaited_once_with(VmId(str(vm_hash)), wipe=True)
     # registry record must be forgotten after erase
     assert app["vm_registry"].get(vm_hash) is None
+
+
+@pytest.mark.asyncio
+async def test_operator_backup_status_authorized_reads_registry(aiohttp_client, mocker, tmp_path):
+    """Authorized backup-status reaches the backup logic with an empty pool."""
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    fake_vm_pool = mocker.AsyncMock(executions={})
+
+    mocker.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value=instance_message.sender,
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.is_sender_authorized",
+        return_value=True,
+    )
+    # get_backup_directory() mkdirs under settings.EXECUTION_ROOT; patch the
+    # operator-local name to a tmp dir.
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.get_backup_directory",
+        return_value=tmp_path,
+    )
+    app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    client: TestClient = await aiohttp_client(app)
+    response = await client.get(f"/control/machine/{vm_hash}/backup")
+    # Past auth: no backup exists, so the backup logic returns its own 404.
+    body = await response.text()
+    assert response.status == 404, body
+    assert "No backup found" in body
+
+
+@pytest.mark.asyncio
+async def test_operator_backup_status_unauthorized_reads_registry(aiohttp_client, mocker):
+    """Backup-status authorizes against the registry, not the pool."""
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    fake_vm_pool = mocker.AsyncMock(executions={})
+
+    mocker.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value="0xstranger",
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.is_sender_authorized",
+        return_value=False,
+    )
+    app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    client: TestClient = await aiohttp_client(app)
+    response = await client.get(f"/control/machine/{vm_hash}/backup")
+    assert response.status == 403, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_operator_backup_delete_authorized_reads_registry(aiohttp_client, mocker, tmp_path):
+    """Authorized backup-delete reaches the delete logic with an empty pool."""
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    fake_vm_pool = mocker.AsyncMock(executions={})
+
+    mocker.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value=instance_message.sender,
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.is_sender_authorized",
+        return_value=True,
+    )
+    mocker.patch(
+        "aleph.vm.orchestrator.views.operator.get_backup_directory",
+        return_value=tmp_path,
+    )
+    app = setup_webapp(pool=fake_vm_pool)
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    client: TestClient = await aiohttp_client(app)
+    response = await client.delete(f"/control/machine/{vm_hash}/backup/{vm_hash}aa")
+    # Past auth: no such backup file, so the delete logic returns its own 404.
+    body = await response.text()
+    assert response.status == 404, body
+    assert "not found" in body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Third of the Phase-0 residual cleanups in the message-free supervisor series (after #969 expiry, #970 update-watching). Moves **operator owner-authorization** off the hypervisor pool object and onto the agent registry, so `execution.message` is read **nowhere** in `orchestrator/views/operator.py`.

Design: `docs/plans/2026-06-09-supervisor-owner-auth-registry-design.md`
Plan: `docs/plans/2026-06-09-supervisor-owner-auth-registry-plan.md`

## Why

Owner-auth is agent policy: a request is authorized iff the authenticated sender is the message owner or a delegate. The message it checks is the agent's own — so it should come from the agent registry (`get_agent_record_or_404(request, vm_hash).message`), not from a reach through `pool.executions` into the hypervisor object's `spec.message`. `operate_stop`/`operate_reboot`/`operate_erase` already did this; this PR finishes the migration for the remaining endpoints.

## What

Nine `execution.message` sites in `operator.py`, migrated in three shapes:

- **Delete (dead code):** `authenticate_websocket_for_vm_or_403` — zero callers repo-wide (YAGNI). Plus a stale `# TODO ... execution.message.address` comment.
- **Become execution-free** (used the execution *only* for auth): `operate_expire`, `operate_backup_status`, `operate_backup_delete` — authorize from the registry, drop the pool lookup entirely.
- **Auth-only swap** (genuinely need `execution.vm` for the hypervisor op): `operate_confidential_initialize`, `operate_confidential_measurement`, `operate_confidential_inject_secret`, `operate_backup`, `_do_restore` — keep the `get_execution_or_404` lookup, but read the auth message from the registry *before* it (incl. `_do_restore`'s two `execution.message.rootfs.size_mib` content reads → `record.message.rootfs.size_mib`).

A source-scan guard test (`test_operator_module_does_not_read_execution_message`) locks the invariant.

## Behavior parity

Authorized callers: unchanged (auth passes, the retained execution lookup still 404s a non-running VM exactly as before).

One deliberate change for **unauthorized** callers: auth now runs before the running-VM lookup, so an unauthorized request against a *known-but-stopped* VM returns **403** instead of **404**. This matches the already-migrated `operate_stop`/reboot/erase and is arguably more correct (authorization precedes VM-state disclosure). The unknown-VM path still 404s (registry miss).

## Regression caught in review

`tests/supervisor/test_views.py::test_restore_rejects_invalid_image_format` calls `_do_restore` **directly** with a hand-built `request.app` that had no `vm_registry`, so the migration broke it (`KeyError: 'vm_registry'`). Fixed by wiring a `vm_registry` mock into that test (separate commit). A tree-wide sweep confirmed it was the only direct-caller test affected; every other test routes through `setup_webapp`, which provides the registry.

## Residuals (explicitly out of scope, design §7)

- `execution.vm` / `execution.is_running` direct hypervisor reads in operator.py — Phase-1 Supervisor-boundary work, not message-coupling.
- The `create_vm_execution` `save()` readback — still deferred.
- `operate_expire`'s broken route (no `{timeout}` segment → always 400) — pre-existing dead route; its auth read was migrated but the routing bug is left as-is.

## Tests

Per migrated endpoint: unauthorized → 403, authorized → past-auth, registry-miss → 404, all sourced from a seeded `app["vm_registry"]` with an empty pool (so pre-migration code 404s — the red→green signal). Plus the four existing `confidential_initialize` tests reseeded onto the registry, the source-scan guard, and the dead-function guard. `tests/supervisor/views/test_operator.py` + `tests/supervisor/test_views.py` are green (79 passed). Remaining `tests/supervisor` failures are the pre-existing environmental set (pyroute2/netlink, Firecracker subprocess, `/var` paths) — identical to the dev baseline.

## Stacking

Stacked on #970 (`od/wire-supervisor-update-watch`). Base this PR on that branch; retarget to `dev` once #970 merges.
