### PR TITLE
refactor(supervisor): retype VM identity from ItemHash to VmId

### DIFF
--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -7,12 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 
-from aleph_message.models import (
-    ExecutableContent,
-    InstanceContent,
-    ItemHash,
-    ProgramContent,
-)
+from aleph_message.models import ExecutableContent, InstanceContent, ProgramContent
 from aleph_message.models.execution.environment import (
     GpuProperties,
     HypervisorType,
@@ -61,7 +56,7 @@ from aleph.vm.orchestrator.metrics import (
     save_record,
 )
 from aleph.vm.resources import GpuDevice, HostGPU
-from aleph.vm.supervisor.types import Backend, CreateVmSpec
+from aleph.vm.supervisor.types import Backend, CreateVmSpec, VmId
 from aleph.vm.systemd import SystemDManager
 from aleph.vm.utils import dumps_for_json
 from aleph.vm.utils.aggregate import get_user_settings
@@ -120,7 +115,7 @@ class VmExecution:
     """
 
     uuid: uuid.UUID  # Unique identifier of this execution
-    vm_hash: ItemHash
+    vm_hash: VmId
     # The source of this execution: either an Aleph message (MessageSpec) or a
     # message-free CreateVmSpec. Exactly one — "neither" is unrepresentable. The
     # legacy ``message``/``original``/``vm_spec`` accessors derive from it.
@@ -454,7 +449,7 @@ class VmExecution:
 
     def __init__(
         self,
-        vm_hash: ItemHash,
+        vm_hash: VmId,
         message: ExecutableContent | None = None,
         original: ExecutableContent | None = None,
         snapshot_manager: SnapshotManager | None = None,
@@ -500,7 +495,7 @@ class VmExecution:
         for its own consumers (operator API, billing) — see orchestrator/run.py.
         """
         return cls(
-            vm_hash=ItemHash(spec.vm_id),
+            vm_hash=spec.vm_id,
             vm_spec=spec,
             snapshot_manager=snapshot_manager,
             systemd_manager=systemd_manager,

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -9,7 +9,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import psutil
-from aleph_message.models import ItemHash
 
 from aleph.vm.conf import settings
 from aleph.vm.controllers.configuration import (
@@ -34,7 +33,7 @@ from aleph.vm.supervisor.qemu_build import (
     build_qemu_configuration,
     spec_from_controller_configuration,
 )
-from aleph.vm.supervisor.types import Backend, CreateVmSpec, GpuSpec, PciAddress
+from aleph.vm.supervisor.types import Backend, CreateVmSpec, GpuSpec, PciAddress, VmId
 from aleph.vm.systemd import SystemDManager
 from aleph.vm.vm_type import VmType
 
@@ -59,7 +58,7 @@ class VmPool:
     configurable duration.
     """
 
-    executions: dict[ItemHash, VmExecution]
+    executions: dict[VmId, VmExecution]
     network: Network | None
     snapshot_manager: SnapshotManager | None = None
     systemd_manager: SystemDManager
@@ -294,7 +293,7 @@ class VmPool:
         if spec.backend is Backend.FIRECRACKER:
             return await self._create_firecracker_from_spec(spec)
 
-        vm_hash = ItemHash(spec.vm_id)
+        vm_hash = spec.vm_id
         async with self.creation_lock:
             current_execution = self.executions.get(vm_hash)
             if current_execution and current_execution.is_running and not current_execution.is_stopping:
@@ -414,7 +413,7 @@ class VmPool:
             msg = "Firecracker spec VMs require a guest_channel"
             raise InvalidBackendError(msg)
 
-        vm_hash = ItemHash(spec.vm_id)
+        vm_hash = spec.vm_id
         async with self.creation_lock:
             current_execution = self.executions.get(vm_hash)
             if current_execution and current_execution.is_running and not current_execution.is_stopping:
@@ -488,7 +487,7 @@ class VmPool:
         msg = "No available value for vm_id."
         raise ValueError(msg)
 
-    def get_running_or_starting_vm(self, vm_hash: ItemHash) -> VmExecution | None:
+    def get_running_or_starting_vm(self, vm_hash: VmId) -> VmExecution | None:
         """Return a running VM or None."""
         execution = self.executions.get(vm_hash)
         if execution and execution.is_running and not execution.is_stopping:
@@ -496,7 +495,7 @@ class VmPool:
         else:
             return None
 
-    def get_running_vm(self, vm_hash: ItemHash) -> VmExecution | None:
+    def get_running_vm(self, vm_hash: VmId) -> VmExecution | None:
         """Return a running VM or None."""
         execution = self.executions.get(vm_hash)
         if execution and execution.is_running and not execution.is_stopping:
@@ -504,7 +503,7 @@ class VmPool:
         else:
             return None
 
-    async def stop_vm(self, vm_hash: ItemHash) -> VmExecution | None:
+    async def stop_vm(self, vm_hash: VmId) -> VmExecution | None:
         """Stop a VM."""
         execution = self.executions.get(vm_hash)
         if not execution:
@@ -513,7 +512,7 @@ class VmPool:
         await execution.stop()
         return execution
 
-    def forget_vm(self, vm_hash: ItemHash) -> None:
+    def forget_vm(self, vm_hash: VmId) -> None:
         """Remove a VM from the executions pool.
 
         Used after VM creation raised an error in order to completely
@@ -597,7 +596,7 @@ class VmPool:
         configs: list[Configuration] = []
         for config_path in config_paths:
             vm_hash = config_path.name[: -len("-controller.json")]
-            if ItemHash(vm_hash) in self.executions:
+            if VmId(vm_hash) in self.executions:
                 continue
             config = load_controller_configuration(vm_hash)
             if config is None:
@@ -614,7 +613,7 @@ class VmPool:
         claimed_vm_ids: set[int] = set()
 
         for config in configs:
-            vm_hash = ItemHash(str(config.vm_hash))
+            vm_hash = VmId(str(config.vm_hash))
             vm_id = config.vm_id
             service_name = f"aleph-vm-controller@{config.vm_hash}.service"
             is_active = service_active_states.get(service_name, False)
@@ -640,7 +639,7 @@ class VmPool:
 
         logger.info("Loaded %d executions", len(self.executions))
 
-    async def _restore_network(self, vm_id: int, vm_hash: ItemHash) -> TapInterface | None:
+    async def _restore_network(self, vm_id: int, vm_hash: VmId) -> TapInterface | None:
         """Restore tap interface, NDP proxy, and nftables rules for a VM."""
         if not self.network:
             return None
@@ -663,9 +662,7 @@ class VmPool:
         setup_nftables_for_vm(vm_id, interface=tap_interface)
         return tap_interface
 
-    async def _restore_running_execution_from_config(
-        self, config: Configuration, vm_id: int, vm_hash: ItemHash
-    ) -> None:
+    async def _restore_running_execution_from_config(self, config: Configuration, vm_id: int, vm_hash: VmId) -> None:
         """Rebuild in-memory state for a VM whose controller is still active.
 
         Sourced entirely from the on-disk controller config -- message-free.


### PR DESCRIPTION
## What

Removes the last `aleph_message` symbol from `src/aleph/vm/pool.py` by retyping the daemon's VM-identity from `aleph_message.models.ItemHash` to the message-free `VmId = NewType("VmId", str)` (defined in `supervisor/types.py`). `VmExecution.vm_hash` is retyped to match so the pool's `dict[VmId, VmExecution]` key type stays honest.

This is the VM-identity slice of the "remove `aleph_message` from the supervisor" follow-up flagged during Phase 2. It is intentionally scoped: `models.py` keeps its message-content imports (`ExecutableContent`/`InstanceContent`/`ProgramContent`), which drive the message path. Removing the message object from `VmExecution` entirely is a separate, larger refactor.

## Why it's safe

- `ItemHash` is a `str` subclass and `VmId` a `str` `NewType`, so stored keys and lookups stay compatible (`hash`/`==` identical). `local.py` already looked the pool up with `VmId` values; the create path now stores `spec.vm_id` directly instead of re-wrapping it as `ItemHash`.
- No daemon consumer relies on `ItemHash`-specific behavior (no `isinstance`, no `.item_hash`, no pydantic coercion); consumers either `str()` the value or use it as a plain string dict key.
- The only behavioral delta is dropping `ItemHash` format validation on the spec path. Content-consuming helpers (`cloudinit.get_hostname_from_hash`, `hostnetwork.allocate_vm_ipv6_subnet`) still assume a valid hex hash; the agent always supplies one, so a malformed id now fails inside those consumers rather than eagerly at `ItemHash()`. Out of scope, flagged for awareness.

## Verification

- `pool.py` confirmed free of `ItemHash`/`aleph_message`.
- ruff format + isort clean; mypy adds zero new errors (2 pre-existing env-noise at the same spot on the base).
- Tests: supervisor **901 passed** (7 pre-existing environment failures: jailman `chown` subprocess + pyroute2 netlink), migration+network **26 passed**.
- Reviewed by an adversarial code-quality pass: APPROVED, no defects.

## Base

Stacked on #981 (`od/grpc-only-supervisor-phase2`); `pool.py` here is already the Phase 2 pool. Merge after #981.