### PR TITLE
fix(connectivity): replace flaky example.org DNS probe with dual-stack fallback

### DIFF
--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -207,6 +207,10 @@ jobs:
           echo ALEPH_VM_SUPERVISOR_HOST=0.0.0.0 >> supervisor.env
           echo ALEPH_VM_ALLOCATION_TOKEN_HASH=9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08 >> supervisor.env
           echo ALEPH_VM_SENTRY_DSN=${{ secrets.SENTRY_DSN }} >> supervisor.env
+          # Pin public resolvers for guest VMs: DNS auto-detection on the droplet
+          # picks up DigitalOcean's VPC-internal resolver (e.g. 10.110.15.254),
+          # which is unreachable from inside the VMs and breaks all guest DNS.
+          echo 'ALEPH_VM_DNS_NAMESERVERS=["1.1.1.1","8.8.8.8"]' >> supervisor.env
           ssh  root@${DROPLET_IPV4} mkdir -p /etc/aleph-vm/
           scp supervisor.env root@${DROPLET_IPV4}:/etc/aleph-vm/supervisor.env
           scp packaging/target/${{ matrix.os_config.package_name }} root@${DROPLET_IPV4}:/opt
@@ -354,6 +358,10 @@ jobs:
           echo ALEPH_VM_SUPERVISOR_HOST=0.0.0.0 >> supervisor.env
           echo ALEPH_VM_FAKE_DATA_PROGRAM=/opt/examples/example_fastapi >> supervisor.env
           echo ALEPH_VM_FAKE_DATA_RUNTIME=/opt/rootfs.squashfs >> supervisor.env
+          # Pin public resolvers for guest VMs: DNS auto-detection on the droplet
+          # picks up DigitalOcean's VPC-internal resolver (e.g. 10.110.15.254),
+          # which is unreachable from inside the VMs and breaks all guest DNS.
+          echo 'ALEPH_VM_DNS_NAMESERVERS=["1.1.1.1","8.8.8.8"]' >> supervisor.env
           ssh  root@${DROPLET_IPV4} mkdir -p /etc/aleph-vm/
           scp supervisor.env root@${DROPLET_IPV4}:/etc/aleph-vm/supervisor.env
           scp packaging/target/aleph-vm.debian-12.deb root@${DROPLET_IPV4}:/opt

--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: droplet-aleph-vm-runtime
     timeout-minutes: 10
-    needs: build_deb
+    needs: [build_deb, build_example_venv_volume]
 
     steps:
       - name: Checkout repository
@@ -330,6 +330,15 @@ jobs:
         with:
           name: "aleph-vm.debian-12.deb"
           path: packaging/target/
+
+      # The supervisor requires the example venv volume when running with fake data
+      # (ALEPH_VM_FAKE_DATA_VOLUME, asserted at startup). It is built by the
+      # build_example_venv_volume job; place it where `scp -pr ./examples` ships it.
+      - uses: actions/download-artifact@v4
+        name: "Download the example venv volume from artifacts."
+        with:
+          name: "example-volume-venv.squashfs"
+          path: examples/volumes/
 
       #      - name: Build Debian Package
       #        run: |

--- a/examples/example_fastapi/main.py
+++ b/examples/example_fastapi/main.py
@@ -226,31 +226,48 @@ async def read_aleph_messages() -> dict[str, MessagesResponse]:
 
 @app.get("/dns")
 async def resolve_dns_hostname():
-    """Check if DNS resolution is working."""
-    hostname = "example.org"
+    """Check if DNS resolution is working.
+
+    example.org (an RFC 2606 documentation domain) is not meant as a live
+    resolution target and proved DNS-flaky, so we try a list of reliable
+    dual-stack hosts from independent providers and report the first that
+    resolves to both an IPv4 and an IPv6 address.
+    """
+    hostnames = ["one.one.one.one", "dns.google"]
     ipv4: str | None = None
     ipv6: str | None = None
 
