### PR TITLE
perf(ci): cache slow build steps and skip redundant work

### DIFF
--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -12,6 +12,12 @@ on:
 # This action build the package for Ubuntu and Debian
 # Then run e2e integration tests on Digital Ocean droplets (on demand VM)
 
+# Cancel superseded runs when new commits are pushed to a PR branch.
+# This also releases the global droplet concurrency groups earlier.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build_deb:
     name: "Build ${{ matrix.os }} Package"
@@ -43,6 +49,17 @@ jobs:
 
       - name: Initialize git submodules
         run: git submodule init
+
+      # sevctl is built with `cargo install` at a rev pinned in packaging/Makefile,
+      # which takes ~2 minutes on every build. `target/bin/sevctl` is a file target
+      # in the Makefile, so restoring the binary from cache skips the build entirely.
+      # The key includes the Makefile (pins the sevctl rev) and the dockerfile
+      # (pins the toolchain used to build it).
+      - name: Cache the sevctl binary
+        uses: actions/cache@v4
+        with:
+          path: packaging/target/bin
+          key: sevctl-${{ matrix.os }}-${{ hashFiles('packaging/Makefile', format('packaging/{0}.dockerfile', matrix.os)) }}
 
       - run: |
           cd packaging && make ${{ matrix.make_target }} && cd ..
@@ -76,7 +93,22 @@ jobs:
       - name: Workaround github issue https://github.com/actions/runner-images/issues/7192
         run: sudo echo RESET grub-efi/install_devices | sudo debconf-communicate grub-pc
 
+      # The runtime takes ~2 minutes to debootstrap and rarely changes. Cache it on
+      # the content of its build scripts, with a monthly stamp so the packages
+      # pulled by debootstrap and pip do not become indefinitely stale.
+      - name: Compute monthly cache stamp
+        id: stamp
+        run: echo "month=$(date +%Y-%m)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache the built runtime
+        id: cache-runtime
+        uses: actions/cache@v4
+        with:
+          path: runtimes/aleph-${{ matrix.os }}-python/rootfs.squashfs
+          key: runtime-aleph-${{ matrix.os }}-python-${{ steps.stamp.outputs.month }}-${{ hashFiles(format('runtimes/aleph-{0}-python/**', matrix.os)) }}
+
       - name: Install dep and build
+        if: steps.cache-runtime.outputs.cache-hit != 'true'
         run: |
           sudo apt update
           sudo apt install -y debootstrap
@@ -222,7 +254,12 @@ jobs:
           while ssh root@${DROPLET_IPV4} lsof /var/lib/apt/lists/lock; do sleep 1; done
 
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 update"
-          ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 upgrade -y"
+          # A full system upgrade takes ~1 minute. Only run it on pushes to main
+          # to catch incompatibilities with the latest distro packages, and skip
+          # it on pull requests to keep iteration fast.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 upgrade -y"
+          fi
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 install -y docker.io apparmor-profiles"
           ssh root@${DROPLET_IPV4} "docker pull ghcr.io/aleph-im/vm-connector:alpha"
           ssh root@${DROPLET_IPV4} "docker run -d -p 127.0.0.1:4021:4021/tcp --restart=always --name vm-connector ghcr.io/aleph-im/vm-connector:alpha"
@@ -281,7 +318,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: droplet-aleph-vm-runtime
     timeout-minutes: 10
-    needs: [build_deb, build_example_venv_volume]
+    needs: [build_deb, build_rootfs, build_example_venv_volume]
 
     steps:
       - name: Checkout repository
@@ -289,9 +326,6 @@ jobs:
         with:
           # Fetch the whole history for all tags and branches (required for aleph.__version__)
           fetch-depth: 0
-
-      - name: Workaround github issue https://github.com/actions/runner-images/issues/7192
-        run: sudo echo RESET grub-efi/install_devices | sudo debconf-communicate grub-pc
 
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
@@ -318,12 +352,13 @@ jobs:
           --ssh-keys ab:2b:25:16:46:6f:25:d0:80:63:e5:be:67:04:cb:64 \
           aleph-vm-ci-runtime
 
