### PR TITLE
fix(confidential): record owner identity before resource download

### DIFF
--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -265,29 +265,29 @@ async def create_vm_execution(
         return None
 
     if _is_spec_eligible(content):
-        # The spec carries the owner address (build_create_vm_spec reads it from
-        # message.address), so the engine consumes this owner's own GPU
-        # reservation and skips other users' valid reservations during create.
-        # The agent does not touch reservations at all.
-        spec = await build_create_vm_spec(vm_hash, content)
-        # Agent territory: record the message in the agent's own cache *before*
-        # create_vm, mirroring 1.13 where the VM entered the pool at the start of
-        # create. create_vm takes ~20s while the scheduler exposes placement
-        # earlier, so a confidential owner's one-shot init-session call can land
-        # before create returns. Recording the owner identity up front lets the
-        # operator API answer owner-auth immediately (get_agent_record_or_404)
-        # instead of polling for the record; the endpoint still waits for the VM
-        # to reach the awaiting-init state before initializing it. The supervisor
-        # machinery that creates the VM never reads this record.
-        # Spec-eligible VMs are QEMU instances, which are always persistent.
+        # Record the owner identity up front — BEFORE build_create_vm_spec (which
+        # downloads the confidential rootfs/firmware, several seconds) and before
+        # create_vm (~20s). The scheduler exposes placement earlier, so a
+        # confidential owner's one-shot init-session call can land anywhere in that
+        # download+create window. Recording here lets the operator API answer
+        # owner-auth immediately via get_agent_record_or_404; otherwise that lookup
+        # 404s before the awaiting-init wait can even run, the owner's single call
+        # is lost, and the test forgets the instance (which the reconcile then
+        # reaps). The endpoint still waits for the VM to reach the awaiting-init
+        # state before initializing it; the supervisor machinery never reads this
+        # record. (build_create_vm_spec reads the owner address from
+        # message.address for the engine's own GPU-reservation handling; the agent
+        # touches no reservations.) Spec-eligible VMs are QEMU instances, always
+        # persistent.
         record = registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
         try:
+            spec = await build_create_vm_spec(vm_hash, content)
             info = await supervisor.create_vm(spec)
         except Exception:
-            # create_vm failed: drop the early record so a failed create never
-            # leaves a dangling owner-identity entry behind (a record with no VM
-            # the supervisor knows about). Nothing is persisted yet, so forgetting
-            # the in-memory entry is sufficient.
+            # build or create failed: drop the early record so a failed create
+            # never leaves a dangling owner-identity entry behind (a record with no
+            # VM the supervisor knows about). Nothing is persisted yet, so
+            # forgetting the in-memory entry is sufficient.
             registry.forget(vm_hash)
             raise
         if info.awaiting_confidential_init:

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -128,6 +128,45 @@ async def test_eligible_instance_routed_through_supervisor(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_owner_record_recorded_before_resource_download(monkeypatch):
+    """Regression: the owner record must reach the registry BEFORE
+    build_create_vm_spec runs (it downloads the confidential rootfs/firmware,
+    several seconds, then create_vm takes ~20s more). A confidential owner's
+    one-shot init-session can land anywhere in that window; if the record is not
+    yet present, get_agent_record_or_404 404s, the single call is lost, and the
+    instance is forgotten/reaped. So owner-auth must resolve from the moment
+    create begins, not only after the download completes.
+    """
+    content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
+    message = MagicMock(content=content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
+    )
+
+    supervisor = _fake_supervisor()
+    registry = AgentVmRegistry()
+
+    seen = {}
+
+    async def fake_build(vm_hash, _content):
+        # build_create_vm_spec is where the download happens; the owner record
+        # must already be queryable here.
+        seen["record_present_at_build"] = registry.get(vm_hash) is not None
+        return _spec()
+
+    monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(side_effect=fake_build))
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(run_module, "persist_record", AsyncMock())
+
+    await run_module.create_vm_execution(_HASH, supervisor=supervisor, registry=registry, persistent=True)
+
+    assert (
+        seen.get("record_present_at_build") is True
+    ), "owner record must be recorded before build_create_vm_spec downloads resources"
+
+
+@pytest.mark.asyncio
 async def test_eligible_instance_timeout_tears_down(monkeypatch):
     content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
     message = MagicMock(content=content)


### PR DESCRIPTION
## Problem

The confidential integration test (`test_confidential_instance_create_and_ssh`, aleph-testnets #27) fails at `init-session` with `VM not found` — reproducibly, on **dev** as well as feature branches. Root-caused from the CRN `tee-agent` journal:

```
11:57:30  agent starts the persistent confidential VM
11:57:36  POST .../confidential/initialize → 404   (init-session, IMMEDIATE)
11:57:46  "…waiting for its owner to initialize"   (reaches awaiting, +10s)
11:57:51→11:59:51  forgotten 1/3 → 2/3 → reaped
```

The 404 is in the **same second** as the POST — not the 120 s awaiting-init wait timing out. It fires **upstream** of that wait, at `get_agent_record_or_404` (`operator.py`), because the agent owner-record isn't in the registry yet.

Why: in `create_vm_execution` (`run.py`, spec/instance branch) the owner record was written **after** `build_create_vm_spec`, which **downloads the confidential rootfs/firmware** (several seconds) before `create_vm` (~20s more). A confidential owner's **single, one-shot** `init-session` lands somewhere in that download+create window; arriving before the record is written → `get_agent_record_or_404` 404s. The aleph CLI's `init-session` is `check=True`, so the call fails hard, the test's `finally` forgets the instance, and `check_payment` then reaps the now-genuinely-forgotten VM.

(This supersedes this PR's previous content — a reconcile-teardown skip for `awaiting_confidential_init` VMs. That was the wrong layer: the `FORGOTTEN` reap is the test's own cleanup of a VM `init-session` could never reach, so suppressing it would only leak the VM.)

## Fix

Record the owner identity **before** `build_create_vm_spec`, so owner-auth resolves the moment create begins (matching the design's stated intent — the record was meant to be written "up front", it just landed after the download). The failure guard is widened to cover the download too.

## Tests

- Regression test (`test_owner_record_recorded_before_resource_download`): asserts the owner record is present when `build_create_vm_spec` runs (fails on the old ordering).
- Local: mypy clean; `test_supervisor_run_routing` 19/19; create-path/operator suite 83/83; isort + ruff clean. No test deleted/skipped/weakened.

Full confidential validation requires the SEV testnet (#27); GitHub CI cannot exercise the SEV path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
