### PR TITLE
build(deb): mirror pyproject dependency versions in packaging Makefile

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -18,8 +18,10 @@ debian-package-code:
 	# Making a venv to build the wheel. to work arround a strange problem while building the wheel
 	python3 -m venv build_venv
 	build_venv/bin/pip install   --progress-bar off --upgrade pip setuptools wheel
-	# Fixing this protobuf dependency version to avoid getting CI errors as version 5.29.0 have this compilation issue
-	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message~=1.0.1' 'eth-account==0.10' 'sentry-sdk==1.31.0' 'qmp==1.1.0' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2.0' 'aiosqlite==0.19.0' 'alembic==1.13.1' 'aiohttp_cors==0.7.0' 'pydantic-settings==2.6.1' 'pyroute2==0.7.12' 'python-cpuid==0.1.0' 'solathon==1.0.2' 'protobuf==5.29.6' 'grpcio>=1.70,<1.71' 'redis>=4.2.0' 'legacy-cgi>=1.0'
+	# Versions below MUST mirror pyproject.toml so the .deb ships what the code is tested against.
+	# protobuf is pinned to 5.29.6: 5.29.0 has a compilation issue; 6.x needs grpcio/tools 1.71+.
+	# legacy-cgi is packaging-only: it backfills the `cgi` module removed from the Python 3.13+ stdlib.
+	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message~=1.1' 'eth-account~=0.10' 'sentry-sdk==2.8' 'qmp==1.1' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2' 'aiosqlite==0.19' 'alembic==1.13.1' 'aiohttp-cors~=0.7.0' 'pydantic-settings~=2.6.1' 'pyroute2==0.7.12' 'python-cpuid==0.1.1' 'solathon==1.0.7' 'protobuf==5.29.6' 'grpcio>=1.70,<1.71' 'redis>=4.2' 'legacy-cgi>=1.0'
 	build_venv/bin/python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux target/bin/sevctl


### PR DESCRIPTION
## What

The Debian package pip-installs a curated subset of dependencies (the ones not provided by apt) with version pins maintained by hand in `packaging/Makefile`. These had drifted from `pyproject.toml`, so the `.deb` shipped different versions than the code is tested against:

| package | .deb shipped | pyproject (tested) |
|---|---|---|
| aleph-message | `~=1.0.1` | `~=1.1` |
| sentry-sdk | `==1.31.0` | `==2.8` |
| python-cpuid | `==0.1.0` | `==0.1.1` |
| solathon | `==1.0.2` | `==1.0.7` |

`aleph-message` is the most consequential: `~=1.0.1` excludes the `1.1` line the current code targets.

## Change

Align every shared specifier in the Makefile pip line to its `pyproject.toml` counterpart verbatim, and add a comment requiring the two to stay in sync. No packages added or removed; only version specifiers corrected/normalized. `legacy-cgi` stays (packaging-only `cgi` backfill for Python 3.13+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)