-      # We can probably reuse the previous artefact.
-      - name: "Build custom runtime"
-        run: |
-          sudo apt update
-          sudo apt install -y debootstrap
-          cd runtimes/aleph-debian-12-python && sudo ./create_disk_image.sh && cd ../..
+      # Reuse the runtime built by the build_rootfs job instead of spending
+      # ~2 minutes rebuilding it here with debootstrap.
+      - uses: actions/download-artifact@v4
+        name: "Download the runtime from artifacts."
+        with:
+          name: "aleph-debian-12-python.squashfs"
+          path: runtimes/aleph-debian-12-python/
 
       - uses: actions/download-artifact@v4
         name: "Download the debian package from artifacts."
@@ -376,7 +411,12 @@ jobs:
           scp packaging/target/aleph-vm.debian-12.deb root@${DROPLET_IPV4}:/opt
 
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 update"
-          ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 upgrade -y"
+          # A full system upgrade takes ~1 minute. Only run it on pushes to main
+          # to catch incompatibilities with the latest distro packages, and skip
+          # it on pull requests to keep iteration fast.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 upgrade -y"
+          fi
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 install -y docker.io apparmor-profiles"
           ssh root@${DROPLET_IPV4} "docker run -d -p 127.0.0.1:4021:4021/tcp --restart=always --name vm-connector alephim/vm-connector:alpha"
 

--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -18,6 +18,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+
 jobs:
   build_deb:
     name: "Build ${{ matrix.os }} Package"
@@ -59,7 +60,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: packaging/target/bin
-          key: sevctl-${{ matrix.os }}-${{ hashFiles('packaging/Makefile', format('packaging/{0}.dockerfile', matrix.os)) }}
+          key: sevctl-${{ matrix.os }}-${{ hashFiles('packaging/Makefile', format('packaging/{0}.dockerfile',
+            matrix.os)) }}
 
       - run: |
           cd packaging && make ${{ matrix.make_target }} && cd ..
@@ -94,18 +96,23 @@ jobs:
         run: sudo echo RESET grub-efi/install_devices | sudo debconf-communicate grub-pc
 
       # The runtime takes ~2 minutes to debootstrap and rarely changes. Cache it on
-      # the content of its build scripts, with a monthly stamp so the packages
+      # the content of its build inputs, with a monthly stamp so the packages
       # pulled by debootstrap and pip do not become indefinitely stale.
