### PR TITLE
Message-free supervisor: agent-owned record persistence; kill the create_vm_execution readback

### DIFF
--- a/docs/plans/2026-06-10-agent-record-persistence-design.md
+++ b/docs/plans/2026-06-10-agent-record-persistence-design.md
@@ -1,0 +1,336 @@
+# Agent-owned record persistence + message reads off the pool
+
+**Status:** design
+**Date:** 2026-06-10
+**Series:** message-free supervisor (Phase-0 residual cleanup, after #969 expiry, #970 update-watching, #971 owner-auth)
+**Stacks on:** `od/wire-supervisor-owner-auth` (#971)
+
+## 1. Goal
+
+Kill the last agent reach-in on the create path — the `create_vm_execution`
+readback (`pool.executions[vm_hash]` → `MessageSpec` attach → `execution.save()`)
+— by making the agent persist its own `ExecutionRecord`, and migrate the
+remaining agent-side readers of `pool.executions[...].message` to the agent
+registry. After this PR, nothing agent-side learns a VM's message by reaching
+through the hypervisor's pool object.
+
+## 2. Background
+
+The message-free-supervisor effort splits the `VmExecution` god-object into an
+agent-side concept (message, owner, billing, expiry, update-watching — backed by
+the `AgentVmRegistry` + agent DB) and a hypervisor-side `Vm` (process,
+networking, status). The supervisor's spec create path is already message-free —
+but `create_vm_execution` immediately undoes it (run.py:249-254):
+
+```python
+execution = pool.executions[vm_hash]                  # reach into the hypervisor's bookkeeping
+execution.spec = MessageSpec(message=content, ...)    # glue the message back on
+await execution.save()                                # have IT write the agent's DB record
+```
+
+The comment on the block says TEMPORARY. It exists for two reasons:
+
+1. **Persistence.** `VmExecution.save()` no-ops unless the spec is a
+   `MessageSpec` (models.py:821-825). The attach exists so `save()` writes the
+   message into the agent DB — which `rehydrate_registry` and past-logs
+   owner-auth read back after an agent restart. Delete `save()` with no
+   replacement and the agent forgets spec-created VMs on every reboot.
+2. **In-memory readers.** A few agent-side code paths still learn the message by
+   reading it off pool executions; the attach is what makes that work for
+   spec-created VMs during their first lifetime. (It does NOT survive a restart:
+   restored executions are spec-built with no message — these readers already
+   silently skip them today.)
+
+### The scheduler context (decision 2026-06-10)
+
+The new scheduler provides allocations for PAYG too; the
+`/control/allocations/notify` flow is legacy and will be deprecated. Payment
+enforcement is the scheduler's prerogative — agent-side payment checking is on
+the deprecation path. Consequences for this design:
+
+- `update_allocations`' reap protection is the allocation set itself; its
+  payment-tier guards are transition-window defense, not the primary mechanism.
+- `check_payment`'s logic is NOT extended or redesigned here. This PR only moves
+  **where its data comes from** (registry instead of pool-message), because the
+  transition window is long enough that the checks still matter — including for
+  restored VMs, which currently escape them entirely.
+
+## 3. Scope
+
+### In scope
+
+1. **`persist_record` (vm_registry.py)** — the write-side sibling of
+   `rehydrate_registry`: the agent writes an `ExecutionRecord` directly from an
+   `AgentVmRecord`.
+2. **`create_vm_execution` (run.py)** — spec path drops the readback / attach /
+   `save()`; calls `persist_record`; returns `None`.
+3. **Payment grouping moves to the agent** — `pool.get_executions_by_address`
+   is deleted; a registry-sourced `_group_executions_by_payment(pool, registry,
+   payment_type)` in tasks.py replaces it at `check_payment`'s three call sites.
+4. **`update_allocations` payment guards read the registry** —
+   `AgentVmRecord` gains `uses_payment_stream` / `uses_payment_credit`; the
+   now-dead `VmExecution.uses_payment_stream` / `uses_payment_credit` properties
+   are deleted (no other readers).
+5. **`_handle_domains_aggregate` reads the registry** for the owner-address
+   check.
+
+### Out of scope (explicit residuals, unchanged)
+
+- **Agent-side payment enforcement itself** — `check_payment`'s balance / credit
+  / stream logic and the terminal-status stop loop (liveness, not payment) are
+  untouched; the whole apparatus deprecates with the legacy notify flow.
+- **Structural `pool.executions` iteration** — grouping and the terminal-status
+  loop still iterate pool executions for liveness/structure (`is_running`,
+  `is_confidential`, `times`). Replacing that with supervisor list views is
+  Phase-1.
+- **`update_allocations`' other guards** (`gpus`, `is_confidential`,
+  `is_instance`) — structural, spec-safe (they branch on `CreateVmSpec`).
+- **The `about_executions` debug endpoint** (raw pool dump residual).
+- **`operate_expire`'s dead route, `execution.vm` reads in operator.py** —
+  carried residuals from earlier PRs.
+
+## 4. Components
+
+### 4.1 `persist_record` (`src/aleph/vm/orchestrator/vm_registry.py`)
+
+```python
+async def persist_record(vm_hash: ItemHash, record: AgentVmRecord) -> None:
+    """Persist the agent's knowledge of a VM to the agent DB.
+
+    Write-side sibling of rehydrate_registry: what this writes is exactly what
+    rehydrate_registry needs to rebuild the registry after a restart (message,
+    original, persistent), carried on the existing ExecutionRecord table.
+    """
+    now = datetime.now(tz=timezone.utc)
+    resources = record.message.resources
+    db_record = ExecutionRecord(
+        uuid=str(uuid4()),
+        vm_hash=str(vm_hash),
+        vm_id=None,            # numeric hypervisor id; unknown agent-side (debug-only column)
+        time_defined=now,
+        time_prepared=now,
+        time_started=now,
+        time_stopping=None,
+        cpu_time_user=None,
+        cpu_time_system=None,
+        io_read_count=None,
+        io_write_count=None,
+        io_read_bytes=None,
+        io_write_bytes=None,
+        vcpus=resources.vcpus,
+        memory=resources.memory,
+        message=record.message.model_dump_json(),
+        original_message=record.original.model_dump_json(),
+        persistent=record.persistent,
+        gpus=json.dumps([]),   # spec path excludes GPUs (_is_spec_eligible)
+        mapped_ports=None,     # the PortMapping table is the authority
+    )
+    await save_record(db_record)
+```
+
+**Field deltas vs. the readback-save** (all consumed only by the
+`about/execution/records` debug endpoint; `rehydrate_registry` and the
+past-logs owner-auth fallback read only `message` / `original_message` /
+`persistent` / `vm_hash`):
+
+| column | readback-save wrote | persist_record writes |
+|---|---|---|
+| `vm_id` | numeric hypervisor id | `None` |
+| `time_*` | execution lifecycle stamps | agent-stamped now |
+| `mapped_ports` | `execution.mapped_ports` | `None` (PortMapping table is the authority) |
+| `vcpus` / `memory` | `vm.hardware_resources` | `message.resources` (the same values the spec was built from) |
+
+A new record (fresh uuid) per create matches today's behavior; rehydration is
+newest-first and keeps the latest record per vm_hash.
+
+### 4.2 `AgentVmRecord` payment helpers (`vm_registry.py`)
+
+```python
+@property
+def uses_payment_stream(self) -> bool:
+    return bool(self.message.payment and self.message.payment.is_stream)
+
+@property
+def uses_payment_credit(self) -> bool:
+    return bool(self.message.payment and self.message.payment.is_credit)
+```
+
+Mirrors of the `VmExecution` properties (models.py:404-412), which are deleted —
+`update_allocations` was their only reader.
+
+### 4.3 `create_vm_execution` (`src/aleph/vm/orchestrator/run.py`)
+
+Spec path tail becomes:
+
+```python
+        record = registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
+        try:
+            await _wait_until_running(supervisor, info.vm_id)
+            ...
+        except Exception:
+            ...
+            raise
+        # Agent persists its own knowledge; the hypervisor object is not touched.
+        await persist_record(vm_hash, record)
+        return None
+```
+
+- Return type: `-> VmExecution | None` (also on
+  `create_vm_execution_or_raise_http_error`). Verified callers: the three
+  operator endpoints and `start_persistent_vm` discard the return;
+  `run_code_on_request` / `run_code_on_event` use it but are program paths —
+  `_is_spec_eligible` requires `InstanceContent`, so they can never receive
+  `None` from the spec path *by construction*. Each gets an explicit guard
+  anyway (clear 400 instead of a deep crash if an instance hash is ever
+  submitted to the program path):
+
+  ```python
+  if execution is None:
+      msg = f"VM {vm_hash} is an instance, not a program"
+      raise HTTPBadRequest(reason=msg)
+  ```
+
+- The `MessageSpec` import in run.py goes if unused after this.
+- Consequence, stated deliberately: spec-created executions now **never** carry
+  a `MessageSpec` — `execution.message` is `None` for them in all code paths,
+  first lifetime included. Future code reaching for `pool.executions[...].message`
+  fails visibly in development rather than working-until-reboot.
+
+### 4.4 Payment grouping (`tasks.py`): `_group_executions_by_payment`
+
+`pool.get_executions_by_address` (pool.py:897-922) is **deleted** — payment
+grouping is agent policy and does not belong on the pool. Replacement, private
+to tasks.py next to its only consumer `check_payment`:
+
+```python
+def _group_executions_by_payment(
+    pool: VmPool, registry: AgentVmRegistry, payment_type: PaymentType
+) -> dict[str, dict[Chain, list[VmExecution]]]:
+    """Group running executions by sender address and chain for one payment type.
+
+    The message (payment tier, owner address) comes from the agent registry;
+    the execution supplies only structural facts. Replaces the pool method that
+    read the message off the hypervisor object — and thereby skipped spec-built
+    and restart-restored VMs entirely.
+    """
+    executions_by_address: dict[str, dict[Chain, list[VmExecution]]] = {}
+    for vm_hash, execution in pool.executions.items():
+        record = registry.get(vm_hash)
+        if record is None:
+            # The agent has no message for this VM (e.g. the diagnostic fake
+            # never enters the registry); payment grouping cannot apply.
+            continue
+        if execution.vm_hash in (settings.CHECK_FASTAPI_VM_ID, settings.LEGACY_CHECK_FASTAPI_VM_ID):
+            continue  # diagnostic VM
+        if not execution.is_running:
+            continue
+        payment = record.message.payment if record.message.payment else Payment(chain=Chain.ETH, type=PaymentType.hold)
+        if payment.type == payment_type:
+            executions_by_address.setdefault(record.message.address, {}).setdefault(payment.chain, []).append(execution)
+    return executions_by_address
+```
+
+`check_payment`'s three call sites
+(`pool.get_executions_by_address(payment_type=...)`, tasks.py:354/381/404)
+become `_group_executions_by_payment(pool, registry, ...)`; the registry is
+already a `check_payment` parameter. Everything downstream is untouched — the
+returned executions are only read structurally (`is_confidential`, `vm_hash`,
+`times.started_at`; the `compute_required_*` helpers read `vm_hash`), all
+spec-safe.
+
+**Behavior change (intended):** spec-built and restart-restored VMs were
+silently excluded from all payment checks (the old method skipped
+`message is None`); with the registry as source (rehydrated from the agent DB)
+they are now covered. The diagnostic fake VM stays excluded (never recorded in
+the registry, plus the explicit hash check).
+
+### 4.5 `update_allocations` guards (`views/__init__.py`)
+
+In the persistent-execution stop loop (views/__init__.py:582-601), the two
+`execution.uses_payment_*` reads become registry-record reads. Concretely:
+
+```python
+for execution in list(pool.get_persistent_executions()):
+    record = registry.get(execution.vm_hash)
+    if (
+        execution.vm_hash not in allocations
+        and execution.is_running
+        and not (record and record.uses_payment_stream)
+        and not (record and record.uses_payment_credit)
+        and not execution.gpus
+        and not execution.is_confidential
+    ):
+        ...
+```
+
+(`registry` is already in scope in `update_allocations`.) A VM without a
+registry record behaves
+as today's message-less execution (`False` / hold-tier). With the registry
+rehydrated across restarts, a restored PAYG VM under the legacy notify flow is
+no longer reapable as "unallocated hold-tier" — the transition-window hole this
+migration closes.
+
+### 4.6 `_handle_domains_aggregate` (`tasks.py`)
+
+Gains a `registry` parameter (in scope at the call site, tasks.py:192):
+
+```python
+has_local_instance = any(
+    execution.is_instance
+    and execution.vm
+    and (record := registry.get(execution.vm_hash)) is not None
+    and record.message.address == address
+    for execution in pool.executions.values()
+)
+```
+
+Spec-built and restored instances now trigger HAProxy domain-mapping refreshes;
+previously they were silently skipped (message-less).
+
+### 4.7 `VmExecution` removals (`src/aleph/vm/models.py`)
+
+Delete `uses_payment_stream` and `uses_payment_credit` (only reader was
+`update_allocations`; verify tests). `VmExecution.save()` and the `message` /
+`original` properties stay — the legacy (non-spec) create path still uses them.
+
+## 5. Behavior parity / changes
+
+| Surface | Before | After |
+|---|---|---|
+| Agent restart memory | spec VMs persisted via readback-save | persisted via `persist_record` (same rehydration inputs) |
+| Record debug fields | numeric `vm_id`, lifecycle times, mapped_ports | `None` / agent-stamped (debug endpoint only) |
+| Payment checks, spec VM first lifetime | covered (via attach) | covered (via registry) |
+| Payment checks, restored VMs | **silently escaped** | covered (registry rehydrates) |
+| `update_allocations`, restored PAYG under legacy flow | reapable as hold-tier | protected (registry tier) |
+| Domains aggregate, spec/restored VMs | silently skipped | covered |
+| `pool.executions[...].message` for spec VMs | non-None in first lifetime | always `None` (fails visibly if newly depended on) |
+| run_code paths given an instance hash | deep failure | explicit 400 |
+
+## 6. Testing
+
+- `persist_record` → `rehydrate_registry` round-trip (message/original/
+  persistent survive; field deltas as specified).
+- Routing test (`test_supervisor_run_routing.py`): spec path returns `None`,
+  never touches `pool.executions`, and a record lands in the DB (existing test
+  asserting the readback updates accordingly).
+- `_group_executions_by_payment`: registry-sourced grouping; a message-less
+  execution WITH a registry record (the restored-VM scenario) is included; one
+  WITHOUT a record is skipped; diagnostic hash excluded; payment default =
+  hold.
+- `update_allocations`: a persistent execution whose registry record is
+  stream-paid is spared even when absent from allocations.
+- Domains aggregate: spec VM + registry record triggers the refresh.
+- Guard: `pool.py` contains no `.message` read (source scan), mirroring the
+  operator.py guard from #971.
+- `VmExecution.uses_payment_*` gone (API test), existing suites green.
+
+## 7. Out-of-scope residuals after this PR
+
+- Deletion of agent-side payment enforcement (with the legacy notify flow /
+  scheduler transition).
+- Structural `pool.executions` iteration in grouping, `check_payment`'s
+  terminal loop, and `update_allocations` → supervisor list views (Phase-1).
+- `execution.vm` hypervisor reads in operator.py (Phase-1 Supervisor API).
+- `about_executions` raw-pool debug endpoint.
+- The `create_vm_execution` legacy (non-spec) path — unchanged until the pool
+  create path itself is supervisor-routed.

--- a/docs/plans/2026-06-10-agent-record-persistence-plan.md
+++ b/docs/plans/2026-06-10-agent-record-persistence-plan.md
@@ -1,0 +1,939 @@
+# Agent-owned record persistence — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Kill the `create_vm_execution` readback (`pool.executions[vm_hash]` → `MessageSpec` attach → `execution.save()`) by making the agent persist its own `ExecutionRecord`, after migrating the remaining agent-side readers of pool-execution messages to the `AgentVmRegistry`.
+
+**Architecture:** Reader migrations land first (payment grouping, `update_allocations` guards, domains aggregate) — each is a pure data-source swap that works with or without the readback. The readback removal lands last, once nothing depends on the glued-on message. A new `persist_record` in `vm_registry.py` is the write-side sibling of `rehydrate_registry`.
+
+**Tech Stack:** Python 3, aiohttp, SQLAlchemy (async), pytest / pytest-asyncio, `mocker` / `monkeypatch`.
+
+**Design doc:** `docs/plans/2026-06-10-agent-record-persistence-design.md`
+
+**Branch:** `od/wire-supervisor-agent-records` (stacked on #971 `od/wire-supervisor-owner-auth`).
+
+---
+
+## Environment notes (read before running anything)
+
+- **Every `Bash` command needs `dangerouslyDisableSandbox: true`** (the repo's seccomp profile blocks sandboxed exec with `apply-seccomp ... Permission denied`).
+- **This worktree has no local venv, and `settings.setup()` mkdirs under `/var`** (PermissionError in this sandbox). Run ALL tests as:
+  ```bash
+  cd /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-expiry
+  mkdir -p "$TMPDIR/alephcache" "$TMPDIR/alephlib"
+  ALEPH_VM_CACHE_ROOT="$TMPDIR/alephcache" ALEPH_VM_EXECUTION_ROOT="$TMPDIR/alephlib" \
+    PYTHONPATH=src /home/olivier/git/aleph/aleph-vm/.worktrees/wire-supervisor-read-views/.testvenv/bin/python \
+    -m pytest <args> -p no:warnings
+  ```
+  Later steps abbreviate this as `...pytest <args>`; the env vars are always implied.
+- **Style gates (CI):**
+  ```bash
+  uvx ruff@0.4.6 format --diff <touched files>
+  uvx isort==5.13.2 --check-only --profile black <touched files>
+  ```
+  Apply with `uvx ruff@0.4.6 format <files>` if a diff shows. `uvx` writes an untracked `uv.lock` — **never `git add` it.**
+- **Pre-existing environmental failures** in the broader `tests/supervisor` suite (pyroute2/netlink, Firecracker subprocess, `chown` Operation-not-permitted) are NOT regressions; judge against the dev baseline. The targeted files in this plan are fully green with the env overrides.
+- **No `Co-Authored-By` trailer in commits.**
+
+## Shared facts
+
+- `AgentVmRecord` / `AgentVmRegistry` / `rehydrate_registry` live in `src/aleph/vm/orchestrator/vm_registry.py`. `AgentVmRecord` is a `@dataclass` with `message: ExecutableContent`, `original: ExecutableContent`, `persistent: bool = False`. `registry.record(...)` RETURNS the `AgentVmRecord`.
+- `ExecutionRecord` and `save_record(record)` live in `src/aleph/vm/orchestrator/metrics.py` (`save_record` does a session merge+commit). `vm_registry.py` already imports `get_execution_records` from there.
+- The readback being killed is `src/aleph/vm/orchestrator/run.py:243-255` (comment block starting `# TEMPORARY (PR 1 boundary, ...)`).
+- `check_payment(pool, supervisor, registry)` in `src/aleph/vm/orchestrator/tasks.py` already receives the registry; its three grouping call sites are lines 354, 381, 404 (`pool.get_executions_by_address(payment_type=...)`).
+- `tasks.py` already imports `PaymentType` (from `aleph_message.models`), `settings`, `VmPool`, `AgentVmRegistry`. It does NOT yet import `Payment`, `Chain`, or `VmExecution`.
+- `pool.py` line 12 imports `Chain, InstanceContent, ItemHash, Payment, PaymentType` — `Chain`/`Payment`/`PaymentType` are used ONLY inside `get_executions_by_address` (verify before pruning; `InstanceContent`/`ItemHash` are used elsewhere).
+- `update_allocations` (`src/aleph/vm/orchestrator/views/__init__.py:545`) already has `registry = request.app["vm_registry"]` in scope (line 572).
+- Test-mocking pattern for registry DB functions: `monkeypatch.setattr("aleph.vm.orchestrator.vm_registry.<name>", AsyncMock(...))` (see `tests/supervisor/test_agent_vm_registry.py`).
+
+---
+
+## Task 1: `persist_record` + `AgentVmRecord` payment helpers
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/vm_registry.py`
+- Test: `tests/supervisor/test_agent_vm_registry.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/supervisor/test_agent_vm_registry.py` (file already imports `SimpleNamespace`, `AsyncMock`, `MagicMock`, `pytest`, `ItemHash`, `AgentVmRecord`, `AgentVmRegistry`, `rehydrate_registry`; extend the `vm_registry` import to add `persist_record`):
+
+```python
+def test_record_payment_helpers():
+    stream = AgentVmRecord(
+        message=SimpleNamespace(payment=SimpleNamespace(is_stream=True, is_credit=False)),
+        original=MagicMock(),
+    )
+    credit = AgentVmRecord(
+        message=SimpleNamespace(payment=SimpleNamespace(is_stream=False, is_credit=True)),
+        original=MagicMock(),
+    )
+    hold = AgentVmRecord(message=SimpleNamespace(payment=None), original=MagicMock())
+
+    assert stream.uses_payment_stream is True and stream.uses_payment_credit is False
+    assert credit.uses_payment_stream is False and credit.uses_payment_credit is True
+    assert hold.uses_payment_stream is False and hold.uses_payment_credit is False
+
+
+@pytest.mark.asyncio
+async def test_persist_record_writes_agent_fields(monkeypatch):
+    saved = []
+    monkeypatch.setattr(
+        "aleph.vm.orchestrator.vm_registry.save_record",
+        AsyncMock(side_effect=saved.append),
+    )
+    message = MagicMock()
+    message.resources.vcpus = 2
+    message.resources.memory = 1024
+    message.model_dump_json.return_value = '{"m": 1}'
+    original = MagicMock()
+    original.model_dump_json.return_value = '{"o": 1}'
+
+    await persist_record(_HASH, AgentVmRecord(message=message, original=original, persistent=True))
+
+    assert len(saved) == 1
+    db = saved[0]
+    assert db.vm_hash == str(_HASH)
+    assert db.vm_id is None  # numeric hypervisor id unknown agent-side (debug-only column)
+    assert db.vcpus == 2 and db.memory == 1024
+    assert db.message == '{"m": 1}'
+    assert db.original_message == '{"o": 1}'
+    assert db.persistent is True
+    assert db.mapped_ports is None  # the PortMapping table is the authority
+    assert db.time_defined is not None
+    assert db.uuid  # fresh uuid per create, matching the old per-execution behavior
+
+
+@pytest.mark.asyncio
+async def test_persist_then_rehydrate_round_trip(monkeypatch):
+    """What persist_record writes is exactly what rehydrate_registry needs."""
+    saved = []
+    monkeypatch.setattr(
+        "aleph.vm.orchestrator.vm_registry.save_record",
+        AsyncMock(side_effect=saved.append),
+    )
+    message = MagicMock()
+    message.resources.vcpus = 1
+    message.resources.memory = 256
+    message.model_dump_json.return_value = '{"address": "0xabc"}'
+    original = MagicMock()
+    original.model_dump_json.return_value = '{"address": "0xabc"}'
+    await persist_record(_HASH, AgentVmRecord(message=message, original=original, persistent=True))
+
+    monkeypatch.setattr(
+        "aleph.vm.orchestrator.vm_registry.get_execution_records",
+        AsyncMock(return_value=saved),
+    )
+    parsed = MagicMock()
+    monkeypatch.setattr(
+        "aleph.vm.orchestrator.vm_registry.get_message_executable_content",
+        MagicMock(return_value=parsed),
+    )
+    registry = AgentVmRegistry()
+
+    count = await rehydrate_registry(registry)
+
+    assert count == 1
+    rec = registry.get(_HASH)
+    assert rec.message is parsed
+    assert rec.persistent is True
+```
+
+- [ ] **Step 2: Run, verify they fail**
+
+Run: `...pytest tests/supervisor/test_agent_vm_registry.py -v -p no:warnings`
+Expected: ImportError on `persist_record` (and `uses_payment_stream` AttributeError if imports are split).
+
+- [ ] **Step 3: Implement**
+
+In `src/aleph/vm/orchestrator/vm_registry.py`:
+
+Extend the imports:
+
+```python
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from aleph.vm.orchestrator.metrics import (
+    ExecutionRecord,
+    get_execution_records,
+    save_record,
+)
+```
+
+(`json` and `logging` are already imported.)
+
+Add the two properties to `AgentVmRecord` (after the dataclass fields):
+
+```python
+    @property
+    def uses_payment_stream(self) -> bool:
+        return bool(self.message.payment and self.message.payment.is_stream)
+
+    @property
+    def uses_payment_credit(self) -> bool:
+        return bool(self.message.payment and self.message.payment.is_credit)
+```
+
+Add at module level (after `rehydrate_registry`):
+
+```python
+async def persist_record(vm_hash: ItemHash, record: AgentVmRecord) -> None:
+    """Persist the agent's knowledge of a VM to the agent DB.
+
+    Write-side sibling of rehydrate_registry: what this writes is exactly what
+    rehydrate_registry needs to rebuild the registry after a restart (message,
+    original, persistent), carried on the existing ExecutionRecord table.
+    Hypervisor-owned facts are deliberately absent: vm_id (numeric id unknown
+    agent-side) and mapped_ports (the PortMapping table is the authority) are
+    None; both are read only by the debug records endpoint.
+    """
+    now = datetime.now(tz=timezone.utc)
+    resources = record.message.resources
+    db_record = ExecutionRecord(
+        uuid=str(uuid4()),
+        vm_hash=str(vm_hash),
+        vm_id=None,
+        time_defined=now,
+        time_prepared=now,
+        time_started=now,
+        time_stopping=None,
+        cpu_time_user=None,
+        cpu_time_system=None,
+        io_read_count=None,
+        io_write_count=None,
+        io_read_bytes=None,
+        io_write_bytes=None,
+        vcpus=resources.vcpus,
+        memory=resources.memory,
+        message=record.message.model_dump_json(),
+        original_message=record.original.model_dump_json(),
+        persistent=record.persistent,
+        gpus=json.dumps([]),
+        mapped_ports=None,
+    )
+    await save_record(db_record)
+```
+
+- [ ] **Step 4: Run, verify green**
+
+Run: `...pytest tests/supervisor/test_agent_vm_registry.py -v -p no:warnings`
+Expected: all PASS (the pre-existing rehydrate tests included).
+
+- [ ] **Step 5: Style + commit**
+
+```bash
+uvx ruff@0.4.6 format --diff src/aleph/vm/orchestrator/vm_registry.py tests/supervisor/test_agent_vm_registry.py
+uvx isort==5.13.2 --check-only --profile black src/aleph/vm/orchestrator/vm_registry.py tests/supervisor/test_agent_vm_registry.py
+git add src/aleph/vm/orchestrator/vm_registry.py tests/supervisor/test_agent_vm_registry.py
+git commit -m "feat(agent-records): persist_record + AgentVmRecord payment helpers"
+```
+
+---
+
+## Task 2: Payment grouping moves to the agent
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/tasks.py` (new `_group_executions_by_payment`, 3 call-site swaps in `check_payment`)
+- Modify: `src/aleph/vm/pool.py` (delete `get_executions_by_address`, prune orphaned imports)
+- Create: `tests/supervisor/test_tasks_registry_reads.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/supervisor/test_tasks_registry_reads.py`:
+
+```python
+"""Agent-side registry reads in tasks.py: payment grouping and the domains aggregate."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aleph_message.models import Chain, ItemHash, Payment, PaymentType
+
+from aleph.vm.conf import settings
+from aleph.vm.orchestrator.tasks import _group_executions_by_payment
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
+
+_HASH = ItemHash("deadbeef" * 8)
+_OTHER = ItemHash("cafecafe" * 8)
+
+
+def _execution(vm_hash: ItemHash, *, is_running: bool = True) -> SimpleNamespace:
+    # Message-less, structurally-typed stand-in for a spec-built pool execution.
+    return SimpleNamespace(vm_hash=vm_hash, is_running=is_running)
+
+
+def _registry_with(vm_hash: ItemHash, *, payment: Payment | None, address: str = "0xabc") -> AgentVmRegistry:
+    registry = AgentVmRegistry()
+    registry.record(
+        vm_hash,
+        message=SimpleNamespace(payment=payment, address=address),
+        original=MagicMock(),
+        persistent=True,
+    )
+    return registry
+
+
+def test_grouping_sources_message_from_registry():
+    """A message-less (spec-built / restored) execution with a registry record is grouped."""
+    payment = Payment(chain=Chain.ETH, type=PaymentType.superfluid)
+    registry = _registry_with(_HASH, payment=payment)
+    pool = SimpleNamespace(executions={_HASH: _execution(_HASH)})
+
+    groups = _group_executions_by_payment(pool, registry, PaymentType.superfluid)
+
+    assert list(groups) == ["0xabc"]
+    assert list(groups["0xabc"]) == [Chain.ETH]
+    assert groups["0xabc"][Chain.ETH][0].vm_hash == _HASH
+
+
+def test_grouping_skips_unrecorded_executions():
+    """No registry record -> the agent knows no message -> not grouped."""
+    pool = SimpleNamespace(executions={_HASH: _execution(_HASH)})
+
+    groups = _group_executions_by_payment(pool, AgentVmRegistry(), PaymentType.superfluid)
+
+    assert groups == {}
+
+
+def test_grouping_defaults_to_hold_and_filters_by_type():
+    registry = _registry_with(_HASH, payment=None)  # no payment -> hold tier
+    pool = SimpleNamespace(executions={_HASH: _execution(_HASH)})
+
+    assert _group_executions_by_payment(pool, registry, PaymentType.superfluid) == {}
+    hold_groups = _group_executions_by_payment(pool, registry, PaymentType.hold)
+    assert hold_groups["0xabc"][Chain.ETH][0].vm_hash == _HASH
+
+
+def test_grouping_skips_stopped_and_diagnostic_executions():
+    payment = Payment(chain=Chain.ETH, type=PaymentType.hold)
+    registry = _registry_with(_HASH, payment=payment)
+    fake_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    registry.record(
+        fake_hash,
+        message=SimpleNamespace(payment=payment, address="0xabc"),
+        original=MagicMock(),
+        persistent=True,
+    )
+    diag = SimpleNamespace(vm_hash=ItemHash(settings.CHECK_FASTAPI_VM_ID), is_running=True)
+    registry.record(
+        diag.vm_hash,
+        message=SimpleNamespace(payment=payment, address="0xabc"),
+        original=MagicMock(),
+        persistent=True,
+    )
+    pool = SimpleNamespace(
+        executions={
+            _HASH: _execution(_HASH, is_running=False),  # stopped -> skipped
+            diag.vm_hash: diag,  # diagnostic -> skipped
+        }
+    )
+
+    assert _group_executions_by_payment(pool, registry, PaymentType.hold) == {}
+
+
+def test_pool_has_no_message_reads():
+    """pool.py must not learn messages off executions; that is registry territory."""
+    import inspect
+
+    from aleph.vm import pool as pool_module
+
+    source = inspect.getsource(pool_module)
+    assert "execution.message" not in source
+    assert "get_executions_by_address" not in source
+```
+
+- [ ] **Step 2: Run, verify they fail**
+
+Run: `...pytest tests/supervisor/test_tasks_registry_reads.py -v -p no:warnings`
+Expected: ImportError on `_group_executions_by_payment`; the source-scan test fails on both assertions.
+
+- [ ] **Step 3: Implement `_group_executions_by_payment` in tasks.py**
+
+In `src/aleph/vm/orchestrator/tasks.py`:
+
+Extend imports: the `from aleph_message.models import ...` line gains `Chain` and `Payment` (alongside the existing `PaymentType`); add `from aleph.vm.models import VmExecution` (needed for the annotation; no import cycle — models does not import tasks).
+
+Add the function directly above `check_payment`:
+
+```python
+def _group_executions_by_payment(
+    pool: VmPool, registry: AgentVmRegistry, payment_type: PaymentType
+) -> dict[str, dict[Chain, list[VmExecution]]]:
+    """Group running executions by sender address and chain for one payment type.
+
+    The message (payment tier, owner address) comes from the agent registry;
+    the execution supplies only structural facts. Replaces the pool method that
+    read the message off the hypervisor object — and thereby skipped spec-built
+    and restart-restored VMs entirely.
+    """
+    executions_by_address: dict[str, dict[Chain, list[VmExecution]]] = {}
+    for vm_hash, execution in pool.executions.items():
+        record = registry.get(vm_hash)
+        if record is None:
+            # The agent has no message for this VM (e.g. the diagnostic fake
+            # never enters the registry); payment grouping cannot apply.
+            continue
+        if execution.vm_hash in (settings.CHECK_FASTAPI_VM_ID, settings.LEGACY_CHECK_FASTAPI_VM_ID):
+            # Ignore the diagnostic VM
+            continue
+        if not execution.is_running:
+            continue
+        payment = record.message.payment if record.message.payment else Payment(chain=Chain.ETH, type=PaymentType.hold)
+        if payment.type == payment_type:
+            executions_by_address.setdefault(record.message.address, {}).setdefault(payment.chain, []).append(
+                execution
+            )
+    return executions_by_address
+```
+
+- [ ] **Step 4: Swap the three call sites in `check_payment`**
+
+Replace (tasks.py:354):
+```python
+    for execution_address, chains in pool.get_executions_by_address(payment_type=PaymentType.hold).items():
+```
+with:
+```python
+    for execution_address, chains in _group_executions_by_payment(pool, registry, PaymentType.hold).items():
+```
+
+Replace (tasks.py:381):
+```python
+    for execution_address, chains in pool.get_executions_by_address(payment_type=PaymentType.credit).items():
+```
+with:
+```python
+    for execution_address, chains in _group_executions_by_payment(pool, registry, PaymentType.credit).items():
+```
+
+Replace (tasks.py:404):
+```python
+    for execution_address, chains in pool.get_executions_by_address(payment_type=PaymentType.superfluid).items():
+```
+with:
+```python
+    for execution_address, chains in _group_executions_by_payment(pool, registry, PaymentType.superfluid).items():
+```
+
+- [ ] **Step 5: Delete `pool.get_executions_by_address` and prune imports**
+
+In `src/aleph/vm/pool.py`, delete the whole method (lines 897-922):
+
+```python
+    def get_executions_by_address(self, payment_type: PaymentType) -> dict[str, dict[str, list[VmExecution]]]:
+        """Return all executions of the given type, grouped by sender and by chain."""
+        executions_by_address: dict[str, dict[str, list[VmExecution]]] = {}
+        for vm_hash, execution in self.executions.items():
+            message = execution.message
+            if message is None:
+                # Spec-built (supervisor-owned) executions carry no message;
+                # payment grouping is an agent concern.
+                continue
+            if execution.vm_hash in (settings.CHECK_FASTAPI_VM_ID, settings.LEGACY_CHECK_FASTAPI_VM_ID):
+                # Ignore Diagnostic VM execution
+                continue
+
+            if not execution.is_running:
+                # Ignore the execution that is stopping or not running anymore
+                continue
+            if execution.vm_hash == settings.CHECK_FASTAPI_VM_ID:
+                # Ignore Diagnostic VM execution
+                continue
+            execution_payment = message.payment if message.payment else Payment(chain=Chain.ETH, type=PaymentType.hold)
+            if execution_payment.type == payment_type:
+                address = message.address
+                chain = execution_payment.chain
+                executions_by_address.setdefault(address, {})
+                executions_by_address[address].setdefault(chain, []).append(execution)
+        return executions_by_address
+```
+
+Then check whether `Payment`, `PaymentType`, `Chain` are still used anywhere in pool.py (`grep -n "Payment\|Chain" src/aleph/vm/pool.py`); they are expected to be orphaned — trim the line-12 import to `from aleph_message.models import InstanceContent, ItemHash` (keep any name still in use).
+
+- [ ] **Step 6: Run, verify green**
+
+Run: `...pytest tests/supervisor/test_tasks_registry_reads.py tests/supervisor/test_views.py -q -p no:warnings`
+Expected: new tests PASS; `test_views.py` stays green (check_payment is not HTTP-exercised there, but the import graph is — a broken pool.py import would fail collection).
+
+- [ ] **Step 7: Style + commit**
+
+```bash
+uvx ruff@0.4.6 format --diff src/aleph/vm/orchestrator/tasks.py src/aleph/vm/pool.py tests/supervisor/test_tasks_registry_reads.py
+uvx isort==5.13.2 --check-only --profile black src/aleph/vm/orchestrator/tasks.py src/aleph/vm/pool.py tests/supervisor/test_tasks_registry_reads.py
+git add src/aleph/vm/orchestrator/tasks.py src/aleph/vm/pool.py tests/supervisor/test_tasks_registry_reads.py
+git commit -m "refactor(agent-records): payment grouping reads the registry, off the pool"
+```
+
+---
+
+## Task 3: `update_allocations` guards read the registry; delete the dead `VmExecution` properties
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/views/__init__.py:582-590`
+- Modify: `src/aleph/vm/models.py` (delete `uses_payment_stream` / `uses_payment_credit`, lines 404-412)
+- Test: `tests/supervisor/test_views.py`, `tests/supervisor/test_execution.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/supervisor/test_views.py` (model: `test_update_allocations_stop_loop_uses_supervisor` at line 1170 — reuse its imports and the same `instance_content` shape):
+
+```python
+@pytest.mark.asyncio
+async def test_update_allocations_spares_payg_via_registry(aiohttp_client, mocker):
+    """A message-less execution whose REGISTRY record is stream-paid must be spared
+    by the stop loop even when absent from the allocation (the restored-PAYG case)."""
+    vm_hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
+    instance_content = {
+        "address": "0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9",
+        "time": 1713874241.800818,
+        "allow_amend": False,
+        "metadata": None,
+        "authorized_keys": None,
+        "variables": None,
+        "environment": {"reproducible": False, "internet": True, "aleph_api": True, "shared_cache": False},
+        "resources": {"vcpus": 1, "memory": 256, "seconds": 30, "published_ports": None},
+        "payment": {"type": "superfluid", "chain": "BASE"},
+        "requirements": None,
+        "replaces": None,
+        "rootfs": {
+            "parent": {"ref": "63f07193e6ee9d207b7d1fcf8286f9aee34e6f12f101d2ec77c1229f92964696"},
+            "ref": "63f07193e6ee9d207b7d1fcf8286f9aee34e6f12f101d2ec77c1229f92964696",
+            "use_latest": True,
+            "comment": "",
+            "persistence": "host",
+            "size_mib": 1000,
+        },
+    }
+    message = InstanceContent.model_validate(instance_content)
+
+    # Message-less, structurally-typed stand-in for a restored spec-built execution:
+    # the payment tier is knowable only through the registry.
+    execution = SimpleNamespace(
+        vm_hash=ItemHash(vm_hash),
+        is_running=True,
+        gpus=[],
+        is_confidential=False,
+        is_instance=True,
+    )
+
+    class FakeVmPool:
+        def get_persistent_executions(self):
+            return [execution]
+
+    pool = FakeVmPool()
+    app = setup_webapp(pool=pool)
+    app["pubsub"] = None
+    app["vm_registry"].record(ItemHash(vm_hash), message=message, original=message, persistent=True)
+
+    fake_supervisor = MagicMock(delete_vm=AsyncMock())
+    app["supervisor"] = fake_supervisor
+
+    settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
+    client = await aiohttp_client(app)
+
+    response = await client.post(
+        "/control/allocations",
+        json={"persistent_vms": []},
+        headers={"X-Auth-Signature": "test"},
+    )
+    assert response.status == 200
+    resp_json = await response.json()
+    assert vm_hash not in resp_json["stopped"]
+    fake_supervisor.delete_vm.assert_not_awaited()
+    assert ItemHash(vm_hash) in app["vm_registry"]
+```
+
+(If `SimpleNamespace` is not yet imported in test_views.py, add `from types import SimpleNamespace`.)
+
+Append to `tests/supervisor/test_execution.py` (mirroring the `#970` pattern `test_vm_execution_has_no_update_watch_api`):
+
+```python
+def test_vm_execution_has_no_payment_api():
+    """Payment tier is agent knowledge (AgentVmRecord), not a hypervisor-object concern."""
+    assert not hasattr(VmExecution, "uses_payment_stream")
+    assert not hasattr(VmExecution, "uses_payment_credit")
+```
+
+- [ ] **Step 2: Run, verify they fail**
+
+Run: `...pytest "tests/supervisor/test_views.py::test_update_allocations_spares_payg_via_registry" "tests/supervisor/test_execution.py::test_vm_execution_has_no_payment_api" -v -p no:warnings`
+Expected: the views test FAILS — current code reads `execution.uses_payment_stream`, which the `SimpleNamespace` lacks → AttributeError → 500 (or, were a real message-less execution used, `False` → wrongly stopped). The execution test FAILS (properties still exist).
+
+- [ ] **Step 3: Migrate the guard in `update_allocations`**
+
+In `src/aleph/vm/orchestrator/views/__init__.py`, replace (lines 582-590):
+
+```python
+        for execution in list(pool.get_persistent_executions()):
+            if (
+                execution.vm_hash not in allocations
+                and execution.is_running
+                and not execution.uses_payment_stream
+                and not execution.uses_payment_credit
+                and not execution.gpus
+                and not execution.is_confidential
+            ):
+```
+
+with:
+
+```python
+        for execution in list(pool.get_persistent_executions()):
+            # Payment tier comes from the agent registry, not the hypervisor
+            # object: spec-built and restart-restored executions carry no
+            # message, but their registry record (rehydrated from the agent DB)
+            # does. No record behaves as hold-tier, exactly like the old
+            # message-less False.
+            record = registry.get(execution.vm_hash)
+            if (
+                execution.vm_hash not in allocations
+                and execution.is_running
+                and not (record and record.uses_payment_stream)
+                and not (record and record.uses_payment_credit)
+                and not execution.gpus
+                and not execution.is_confidential
+            ):
+```
+
+- [ ] **Step 4: Delete the dead properties from `VmExecution`**
+
+First verify there are no remaining readers: `grep -rn "uses_payment_stream\|uses_payment_credit" src/ tests/` — expected hits only in `vm_registry.py` (the new record properties), `views/__init__.py` (now via `record.`), and the tests from this plan. Then delete from `src/aleph/vm/models.py` (lines 404-412):
+
+```python
+    @property
+    def uses_payment_stream(self) -> bool:
+        message = self.message
+        return bool(message and message.payment and message.payment.is_stream)
+
+    @property
+    def uses_payment_credit(self) -> bool:
+        message = self.message
+        return bool(message and message.payment and message.payment.is_credit)
+```
+
+- [ ] **Step 5: Run, verify green (including the pre-existing stop-loop test)**
+
+Run: `...pytest tests/supervisor/test_views.py tests/supervisor/test_execution.py -q -p no:warnings`
+Expected: the new tests PASS; `test_update_allocations_stop_loop_uses_supervisor` STAYS green (its registry record is hold-paid → guard still false → VM still stopped). `test_execution.py` has pre-existing environmental failures (`chown` Operation-not-permitted) — only the new test and no NEW failures matter.
+
+- [ ] **Step 6: Style + commit**
+
+```bash
+uvx ruff@0.4.6 format --diff src/aleph/vm/orchestrator/views/__init__.py src/aleph/vm/models.py tests/supervisor/test_views.py tests/supervisor/test_execution.py
+uvx isort==5.13.2 --check-only --profile black src/aleph/vm/orchestrator/views/__init__.py src/aleph/vm/models.py tests/supervisor/test_views.py tests/supervisor/test_execution.py
+git add src/aleph/vm/orchestrator/views/__init__.py src/aleph/vm/models.py tests/supervisor/test_views.py tests/supervisor/test_execution.py
+git commit -m "refactor(agent-records): update_allocations payment guards read the registry; drop dead VmExecution payment properties"
+```
+
+---
+
+## Task 4: `_handle_domains_aggregate` reads the registry
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/tasks.py:192,224-240`
+- Test: `tests/supervisor/test_tasks_registry_reads.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/supervisor/test_tasks_registry_reads.py` (add `_handle_domains_aggregate` to the tasks import):
+
+```python
+@pytest.mark.asyncio
+async def test_domains_aggregate_triggers_for_registry_recorded_instance():
+    """A message-less (spec-built / restored) instance must still trigger the
+    HAProxy domain-mapping refresh when its registry record matches the owner."""
+    registry = _registry_with(_HASH, payment=None, address="0xowner")
+    execution = SimpleNamespace(vm_hash=_HASH, is_instance=True, vm=object())
+    pool = SimpleNamespace(
+        executions={_HASH: execution},
+        update_domain_mapping=AsyncMock(),
+    )
+    aggregate = SimpleNamespace(content=SimpleNamespace(address="0xowner"))
+
+    await _handle_domains_aggregate(aggregate, pool, registry)
+
+    pool.update_domain_mapping.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_domains_aggregate_ignores_unrelated_address():
+    registry = _registry_with(_HASH, payment=None, address="0xowner")
+    execution = SimpleNamespace(vm_hash=_HASH, is_instance=True, vm=object())
+    pool = SimpleNamespace(
+        executions={_HASH: execution},
+        update_domain_mapping=AsyncMock(),
+    )
+    aggregate = SimpleNamespace(content=SimpleNamespace(address="0xsomeoneelse"))
+
+    await _handle_domains_aggregate(aggregate, pool, registry)
+
+    pool.update_domain_mapping.assert_not_awaited()
+```
+
+- [ ] **Step 2: Run, verify they fail**
+
+Run: `...pytest tests/supervisor/test_tasks_registry_reads.py -k domains -v -p no:warnings`
+Expected: TypeError (the function takes 2 positional args today) — and were the signature already extended, the first test would fail because current code reads `execution.message` (absent on the `SimpleNamespace`).
+
+- [ ] **Step 3: Implement**
+
+In `src/aleph/vm/orchestrator/tasks.py`, change the signature and the check (lines 224-240):
+
+```python
+async def _handle_domains_aggregate(message: AggregateMessage, pool: VmPool, registry: AgentVmRegistry):
+    """Update HAProxy domain mapping when a domains aggregate changes.
+
+    The aggregate content maps domain names to instance configs:
+    {"testd.example.com": {"message_id": "<item_hash>", "type": "instance"}}
+
+    Only trigger if any referenced message_id matches a locally running instance.
+    """
+    address = message.content.address
+
+    # Trigger if the address owns any running instance on this node. The owner
+    # address comes from the agent registry, not the hypervisor object —
+    # spec-built and restored executions carry no message.
+    # This covers both additions (new domain pointing to local instance)
+    # and deletions (domain removed — need to clean up the map).
+    has_local_instance = any(
+        execution.is_instance
+        and execution.vm
+        and (record := registry.get(execution.vm_hash)) is not None
+        and record.message.address == address
+        for execution in pool.executions.values()
+    )
+    if not has_local_instance:
+        return
+```
+
+(the `logger.info` / `try: await pool.update_domain_mapping()` tail is unchanged.)
+
+Update the caller (tasks.py:192):
+
+```python
+                elif key == "domains":
+                    await _handle_domains_aggregate(message, pool, registry)
+```
+
+(`registry` is already in scope in `watch_for_messages` — it is passed to the port-forwarding handler two lines above.)
+
+- [ ] **Step 4: Run, verify green**
+
+Run: `...pytest tests/supervisor/test_tasks_registry_reads.py -v -p no:warnings`
+Expected: all PASS.
+
+- [ ] **Step 5: Style + commit**
+
+```bash
+uvx ruff@0.4.6 format --diff src/aleph/vm/orchestrator/tasks.py tests/supervisor/test_tasks_registry_reads.py
+uvx isort==5.13.2 --check-only --profile black src/aleph/vm/orchestrator/tasks.py tests/supervisor/test_tasks_registry_reads.py
+git add src/aleph/vm/orchestrator/tasks.py tests/supervisor/test_tasks_registry_reads.py
+git commit -m "refactor(agent-records): domains aggregate reads the owner address from the registry"
+```
+
+---
+
+## Task 5: Kill the `create_vm_execution` readback
+
+**Files:**
+- Modify: `src/aleph/vm/orchestrator/run.py` (spec-path tail, signatures, None-guards, imports)
+- Test: `tests/supervisor/test_supervisor_run_routing.py`
+
+- [ ] **Step 1: Update the routing test (red)**
+
+In `tests/supervisor/test_supervisor_run_routing.py`, rewrite `test_eligible_instance_routed_through_supervisor` (lines 85-122) as:
+
+```python
+@pytest.mark.asyncio
+async def test_eligible_instance_routed_through_supervisor(monkeypatch):
+    content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
+    original_content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
+    message = MagicMock(content=content)
+    original_message = MagicMock(content=original_content)
+    monkeypatch.setattr(run_module, "load_updated_message", AsyncMock(return_value=(message, original_message)))
+    spec = _spec()
+    monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(return_value=spec))
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+    persist = AsyncMock()
+    monkeypatch.setattr(run_module, "persist_record", persist)
+
+    supervisor = _fake_supervisor()
+    registry = AgentVmRegistry()
+    # An EMPTY pool: the spec path must never read pool.executions (the old
+    # readback would KeyError here).
+    pool = SimpleNamespace(executions={}, create_a_vm=AsyncMock())
+
+    execution = await run_module.create_vm_execution(
+        _HASH, pool, supervisor=supervisor, registry=registry, persistent=True
+    )
+
+    supervisor.create_vm.assert_awaited_once_with(spec)
+    pool.create_a_vm.assert_not_awaited()
+    # The message is recorded in the agent registry, not on the execution.
+    record = registry.get(_HASH)
+    assert record.message is content
+    assert record.original is original_content
+    assert record.persistent is True
+    # The agent persists its own record; the hypervisor object is never touched.
+    persist.assert_awaited_once_with(_HASH, record)
+    # SSH port-forward applied through the abstraction.
+    assert supervisor.add_port_forward.await_count >= 1
+    # Spec path returns None: no caller consumes a hypervisor object from it.
+    assert execution is None
+    supervisor.delete_vm.assert_not_awaited()
+```
+
+Also remove the now-unused `from aleph.vm.models import MessageSpec` import at the top of the test file (line 20) — it was used only by the deleted assertion (verify with a grep within the file before removing).
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `...pytest tests/supervisor/test_supervisor_run_routing.py -v -p no:warnings`
+Expected: `test_eligible_instance_routed_through_supervisor` FAILS — current code does `pool.executions[vm_hash]` → KeyError on the empty pool (and `run_module.persist_record` does not exist yet for the monkeypatch → AttributeError; either way red).
+
+- [ ] **Step 3: Implement in run.py**
+
+In `src/aleph/vm/orchestrator/run.py`:
+
+Imports: extend the registry import to `from aleph.vm.orchestrator.vm_registry import AgentVmRegistry, persist_record`. Check remaining uses of `MessageSpec` in the file (`grep -n "MessageSpec" src/aleph/vm/orchestrator/run.py`); after this change the attach is gone — if no use remains, trim line 26 to `from aleph.vm.models import VmExecution`.
+
+Signature (line 209-216): change the return annotation:
+
+```python
+async def create_vm_execution(
+    vm_hash: ItemHash,
+    pool: VmPool,
+    *,
+    supervisor: Supervisor,
+    registry: AgentVmRegistry,
+    persistent: bool = False,
+) -> VmExecution | None:
+```
+
+Capture the record (line 229):
+
+```python
+        record = registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
+```
+
+Replace the readback tail (lines 243-255):
+
+```python
+        # TEMPORARY (PR 1 boundary, design doc sections 5/8): the operator
+        # endpoints, billing and update-watching still read owner identity and
+        # the message off the VmExecution, and start_persistent_vm drives it for
+        # the pre-existing check and expiry-cancel. Re-source the message-free
+        # execution as message-driven and hand it back unchanged. This goes away
+        # when those consumers read the registry instead.
+        execution = pool.executions[vm_hash]
+        execution.spec = MessageSpec(message=content, original=original_message.content)
+        # The spec create path skipped save() (no MessageSpec at start time).
+        # Persist the record now: registry rehydration and past-logs owner
+        # auth read the message back from the agent DB.
+        await execution.save()
+        return execution
+```
+
+with:
+
+```python
+        # Agent persists its own knowledge; the hypervisor object is not
+        # touched. Registry rehydration and past-logs owner-auth read the
+        # message back from the agent DB.
+        await persist_record(vm_hash, record)
+        return None
+```
+
+`create_vm_execution_or_raise_http_error` (line 267-273): return annotation becomes `-> VmExecution | None`.
+
+None-guards in the two program paths — in `run_code_on_request`, after the create call (lines 337-339):
+
+```python
+        execution = await create_vm_execution_or_raise_http_error(
+            vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry
+        )
+        if execution is None:
+            # Spec-eligible messages are instances; they cannot serve code requests.
+            raise HTTPBadRequest(reason=f"VM {vm_hash} is an instance, not a program")
+```
+
+and identically in `run_code_on_event` after its create call (lines 455-457):
+
+```python
+        execution = await create_vm_execution_or_raise_http_error(
+            vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry
+        )
+        if execution is None:
+            # Spec-eligible messages are instances; they cannot serve code requests.
+            raise HTTPBadRequest(reason=f"VM {vm_hash} is an instance, not a program")
+```
+
+(`HTTPBadRequest` is already imported in run.py.)
+
+- [ ] **Step 4: Run, verify green**
+
+Run: `...pytest tests/supervisor/test_supervisor_run_routing.py tests/supervisor/test_views.py tests/supervisor/views/test_operator.py -q -p no:warnings`
+Expected: all PASS — the routing file's teardown tests (`timeout_tears_down`, `port_forward_failure_tears_down`) already use `executions={}` pools and never reach the tail; operator/views suites prove the three discard-return callers and `start_persistent_vm` are unaffected.
+
+- [ ] **Step 5: Style + commit**
+
+```bash
+uvx ruff@0.4.6 format --diff src/aleph/vm/orchestrator/run.py tests/supervisor/test_supervisor_run_routing.py
+uvx isort==5.13.2 --check-only --profile black src/aleph/vm/orchestrator/run.py tests/supervisor/test_supervisor_run_routing.py
+git add src/aleph/vm/orchestrator/run.py tests/supervisor/test_supervisor_run_routing.py
+git commit -m "refactor(agent-records): create_vm_execution persists agent-side; drop the pool readback"
+```
+
+---
+
+## Task 6: Whole-branch verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Source-scan invariants**
+
+```bash
+grep -n "execution.message" src/aleph/vm/pool.py src/aleph/vm/orchestrator/views/operator.py
+grep -rn "get_executions_by_address\|uses_payment_stream\|uses_payment_credit" src/aleph/vm/pool.py src/aleph/vm/models.py
+grep -n "pool.executions\[" src/aleph/vm/orchestrator/run.py
+```
+Expected: no output from any of the three.
+
+- [ ] **Step 2: Run the touched test files**
+
+Run: `...pytest tests/supervisor/test_agent_vm_registry.py tests/supervisor/test_tasks_registry_reads.py tests/supervisor/test_supervisor_run_routing.py tests/supervisor/test_views.py tests/supervisor/views/test_operator.py -q -p no:warnings`
+Expected: all PASS.
+
+- [ ] **Step 3: Baseline check on the broader supervisor suite**
+
+Run: `...pytest tests/supervisor -q -p no:warnings 2>&1 | tail -10`
+Expected: the failing set matches the pre-existing environmental baseline (pyroute2/netlink, Firecracker subprocess/`chown`); no NEW failures in registry/payment/views/run files. If a failure looks new, check the same test against the branch base (`git stash` is NOT sufficient for committed work — check out the base commit) before attributing it.
+
+- [ ] **Step 4: Final style gate + commit (only if anything changed)**
+
+```bash
+uvx ruff@0.4.6 format --diff $(git diff --name-only od/wire-supervisor-owner-auth..HEAD -- 'src/*.py' 'tests/*.py')
+uvx isort==5.13.2 --check-only --profile black $(git diff --name-only od/wire-supervisor-owner-auth..HEAD -- 'src/*.py' 'tests/*.py')
+git status --porcelain   # must NOT list uv.lock as staged
+```
+
+---
+
+## Done criteria
+
+- `create_vm_execution`'s spec path never touches `pool.executions`; the agent persists its own `ExecutionRecord` (`persist_record`), and the path returns `None`.
+- `pool.py` contains no message reads and no `get_executions_by_address` (guard test).
+- Payment grouping, `update_allocations` guards, and the domains aggregate read the registry; restored/spec VMs are covered by all three (tests).
+- `VmExecution.uses_payment_stream` / `uses_payment_credit` are gone (API test).
+- Touched test files green; broader suite matches the environmental baseline.
+- Style gates clean; no `uv.lock` staged; no `Co-Authored-By` trailer.
+
+## Out of scope (design §7)
+
+- `check_payment`'s balance/credit/stream logic and terminal-status loop (deprecates with the legacy notify flow).
+- Structural `pool.executions` iteration (Phase-1 supervisor list views).
+- `execution.vm` reads in operator.py; the `about_executions` debug endpoint; the legacy (non-spec) create path.

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -402,16 +402,6 @@ class VmExecution:
         return f"aleph-vm-controller@{self.vm_hash}.service"
 
     @property
-    def uses_payment_stream(self) -> bool:
-        message = self.message
-        return bool(message and message.payment and message.payment.is_stream)
-
-    @property
-    def uses_payment_credit(self) -> bool:
-        message = self.message
-        return bool(message and message.payment and message.payment.is_credit)
-
-    @property
     def allocated_memory_mib(self) -> int:
         """Requested memory in MiB, from the spec or the message."""
         if isinstance(self.spec, CreateVmSpec):

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -23,10 +23,10 @@ from aleph.vm.controllers.firecracker.program import (
     VmSetupError,
 )
 from aleph.vm.hypervisors.firecracker.microvm import MicroVMFailedInitError
-from aleph.vm.models import MessageSpec, VmExecution
+from aleph.vm.models import VmExecution
 from aleph.vm.orchestrator.expiry import ExpiryManager
 from aleph.vm.orchestrator.update_watcher import UpdateWatcher
-from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry, persist_record
 from aleph.vm.pool import VmPool
 from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.supervisor.abc import Supervisor
@@ -213,7 +213,16 @@ async def create_vm_execution(
     supervisor: Supervisor,
     registry: AgentVmRegistry,
     persistent: bool = False,
-) -> VmExecution:
+) -> VmExecution | None:
+    """Create a VM for the given message.
+
+    Spec-eligible messages (QEMU instances) are created through the Supervisor
+    abstraction: the agent records and persists its own knowledge of the VM and
+    returns None — the hypervisor object lives behind the supervisor, not in the
+    pool. Legacy messages (programs) take the pool create path and return the
+    pool-managed VmExecution. The two program callers (run_code_on_request /
+    run_code_on_event) guard the None case explicitly.
+    """
     message, original_message = await load_updated_message(vm_hash)
 
     logger.debug(f"Message: {json.dumps(message.model_dump(exclude_none=True), indent=4, sort_keys=True, default=str)}")
@@ -226,7 +235,8 @@ async def create_vm_execution(
         # what the message-free agent will read once owner-auth and billing move
         # off the VmExecution (design doc section 5). The supervisor machinery
         # that created the VM never reads it.
-        registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
+        # Spec-eligible VMs are QEMU instances, which are always persistent.
+        record = registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
         try:
             await _wait_until_running(supervisor, info.vm_id)
             for forward in await resolve_port_forwards(info.vm_id, content):
@@ -240,19 +250,11 @@ async def create_vm_execution(
             except Exception:
                 logger.exception("Teardown of half-started VM %s failed", vm_hash)
             raise
-        # TEMPORARY (PR 1 boundary, design doc sections 5/8): the operator
-        # endpoints, billing and update-watching still read owner identity and
-        # the message off the VmExecution, and start_persistent_vm drives it for
-        # the pre-existing check and expiry-cancel. Re-source the message-free
-        # execution as message-driven and hand it back unchanged. This goes away
-        # when those consumers read the registry instead.
-        execution = pool.executions[vm_hash]
-        execution.spec = MessageSpec(message=content, original=original_message.content)
-        # The spec create path skipped save() (no MessageSpec at start time).
-        # Persist the record now: registry rehydration and past-logs owner
-        # auth read the message back from the agent DB.
-        await execution.save()
-        return execution
+        # Agent persists its own knowledge; the hypervisor object is not
+        # touched. Registry rehydration and past-logs owner-auth read the
+        # message back from the agent DB.
+        await persist_record(vm_hash, record)
+        return None
 
     execution = await pool.create_a_vm(
         vm_hash=vm_hash,
@@ -270,7 +272,7 @@ async def create_vm_execution_or_raise_http_error(
     *,
     supervisor: Supervisor,
     registry: AgentVmRegistry,
-) -> VmExecution:
+) -> VmExecution | None:
     try:
         return await create_vm_execution(vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry)
     except ResourceDownloadError as error:
@@ -337,6 +339,9 @@ async def run_code_on_request(vm_hash: ItemHash, path: str, pool: VmPool, reques
         execution = await create_vm_execution_or_raise_http_error(
             vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry
         )
+        if execution is None:
+            # Spec-eligible messages are instances; they cannot serve code requests.
+            raise HTTPBadRequest(reason=f"VM {vm_hash} is an instance, not a program")
 
     logger.debug(f"Using vm={execution.vm_id}")
 
@@ -455,6 +460,9 @@ async def run_code_on_event(
         execution = await create_vm_execution_or_raise_http_error(
             vm_hash=vm_hash, pool=pool, supervisor=supervisor, registry=registry
         )
+        if execution is None:
+            # Spec-eligible messages are instances; they cannot serve code requests.
+            raise HTTPBadRequest(reason=f"VM {vm_hash} is an instance, not a program")
 
     logger.debug(f"Using vm={execution.vm_id}")
 

--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -192,7 +192,7 @@ async def watch_for_messages(
                 if key == "port-forwarding":
                     await _handle_port_forwarding_aggregate(message, supervisor, registry)
                 elif key == "domains":
-                    await _handle_domains_aggregate(message, pool)
+                    await _handle_domains_aggregate(message, pool, registry)
 
 
 async def _handle_port_forwarding_aggregate(
@@ -224,7 +224,7 @@ async def _handle_port_forwarding_aggregate(
             logger.exception("Failed to update port redirects for %s", vm_hash)
 
 
-async def _handle_domains_aggregate(message: AggregateMessage, pool: VmPool):
+async def _handle_domains_aggregate(message: AggregateMessage, pool: VmPool, registry: AgentVmRegistry):
     """Update HAProxy domain mapping when a domains aggregate changes.
 
     The aggregate content maps domain names to instance configs:
@@ -234,11 +234,16 @@ async def _handle_domains_aggregate(message: AggregateMessage, pool: VmPool):
     """
     address = message.content.address
 
-    # Trigger if the address owns any running instance on this node.
+    # Trigger if the address owns any running instance on this node. The owner
+    # address comes from the agent registry, not the hypervisor object —
+    # spec-built and restored executions carry no message.
     # This covers both additions (new domain pointing to local instance)
     # and deletions (domain removed — need to clean up the map).
     has_local_instance = any(
-        execution.is_instance and execution.vm and execution.message and execution.message.address == address
+        execution.is_instance
+        and execution.vm
+        and (record := registry.get(execution.vm_hash)) is not None
+        and record.message.address == address
         for execution in pool.executions.values()
     )
     if not has_local_instance:

--- a/src/aleph/vm/orchestrator/tasks.py
+++ b/src/aleph/vm/orchestrator/tasks.py
@@ -13,7 +13,9 @@ from aiohttp import web
 from aleph_message.models import (
     AggregateMessage,
     AlephMessage,
+    Chain,
     InstanceContent,
+    Payment,
     PaymentType,
     ProgramMessage,
     parse_message,
@@ -22,6 +24,7 @@ from aleph_message.status import MessageStatus
 from yarl import URL
 
 from aleph.vm.conf import settings
+from aleph.vm.models import VmExecution
 from aleph.vm.orchestrator.metrics import delete_port_mappings
 from aleph.vm.orchestrator.run import reconcile_port_forwards
 from aleph.vm.orchestrator.utils import (
@@ -302,6 +305,34 @@ async def monitor_payments(app: web.Application):
             logger.warning(f"check_payment failed {e}", exc_info=True)
 
 
+def _group_executions_by_payment(
+    pool: VmPool, registry: AgentVmRegistry, payment_type: PaymentType
+) -> dict[str, dict[Chain, list[VmExecution]]]:
+    """Group running executions by sender address and chain for one payment type.
+
+    The message (payment tier, owner address) comes from the agent registry;
+    the execution supplies only structural facts. Replaces the pool method that
+    read the message off the hypervisor object — and thereby skipped spec-built
+    and restart-restored VMs entirely.
+    """
+    executions_by_address: dict[str, dict[Chain, list[VmExecution]]] = {}
+    for vm_hash, execution in pool.executions.items():
+        record = registry.get(vm_hash)
+        if record is None:
+            # The agent has no message for this VM (e.g. the diagnostic fake
+            # never enters the registry); payment grouping cannot apply.
+            continue
+        if execution.vm_hash in (settings.CHECK_FASTAPI_VM_ID, settings.LEGACY_CHECK_FASTAPI_VM_ID):
+            # Ignore the diagnostic VM
+            continue
+        if not execution.is_running:
+            continue
+        payment = record.message.payment if record.message.payment else Payment(chain=Chain.ETH, type=PaymentType.hold)
+        if payment.type == payment_type:
+            executions_by_address.setdefault(record.message.address, {}).setdefault(payment.chain, []).append(execution)
+    return executions_by_address
+
+
 async def check_payment(pool: VmPool, supervisor: Supervisor, registry: AgentVmRegistry):
     """Ensures VMs are stopped if payment conditions are unmet, such as insufficient
     funds in the wallet or inadequate payment stream coverage. Handles forgotten VMs
@@ -351,7 +382,7 @@ async def check_payment(pool: VmPool, supervisor: Supervisor, registry: AgentVmR
             _terminal_strike_count.pop(str(vm_hash), None)
 
     # Check if the balance held in the wallet is sufficient holder tier resources (Not do it yet)
-    for execution_address, chains in pool.get_executions_by_address(payment_type=PaymentType.hold).items():
+    for execution_address, chains in _group_executions_by_payment(pool, registry, PaymentType.hold).items():
         for chain, executions in chains.items():
             executions = [execution for execution in executions if execution.is_confidential]
             if not executions:
@@ -378,7 +409,7 @@ async def check_payment(pool: VmPool, supervisor: Supervisor, registry: AgentVmR
         logger.error("Monitor payment ERROR: No community wallet set. Cannot check community payment")
 
     # Check if the credit balance held in the wallet is sufficient credit tier resources (Not do it yet)
-    for execution_address, chains in pool.get_executions_by_address(payment_type=PaymentType.credit).items():
+    for execution_address, chains in _group_executions_by_payment(pool, registry, PaymentType.credit).items():
         for chain, executions in chains.items():
             executions = [execution for execution in executions]
             if not executions:
@@ -401,7 +432,7 @@ async def check_payment(pool: VmPool, supervisor: Supervisor, registry: AgentVmR
                 required_credits = await compute_required_credit_balance(executions)
 
     # Check if the balance held in the wallet is sufficient stream tier resources
-    for execution_address, chains in pool.get_executions_by_address(payment_type=PaymentType.superfluid).items():
+    for execution_address, chains in _group_executions_by_payment(pool, registry, PaymentType.superfluid).items():
         for chain, executions in chains.items():
             try:
                 stream = await get_stream(

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -580,11 +580,17 @@ async def update_allocations(request: web.Request):
         stopped_vms = []
         # Make a copy since the pool is modified
         for execution in list(pool.get_persistent_executions()):
+            # Payment tier comes from the agent registry, not the hypervisor
+            # object: spec-built and restart-restored executions carry no
+            # message, but their registry record (rehydrated from the agent DB)
+            # does. No record behaves as hold-tier, exactly like the old
+            # message-less False.
+            record = registry.get(execution.vm_hash)
             if (
                 execution.vm_hash not in allocations
                 and execution.is_running
-                and not execution.uses_payment_stream
-                and not execution.uses_payment_credit
+                and not (record and record.uses_payment_stream)
+                and not (record and record.uses_payment_credit)
                 and not execution.gpus
                 and not execution.is_confidential
             ):

--- a/src/aleph/vm/orchestrator/vm_registry.py
+++ b/src/aleph/vm/orchestrator/vm_registry.py
@@ -13,10 +13,16 @@ import json
 import logging
 from collections.abc import ItemsView
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from uuid import uuid4
 
 from aleph_message.models import ExecutableContent, ItemHash
 
-from aleph.vm.orchestrator.metrics import get_execution_records
+from aleph.vm.orchestrator.metrics import (
+    ExecutionRecord,
+    get_execution_records,
+    save_record,
+)
 from aleph.vm.utils import get_message_executable_content
 
 logger = logging.getLogger(__name__)
@@ -32,6 +38,14 @@ class AgentVmRecord:
     message: ExecutableContent
     original: ExecutableContent
     persistent: bool = False
+
+    @property
+    def uses_payment_stream(self) -> bool:
+        return bool(self.message.payment and self.message.payment.is_stream)
+
+    @property
+    def uses_payment_credit(self) -> bool:
+        return bool(self.message.payment and self.message.payment.is_credit)
 
 
 class AgentVmRegistry:
@@ -94,3 +108,40 @@ async def rehydrate_registry(registry: AgentVmRegistry) -> int:
         registry.record(vm_hash, message=message, original=original, persistent=bool(db_record.persistent))
         count += 1
     return count
+
+
+async def persist_record(vm_hash: ItemHash, record: AgentVmRecord) -> None:
+    """Persist the agent's knowledge of a VM to the agent DB.
+
+    Write-side sibling of rehydrate_registry: what this writes is exactly what
+    rehydrate_registry needs to rebuild the registry after a restart (message,
+    original, persistent), carried on the existing ExecutionRecord table.
+    Hypervisor-owned facts are deliberately absent: vm_id (numeric id unknown
+    agent-side) and mapped_ports (the PortMapping table is the authority) are
+    None; both are read only by the debug records endpoint.
+    """
+    now = datetime.now(tz=timezone.utc)
+    resources = record.message.resources
+    db_record = ExecutionRecord(
+        uuid=str(uuid4()),
+        vm_hash=str(vm_hash),
+        vm_id=None,
+        time_defined=now,
+        time_prepared=now,
+        time_started=now,
+        time_stopping=None,
+        cpu_time_user=None,
+        cpu_time_system=None,
+        io_read_count=None,
+        io_write_count=None,
+        io_read_bytes=None,
+        io_write_bytes=None,
+        vcpus=resources.vcpus,
+        memory=resources.memory,
+        message=record.message.model_dump_json(),
+        original_message=record.original.model_dump_json(),
+        persistent=record.persistent,
+        gpus=json.dumps([]),
+        mapped_ports=None,
+    )
+    await save_record(db_record)

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import psutil
-from aleph_message.models import Chain, InstanceContent, ItemHash, Payment, PaymentType
+from aleph_message.models import InstanceContent, ItemHash
 
 from aleph.vm.conf import settings
 from aleph.vm.controllers.configuration import (
@@ -893,33 +893,6 @@ class VmPool:
             if not used:
                 available_gpus.append(gpu)
         return available_gpus
-
-    def get_executions_by_address(self, payment_type: PaymentType) -> dict[str, dict[str, list[VmExecution]]]:
-        """Return all executions of the given type, grouped by sender and by chain."""
-        executions_by_address: dict[str, dict[str, list[VmExecution]]] = {}
-        for vm_hash, execution in self.executions.items():
-            message = execution.message
-            if message is None:
-                # Spec-built (supervisor-owned) executions carry no message;
-                # payment grouping is an agent concern.
-                continue
-            if execution.vm_hash in (settings.CHECK_FASTAPI_VM_ID, settings.LEGACY_CHECK_FASTAPI_VM_ID):
-                # Ignore Diagnostic VM execution
-                continue
-
-            if not execution.is_running:
-                # Ignore the execution that is stopping or not running anymore
-                continue
-            if execution.vm_hash == settings.CHECK_FASTAPI_VM_ID:
-                # Ignore Diagnostic VM execution
-                continue
-            execution_payment = message.payment if message.payment else Payment(chain=Chain.ETH, type=PaymentType.hold)
-            if execution_payment.type == payment_type:
-                address = message.address
-                chain = execution_payment.chain
-                executions_by_address.setdefault(address, {})
-                executions_by_address[address].setdefault(chain, []).append(execution)
-        return executions_by_address
 
     def get_valid_reservation(self, resource) -> Reservation | None:
         if resource in self.reservations and self.reservations[resource].is_expired():

--- a/tests/supervisor/test_agent_vm_registry.py
+++ b/tests/supervisor/test_agent_vm_registry.py
@@ -8,9 +8,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aleph_message.models import ItemHash
 
+from aleph.vm.orchestrator.metrics import ExecutionRecord
 from aleph.vm.orchestrator.vm_registry import (
     AgentVmRecord,
     AgentVmRegistry,
+    persist_record,
     rehydrate_registry,
 )
 
@@ -139,3 +141,84 @@ async def test_rehydrate_propagates_db_error(monkeypatch):
     )
     with pytest.raises(RuntimeError, match="DB unavailable"):
         await rehydrate_registry(AgentVmRegistry())
+
+
+def test_record_payment_helpers():
+    stream = AgentVmRecord(
+        message=SimpleNamespace(payment=SimpleNamespace(is_stream=True, is_credit=False)),
+        original=MagicMock(),
+    )
+    credit = AgentVmRecord(
+        message=SimpleNamespace(payment=SimpleNamespace(is_stream=False, is_credit=True)),
+        original=MagicMock(),
+    )
+    hold = AgentVmRecord(message=SimpleNamespace(payment=None), original=MagicMock())
+
+    assert stream.uses_payment_stream is True and stream.uses_payment_credit is False
+    assert credit.uses_payment_stream is False and credit.uses_payment_credit is True
+    assert hold.uses_payment_stream is False and hold.uses_payment_credit is False
+
+
+@pytest.mark.asyncio
+async def test_persist_record_writes_agent_fields(monkeypatch):
+    saved: list[ExecutionRecord] = []
+    monkeypatch.setattr(
+        "aleph.vm.orchestrator.vm_registry.save_record",
+        AsyncMock(side_effect=saved.append),
+    )
+    message = MagicMock()
+    message.resources.vcpus = 2
+    message.resources.memory = 1024
+    message.model_dump_json.return_value = '{"m": 1}'
+    original = MagicMock()
+    original.model_dump_json.return_value = '{"o": 1}'
+
+    await persist_record(_HASH, AgentVmRecord(message=message, original=original, persistent=True))
+
+    assert len(saved) == 1
+    db = saved[0]
+    assert db.vm_hash == str(_HASH)
+    assert db.vm_id is None  # numeric hypervisor id unknown agent-side (debug-only column)
+    assert db.vcpus == 2 and db.memory == 1024
+    assert db.message == '{"m": 1}'
+    assert db.original_message == '{"o": 1}'
+    assert db.persistent is True
+    assert db.mapped_ports is None  # the PortMapping table is the authority
+    assert db.time_defined is not None
+    assert db.uuid  # fresh uuid per create, matching the old per-execution behavior
+
+
+@pytest.mark.asyncio
+async def test_persist_then_rehydrate_round_trip(monkeypatch):
+    """What persist_record writes is exactly what rehydrate_registry needs."""
+    saved: list[ExecutionRecord] = []
+    monkeypatch.setattr(
+        "aleph.vm.orchestrator.vm_registry.save_record",
+        AsyncMock(side_effect=saved.append),
+    )
+    message = MagicMock()
+    message.resources.vcpus = 1
+    message.resources.memory = 256
+    message.model_dump_json.return_value = '{"address": "0xabc"}'
+    original = MagicMock()
+    original.model_dump_json.return_value = '{"address": "0xabc"}'
+    await persist_record(_HASH, AgentVmRecord(message=message, original=original, persistent=True))
+
+    monkeypatch.setattr(
+        "aleph.vm.orchestrator.vm_registry.get_execution_records",
+        AsyncMock(return_value=saved),
+    )
+    parsed = MagicMock()
+    monkeypatch.setattr(
+        "aleph.vm.orchestrator.vm_registry.get_message_executable_content",
+        MagicMock(return_value=parsed),
+    )
+    registry = AgentVmRegistry()
+
+    count = await rehydrate_registry(registry)
+
+    assert count == 1
+    rec = registry.get(_HASH)
+    assert rec.message is parsed
+    assert rec.original is parsed
+    assert rec.persistent is True

--- a/tests/supervisor/test_checkpayment.py
+++ b/tests/supervisor/test_checkpayment.py
@@ -2,12 +2,13 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from aleph_message.models import Chain, InstanceContent, PaymentType
+from aleph_message.models import Chain, InstanceContent, ItemHash, PaymentType
 from aleph_message.status import MessageStatus
 
 from aleph.vm.conf import settings
 from aleph.vm.models import VmExecution
-from aleph.vm.orchestrator.tasks import check_payment
+from aleph.vm.orchestrator.tasks import _group_executions_by_payment, check_payment
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.pool import VmPool
 from aleph.vm.supervisor.types import VmId
 
@@ -44,9 +45,9 @@ def _make_supervisor() -> MagicMock:
     return MagicMock(delete_vm=AsyncMock())
 
 
-def _make_registry() -> MagicMock:
-    """Return a fake AgentVmRegistry with a no-op forget."""
-    return MagicMock(forget=MagicMock())
+def _make_registry() -> AgentVmRegistry:
+    """Return a real AgentVmRegistry (check_payment groups via the registry)."""
+    return AgentVmRegistry()
 
 
 @pytest.mark.asyncio
@@ -95,8 +96,9 @@ async def test_enough_flow(mocker, fake_instance_content):
     assert execution.times.started_at is None
 
     pool.executions = {hash: execution}
+    registry.record(ItemHash(hash), message=message, original=message, persistent=execution.persistent)
 
-    executions_by_sender = pool.get_executions_by_address(payment_type=PaymentType.superfluid)
+    executions_by_sender = _group_executions_by_payment(pool, registry, PaymentType.superfluid)
     assert len(executions_by_sender) == 1
     assert executions_by_sender == {"0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9": {Chain.BASE: [execution]}}
 
@@ -152,8 +154,9 @@ async def test_enough_flow_not_community(mocker, fake_instance_content):
     assert execution.times.started_at is None
 
     pool.executions = {hash: execution}
+    registry.record(ItemHash(hash), message=message, original=message, persistent=execution.persistent)
 
-    executions_by_sender = pool.get_executions_by_address(payment_type=PaymentType.superfluid)
+    executions_by_sender = _group_executions_by_payment(pool, registry, PaymentType.superfluid)
     assert len(executions_by_sender) == 1
     assert executions_by_sender == {"0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9": {Chain.BASE: [execution]}}
 
@@ -192,8 +195,9 @@ async def test_not_enough_flow(mocker, fake_instance_content):
     )
 
     pool.executions = {hash: execution}
+    registry.record(ItemHash(hash), message=message, original=message, persistent=execution.persistent)
 
-    executions_by_sender = pool.get_executions_by_address(payment_type=PaymentType.superfluid)
+    executions_by_sender = _group_executions_by_payment(pool, registry, PaymentType.superfluid)
     assert len(executions_by_sender) == 1
     assert executions_by_sender == {"0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9": {Chain.BASE: [execution]}}
 
@@ -202,7 +206,7 @@ async def test_not_enough_flow(mocker, fake_instance_content):
     # Insufficient-funds stop: supervisor.delete_vm is called, registry.forget is NOT called
     # (VM may be re-paid and restarted).
     supervisor.delete_vm.assert_awaited_once_with(VmId(str(hash)))
-    registry.forget.assert_not_called()
+    assert ItemHash(hash) in registry
 
 
 @pytest.mark.asyncio
@@ -241,8 +245,9 @@ async def test_not_enough_community_flow(mocker, fake_instance_content):
     )
 
     pool.executions = {hash: execution}
+    registry.record(ItemHash(hash), message=message, original=message, persistent=execution.persistent)
 
-    executions_by_sender = pool.get_executions_by_address(payment_type=PaymentType.superfluid)
+    executions_by_sender = _group_executions_by_payment(pool, registry, PaymentType.superfluid)
     assert len(executions_by_sender) == 1
     assert executions_by_sender == {"0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9": {Chain.BASE: [execution]}}
 
@@ -250,7 +255,7 @@ async def test_not_enough_community_flow(mocker, fake_instance_content):
 
     # Insufficient-funds stop: supervisor.delete_vm is called, registry.forget is NOT called.
     supervisor.delete_vm.assert_awaited_once_with(VmId(str(hash)))
-    registry.forget.assert_not_called()
+    assert ItemHash(hash) in registry
 
 
 @pytest.mark.asyncio
@@ -282,15 +287,16 @@ async def test_message_removing_status(mocker, fake_instance_content):
     )
 
     pool.executions = {hash: execution}
+    registry.record(ItemHash(hash), message=message, original=message, persistent=execution.persistent)
 
-    executions_by_sender = pool.get_executions_by_address(payment_type=PaymentType.superfluid)
+    executions_by_sender = _group_executions_by_payment(pool, registry, PaymentType.superfluid)
     assert len(executions_by_sender) == 1
     assert executions_by_sender == {"0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9": {Chain.BASE: [execution]}}
 
     await check_payment(pool=pool, supervisor=supervisor, registry=registry)
 
     supervisor.delete_vm.assert_not_called()
-    registry.forget.assert_not_called()
+    assert ItemHash(hash) in registry
 
 
 @pytest.mark.asyncio
@@ -324,8 +330,9 @@ async def test_removed_message_status(mocker, fake_instance_content):
     )
 
     pool.executions = {hash: execution}
+    registry.record(ItemHash(hash), message=message, original=message, persistent=execution.persistent)
 
-    executions_by_sender = pool.get_executions_by_address(payment_type=PaymentType.superfluid)
+    executions_by_sender = _group_executions_by_payment(pool, registry, PaymentType.superfluid)
     assert len(executions_by_sender) == 1
     assert executions_by_sender == {"0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9": {Chain.BASE: [execution]}}
 
@@ -340,5 +347,5 @@ async def test_removed_message_status(mocker, fake_instance_content):
     # Terminal-status dealloc: supervisor.delete_vm + delete_port_mappings (residual) + registry.forget
     supervisor.delete_vm.assert_awaited_once_with(VmId(str(hash)))
     mock_delete_port_mappings.assert_awaited_once_with(hash)
-    registry.forget.assert_called_once_with(hash)
+    assert ItemHash(hash) not in registry
     # pool.stop_vm and pool.forget_vm must NOT be called

--- a/tests/supervisor/test_execution.py
+++ b/tests/supervisor/test_execution.py
@@ -326,3 +326,9 @@ def test_vm_execution_has_no_update_watch_api():
 
     for gone in ("start_watching_for_updates", "watch_for_updates", "cancel_update"):
         assert not hasattr(VmExecution, gone), f"{gone} should be removed from VmExecution"
+
+
+def test_vm_execution_has_no_payment_api():
+    """Payment tier is agent knowledge (AgentVmRecord), not a hypervisor-object concern."""
+    assert not hasattr(VmExecution, "uses_payment_stream")
+    assert not hasattr(VmExecution, "uses_payment_credit")

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -17,7 +17,6 @@ from aleph_message.models.execution.environment import (
 )
 from test_supervisor_translate import _make_qemu_instance_message
 
-from aleph.vm.models import MessageSpec
 from aleph.vm.orchestrator import run as run_module
 from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 from aleph.vm.supervisor.errors import VmNotFoundError
@@ -93,11 +92,14 @@ async def test_eligible_instance_routed_through_supervisor(monkeypatch):
     monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(return_value=spec))
     monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
     monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+    persist = AsyncMock()
+    monkeypatch.setattr(run_module, "persist_record", persist)
 
     supervisor = _fake_supervisor()
     registry = AgentVmRegistry()
-    created = SimpleNamespace(save=AsyncMock())
-    pool = SimpleNamespace(executions={_HASH: created}, create_a_vm=AsyncMock())
+    # An EMPTY pool: the spec path must never read pool.executions (the old
+    # readback would KeyError here).
+    pool = SimpleNamespace(executions={}, create_a_vm=AsyncMock())
 
     execution = await run_module.create_vm_execution(
         _HASH, pool, supervisor=supervisor, registry=registry, persistent=True
@@ -106,19 +108,16 @@ async def test_eligible_instance_routed_through_supervisor(monkeypatch):
     supervisor.create_vm.assert_awaited_once_with(spec)
     pool.create_a_vm.assert_not_awaited()
     # The message is recorded in the agent registry, not on the execution.
-    assert registry.get(_HASH).message is content
-    assert registry.get(_HASH).original is original_content
-    assert registry.get(_HASH).persistent is True
-    # The spec create path must persist the execution record after re-sourcing.
-    created.save.assert_awaited_once()
+    record = registry.get(_HASH)
+    assert record.message is content
+    assert record.original is original_content
+    assert record.persistent is True
+    # The agent persists its own record; the hypervisor object is never touched.
+    persist.assert_awaited_once_with(_HASH, record)
     # SSH port-forward applied through the abstraction.
     assert supervisor.add_port_forward.await_count >= 1
-    # The execution is read back from the pool once for start_persistent_vm.
-    assert execution is created
-    # PR 1 boundary: the message-free execution is re-sourced as message-driven
-    # so the operator API (owner-auth, billing) keeps reading execution.message
-    # until those consumers move to the registry.
-    assert execution.spec == MessageSpec(message=content, original=original_content)
+    # Spec path returns None: no caller consumes a hypervisor object from it.
+    assert execution is None
     supervisor.delete_vm.assert_not_awaited()
 
 

--- a/tests/supervisor/test_supervisor_spec_execution.py
+++ b/tests/supervisor/test_supervisor_spec_execution.py
@@ -55,9 +55,6 @@ def test_spec_properties_for_qemu_instance():
     assert execution.is_program is False
     assert execution.is_confidential is False
     assert execution.hypervisor is HypervisorType.qemu
-    # Payment flags are agent-side; absent without a message.
-    assert execution.uses_payment_stream is False
-    assert execution.uses_payment_credit is False
 
 
 def test_from_spec_sets_spec_and_no_message():

--- a/tests/supervisor/test_supervisor_spec_pool_guards.py
+++ b/tests/supervisor/test_supervisor_spec_pool_guards.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from aleph_message.models import PaymentType
-
 from aleph.vm.models import VmExecution
 from aleph.vm.pool import VmPool
 from aleph.vm.supervisor.types import (
@@ -49,17 +47,3 @@ def test_allocated_properties_from_spec():
     execution = VmExecution.from_spec(_spec(), snapshot_manager=None, systemd_manager=None)
     assert execution.allocated_memory_mib == 1024
     assert execution.allocated_vcpus == 2
-
-
-def test_get_executions_by_address_skips_message_less():
-    pool = VmPool.__new__(VmPool)
-    pool.executions = {}
-    spec_exec = VmExecution.from_spec(_spec(), snapshot_manager=None, systemd_manager=None)
-    # Mark it "running" so the iteration does not skip it for that reason;
-    # systemd_manager is None so is_running falls back to the times check.
-    spec_exec.times.started_at = spec_exec.times.starting_at = spec_exec.times.defined_at
-    pool.executions[_HASH] = spec_exec
-
-    # Must not raise even though execution.message is None.
-    result = pool.get_executions_by_address(PaymentType.hold)
-    assert result == {}

--- a/tests/supervisor/test_tasks_registry_reads.py
+++ b/tests/supervisor/test_tasks_registry_reads.py
@@ -9,7 +9,10 @@ import pytest
 from aleph_message.models import Chain, ItemHash, Payment, PaymentType
 
 from aleph.vm.conf import settings
-from aleph.vm.orchestrator.tasks import _group_executions_by_payment
+from aleph.vm.orchestrator.tasks import (
+    _group_executions_by_payment,
+    _handle_domains_aggregate,
+)
 from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
 
 _HASH = ItemHash("deadbeef" * 8)
@@ -95,6 +98,64 @@ def test_grouping_skips_stopped_and_diagnostic_executions():
     )
 
     assert _group_executions_by_payment(pool, registry, PaymentType.hold) == {}
+
+
+@pytest.mark.asyncio
+async def test_domains_aggregate_triggers_for_registry_recorded_instance():
+    """A message-less (spec-built / restored) instance must still trigger the
+    HAProxy domain-mapping refresh when its registry record matches the owner."""
+    registry = _registry_with(_HASH, payment=None, address="0xowner")
+    execution = SimpleNamespace(vm_hash=_HASH, is_instance=True, vm=object())
+    pool = SimpleNamespace(
+        executions={_HASH: execution},
+        update_domain_mapping=AsyncMock(),
+    )
+    aggregate = SimpleNamespace(content=SimpleNamespace(address="0xowner"))
+
+    await _handle_domains_aggregate(aggregate, pool, registry)
+
+    pool.update_domain_mapping.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_domains_aggregate_ignores_unrelated_address():
+    registry = _registry_with(_HASH, payment=None, address="0xowner")
+    execution = SimpleNamespace(vm_hash=_HASH, is_instance=True, vm=object())
+    pool = SimpleNamespace(
+        executions={_HASH: execution},
+        update_domain_mapping=AsyncMock(),
+    )
+    aggregate = SimpleNamespace(content=SimpleNamespace(address="0xsomeoneelse"))
+
+    await _handle_domains_aggregate(aggregate, pool, registry)
+
+    pool.update_domain_mapping.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_domains_aggregate_ignores_unrecorded_execution():
+    """A matching-owner instance the agent has no record for must NOT trigger a
+    refresh (no registry record -> short-circuits before the address compare)."""
+    execution = SimpleNamespace(vm_hash=_HASH, is_instance=True, vm=object())
+    pool = SimpleNamespace(executions={_HASH: execution}, update_domain_mapping=AsyncMock())
+    aggregate = SimpleNamespace(content=SimpleNamespace(address="0xowner"))
+
+    await _handle_domains_aggregate(aggregate, pool, AgentVmRegistry())
+
+    pool.update_domain_mapping.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_domains_aggregate_ignores_non_instance():
+    """A program (not an instance) owned by the address must NOT trigger a refresh."""
+    registry = _registry_with(_HASH, payment=None, address="0xowner")
+    execution = SimpleNamespace(vm_hash=_HASH, is_instance=False, vm=object())
+    pool = SimpleNamespace(executions={_HASH: execution}, update_domain_mapping=AsyncMock())
+    aggregate = SimpleNamespace(content=SimpleNamespace(address="0xowner"))
+
+    await _handle_domains_aggregate(aggregate, pool, registry)
+
+    pool.update_domain_mapping.assert_not_awaited()
 
 
 def test_pool_has_no_message_reads():

--- a/tests/supervisor/test_tasks_registry_reads.py
+++ b/tests/supervisor/test_tasks_registry_reads.py
@@ -1,0 +1,108 @@
+"""Agent-side registry reads in tasks.py: payment grouping and the domains aggregate."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aleph_message.models import Chain, ItemHash, Payment, PaymentType
+
+from aleph.vm.conf import settings
+from aleph.vm.orchestrator.tasks import _group_executions_by_payment
+from aleph.vm.orchestrator.vm_registry import AgentVmRegistry
+
+_HASH = ItemHash("deadbeef" * 8)
+
+
+def _execution(vm_hash: ItemHash, *, is_running: bool = True) -> SimpleNamespace:
+    # Message-less, structurally-typed stand-in for a spec-built pool execution.
+    return SimpleNamespace(vm_hash=vm_hash, is_running=is_running)
+
+
+def _registry_with(vm_hash: ItemHash, *, payment: Payment | None, address: str = "0xabc") -> AgentVmRegistry:
+    registry = AgentVmRegistry()
+    registry.record(
+        vm_hash,
+        message=SimpleNamespace(payment=payment, address=address),
+        original=MagicMock(),
+        persistent=True,
+    )
+    return registry
+
+
+def test_grouping_sources_message_from_registry():
+    """A message-less (spec-built / restored) execution with a registry record is grouped."""
+    payment = Payment(chain=Chain.ETH, type=PaymentType.superfluid)
+    registry = _registry_with(_HASH, payment=payment)
+    pool = SimpleNamespace(executions={_HASH: _execution(_HASH)})
+
+    groups = _group_executions_by_payment(pool, registry, PaymentType.superfluid)
+
+    assert list(groups) == ["0xabc"]
+    assert list(groups["0xabc"]) == [Chain.ETH]
+    assert groups["0xabc"][Chain.ETH][0].vm_hash == _HASH
+
+
+def test_grouping_skips_unrecorded_executions():
+    """No registry record -> the agent knows no message -> not grouped."""
+    pool = SimpleNamespace(executions={_HASH: _execution(_HASH)})
+
+    groups = _group_executions_by_payment(pool, AgentVmRegistry(), PaymentType.superfluid)
+
+    assert groups == {}
+
+
+def test_grouping_defaults_to_hold_and_filters_by_type():
+    registry = _registry_with(_HASH, payment=None)  # no payment -> hold tier
+    pool = SimpleNamespace(executions={_HASH: _execution(_HASH)})
+
+    assert _group_executions_by_payment(pool, registry, PaymentType.superfluid) == {}
+    hold_groups = _group_executions_by_payment(pool, registry, PaymentType.hold)
+    assert hold_groups["0xabc"][Chain.ETH][0].vm_hash == _HASH
+
+
+def test_grouping_skips_stopped_and_diagnostic_executions():
+    payment = Payment(chain=Chain.ETH, type=PaymentType.hold)
+    registry = _registry_with(_HASH, payment=payment)
+    fake_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    registry.record(
+        fake_hash,
+        message=SimpleNamespace(payment=payment, address="0xabc"),
+        original=MagicMock(),
+        persistent=True,
+    )
+    diag = SimpleNamespace(vm_hash=ItemHash(settings.CHECK_FASTAPI_VM_ID), is_running=True)
+    registry.record(
+        diag.vm_hash,
+        message=SimpleNamespace(payment=payment, address="0xabc"),
+        original=MagicMock(),
+        persistent=True,
+    )
+    legacy = SimpleNamespace(vm_hash=ItemHash(settings.LEGACY_CHECK_FASTAPI_VM_ID), is_running=True)
+    registry.record(
+        legacy.vm_hash,
+        message=SimpleNamespace(payment=payment, address="0xabc"),
+        original=MagicMock(),
+        persistent=True,
+    )
+    pool = SimpleNamespace(
+        executions={
+            _HASH: _execution(_HASH, is_running=False),  # stopped -> skipped
+            diag.vm_hash: diag,  # diagnostic -> skipped
+            legacy.vm_hash: legacy,  # legacy diagnostic -> skipped
+        }
+    )
+
+    assert _group_executions_by_payment(pool, registry, PaymentType.hold) == {}
+
+
+def test_pool_has_no_message_reads():
+    """pool.py must not learn messages off executions; that is registry territory."""
+    import inspect
+
+    from aleph.vm import pool as pool_module
+
+    source = inspect.getsource(pool_module)
+    assert "execution.message" not in source
+    assert "get_executions_by_address" not in source

--- a/tests/supervisor/test_tasks_registry_reads.py
+++ b/tests/supervisor/test_tasks_registry_reads.py
@@ -68,13 +68,6 @@ def test_grouping_defaults_to_hold_and_filters_by_type():
 def test_grouping_skips_stopped_and_diagnostic_executions():
     payment = Payment(chain=Chain.ETH, type=PaymentType.hold)
     registry = _registry_with(_HASH, payment=payment)
-    fake_hash = ItemHash(settings.FAKE_INSTANCE_ID)
-    registry.record(
-        fake_hash,
-        message=SimpleNamespace(payment=payment, address="0xabc"),
-        original=MagicMock(),
-        persistent=True,
-    )
     diag = SimpleNamespace(vm_hash=ItemHash(settings.CHECK_FASTAPI_VM_ID), is_running=True)
     registry.record(
         diag.vm_hash,

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from datetime import datetime, timezone
 from hashlib import sha256
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, call
 
@@ -1367,3 +1368,111 @@ async def test_v2_executions_list_omits_ghost_mapped_ports(
     assert response.status == 200
     body = await response.json()
     assert body[vm_hash]["networking"]["mapped_ports"] == {"22": {"host": 24000, "tcp": True, "udp": False}}
+
+
+@pytest.mark.asyncio
+async def test_update_allocations_spares_payg_via_registry(aiohttp_client):
+    """A message-less execution whose REGISTRY record is stream-paid must be spared
+    by the stop loop even when absent from the allocation (the restored-PAYG case)."""
+    vm_hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
+    instance_content = {
+        "address": "0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9",
+        "time": 1713874241.800818,
+        "allow_amend": False,
+        "metadata": None,
+        "authorized_keys": None,
+        "variables": None,
+        "environment": {"reproducible": False, "internet": True, "aleph_api": True, "shared_cache": False},
+        "resources": {"vcpus": 1, "memory": 256, "seconds": 30, "published_ports": None},
+        "payment": {"type": "superfluid", "chain": "BASE"},
+        "requirements": None,
+        "replaces": None,
+        "rootfs": {
+            "parent": {"ref": "63f07193e6ee9d207b7d1fcf8286f9aee34e6f12f101d2ec77c1229f92964696"},
+            "ref": "63f07193e6ee9d207b7d1fcf8286f9aee34e6f12f101d2ec77c1229f92964696",
+            "use_latest": True,
+            "comment": "",
+            "persistence": "host",
+            "size_mib": 1000,
+        },
+    }
+    message = InstanceContent.model_validate(instance_content)
+
+    # Message-less, structurally-typed stand-in for a restored spec-built execution:
+    # the payment tier is knowable only through the registry.
+    execution = SimpleNamespace(
+        vm_hash=ItemHash(vm_hash),
+        is_running=True,
+        gpus=[],
+        is_confidential=False,
+        is_instance=True,
+    )
+
+    class FakeVmPool:
+        def get_persistent_executions(self):
+            return [execution]
+
+    pool = FakeVmPool()
+    app = setup_webapp(pool=pool)
+    app["pubsub"] = None
+    app["vm_registry"].record(ItemHash(vm_hash), message=message, original=message, persistent=True)
+
+    fake_supervisor = MagicMock(delete_vm=AsyncMock())
+    app["supervisor"] = fake_supervisor
+
+    settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
+    client = await aiohttp_client(app)
+
+    response = await client.post(
+        "/control/allocations",
+        json={"persistent_vms": []},
+        headers={"X-Auth-Signature": "test"},
+    )
+    assert response.status == 200
+    resp_json = await response.json()
+    assert vm_hash not in resp_json["stopped"]
+    fake_supervisor.delete_vm.assert_not_awaited()
+    assert ItemHash(vm_hash) in app["vm_registry"]
+
+
+@pytest.mark.asyncio
+async def test_update_allocations_stops_unrecorded_execution(aiohttp_client, mocker):
+    """No registry record behaves as hold-tier: a record-less persistent VM absent
+    from the allocation must still be stopped (mirrors the old message-less False)."""
+    vm_hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
+    # Message-less execution with NO registry record seeded.
+    execution = SimpleNamespace(
+        vm_hash=ItemHash(vm_hash),
+        is_running=True,
+        gpus=[],
+        is_confidential=False,
+        is_instance=True,
+    )
+
+    class FakeVmPool:
+        def get_persistent_executions(self):
+            return [execution]
+
+    pool = FakeVmPool()
+    app = setup_webapp(pool=pool)
+    app["pubsub"] = None
+    # Deliberately do NOT record vm_hash in app["vm_registry"].
+
+    fake_supervisor = MagicMock(delete_vm=AsyncMock())
+    app["supervisor"] = fake_supervisor
+
+    mock_delete_port_mappings = mocker.patch("aleph.vm.orchestrator.views.delete_port_mappings", new_callable=AsyncMock)
+
+    settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
+    client = await aiohttp_client(app)
+
+    response = await client.post(
+        "/control/allocations",
+        json={"persistent_vms": []},
+        headers={"X-Auth-Signature": "test"},
+    )
+    assert response.status == 200
+    resp_json = await response.json()
+    assert vm_hash in resp_json["stopped"]
+    fake_supervisor.delete_vm.assert_awaited_once_with(VmId(str(vm_hash)))
+    mock_delete_port_mappings.assert_awaited_once_with(vm_hash)


### PR DESCRIPTION
Fourth of the Phase-0 residual cleanups in the message-free supervisor series (after #969 expiry, #970 update-watching, #971 owner-auth). Makes the agent persist its **own** DB record and migrates the last agent-side readers of pool-execution messages to the `AgentVmRegistry`, then **kills the `create_vm_execution` readback**.

Design: `docs/plans/2026-06-10-agent-record-persistence-design.md`
Plan: `docs/plans/2026-06-10-agent-record-persistence-plan.md`

## Why

The supervisor's spec create path is message-free — but `create_vm_execution` immediately undid that: it reached back into `pool.executions[vm_hash]`, glued a `MessageSpec` onto the hypervisor object, and called `execution.save()` to write the agent's DB record (a block commented `TEMPORARY`). That readback is the last agent reach-in on the create path and can't exist once the supervisor is a separate process. Removing it requires (a) the agent persisting its own record, and (b) the few agent-side readers that still learned a VM's message off the pool object reading the agent registry instead.

## What

- **`persist_record`** (`vm_registry.py`) — write-side sibling of `rehydrate_registry`: the agent writes its own `ExecutionRecord` (message/original/persistent/resources; `vm_id`/`mapped_ports` left `None` as hypervisor-owned debug-only fields). Round-trip tested against `rehydrate_registry`.
- **Readback killed** (`run.py`): the spec path now `persist_record(...)` and returns `None` (signature `-> VmExecution | None`); the two program callers guard the `None` case with an explicit 400. The routing test runs against an **empty pool**, so a re-introduced readback would `KeyError`.
- **Payment grouping → registry**: `pool.get_executions_by_address` deleted; replaced by agent-side `_group_executions_by_payment(pool, registry, …)` in `tasks.py` (message from the registry, liveness from the execution).
- **`update_allocations`** payment-tier guards read `record.uses_payment_*`; the dead `VmExecution.uses_payment_stream/credit` properties are deleted.
- **Domains aggregate** reads the owner address from the registry.

## Behavior

Authorized/legacy paths unchanged. Two intended changes, both from sourcing the message via the registry (rehydrated from the agent DB) instead of the hypervisor object:

- **Spec-built and restart-restored VMs are now covered** by payment grouping, the `update_allocations` guards, and the domains-aggregate refresh — previously they carried no message on the pool object and were silently skipped.
- Spec-created executions now **never** carry a `MessageSpec`: `execution.message` is `None` for them in all code paths (a `test_pool_has_no_message_reads` source guard, plus the operator.py guard from #971, lock this in), so any new pool-message dependency fails visibly in dev rather than working-until-reboot.

## Scope (per design §3 / scheduler decision)

The new scheduler allocates PAYG and the legacy `/control/allocations/notify` flow is deprecating, so payment enforcement is a scheduler prerogative. This PR moves **where payment data comes from** (registry, not pool-message); it does **not** redesign or delete `check_payment`'s balance/credit/stream logic or the terminal-status stop loop — those deprecate later with the legacy flow. Structural `pool.executions` iteration, `execution.vm` operator reads, and the `about_executions` debug endpoint are deferred Phase-1 residuals (§7).

## Tests

`persist_record`→`rehydrate` round-trip; registry-sourced grouping (incl. the restored-VM coverage case, both diagnostic-hash skips, hold default); `update_allocations` spares-PAYG-via-registry and stops-unrecorded; domains skip-matrix; empty-pool routing regression guard; `uses_payment_*`-gone API guard; `pool.py`-has-no-message-reads source guard. Pre-existing `test_checkpayment.py` (×6) and `test_supervisor_spec_pool_guards.py` migrated to a real seeded registry. Touched test files: **125 passed**.

Remaining `tests/supervisor` failures are pre-existing on the stack and unrelated to this PR: `test_run_idle_teardown.py` (4 tests — a `KeyError: 'update_watcher'` introduced by #970's run.py change, whose `FakeRequest` was never updated; verified failing at this PR's base) plus the environmental `chown`/pyroute2/firecracker failures.

## Stacking

Stacked on #971 (`od/wire-supervisor-owner-auth`). Base this PR on that branch; retarget to `dev` once #971 merges.
