### PR TITLE
test(update-watch): await reap/cancel tasks instead of wall-clock sleeps

### DIFF
--- a/tests/supervisor/test_expiry.py
+++ b/tests/supervisor/test_expiry.py
@@ -109,7 +109,9 @@ async def test_expiry_on_reaped_called_after_reap():
     vm_id = VmId("vm-a")
 
     expiry.schedule(vm_id, 0.01)
-    await asyncio.sleep(0.05)
+    # on_reaped fires inside _expire's finally, before the task completes, so
+    # awaiting the task deterministically guarantees the callback has run.
+    await asyncio.wait_for(expiry._tasks[vm_id], timeout=WAIT_TIMEOUT)
 
     assert reaped == [vm_id]
 
@@ -123,7 +125,11 @@ async def test_expiry_on_reaped_not_called_on_cancel():
     vm_id = VmId("vm-a")
 
     expiry.schedule(vm_id, 0.05)
+    task = expiry._tasks[vm_id]
     expiry.cancel(vm_id)
-    await asyncio.sleep(0.1)
+    # Awaiting the cancelled task drives it to completion (its finally runs and
+    # leaves reaped False), so the assertion no longer races a wall-clock sleep.
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
     assert reaped == []

--- a/tests/supervisor/test_update_watcher.py
+++ b/tests/supervisor/test_update_watcher.py
@@ -53,6 +53,7 @@ def _registry_with(vm_hash: str, original):
 
 
 _HASH = "a" * 64
+WAIT_TIMEOUT = 5.0
 
 
 def test_update_refs_instance_uses_volume_refs():
@@ -210,7 +211,9 @@ async def test_expiry_reap_cancels_update_watch():
 
     watcher.watch(vm_id, _HASH, FakePubSub())
     expiry.schedule(vm_id, 0.01)
-    await asyncio.sleep(0.05)  # expiry fires, reaps, cancels the watch
+    # expiry.on_reaped (= watcher.cancel) runs inside _expire's finally before the
+    # task completes, so awaiting the task is enough to observe the cancellation.
+    await asyncio.wait_for(expiry._tasks[vm_id], timeout=WAIT_TIMEOUT)
 
     assert sup.deleted == [(_HASH, False)]  # expiry reaped
     assert watcher.cancel(vm_id) is False  # the watch was cancelled (gone)
@@ -243,8 +246,11 @@ async def test_update_watch_on_reaped_not_called_on_cancel():
     vm_id = VmId(_HASH)
 
     watcher.watch(vm_id, _HASH, pubsub)
-    await asyncio.sleep(0)
+    task = watcher._tasks[vm_id]
     watcher.cancel(vm_id)
-    await asyncio.sleep(0.02)
+    # Awaiting the cancelled task runs its finally (reaped stays False) without
+    # relying on a wall-clock sleep to let the cancellation settle.
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
     assert reaped == []  # cancellation is not a reap


### PR DESCRIPTION
## Context

The CI-robustness fixes requested in the #970 review were committed but never pushed before #970 was squash-merged, so they did not land in `dev`. This re-applies them as a standalone change.

## What changed

Replace time-based sleeps in the `on_reaped` reap/cancel tests with direct awaits on the timer task. `on_reaped` fires inside `_expire`/`_watch`'s `finally` block, *before* the task completes, so awaiting the task deterministically observes the callback (or, for cancellation, drives the `finally` to completion without firing it).

- `test_expiry_on_reaped_called_after_reap` — `sleep(0.05)` → `await wait_for(expiry._tasks[vm_id], WAIT_TIMEOUT)`
- `test_expiry_on_reaped_not_called_on_cancel` — `sleep(0.1)` → capture task, cancel, `pytest.raises(CancelledError)` on await
- `test_expiry_reap_cancels_update_watch` — `sleep(0.05)` → `await wait_for(...)`
- `test_update_watch_on_reaped_not_called_on_cancel` — `sleep(0.02)` → capture task, cancel, `pytest.raises(CancelledError)` on await

Removes the 0.01s-timer-vs-0.05s-sleep margin that could flake on loaded CI runners, matching the existing `wait_for(expiry._tasks[vm_id], ...)` pattern already used elsewhere in `test_expiry.py`.

## Verification

`test_expiry.py` + `test_update_watcher.py`: 19 passed, stable across repeated runs.