-      - name: Compute monthly cache stamp
-        id: stamp
-        run: echo "month=$(date +%Y-%m)" >> "$GITHUB_OUTPUT"
+      # The key is computed in shell because hashFiles() is re-evaluated in the
+      # cache post step, after the build filled the directory with the
+      # debootstrapped tree (hashing it times out).
+      - name: Compute runtime cache key
+        id: cache-key
+        run: |
+          input_hash=$(cat runtimes/aleph-${{ matrix.os }}-python/*.sh runtimes/aleph-${{ matrix.os }}-python/*.py runtimes/aleph-${{ matrix.os }}-python/*.html | sha256sum | cut -c -16)
+          echo "key=runtime-aleph-${{ matrix.os }}-python-$(date +%Y-%m)-${input_hash}" >> "$GITHUB_OUTPUT"
 
       - name: Cache the built runtime
         id: cache-runtime
         uses: actions/cache@v4
         with:
           path: runtimes/aleph-${{ matrix.os }}-python/rootfs.squashfs
-          key: runtime-aleph-${{ matrix.os }}-python-${{ steps.stamp.outputs.month }}-${{ hashFiles(format('runtimes/aleph-{0}-python/**', matrix.os)) }}
+          key: ${{ steps.cache-key.outputs.key }}
 
       - name: Install dep and build
         if: steps.cache-runtime.outputs.cache-hit != 'true'

--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -207,6 +207,10 @@ jobs:
           echo ALEPH_VM_SUPERVISOR_HOST=0.0.0.0 >> supervisor.env
           echo ALEPH_VM_ALLOCATION_TOKEN_HASH=9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08 >> supervisor.env
           echo ALEPH_VM_SENTRY_DSN=${{ secrets.SENTRY_DSN }} >> supervisor.env
+          # Pin public resolvers for guest VMs: DNS auto-detection on the droplet
+          # picks up DigitalOcean's VPC-internal resolver (e.g. 10.110.15.254),
+          # which is unreachable from inside the VMs and breaks all guest DNS.
+          echo 'ALEPH_VM_DNS_NAMESERVERS=["1.1.1.1","8.8.8.8"]' >> supervisor.env
           ssh  root@${DROPLET_IPV4} mkdir -p /etc/aleph-vm/
           scp supervisor.env root@${DROPLET_IPV4}:/etc/aleph-vm/supervisor.env
           scp packaging/target/${{ matrix.os_config.package_name }} root@${DROPLET_IPV4}:/opt
@@ -354,6 +358,10 @@ jobs:
           echo ALEPH_VM_SUPERVISOR_HOST=0.0.0.0 >> supervisor.env
           echo ALEPH_VM_FAKE_DATA_PROGRAM=/opt/examples/example_fastapi >> supervisor.env
           echo ALEPH_VM_FAKE_DATA_RUNTIME=/opt/rootfs.squashfs >> supervisor.env
+          # Pin public resolvers for guest VMs: DNS auto-detection on the droplet
+          # picks up DigitalOcean's VPC-internal resolver (e.g. 10.110.15.254),
+          # which is unreachable from inside the VMs and breaks all guest DNS.
+          echo 'ALEPH_VM_DNS_NAMESERVERS=["1.1.1.1","8.8.8.8"]' >> supervisor.env
           ssh  root@${DROPLET_IPV4} mkdir -p /etc/aleph-vm/
           scp supervisor.env root@${DROPLET_IPV4}:/etc/aleph-vm/supervisor.env
           scp packaging/target/aleph-vm.debian-12.deb root@${DROPLET_IPV4}:/opt

--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: droplet-aleph-vm-runtime
     timeout-minutes: 10
-    needs: build_deb
+    needs: [build_deb, build_example_venv_volume]
 
     steps:
       - name: Checkout repository
@@ -330,6 +330,15 @@ jobs:
         with:
           name: "aleph-vm.debian-12.deb"
           path: packaging/target/
+
+      # The supervisor requires the example venv volume when running with fake data
+      # (ALEPH_VM_FAKE_DATA_VOLUME, asserted at startup). It is built by the
+      # build_example_venv_volume job; place it where `scp -pr ./examples` ships it.
+      - uses: actions/download-artifact@v4
+        name: "Download the example venv volume from artifacts."
+        with:
+          name: "example-volume-venv.squashfs"
+          path: examples/volumes/
 
       #      - name: Build Debian Package
       #        run: |

--- a/.github/workflows/test-using-pytest.yml
+++ b/.github/workflows/test-using-pytest.yml
@@ -9,7 +9,6 @@ on:
     # The branches below must be a subset of the branches above
     branches: [main]
 
-
 # Cancel superseded runs when new commits are pushed to a PR branch.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -71,20 +70,24 @@ jobs:
           #  find /opt
 
       # The aleph-debian-12-python runtime takes ~2 minutes to debootstrap and
-      # rarely changes. Cache it on the content of its build scripts, with a
+      # rarely changes. Cache it on the content of its build inputs, with a
       # monthly stamp so the packages pulled by debootstrap and pip do not
       # become indefinitely stale. The key is shared with the build_rootfs job
-      # of the droplet test workflow.
-      - name: Compute monthly cache stamp
-        id: stamp
-        run: echo "month=$(date +%Y-%m)" >> "$GITHUB_OUTPUT"
+      # of the droplet test workflow and computed in shell because hashFiles()
+      # is re-evaluated in the cache post step, after the build filled the
+      # directory with the debootstrapped tree (hashing it times out).
+      - name: Compute runtime cache key
+        id: cache-key
+        run: |
+          input_hash=$(cat runtimes/aleph-debian-12-python/*.sh runtimes/aleph-debian-12-python/*.py runtimes/aleph-debian-12-python/*.html | sha256sum | cut -c -16)
+          echo "key=runtime-aleph-debian-12-python-$(date +%Y-%m)-${input_hash}" >> "$GITHUB_OUTPUT"
 
       - name: Cache the aleph-debian-12-python runtime
         id: cache-runtime
         uses: actions/cache@v4
         with:
           path: runtimes/aleph-debian-12-python/rootfs.squashfs
-          key: runtime-aleph-debian-12-python-${{ steps.stamp.outputs.month }}-${{ hashFiles('runtimes/aleph-debian-12-python/**') }}
+          key: ${{ steps.cache-key.outputs.key }}
 
       - name: "Build custom runtimes"
         run: |

--- a/.github/workflows/test-using-pytest.yml
+++ b/.github/workflows/test-using-pytest.yml
@@ -10,6 +10,12 @@ on:
     branches: [main]
 
 
+# Cancel superseded runs when new commits are pushed to a PR branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+
 jobs:
   tests-python:
     name: "Test Python code"
@@ -64,11 +70,29 @@ jobs:
           # this produces a 33 MB log
           #  find /opt
 
+      # The aleph-debian-12-python runtime takes ~2 minutes to debootstrap and
+      # rarely changes. Cache it on the content of its build scripts, with a
+      # monthly stamp so the packages pulled by debootstrap and pip do not
+      # become indefinitely stale. The key is shared with the build_rootfs job
+      # of the droplet test workflow.
+      - name: Compute monthly cache stamp
+        id: stamp
+        run: echo "month=$(date +%Y-%m)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache the aleph-debian-12-python runtime
+        id: cache-runtime
+        uses: actions/cache@v4
+        with:
+          path: runtimes/aleph-debian-12-python/rootfs.squashfs
+          key: runtime-aleph-debian-12-python-${{ steps.stamp.outputs.month }}-${{ hashFiles('runtimes/aleph-debian-12-python/**') }}
+
       - name: "Build custom runtimes"
         run: |
           sudo apt update
           sudo apt install -y debootstrap ndppd acl cloud-image-utils qemu-utils qemu-system-x86
-          cd runtimes/aleph-debian-12-python && sudo ./create_disk_image.sh && cd ../..
+          if [ ! -f runtimes/aleph-debian-12-python/rootfs.squashfs ]; then
+            cd runtimes/aleph-debian-12-python && sudo ./create_disk_image.sh && cd ../..
+          fi
           cd runtimes/instance-rootfs && sudo ./create-ubuntu-22-04-qemu-disk.sh && cd ../..
           cd runtimes/instance-rootfs && sudo ./create-debian-12-disk.sh && cd ../..
 

--- a/examples/example_fastapi/main.py
+++ b/examples/example_fastapi/main.py
@@ -226,31 +226,48 @@ async def read_aleph_messages() -> dict[str, MessagesResponse]:
 
 @app.get("/dns")
 async def resolve_dns_hostname():
-    """Check if DNS resolution is working."""
-    hostname = "example.org"
+    """Check if DNS resolution is working.
+
+    example.org (an RFC 2606 documentation domain) is not meant as a live
+    resolution target and proved DNS-flaky, so we try a list of reliable
+    dual-stack hosts from independent providers and report the first that
+    resolves to both an IPv4 and an IPv6 address.
+    """
+    hostnames = ["one.one.one.one", "dns.google"]
     ipv4: str | None = None
     ipv6: str | None = None
 
-    info = socket.getaddrinfo(hostname, 80, proto=socket.IPPROTO_TCP)
-    if not info:
-        logger.error("DNS resolution failed")
+    for hostname in hostnames:
+        try:
+            info = socket.getaddrinfo(hostname, 80, proto=socket.IPPROTO_TCP)
+        except OSError:
+            logger.warning(f"DNS resolution failed for {hostname}")
+            continue
 
-    # Iterate over the results to find the IPv4 and IPv6 addresses they may not all be present.
-    # The function returns a list of 5-tuples with the following structure:
-    # (family, type, proto, canonname, sockaddr)
-    for info_tuple in info:
-        if info_tuple[0] == socket.AF_INET:
-            ipv4 = info_tuple[4][0]
-        elif info_tuple[0] == socket.AF_INET6:
-            ipv6 = info_tuple[4][0]
+        # getaddrinfo returns 5-tuples: (family, type, proto, canonname, sockaddr).
+        # A dual-stack host yields both an AF_INET and an AF_INET6 entry.
+        host_ipv4: str | None = None
+        host_ipv6: str | None = None
+        for info_tuple in info:
+            if info_tuple[0] == socket.AF_INET:
+                host_ipv4 = info_tuple[4][0]
+            elif info_tuple[0] == socket.AF_INET6:
+                host_ipv6 = info_tuple[4][0]
+
+        # Keep the best partial result seen so far, but only stop once a single
+        # host gives us both families (what the supervisor's check_dns asserts).
+        ipv4 = ipv4 or host_ipv4
+        ipv6 = ipv6 or host_ipv6
+        if host_ipv4 and host_ipv6:
+            break
 
     if ipv4 and not ipv6:
-        logger.warning(f"DNS resolution for {hostname} returned only an IPv4 address")
+        logger.warning("DNS resolution returned only an IPv4 address")
     elif ipv6 and not ipv4:
-        logger.warning(f"DNS resolution for {hostname} returned only an IPv6 address")
+        logger.warning("DNS resolution returned only an IPv6 address")
 
     result = {"ipv4": ipv4, "ipv6": ipv6}
-    status_code = 200 if len(info) > 1 else 503
+    status_code = 200 if (ipv4 and ipv6) else 503
     return JSONResponse(content=result, status_code=status_code)
 
 

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -163,7 +163,12 @@ class Settings(BaseSettings):
     # real HTTP/1.1 web server, making them reliable egress connectivity probes.
     CONNECTIVITY_IPV4_URL: str = "https://1.1.1.1/"
     CONNECTIVITY_IPV6_URL: str = "https://[2606:4700:4700::1111]/"
-    CONNECTIVITY_DNS_HOSTNAME: str = "example.org"
+    # Hostnames resolved to verify DNS egress. example.org (an RFC 2606
+    # documentation domain) is not meant as a live resolution target and proved
+    # DNS-flaky; these are reliable dual-stack (A + AAAA) names from two
+    # independent providers, tried in order so one provider's hiccup can't break
+    # the check. Cloudflare first, to match CONNECTIVITY_IPV4_URL above.
+    CONNECTIVITY_DNS_HOSTNAMES: list[str] = ["one.one.one.one", "dns.google"]
     # Hostname-based HTTP checks — verify that DNS + egress work end-to-end.
     # Tried in order for both IPv4 and IPv6; the check passes on first success.
     CONNECTIVITY_HTTP_URLS: list[str] = [

--- a/src/aleph/vm/orchestrator/cli.py
+++ b/src/aleph/vm/orchestrator/cli.py
@@ -312,10 +312,15 @@ def main():
         PRINT_SYSTEM_LOGS=args.system_logs,
         PREALLOC_VM_COUNT=args.prealloc_vm_count,
         ALLOW_VM_NETWORKING=args.allow_vm_networking,
-        FAKE_DATA_PROGRAM=args.fake_data_program,
         DEBUG_ASYNCIO=args.debug_asyncio,
         FAKE_INSTANCE_BASE=args.fake_instance_base,
     )
+    # Only override FAKE_DATA_PROGRAM when -f/--fake-data-program was actually
+    # passed: the argparse default is None, and unconditionally writing it here
+    # silently discarded the ALEPH_VM_FAKE_DATA_PROGRAM environment variable
+    # (e.g. from /etc/aleph-vm/supervisor.env, as used by the CI droplet tests).
+    if args.fake_data_program:
+        settings.update(FAKE_DATA_PROGRAM=args.fake_data_program)
 
     if args.run_fake_instance:
         settings.USE_FAKE_INSTANCE_BASE = True

--- a/src/aleph/vm/orchestrator/views/host_status.py
+++ b/src/aleph/vm/orchestrator/views/host_status.py
@@ -118,15 +118,35 @@ async def resolve_dns(hostname: str) -> tuple[str | None, str | None]:
 
 
 async def check_dns_ipv4() -> bool:
-    """Check if DNS resolution is working via IPv4."""
-    ipv4, _ = await resolve_dns(settings.CONNECTIVITY_DNS_HOSTNAME)
-    return bool(ipv4)
+    """Check if DNS resolution is working via IPv4.
+
+    Tries each configured hostname in order, passing on the first that resolves,
+    so a single provider's DNS hiccup does not fail the check.
+    """
+    for hostname in settings.CONNECTIVITY_DNS_HOSTNAMES:
+        try:
+            ipv4, _ = await resolve_dns(hostname)
+        except OSError:
+            continue
+        if ipv4:
+            return True
+    return False
 
 
 async def check_dns_ipv6() -> bool:
-    """Check if DNS resolution is working via IPv6."""
-    _, ipv6 = await resolve_dns(settings.CONNECTIVITY_DNS_HOSTNAME)
-    return bool(ipv6)
+    """Check if DNS resolution is working via IPv6.
+
+    Tries each configured hostname in order, passing on the first that resolves,
+    so a single provider's DNS hiccup does not fail the check.
+    """
+    for hostname in settings.CONNECTIVITY_DNS_HOSTNAMES:
+        try:
+            _, ipv6 = await resolve_dns(hostname)
+        except OSError:
+            continue
+        if ipv6:
+            return True
+    return False
 
 
 async def check_domain_resolution_ipv4() -> bool:

--- a/tests/supervisor/test_status.py
+++ b/tests/supervisor/test_status.py
@@ -6,6 +6,8 @@ from aleph_message.models import ItemHash
 
 from aleph.vm.orchestrator.status import check_internet
 from aleph.vm.orchestrator.views.host_status import (
+    check_dns_ipv4,
+    check_dns_ipv6,
     check_host_http_ipv4,
     check_host_http_ipv6,
     check_http_connectivity_with_fallback,
@@ -121,3 +123,63 @@ async def test_check_host_http_ipv6_returns_false_on_timeout():
     ):
         result = await check_host_http_ipv6()
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_check_dns_ipv4_passes_on_first_host():
+    """The first hostname that resolves an IPv4 address wins; later hosts are not tried."""
+    resolve = AsyncMock(side_effect=[("1.1.1.1", "2606:4700:4700::1111")])
+    with (
+        patch("aleph.vm.orchestrator.views.host_status.settings.CONNECTIVITY_DNS_HOSTNAMES", ["primary", "fallback"]),
+        patch("aleph.vm.orchestrator.views.host_status.resolve_dns", resolve),
+    ):
+        assert await check_dns_ipv4() is True
+    assert resolve.await_count == 1  # fallback host not consulted
+
+
+@pytest.mark.asyncio
+async def test_check_dns_ipv4_falls_back_when_first_host_has_no_ipv4():
+    """A host that resolves no IPv4 address falls through to the next host."""
+    resolve = AsyncMock(side_effect=[(None, "2606:4700:4700::1111"), ("8.8.8.8", None)])
+    with (
+        patch("aleph.vm.orchestrator.views.host_status.settings.CONNECTIVITY_DNS_HOSTNAMES", ["primary", "fallback"]),
+        patch("aleph.vm.orchestrator.views.host_status.resolve_dns", resolve),
+    ):
+        assert await check_dns_ipv4() is True
+    assert resolve.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_check_dns_ipv4_falls_back_when_first_host_raises():
+    """A DNS error on one host does not fail the check; the next host is tried."""
+    resolve = AsyncMock(side_effect=[socket.gaierror("boom"), ("8.8.8.8", None)])
+    with (
+        patch("aleph.vm.orchestrator.views.host_status.settings.CONNECTIVITY_DNS_HOSTNAMES", ["primary", "fallback"]),
+        patch("aleph.vm.orchestrator.views.host_status.resolve_dns", resolve),
+    ):
+        assert await check_dns_ipv4() is True
+    assert resolve.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_check_dns_ipv4_false_when_no_host_resolves():
+    """All hosts failing (no address / error) yields False, not an exception."""
+    resolve = AsyncMock(side_effect=[(None, None), socket.gaierror("boom")])
+    with (
+        patch("aleph.vm.orchestrator.views.host_status.settings.CONNECTIVITY_DNS_HOSTNAMES", ["primary", "fallback"]),
+        patch("aleph.vm.orchestrator.views.host_status.resolve_dns", resolve),
+    ):
+        assert await check_dns_ipv4() is False
+    assert resolve.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_check_dns_ipv6_falls_back_to_second_host():
+    """IPv6 check uses the same first-success fallback across hosts."""
+    resolve = AsyncMock(side_effect=[("1.1.1.1", None), ("8.8.8.8", "2001:4860:4860::8888")])
+    with (
+        patch("aleph.vm.orchestrator.views.host_status.settings.CONNECTIVITY_DNS_HOSTNAMES", ["primary", "fallback"]),
+        patch("aleph.vm.orchestrator.views.host_status.resolve_dns", resolve),
+    ):
+        assert await check_dns_ipv6() is True
+    assert resolve.await_count == 2


### PR DESCRIPTION
## Summary

Cuts PR feedback time roughly in half once caches are warm:

| Workflow | Before | Expected after |
|---|---|---|
| Build Packages and tests on Droplets | 12–18 min | ~8–10 min |
| py.test and linting | ~10 min | ~7.5 min |

Measured sinks and the corresponding changes:

- **Cache the sevctl binary** in the package-build jobs. `cargo install` at the rev pinned in `packaging/Makefile` costs ~2 min in every build job, and the builds gate all droplet tests. `target/bin/sevctl` is a Makefile file target, so the restored binary skips the cargo build entirely. Key includes the Makefile (pins the rev) and the per-OS dockerfile (pins the toolchain).
- **Cache the debootstrapped `aleph-debian-12-python` runtime** (~2 min) in both the pytest workflow and the `build_rootfs` job, keyed on the runtime build scripts plus a monthly stamp so the debootstrap/pip content cannot go stale for more than a month.
- **Reuse the `build_rootfs` artifact** in the fake-data droplet test instead of rebuilding the same runtime in-job (~2 min on the longest job, which already had a comment suggesting this).
- **Run the full `apt-get upgrade` of droplets only on pushes to main** (~1 min per droplet job). PRs skip it; main keeps catching incompatibilities with the latest distro packages before release.
- **Cancel superseded runs on new PR pushes**, which also frees the repo-global droplet concurrency locks earlier. Droplet cleanup steps are `if: always()`, so cancelled runs still delete their droplets.

The first run on a branch only populates the caches; the speedup shows from the second run on.

## Note

Stacked on #975 (`od/fix-dns-connectivity-probe-main`): the droplet tests need its DNS-pin and venv-volume fixes, and the changes touch the same lines. This PR targets main so the workflows trigger; it shows #975's commits until that one merges, after which it can be rebased.

## Possible follow-ups (not in this PR)

- Prebuild the packaging container images (each build job still spends ~1 min pulling `rust:1.79-bookworm` and apt-upgrading it).
- Per-run droplet names to stop concurrent PRs from serializing on the global droplet concurrency groups.
- `pytest-xdist` for the ~4 min unit-test step (needs care: tests create network interfaces as root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)