### PR TITLE
refactor(supervisor): drop dead in-process QEMU cloud-init path

### DIFF
--- a/src/aleph/vm/controllers/qemu/cloudinit.py
+++ b/src/aleph/vm/controllers/qemu/cloudinit.py
@@ -15,16 +15,12 @@ See also the cloud-localds  man page (1)
 
 import base64
 import json
-from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import yaml
 from aleph_message.models import ItemHash
 
-from aleph.vm.conf import settings
-from aleph.vm.controllers.interface import AlephVmControllerInterface
-from aleph.vm.hypervisors.firecracker.config import Drive
-from aleph.vm.utils import is_command_available, run_in_subprocess
+from aleph.vm.utils import run_in_subprocess
 
 
 def get_hostname_from_hash(vm_hash: ItemHash) -> str:
@@ -174,52 +170,4 @@ async def create_cloud_init_drive_image(
                 user_data_config_file.name,
                 metadata_config_file.name,
             ]
-        )
-
-
-class CloudInitMixin(AlephVmControllerInterface):
-    async def _create_cloud_init_drive(self, install_guest_agent: bool = True) -> Drive:
-        """Creates the cloud-init volume to configure and set up the VM"""
-        ssh_authorized_keys = self.resources.message_content.authorized_keys or []
-        if settings.USE_DEVELOPER_SSH_KEYS:
-            ssh_authorized_keys += settings.DEVELOPER_SSH_KEYS
-        ip = self.get_ip()
-        route = self.get_ip_route()
-        ipv6 = self.get_ipv6()
-        ipv6_gateway = self.get_ipv6_gateway()
-        vm_id = self.vm_id
-        nameservers = settings.DNS_NAMESERVERS
-        hostname = get_hostname_from_hash(self.vm_hash)
-
-        disk_image_path: Path = settings.EXECUTION_ROOT / f"cloud-init-{self.vm_hash}.img"
-        assert is_command_available("cloud-localds")
-
-        # Check if this VM has GPUs to enable PCI boot optimizations
-        has_gpu = bool(self.resources.gpus) if hasattr(self.resources, "gpus") else False
-        is_confidential = (
-            self.resources.message_content.environment.trusted_execution is not None
-            if hasattr(self.resources, "message_content")
-            else False
-        )
-
-        await create_cloud_init_drive_image(
-            disk_image_path,
-            hostname,
-            vm_id,
-            ip,
-            ipv6,
-            ipv6_gateway,
-            nameservers,
-            route,
-            ssh_authorized_keys,
-            has_gpu=has_gpu,
-            is_confidential=is_confidential,
-            install_guest_agent=install_guest_agent,
-        )
-
-        return Drive(
-            drive_id="Fake",
-            path_on_host=disk_image_path,
-            is_root_device=False,
-            is_read_only=True,
         )

--- a/src/aleph/vm/controllers/qemu/instance.py
+++ b/src/aleph/vm/controllers/qemu/instance.py
@@ -12,17 +12,8 @@ from aleph_message.models.execution.instance import RootfsVolume
 from aleph_message.models.execution.volume import PersistentVolume, VolumePersistence
 
 from aleph.vm.conf import settings
-from aleph.vm.controllers.configuration import (
-    Configuration,
-    HypervisorType,
-    QemuGPU,
-    QemuVMConfiguration,
-    QemuVMHostVolume,
-    save_controller_configuration,
-)
 from aleph.vm.controllers.firecracker.executable import VmSetupError
 from aleph.vm.controllers.interface import AlephVmControllerInterface