-    info = socket.getaddrinfo(hostname, 80, proto=socket.IPPROTO_TCP)
-    if not info:
-        logger.error("DNS resolution failed")
+    for hostname in hostnames:
+        try:
+            info = socket.getaddrinfo(hostname, 80, proto=socket.IPPROTO_TCP)
+        except OSError:
+            logger.warning(f"DNS resolution failed for {hostname}")
+            continue
 
-    # Iterate over the results to find the IPv4 and IPv6 addresses they may not all be present.
-    # The function returns a list of 5-tuples with the following structure:
-    # (family, type, proto, canonname, sockaddr)
-    for info_tuple in info:
-        if info_tuple[0] == socket.AF_INET:
-            ipv4 = info_tuple[4][0]
-        elif info_tuple[0] == socket.AF_INET6:
-            ipv6 = info_tuple[4][0]
+        # getaddrinfo returns 5-tuples: (family, type, proto, canonname, sockaddr).
+        # A dual-stack host yields both an AF_INET and an AF_INET6 entry.
+        host_ipv4: str | None = None
+        host_ipv6: str | None = None
+        for info_tuple in info:
+            if info_tuple[0] == socket.AF_INET:
+                host_ipv4 = info_tuple[4][0]
+            elif info_tuple[0] == socket.AF_INET6:
+                host_ipv6 = info_tuple[4][0]
+
+        # Keep the best partial result seen so far, but only stop once a single
+        # host gives us both families (what the supervisor's check_dns asserts).
+        ipv4 = ipv4 or host_ipv4
+        ipv6 = ipv6 or host_ipv6
+        if host_ipv4 and host_ipv6:
+            break
 
     if ipv4 and not ipv6:
-        logger.warning(f"DNS resolution for {hostname} returned only an IPv4 address")
+        logger.warning("DNS resolution returned only an IPv4 address")
     elif ipv6 and not ipv4:
-        logger.warning(f"DNS resolution for {hostname} returned only an IPv6 address")
+        logger.warning("DNS resolution returned only an IPv6 address")
 
     result = {"ipv4": ipv4, "ipv6": ipv6}
-    status_code = 200 if len(info) > 1 else 503
+    status_code = 200 if (ipv4 and ipv6) else 503
     return JSONResponse(content=result, status_code=status_code)
 
 

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -163,7 +163,12 @@ class Settings(BaseSettings):
     # real HTTP/1.1 web server, making them reliable egress connectivity probes.
     CONNECTIVITY_IPV4_URL: str = "https://1.1.1.1/"
     CONNECTIVITY_IPV6_URL: str = "https://[2606:4700:4700::1111]/"
-    CONNECTIVITY_DNS_HOSTNAME: str = "example.org"
+    # Hostnames resolved to verify DNS egress. example.org (an RFC 2606
+    # documentation domain) is not meant as a live resolution target and proved
+    # DNS-flaky; these are reliable dual-stack (A + AAAA) names from two
+    # independent providers, tried in order so one provider's hiccup can't break
+    # the check. Cloudflare first, to match CONNECTIVITY_IPV4_URL above.
+    CONNECTIVITY_DNS_HOSTNAMES: list[str] = ["one.one.one.one", "dns.google"]
     # Hostname-based HTTP checks — verify that DNS + egress work end-to-end.
     # Tried in order for both IPv4 and IPv6; the check passes on first success.
     CONNECTIVITY_HTTP_URLS: list[str] = [

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -352,10 +352,15 @@ def main():
         PRINT_SYSTEM_LOGS=args.system_logs,
         PREALLOC_VM_COUNT=args.prealloc_vm_count,
         ALLOW_VM_NETWORKING=args.allow_vm_networking,
-        FAKE_DATA_PROGRAM=args.fake_data_program,
         DEBUG_ASYNCIO=args.debug_asyncio,
         FAKE_INSTANCE_BASE=args.fake_instance_base,
     )
