### PR TITLE
fix(confidential): register agent record early, wait for awaiting-init

### DIFF
--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -270,13 +270,26 @@ async def create_vm_execution(
         # reservation and skips other users' valid reservations during create.
         # The agent does not touch reservations at all.
         spec = await build_create_vm_spec(vm_hash, content)
-        info = await supervisor.create_vm(spec)
-        # Agent territory: record the message in the agent's own cache. This is
-        # what the message-free agent will read once owner-auth and billing move
-        # off the VmExecution (design doc section 5). The supervisor machinery
-        # that created the VM never reads it.
+        # Agent territory: record the message in the agent's own cache *before*
+        # create_vm, mirroring 1.13 where the VM entered the pool at the start of
+        # create. create_vm takes ~20s while the scheduler exposes placement
+        # earlier, so a confidential owner's one-shot init-session call can land
+        # before create returns. Recording the owner identity up front lets the
+        # operator API answer owner-auth immediately (get_agent_record_or_404)
+        # instead of polling for the record; the endpoint still waits for the VM
+        # to reach the awaiting-init state before initializing it. The supervisor
+        # machinery that creates the VM never reads this record.
         # Spec-eligible VMs are QEMU instances, which are always persistent.
         record = registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
+        try:
+            info = await supervisor.create_vm(spec)
+        except Exception:
+            # create_vm failed: drop the early record so a failed create never
+            # leaves a dangling owner-identity entry behind (a record with no VM
+            # the supervisor knows about). Nothing is persisted yet, so forgetting
+            # the in-memory entry is sufficient.
+            registry.forget(vm_hash)
+            raise
         if info.awaiting_confidential_init:
             # A confidential VM is created but not started: only the owner can
             # start it, by uploading the session certificates via

--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -159,13 +159,15 @@ _CONFIDENTIAL_AWAITING_WAIT_SECONDS = 120
 _CONFIDENTIAL_AWAITING_POLL_INTERVAL = 2.0
 
 
-async def wait_for_awaiting_confidential_init(supervisor: Supervisor, vm_id: VmId) -> None:
-    """Block until the VM reaches awaiting_confidential_init, or time out.
+async def wait_for_awaiting_confidential_init(supervisor: Supervisor, vm_id: VmId) -> bool:
+    """Poll until the VM reaches awaiting_confidential_init. Return True once it
+    does, or False if the bounded deadline passes first.
 
     initialize_confidential writes the session files and starts the controller;
     it fails if called before the VM is awaiting-ready. The owner's single
     init-session call may arrive while create_vm is still building the config,
-    so poll get_vm rather than racing it.
+    so poll get_vm rather than racing it. The caller maps a False return to the
+    appropriate HTTP response.
     """
     deadline = asyncio.get_running_loop().time() + _CONFIDENTIAL_AWAITING_WAIT_SECONDS
     while True:
@@ -174,9 +176,9 @@ async def wait_for_awaiting_confidential_init(supervisor: Supervisor, vm_id: VmI
         except VmNotFoundError:
             info = None
         if info is not None and info.awaiting_confidential_init:
-            return
+            return True
         if asyncio.get_running_loop().time() >= deadline:
-            raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_id}")
+            return False
         await asyncio.sleep(_CONFIDENTIAL_AWAITING_POLL_INTERVAL)
 
 
@@ -446,9 +448,12 @@ async def operate_confidential_initialize(request: web.Request, authenticated_se
         # The owner's init-session call can land before create_vm has finished
         # building the controller config and started the VM into the awaiting
         # state. initialize_confidential fails if the VM is not awaiting-ready,
-        # so wait for that state (bounded) before uploading the session files.
+        # so wait for that state (bounded) before uploading the session files. A
+        # VM that never reaches it (timeout, or one the supervisor never
+        # registers) is reported as not found.
         if info is None or not info.awaiting_confidential_init:
-            await wait_for_awaiting_confidential_init(supervisor, vm_id)
+            if not await wait_for_awaiting_confidential_init(supervisor, vm_id):
+                raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_hash}")
 
         post = await request.post()
 

--- a/src/aleph/vm/orchestrator/views/operator.py
+++ b/src/aleph/vm/orchestrator/views/operator.py
@@ -146,26 +146,38 @@ def get_agent_record_or_404(request: web.Request, vm_hash: ItemHash) -> AgentVmR
 
 
 # A confidential instance is created through the allocation path, where
-# create_vm (build config + start to the awaiting state) can take ~20s; the
-# scheduler exposes placement earlier, so the owner's one-shot init-session
-# call can land before the agent has recorded the VM (the record is written
-# once create completes and the VM is awaiting init). Wait it out instead of
-# 404ing the owner. Happy path returns in one poll; the cap only bounds a
-# genuinely-missing VM.
-_CONFIDENTIAL_RECORD_WAIT_SECONDS = 120
-_CONFIDENTIAL_RECORD_POLL_INTERVAL = 2.0
+# create_vm (build config + start to the awaiting state) can take ~20s, but the
+# scheduler exposes placement earlier. The agent now records the owner identity
+# at the *start* of create (see create_vm_execution), so owner-auth resolves
+# immediately via get_agent_record_or_404. The VM itself, however, only reaches
+# awaiting_confidential_init when create_vm completes (the controller config is
+# written and start() sets starting_at). The owner's one-shot init-session call
+# can still land in that window, so wait for the VM to become awaiting-ready
+# before initializing it. Happy path returns in one poll; the cap only bounds a
+# create that never reaches the awaiting state.
+_CONFIDENTIAL_AWAITING_WAIT_SECONDS = 120
+_CONFIDENTIAL_AWAITING_POLL_INTERVAL = 2.0
 
 
-async def wait_for_agent_record_or_404(request: web.Request, vm_hash: ItemHash) -> AgentVmRecord:
-    registry = request.app["vm_registry"]
-    deadline = asyncio.get_running_loop().time() + _CONFIDENTIAL_RECORD_WAIT_SECONDS
+async def wait_for_awaiting_confidential_init(supervisor: Supervisor, vm_id: VmId) -> None:
+    """Block until the VM reaches awaiting_confidential_init, or time out.
+
+    initialize_confidential writes the session files and starts the controller;
+    it fails if called before the VM is awaiting-ready. The owner's single
+    init-session call may arrive while create_vm is still building the config,
+    so poll get_vm rather than racing it.
+    """
+    deadline = asyncio.get_running_loop().time() + _CONFIDENTIAL_AWAITING_WAIT_SECONDS
     while True:
-        record = registry.get(vm_hash)
-        if record is not None:
-            return record
+        try:
+            info = await supervisor.get_vm(vm_id)
+        except VmNotFoundError:
+            info = None
+        if info is not None and info.awaiting_confidential_init:
+            return
         if asyncio.get_running_loop().time() >= deadline:
-            raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_hash}")
-        await asyncio.sleep(_CONFIDENTIAL_RECORD_POLL_INTERVAL)
+            raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_id}")
+        await asyncio.sleep(_CONFIDENTIAL_AWAITING_POLL_INTERVAL)
 
 
 async def check_owner_permissions(authenticated_sender: str, message: BaseExecutableContent) -> bool:
@@ -395,10 +407,11 @@ async def operate_confidential_initialize(request: web.Request, authenticated_se
     """Start the confidential virtual machine if possible."""
     vm_hash = get_itemhash_or_400(request.match_info)
     with set_vm_for_logging(vm_hash=vm_hash):
-        # The owner's init-session may arrive while the confidential create is
-        # still in flight (see wait_for_agent_record_or_404); wait for the VM to
-        # be recorded rather than 404 their single call.
-        record = await wait_for_agent_record_or_404(request, vm_hash)
+        # Owner identity is recorded at the start of create (create_vm_execution),
+        # so this resolves immediately even while create_vm is still in flight;
+        # no long poll for the record. Readiness (the VM reaching the
+        # awaiting-init state) is handled separately, below.
+        record = get_agent_record_or_404(request, vm_hash)
         if not await is_sender_authorized(authenticated_sender, record.message):
             return web.Response(status=403, body="Unauthorized sender")
 
@@ -407,22 +420,35 @@ async def operate_confidential_initialize(request: web.Request, authenticated_se
         try:
             info = await supervisor.get_vm(vm_id)
         except VmNotFoundError:
-            raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_hash}") from None
+            # create_vm may not have registered the VM with the supervisor yet;
+            # the awaiting-init wait below tolerates that, so don't 404 here.
+            info = None
 
         # A confidential VM awaiting its owner's session reports BOOTING on the
         # spec create path (start() sets starting_at without launching the
         # controller), but it is precisely what this endpoint initializes — so
         # only reject a VM that is actually running, not one awaiting init.
-        if info.status in (VmStatus.RUNNING, VmStatus.BOOTING) and not info.awaiting_confidential_init:
+        if (
+            info is not None
+            and info.status in (VmStatus.RUNNING, VmStatus.BOOTING)
+            and not info.awaiting_confidential_init
+        ):
             return web.json_response(
                 {"code": "vm_running", "description": "Operation not allowed, instance already running"},
                 status=HTTPStatus.BAD_REQUEST,
             )
-        if info.confidential_mode is ConfidentialMode.NONE:
+        if info is not None and info.confidential_mode is ConfidentialMode.NONE:
             return web.json_response(
                 {"code": "not_confidential", "description": "Instance is not a confidential instance"},
                 status=HTTPStatus.BAD_REQUEST,
             )
+
+        # The owner's init-session call can land before create_vm has finished
+        # building the controller config and started the VM into the awaiting
+        # state. initialize_confidential fails if the VM is not awaiting-ready,
+        # so wait for that state (bounded) before uploading the session files.
+        if info is None or not info.awaiting_confidential_init:
+            await wait_for_awaiting_confidential_init(supervisor, vm_id)
 
         post = await request.post()
 

--- a/tests/supervisor/views/test_operator.py
+++ b/tests/supervisor/views/test_operator.py
@@ -378,6 +378,111 @@ async def test_operator_confidential_initialize(aiohttp_client, mocker):
 
 
 @pytest.mark.asyncio
+async def test_operator_confidential_initialize_waits_for_awaiting(aiohttp_client, mocker):
+    """Owner identity is recorded at the start of create, so init-session can
+    land before the supervisor registers the VM (VmNotFoundError) or before it
+    reaches awaiting_confidential_init. The endpoint polls get_vm through both
+    states, then delegates once the VM is awaiting-ready."""
+
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.ENABLE_CONFIDENTIAL_COMPUTING = True
+    settings.setup()
+    # Don't sleep between polls in the test.
+    mocker.patch("aleph.vm.orchestrator.views.operator._CONFIDENTIAL_AWAITING_POLL_INTERVAL", 0)
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+
+    with tempfile.NamedTemporaryFile() as temp_file:
+        temp_file.write(b"cert-bytes")
+        temp_file.flush()
+        form_data = aiohttp.FormData()
+        form_data.add_field("session", open(temp_file.name, "rb"), filename="session.b64")
+        form_data.add_field("godh", open(temp_file.name, "rb"), filename="godh.b64")
+
+        with mock.patch(
+            "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+            return_value=instance_message.sender,
+        ):
+            app = setup_webapp(pool=mocker.AsyncMock(executions={}))
+            app["vm_registry"].record(
+                vm_hash,
+                message=instance_message.content,
+                original=instance_message.content,
+                persistent=True,
+            )
+            fake_sup = _fake_supervisor()
+            # 1st call: supervisor hasn't registered the VM yet (info is None path).
+            # 2nd call: registered but still building config (not yet awaiting).
+            # 3rd call: awaiting_confidential_init -> proceed.
+            fake_sup.get_vm = AsyncMock(
+                side_effect=[
+                    VmNotFoundError("not registered yet"),
+                    _vm_info(
+                        VmStatus.BOOTING,
+                        vm_id=str(vm_hash),
+                        confidential_mode=ConfidentialMode.SEV,
+                        awaiting_confidential_init=False,
+                    ),
+                    _vm_info(
+                        VmStatus.BOOTING,
+                        vm_id=str(vm_hash),
+                        confidential_mode=ConfidentialMode.SEV,
+                        awaiting_confidential_init=True,
+                    ),
+                ]
+            )
+            app["supervisor"] = fake_sup
+            client = await aiohttp_client(app)
+            response = await client.post(
+                f"/control/machine/{vm_hash}/confidential/initialize",
+                data=form_data,
+            )
+            assert response.status == 200, await response.text()
+            assert fake_sup.get_vm.await_count == 3
+            fake_sup.initialize_confidential.assert_awaited_once_with(VmId(str(vm_hash)), b"cert-bytes", b"cert-bytes")
+
+
+@pytest.mark.asyncio
+async def test_operator_confidential_initialize_times_out(aiohttp_client, mocker):
+    """A VM that never reaches awaiting_confidential_init within the deadline
+    yields a 404; the session is never uploaded."""
+
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.ENABLE_CONFIDENTIAL_COMPUTING = True
+    settings.setup()
+    # Deadline has already passed on the first loop check: no real wait.
+    mocker.patch("aleph.vm.orchestrator.views.operator._CONFIDENTIAL_AWAITING_WAIT_SECONDS", 0)
+    mocker.patch("aleph.vm.orchestrator.views.operator._CONFIDENTIAL_AWAITING_POLL_INTERVAL", 0)
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+
+    with mock.patch(
+        "aleph.vm.orchestrator.views.authentication.authenticate_jwk",
+        return_value=instance_message.sender,
+    ):
+        app = setup_webapp(pool=mocker.AsyncMock(executions={}))
+        app["vm_registry"].record(
+            vm_hash,
+            message=instance_message.content,
+            original=instance_message.content,
+            persistent=True,
+        )
+        fake_sup = _fake_supervisor()
+        # Supervisor never registers the VM -> never awaiting -> times out.
+        fake_sup.get_vm = AsyncMock(side_effect=VmNotFoundError("never registered"))
+        app["supervisor"] = fake_sup
+        client = await aiohttp_client(app)
+        response = await client.post(
+            f"/control/machine/{vm_hash}/confidential/initialize",
+            data=aiohttp.FormData(),
+        )
+        assert response.status == 404
+        fake_sup.initialize_confidential.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_reboot_ok(aiohttp_client, mocker):
     """Reboot a persistent VM: supervisor.reboot_vm is called."""
     mock_address = "mock_address"

--- a/tests/supervisor/views/test_operator.py
+++ b/tests/supervisor/views/test_operator.py
@@ -43,6 +43,7 @@ def _vm_info(
     status: VmStatus = VmStatus.RUNNING,
     vm_id: str = _FAKE_HASH,
     confidential_mode: ConfidentialMode = ConfidentialMode.NONE,
+    awaiting_confidential_init: bool = False,
 ) -> VmInfo:
     return VmInfo(
         vm_id=VmId(vm_id),
@@ -54,6 +55,7 @@ def _vm_info(
         numa_node=None,
         status_message="",
         confidential_mode=confidential_mode,
+        awaiting_confidential_init=awaiting_confidential_init,
     )
 
 
@@ -353,8 +355,16 @@ async def test_operator_confidential_initialize(aiohttp_client, mocker):
                 persistent=True,
             )
             fake_sup = _fake_supervisor()
+            # A confidential VM ready for its owner's session reports
+            # awaiting_confidential_init; the endpoint waits for this state
+            # before uploading the session files.
             fake_sup.get_vm = AsyncMock(
-                return_value=_vm_info(VmStatus.STOPPED, vm_id=str(vm_hash), confidential_mode=ConfidentialMode.SEV)
+                return_value=_vm_info(
+                    VmStatus.BOOTING,
+                    vm_id=str(vm_hash),
+                    confidential_mode=ConfidentialMode.SEV,
+                    awaiting_confidential_init=True,
+                )
             )
             app["supervisor"] = fake_sup
             client = await aiohttp_client(app)


### PR DESCRIPTION
## What

Replaces the registry poll-bridge in the confidential init endpoint with **early owner-record registration**, so owner-auth resolves immediately (matching pre-1.13's pool, which was populated at the start of create) instead of polling the registry for up to 120 s.

## Why

A confidential instance is created via the allocation/spec path: `create_vm_execution` runs `await supervisor.create_vm(spec)` (~20 s) and only then recorded the agent registry entry. The scheduler exposes placement ~6 s in, so the owner's one-shot `init-session` could arrive before the record existed — previously a 404, then mitigated by `wait_for_agent_record_or_404` polling for the record.

## Design

Separates **identity** (early) from **readiness** (inherent wait):

- `create_vm_execution` now records the owner identity **before** `create_vm` (with `registry.forget(vm_hash)` cleanup if create raises, so a failed create leaves no dangling record).
- `operate_confidential_initialize` resolves `get_agent_record_or_404` immediately (no long poll), runs owner-auth, then — because the VM only reaches `awaiting_confidential_init` when `create_vm` completes — waits on that state via `wait_for_awaiting_confidential_init` (polls `get_vm`, bounded 120 s) before calling `initialize_confidential`. Guards are made `None`-safe for the window where the supervisor hasn't registered the VM yet.

The `awaiting_confidential_init` exemption in the `vm_running` guard and the post-inject `reconcile_port_forwards` (both from #981) are unchanged.

## Verification

- mypy: no new errors (operator.py baseline multipart errors only).
- `test_operator.py` (incl. confidential) + run/registry/allocation tests pass. `test_operator_confidential_initialize` updated to drive `get_vm` in the realistic `awaiting_confidential_init` state.

## ⚠️ Needs SEV-testnet validation

The real interleaving (placement ~6 s vs. record-at-start vs. awaiting-init at ~20 s) is only fully exercised on the AMD SEV-SNP testnet. Recommend an aleph-testnets #27 run against this branch confirming `init-session` no longer needs the long poll and that initialize succeeds on the first awaiting-ready observation before merging.