-from aleph.vm.controllers.qemu.cloudinit import CloudInitMixin
 from aleph.vm.controllers.resources import (
     HostVolume,
     VmResources,
@@ -32,7 +23,6 @@ from aleph.vm.controllers.resources import (
 from aleph.vm.network.firewall import teardown_nftables_for_vm
 from aleph.vm.network.interfaces import TapInterface
 from aleph.vm.resources import HostGPU
-from aleph.vm.sizes import MiB
 from aleph.vm.storage import get_rootfs_base_path
 from aleph.vm.supervisor.types import HardwareResources
 from aleph.vm.utils import run_in_subprocess
@@ -162,7 +152,7 @@ class AlephQemuResources(VmResources):
 ConfigurationType = TypeVar("ConfigurationType")
 
 
-class AlephQemuInstance(Generic[ConfigurationType], CloudInitMixin, AlephVmControllerInterface):
+class AlephQemuInstance(Generic[ConfigurationType], AlephVmControllerInterface):
     vm_id: int
     vm_hash: ItemHash
     resources: AlephQemuResources
@@ -174,7 +164,6 @@ class AlephQemuInstance(Generic[ConfigurationType], CloudInitMixin, AlephVmContr
     qemu_process: Process | None
     support_snapshot = False
     persistent = True
-    controller_configuration: Configuration
 
     def __repr__(self):
         return f"<AlephQemuInstance {self.vm_id}>"
@@ -231,63 +220,6 @@ class AlephQemuInstance(Generic[ConfigurationType], CloudInitMixin, AlephVmContr
 
     async def setup(self):
         pass
-
-    async def configure(self):
-        """Configure the VM by saving controller service configuration."""
-        logger.debug(f"Making Qemu configuration: {self}")
-
-        monitor_socket_path = settings.EXECUTION_ROOT / (str(self.vm_hash) + "-monitor.socket")
-
-        cloud_init_drive = await self._create_cloud_init_drive()
-
-        image_path = str(self.resources.rootfs_path)
-        vcpu_count = self.hardware_resources.vcpus
-        # QEMU's -m flag takes a value in MiB; message memory is already MiB. Pass it
-        # through via a typed size to avoid the prior unit-mixing under-allocation.
-        mem_size_mb = MiB(self.hardware_resources.memory)
-
-        qemu_bin_path = shutil.which("qemu-system-x86_64")
-        interface_name = None
-        if self.tap_interface:
-            interface_name = self.tap_interface.device_name
-        cloud_init_drive_path = str(cloud_init_drive.path_on_host) if cloud_init_drive else None
-        vm_configuration = QemuVMConfiguration(
-            qemu_bin_path=qemu_bin_path,
-            cloud_init_drive_path=cloud_init_drive_path,
-            image_path=image_path,
-            monitor_socket_path=monitor_socket_path,
-            qmp_socket_path=self.qmp_socket_path,
-            qga_socket_path=self.qga_socket_path,
-            vcpu_count=vcpu_count,
-            mem_size_mb=mem_size_mb,
-            interface_name=interface_name,
-            host_volumes=[
-                QemuVMHostVolume(
-                    mount=volume.mount,
-                    path_on_host=volume.path_on_host,
-                    read_only=volume.read_only,
-                )
-                for volume in self.resources.volumes
-            ],
-            gpus=[QemuGPU(pci_host=gpu.pci_host, supports_x_vga=gpu.supports_x_vga) for gpu in self.resources.gpus],
-        )
-
-        configuration = Configuration(
-            vm_id=self.vm_id,
-            vm_hash=self.vm_hash,
-            settings=settings,
-            vm_configuration=vm_configuration,
-            hypervisor=HypervisorType.qemu,
-        )
-        logger.debug(configuration)
-        save_controller_configuration(self.vm_hash, configuration)
-
-    def save_controller_configuration(self):
-        """Save VM configuration to be used by the controller service"""
-        path = Path(f"{settings.EXECUTION_ROOT}/{self.vm_hash}-controller.json")
-        path.write_text(self.controller_configuration.json(by_alias=True, exclude_none=True, indent=4))
-        path.chmod(0o644)
-        return path
 
     @property
     def qmp_socket_path(self) -> Path:

--- a/src/aleph/vm/controllers/qemu_confidential/instance.py
+++ b/src/aleph/vm/controllers/qemu_confidential/instance.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import shutil
 from asyncio.subprocess import Process
 from collections.abc import Callable
 from pathlib import Path
@@ -8,19 +7,9 @@ from typing import TYPE_CHECKING
 
 from aleph_message.models import ItemHash
 
-from aleph.vm.conf import settings
-from aleph.vm.controllers.configuration import (
-    Configuration,
-    HypervisorType,
-    QemuConfidentialVMConfiguration,
-    QemuGPU,
-    QemuVMHostVolume,
-    save_controller_configuration,
-)
 from aleph.vm.controllers.qemu import AlephQemuInstance
 from aleph.vm.controllers.qemu.instance import AlephQemuResources, ConfigurationType
 from aleph.vm.network.interfaces import TapInterface
-from aleph.vm.sizes import MiB
 from aleph.vm.storage import get_existing_file
 from aleph.vm.supervisor.types import HardwareResources
 
@@ -83,7 +72,6 @@ class AlephQemuConfidentialInstance(AlephQemuInstance):
     support_snapshot = False
     persistent = True
     _queue_cancellers: dict[asyncio.Queue, Callable] = {}
-    controller_configuration: Configuration
     confidential_policy: int
 
     def __repr__(self):
@@ -107,65 +95,6 @@ class AlephQemuConfidentialInstance(AlephQemuInstance):
 
     async def setup(self):
         pass
-
-    async def configure(self):
-        """Configure the VM by saving controller service configuration."""
-        logger.debug(f"Making Qemu configuration: {self}")
-        monitor_socket_path = settings.EXECUTION_ROOT / (str(self.vm_id) + "-monitor.socket")
-
-        cloud_init_drive = await self._create_cloud_init_drive(install_guest_agent=False)
-
-        image_path = str(self.resources.rootfs_path)
-        firmware_path = str(self.resources.firmware_path)
-        vcpu_count = self.hardware_resources.vcpus
-        # QEMU's -m flag takes a value in MiB; message memory is already MiB. Pass it
-        # through via a typed size to avoid the prior unit-mixing under-allocation.
-        mem_size_mb = MiB(self.hardware_resources.memory)
-
-        vm_session_path = settings.CONFIDENTIAL_SESSION_DIRECTORY / self.vm_hash
-        session_file_path = vm_session_path / "vm_session.b64"
-        godh_file_path = vm_session_path / "vm_godh.b64"
-
-        qemu_bin_path = shutil.which("qemu-system-x86_64")
-        interface_name = None
-        if self.tap_interface:
-            interface_name = self.tap_interface.device_name
-        cloud_init_drive_path = str(cloud_init_drive.path_on_host) if cloud_init_drive else None
-        vm_configuration = QemuConfidentialVMConfiguration(
-            qemu_bin_path=qemu_bin_path,
-            cloud_init_drive_path=cloud_init_drive_path,
-            image_path=image_path,
-            monitor_socket_path=monitor_socket_path,
-            qmp_socket_path=self.qmp_socket_path,
-            qga_socket_path=self.qga_socket_path,
-            vcpu_count=vcpu_count,
-            mem_size_mb=mem_size_mb,
-            interface_name=interface_name,
-            ovmf_path=firmware_path,
-            sev_session_file=session_file_path,
-            sev_dh_cert_file=godh_file_path,
-            sev_policy=self.confidential_policy,
-            host_volumes=[
-                QemuVMHostVolume(
-                    mount=volume.mount,
-                    path_on_host=volume.path_on_host,
-                    read_only=volume.read_only,
-                )
-                for volume in self.resources.volumes
-            ],
-            gpus=[QemuGPU(pci_host=gpu.pci_host) for gpu in self.resources.gpus],
-        )
-
-        configuration = Configuration(
-            vm_id=self.vm_id,
-            vm_hash=self.vm_hash,
-            settings=settings,
-            vm_configuration=vm_configuration,
-            hypervisor=HypervisorType.qemu,
-        )
-        logger.debug(configuration)
-
-        save_controller_configuration(self.vm_hash, configuration)
 
     async def wait_for_init(self) -> None:
         """Wait for the init process of the instance to be ready."""


### PR DESCRIPTION
## What

Removes the now-dead in-process QEMU cloud-init `configure()` path that still read `message_content`, which is `None` on the message-free spec path (the only path used in production after the gRPC-only-supervisor refactor, #980–#983).

## Why

Production QEMU instance creation goes through `VmPool.create_vm_from_spec`, which builds cloud-init from the spec via `build_qemu_configuration` → `build_cloud_init_drive(ssh_authorized_keys=spec.ssh_authorized_keys)` and starts with `start(write_config=False)`. The in-process `AlephQemuInstance.configure()` → `CloudInitMixin._create_cloud_init_drive` path (which reads `resources.message_content`) is only reachable via `start(write_config=True)`, which production QEMU never uses. Left in place it crashes with `AttributeError: 'NoneType' object has no attribute 'authorized_keys'` if ever hit on the spec path (this is what tripped `test_qemu_instance` until #983 pointed it at the production flow).

## Changes (−193 lines)

- Delete `CloudInitMixin._create_cloud_init_drive` + the now-empty `CloudInitMixin`.
- Delete `AlephQemuInstance.configure()` / `AlephQemuConfidentialInstance.configure()` and their dead `save_controller_configuration` methods/attrs.
- Trim imports that become unused.

## Kept (verified live)

- Spec-based cloud-init in `supervisor/qemu_build.py` (`build_cloud_init_drive`, `create_cloud_init_drive_image`).
- `AlephQemuResources.message_content` + `download_*` — still used by `translate.build_create_vm_spec`.
- Firecracker `configure()` (separate class, reached via the live `start(write_config=True)` FC path).

## Verification

- mypy: no new errors (baseline-only).
- `tests/supervisor/` + `tests/migration/`: pass except known environment-only failures (`test_interfaces` pyroute2-needs-root, `test_log` journald); `test_qemu_instance` stays at its 2 expected XFAILs (no fake disk).

Pure dead-code removal; no functional change to production.