+    # Only override FAKE_DATA_PROGRAM when -f/--fake-data-program was actually
+    # passed: the argparse default is None, and unconditionally writing it here
+    # silently discarded the ALEPH_VM_FAKE_DATA_PROGRAM environment variable
+    # (e.g. from /etc/aleph-vm/supervisor.env, as used by the CI droplet tests).
+    if args.fake_data_program:
+        settings.update(FAKE_DATA_PROGRAM=args.fake_data_program)
 
     if args.run_fake_instance:
         settings.USE_FAKE_INSTANCE_BASE = True

--- a/src/aleph/vm/orchestrator/views/host_status.py
+++ b/src/aleph/vm/orchestrator/views/host_status.py
@@ -118,15 +118,35 @@ async def resolve_dns(hostname: str) -> tuple[str | None, str | None]:
 
 
 async def check_dns_ipv4() -> bool:
-    """Check if DNS resolution is working via IPv4."""
-    ipv4, _ = await resolve_dns(settings.CONNECTIVITY_DNS_HOSTNAME)
-    return bool(ipv4)
+    """Check if DNS resolution is working via IPv4.
+
+    Tries each configured hostname in order, passing on the first that resolves,
+    so a single provider's DNS hiccup does not fail the check.
+    """
+    for hostname in settings.CONNECTIVITY_DNS_HOSTNAMES:
+        try:
+            ipv4, _ = await resolve_dns(hostname)
+        except OSError:
+            continue
+        if ipv4:
+            return True
+    return False
 
 
 async def check_dns_ipv6() -> bool:
-    """Check if DNS resolution is working via IPv6."""
-    _, ipv6 = await resolve_dns(settings.CONNECTIVITY_DNS_HOSTNAME)
-    return bool(ipv6)
+    """Check if DNS resolution is working via IPv6.
+
+    Tries each configured hostname in order, passing on the first that resolves,
+    so a single provider's DNS hiccup does not fail the check.
+    """
+    for hostname in settings.CONNECTIVITY_DNS_HOSTNAMES:
+        try:
+            _, ipv6 = await resolve_dns(hostname)
+        except OSError:
+            continue
+        if ipv6:
+            return True
+    return False
 
 
 async def check_domain_resolution_ipv4() -> bool:

--- a/tests/supervisor/test_status.py
+++ b/tests/supervisor/test_status.py
@@ -6,6 +6,8 @@ from aleph_message.models import ItemHash
 
 from aleph.vm.orchestrator.status import check_internet
 from aleph.vm.orchestrator.views.host_status import (
+    check_dns_ipv4,
+    check_dns_ipv6,
     check_host_http_ipv4,
     check_host_http_ipv6,
     check_http_connectivity_with_fallback,
@@ -121,3 +123,63 @@ async def test_check_host_http_ipv6_returns_false_on_timeout():
     ):
         result = await check_host_http_ipv6()
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_check_dns_ipv4_passes_on_first_host():
+    """The first hostname that resolves an IPv4 address wins; later hosts are not tried."""
+    resolve = AsyncMock(side_effect=[("1.1.1.1", "2606:4700:4700::1111")])
+    with (
+        patch("aleph.vm.orchestrator.views.host_status.settings.CONNECTIVITY_DNS_HOSTNAMES", ["primary", "fallback"]),
+        patch("aleph.vm.orchestrator.views.host_status.resolve_dns", resolve),
+    ):
+        assert await check_dns_ipv4() is True
+    assert resolve.await_count == 1  # fallback host not consulted
+
+
+@pytest.mark.asyncio
+async def test_check_dns_ipv4_falls_back_when_first_host_has_no_ipv4():
+    """A host that resolves no IPv4 address falls through to the next host."""
+    resolve = AsyncMock(side_effect=[(None, "2606:4700:4700::1111"), ("8.8.8.8", None)])
+    with (
+        patch("aleph.vm.orchestrator.views.host_status.settings.CONNECTIVITY_DNS_HOSTNAMES", ["primary", "fallback"]),
+        patch("aleph.vm.orchestrator.views.host_status.resolve_dns", resolve),
+    ):
+        assert await check_dns_ipv4() is True
+    assert resolve.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_check_dns_ipv4_falls_back_when_first_host_raises():
+    """A DNS error on one host does not fail the check; the next host is tried."""
+    resolve = AsyncMock(side_effect=[socket.gaierror("boom"), ("8.8.8.8", None)])
+    with (
+        patch("aleph.vm.orchestrator.views.host_status.settings.CONNECTIVITY_DNS_HOSTNAMES", ["primary", "fallback"]),
+        patch("aleph.vm.orchestrator.views.host_status.resolve_dns", resolve),
+    ):
+        assert await check_dns_ipv4() is True
+    assert resolve.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_check_dns_ipv4_false_when_no_host_resolves():
+    """All hosts failing (no address / error) yields False, not an exception."""
+    resolve = AsyncMock(side_effect=[(None, None), socket.gaierror("boom")])
+    with (
+        patch("aleph.vm.orchestrator.views.host_status.settings.CONNECTIVITY_DNS_HOSTNAMES", ["primary", "fallback"]),
+        patch("aleph.vm.orchestrator.views.host_status.resolve_dns", resolve),
+    ):
+        assert await check_dns_ipv4() is False
+    assert resolve.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_check_dns_ipv6_falls_back_to_second_host():
+    """IPv6 check uses the same first-success fallback across hosts."""
+    resolve = AsyncMock(side_effect=[("1.1.1.1", None), ("8.8.8.8", "2001:4860:4860::8888")])
+    with (
+        patch("aleph.vm.orchestrator.views.host_status.settings.CONNECTIVITY_DNS_HOSTNAMES", ["primary", "fallback"]),
+        patch("aleph.vm.orchestrator.views.host_status.resolve_dns", resolve),
+    ):
+        assert await check_dns_ipv6() is True
+    assert resolve.await_count == 2


### PR DESCRIPTION
## Problem

The droplet integration test (`curl --fail .../status/check/fastapi`) has been flaky. Root cause: the DNS connectivity probe resolves **`example.org`** — an RFC 2606 *documentation* domain that is not meant as a live, dual-stack resolution target and has had recurring DNS flakiness (notably AAAA).

Failure chain:
`status_check_fastapi` runs `check_dns` (a **required** key) → GETs `/dns` from the diagnostic VM (run from the repo's `example_fastapi` via `ALEPH_VM_FAKE_DATA_PROGRAM` in CI) → resolves `example.org` and requires **both** A and AAAA → a flaky lookup returns 503 / missing ipv6 → `check_dns` False → `status_check_fastapi` returns 503 → `curl --fail` fails the job.

## Fix

Replace the single hostname with an ordered list of reliable dual-stack hosts from two **independent** providers, tried until one resolves — mirroring the existing `CONNECTIVITY_HTTP_URLS` fallback pattern already in `conf.py`:

```python
CONNECTIVITY_DNS_HOSTNAMES = ["one.one.one.one", "dns.google"]
```

- Cloudflare `one.one.one.one` first (consistent with the existing `CONNECTIVITY_IPV4_URL = https://1.1.1.1/`), Google `dns.google` as fallback — a different failure domain, so one provider's DNS incident can't take out both.
- `host_status.check_dns_ipv4/ipv6`: first-success loop, tolerating a per-host `OSError`.
- Diagnostic VM `/dns`: loops the hosts, returns 200 once a host yields both families (else 503).
- Still env-overridable (`ALEPH_VM_` prefix) for ad-hoc repointing.

## Tests

Added node-side unit tests in `tests/supervisor/test_status.py` covering: first-host success (fallback not consulted), fallback when the first host has no address, fallback when the first host raises, and all-hosts-fail → False. `test_status.py`: 11 passed. The `/dns` endpoint loop was validated against mocked `getaddrinfo` for the dual-stack / IPv4-only-fallback / error-fallback / no-dual-stack cases.

Note: the `vm.example.org` sentinel in `haproxy.py` is a string comparison, not a DNS lookup — intentionally left unchanged.

A sibling PR applies the same change to `main`.