### PR TITLE
refactor(boundary): PR-2 controller split (download/runtime + wire-error vocabulary)

### DIFF
--- a/docs/plans/2026-06-19-controller-split-by-concern-implementation.md
+++ b/docs/plans/2026-06-19-controller-split-by-concern-implementation.md
@@ -140,6 +140,42 @@ to `QemuConfidentialDownloader`; `from_spec` runtime holder stays). The SEV
 runtime path is exercised by unit tests with mocks; full validation needs the
 testnet #27 SEV run before merge (same gate as the confidential-init work).
 
+## 3b. Verified execution notes (code-confirmed 2026-06-19)
+
+Turnkey details confirmed by reading the code, so execution is mechanical:
+
+- **Download is agent-only.** The only external callers of `download_all` are
+  `agent/translate.py:101` (qemu) and `:189` (program). No controller / pool /
+  models code downloads. => the controller runtime holders
+  (`AlephQemuResources`, `AlephFirecrackerResources`, `AlephProgramResources`,
+  `AlephQemuConfidentialResources`) can drop `download_*` / `make_writable_volume`
+  outright once `translate.py` uses the agent downloaders.
+- **Shared-type relocations** (the slice-1 tax, used by both sides):
+  `HostVolume` (dataclass) and `host_volumes_from_message` move from
+  `supervisor/controllers/resources.py` to the neutral foundation
+  `aleph.vm.resources` (already imported by both agent and controllers; holds
+  `HostGPU`). `disk_usage_delta` stays with the runtime holder (controller-side
+  accounting). `VmResources` base stays in `controllers/resources.py`; the agent
+  downloaders **compose** (own `rootfs_path`/`volumes`/`code_*`), they do NOT
+  subclass it (subclassing would re-introduce the `agent -> controllers` import).
+- **Downloader error vocabulary:** the agent downloaders raise
+  `supervisor_interface.errors.{VmSetupError,ResourceDownloadError,FileTooLargeError}`
+  (contract), not the controller exception classes.
+- **Transitional view state (why it stays green per backend):** as each backend
+  migrates, `views/__init__.py` `vm_creation_exceptions` catches BOTH the
+  contract error and the not-yet-migrated controller error. The controller
+  exception imports are dropped and the import-linter residuals removed only in
+  the FINAL slice, after all four backends use agent downloaders. Tests stay
+  green at every backend step; only the linter-tightening is end-loaded.
+- **Test touchpoints:** `tests/supervisor/test_supervisor_translate.py:23,74`
+  (imports `HostVolume`; mocks `AlephQemuResources.download_all` -> retarget to
+  the agent downloader), `test_supervisor_translate_program.py` (same for
+  program), `tests/migration/test_runner.py:699,703` (constructs resources +
+  calls `make_writable_volume` -> retarget to agent downloader),
+  `test_supervisor_spec_resources.py` (uses `from_spec` on the controller holder
+  -> unchanged), `src/aleph/vm/hypervisors/qemu/qemuvm.py:63` (uses `HostVolume`
+  -> update import to `aleph.vm.resources`).
+
 ## 4. Risk / why this is gated on tests, not "moves only"
 
 It splits a class and changes which exceptions the views catch. The step-2

--- a/docs/plans/2026-06-19-controller-split-by-concern-implementation.md
+++ b/docs/plans/2026-06-19-controller-split-by-concern-implementation.md
@@ -140,6 +140,12 @@ to `QemuConfidentialDownloader`; `from_spec` runtime holder stays). The SEV
 runtime path is exercised by unit tests with mocks; full validation needs the
 testnet #27 SEV run before merge (same gate as the confidential-init work).
 
+> **As-built:** no separate `QemuConfidentialDownloader` was needed. Confidential
+> QEMU instances use the plain `QemuDownloader` (runtime + volumes); firmware is
+> resolved inline in `translate.py` alongside the other TEE fields rather than as
+> an agent-side download step, so a confidential subclass would have added no
+> behavior. It was dropped to avoid carrying dead code.
+
 ## 3b. Verified execution notes (code-confirmed 2026-06-19)
 
 Turnkey details confirmed by reading the code, so execution is mechanical:

--- a/docs/plans/2026-06-19-controller-split-by-concern-implementation.md
+++ b/docs/plans/2026-06-19-controller-split-by-concern-implementation.md
@@ -1,0 +1,148 @@
+# Controller split by concern — implementation plan (PR-2)
+
+**Status:** Plan, grounded in a code audit (2026-06-19)
+**Design:** `docs/plans/2026-06-19-controller-split-by-concern-design.md`
+**Branch:** `od/controller-split-by-concern` (stacked on PR-3 `od/agent-supervisor-code-move`)
+**Paths are post-PR-3:** agent = `aleph.vm.agent`, controllers = `aleph.vm.supervisor.controllers`, contract = `aleph.vm.supervisor_interface`.
+
+## 0. Audit findings that change the design's assumptions
+
+A full read of the boundary (see session audit) resolved the design's §5 open
+questions and surfaced one coupling the design under-specified:
+
+- **Backup/QMP boundary coverage is already complete** (design §5 Q3). Every
+  `BackupOps`/`ConfidentialOps` method is on `supervisor_interface.abc.Supervisor`
+  and implemented in `supervisor/local.py` wrapped in `translating_errors()`
+  (`get_measurement`, `inject_secret`, `start_backup`, `get_backup_status`,
+  `list_backups`, `download_backup`, `delete_backup`, `restore_backup`,
+  `restore_from_image`). `QemuVmClient` and the fsfreeze/fsthaw QMP calls are
+  **supervisor-internal only** (`local.py` `_try_fsfreeze`/`_try_fsthaw`, inside
+  `start_backup`). No agent code calls `QemuVmClient`. **No boundary gap.**
+- **error_mapping is complete**: `translate_exception` maps every internal
+  backend exception to the closed `SupervisorError` set; all 30+ boundary methods
+  in `local.py` wrap their body in `translating_errors()`. So **the boundary only
+  ever raises `SupervisorError`** today.
+- **THE COUPLING (design under-specified):** the create path downloads
+  **agent-side**, before the boundary. `agent/translate.py:100-101` builds
+  `AlephQemuResources(message, namespace).download_all()` and
+  `:188-189` builds `AlephProgramResources(message, namespace).download_all()`,
+  resolving paths into the `CreateVmSpec`. The running controller no longer
+  downloads. Therefore `ResourceDownloadError` / `FileTooLargeError` are raised
+  **agent-side by controller code the agent imports** — they are NOT boundary
+  errors. This is why `views/__init__.py` still imports controller exceptions
+  (`vm_creation_exceptions`, lines 618-630 / 946-957). **Consequence:** Residual
+  B (wire-error vocabulary) cannot be removed without Residual A (move the
+  downloader agent-side and have it raise the neutral
+  `supervisor_interface.errors` vocabulary). PR-2 is one coupled change.
+
+### §5 open-question resolutions
+- **Q1 downloader subclass vs compose:** **compose.** The agent downloader holds
+  `message_content` and emits resolved spec fields; it does NOT subclass the
+  controller `VmResources`. This is what actually removes the
+  `agent -> supervisor.controllers` import (subclassing would keep it).
+- **Q2 `make_writable_volume` placement:** **keep in the downloader** (status quo,
+  behavior-neutral). Note for the future `VmExecution`/`VmPool` cleave.
+- **Q3 backup boundary coverage:** no gap (above). The one loose thread is
+  `operator.py:925` calling `controllers.qemu.backup.download_volume_by_ref`
+  directly and `:33-36` importing `get_backup_directory` — agent code reaching a
+  controller util. PR-2 relocates these (see step 4).
+
+## 1. Inventory (file:line)
+
+**Resources classes** (`supervisor/controllers/`):
+- `resources.py:90` `VmResources` (base: `kernel_image_path`, `rootfs_path`,
+  `volumes`, `namespace`, `download_kernel`), `:30` `HostVolume`.
+- `qemu/instance.py:36` `AlephQemuResources(VmResources)` — DOWNLOAD:
+  `download_runtime` `:61`, `download_volumes` `:69`, `download_all` `:74`,
+  `make_writable_volume` `:80`; RUNTIME: `from_spec` `:125`, `gpus`,
+  `get_disk_usage_delta` `:55`; holds optional `message_content` `:48`.
+- `qemu_confidential/instance.py:25` `AlephQemuConfidentialResources(AlephQemuResources)`
+  — `download_firmware` `:28`, `download_all` `:35`, `from_spec` `:43`,
+  `firmware_path`.
+- `firecracker/executable.py:92` `AlephFirecrackerResources(VmResources)` —
+  `download_volumes` `:109`, `download_all` `:112`; required `message_content`.
+- `firecracker/program.py:163` `AlephProgramResources(AlephFirecrackerResources)`
+  — `download_code/runtime/data/all`, code fields.
+- `firecracker/spec_program.py:47` `SpecProgramResources` — already message-free,
+  `from_spec` `:57`. **This is the pattern to mirror for QEMU.**
+
+**Construction sites:**
+- Agent download: `agent/translate.py:100` (qemu), `:188` (program).
+- Supervisor runtime (`from_spec`): `models.py:417` (spec program), `:419`
+  (confidential), `:421` (qemu).
+
+**Leak (supervisor -> agent):** `aleph/vm/resources.py:7`
+`from aleph.vm.agent.utils import get_compatible_gpus` (used `:82`, `:91`).
+
+**View error vocabulary:** `agent/views/__init__.py:67-73` import
+`MicroVMFailedInitError` (hypervisors), `InsufficientResourcesError`
+(`aleph.vm.resources`), `ResourceDownloadError`/`VmSetupError`
+(controllers.firecracker.executable), `FileTooLargeError`
+(controllers.firecracker.program); caught in `vm_creation_exceptions` `:618`,
+`:946`. `operator.py:33-36` imports `download_volume_by_ref`,
+`get_backup_directory` from `controllers.qemu.backup`; uses at `:925`.
+
+## 2. Slice sequence (each committed only when green)
+
+1. **Leak fix (independent, behavior-neutral).** Move `get_compatible_gpus` to a
+   neutral home. It lives in `agent/utils.py` but is GPU-hardware logic with no
+   agent dependency; move it to `aleph.vm.resources` (already the GPU util module)
+   or a neutral `aleph.vm.hardware`. Update `agent/utils.py` to re-export (or
+   update importers). Verify `resources.py` no longer imports `agent.*`;
+   import-linter unaffected (this leak is not yet a contract, but fixing it
+   unblocks a future supervisor-side contract).
+
+2. **Lock HTTP-status contract (tests first, no code change).** Add view-level
+   tests asserting `update_allocations`/`notify_allocation` aggregate status
+   (200 all-ok, 207 partial, 503 all-fail) and that a download failure, setup
+   failure, file-too-large, insufficient-resources each land a VM in `failing`
+   with the right `repr`. These must pass on current code; they pin behavior
+   across the refactor.
+
+3. **Agent-side downloader (Residual A).** New `agent/vm/downloader.py` (or
+   `agent/resources.py`): `QemuDownloader`, `ProgramDownloader`,
+   `QemuConfidentialDownloader` — compose, hold `message_content`, own
+   `download_runtime/volumes/code/data/firmware/all` + `make_writable_volume`,
+   and emit the resolved fields `translate.py` needs. They raise
+   `supervisor_interface.errors.ResourceDownloadError`/`FileTooLargeError`
+   (neutral vocabulary). Rewire `translate.py:100,188` to use them. Keep
+   `test_supervisor_translate*` green (mock the new downloader).
+
+4. **Strip download from controller Resources.** Remove `download_*` /
+   `make_writable_volume` from `AlephQemuResources`,
+   `AlephQemuConfidentialResources`, `AlephFirecrackerResources`,
+   `AlephProgramResources`, leaving the runtime holder (`from_spec` + attribute
+   surface). `from_spec` reads `DiskRole` from `supervisor_interface` (already
+   true post-PR-1). Add a test: the runtime holder has no `message_content` /
+   download surface. Keep `test_supervisor_spec_resources` / `test_qemu_instance`
+   green.
+
+5. **Wire-error vocabulary (Residual B), now unblocked.** The agent now raises
+   only neutral/contract errors (download from step 3; create from the boundary).
+   Add an `ErrorCode -> HTTP status` helper. Replace the controller/hypervisor
+   exception imports in `views/__init__.py` with `SupervisorError` (+ the
+   download errors from `supervisor_interface.errors`). Update
+   `vm_creation_exceptions`. Relocate `operator.py`'s `download_volume_by_ref` /
+   `get_backup_directory`: either behind a boundary method or to a neutral
+   staging util (recommend a thin boundary method `stage_restore_volume` if the
+   restore path needs tenant isolation; else a neutral util). Step-2 tests must
+   stay green.
+
+6. **Tighten import-linter.** Delete the two `agent -> supervisor.controllers`
+   residuals from the ignore list in `pyproject.toml`; the "controllers ... not
+   the agent" / "agent does not reach ..." contracts now hold strictly. Run
+   `lint-imports` (4 kept, 0 broken), full supervisor suite, mypy baseline.
+
+## 3. Confidential / testnet
+
+`AlephQemuConfidentialResources` follows the same split (download_firmware moves
+to `QemuConfidentialDownloader`; `from_spec` runtime holder stays). The SEV
+runtime path is exercised by unit tests with mocks; full validation needs the
+testnet #27 SEV run before merge (same gate as the confidential-init work).
+
+## 4. Risk / why this is gated on tests, not "moves only"
+
+It splits a class and changes which exceptions the views catch. The step-2
+HTTP-contract tests + the existing `translate`/`spec_resources`/`qemu_instance`
+suites are the safety net. Commit each slice only when green; never weaken a test
+to pass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,6 +302,7 @@ type = "forbidden"
 allow_indirect_imports = "true"
 source_modules = [ "aleph.vm.agent" ]
 forbidden_modules = [
+  "aleph.vm.supervisor.controllers",
   "aleph.vm.supervisor.local",
   "aleph.vm.supervisor.grpc_server",
   "aleph.vm.supervisor.grpc_client",
@@ -312,8 +313,11 @@ forbidden_modules = [
   "aleph.vm.supervisor.qemu_build",
 ]
 # Composition root only: the agent entrypoints pick a concrete Supervisor impl.
-# Agent->supervisor.controllers (Resources, controller exception types, cloudinit)
-# remains a documented residual removed by PR-2 (the controller split).
+# The PR-1 agent->supervisor.controllers residuals (Resources downloaders,
+# controller exception types, cloudinit, the QEMU backup utils) were removed by
+# PR-2 (the controller split): the downloaders live agent-side, the wire-error
+# vocabulary is the contract's SupervisorError set, and the shared host-volume /
+# program-config / backup-staging / hostname helpers moved to neutral modules.
 ignore_imports = [
   "aleph.vm.agent.cli -> aleph.vm.supervisor.local",
   "aleph.vm.agent.supervisor -> aleph.vm.supervisor.local",

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -25,14 +25,14 @@ from aleph.vm.conf import settings
 from aleph.vm.hypervisors.firecracker.microvm import MicroVMFailedInitError
 from aleph.vm.models import VmExecution
 from aleph.vm.resources import InsufficientResourcesError
-from aleph.vm.supervisor.controllers.firecracker.executable import (
-    ResourceDownloadError,
-    VmSetupError,
-)
-from aleph.vm.supervisor.controllers.firecracker.program import FileTooLargeError
 from aleph.vm.supervisor_interface import errors as supervisor_errors
 from aleph.vm.supervisor_interface.abc import Supervisor
-from aleph.vm.supervisor_interface.errors import VmNotFoundError
+from aleph.vm.supervisor_interface.errors import (
+    FileTooLargeError,
+    ResourceDownloadError,
+    VmNotFoundError,
+    VmSetupError,
+)
 from aleph.vm.supervisor_interface.types import (
     GuestPort,
     HostPort,
@@ -383,11 +383,11 @@ async def _resolve_program_content(vm_hash: ItemHash, registry: AgentVmRegistry)
 def _raise_http_for_program_error(error: Exception, vm_hash: ItemHash) -> None:
     """Map program create/setup failures to HTTP responses.
 
-    Two vocabularies meet here: the agent-side download phase raises the
-    controller-internal exceptions (ResourceDownloadError, FileTooLargeError),
-    while the supervisor boundary raises the closed SupervisorError set.
+    Both the agent-side download phase and the supervisor boundary now raise the
+    closed ``supervisor_interface.errors.SupervisorError`` vocabulary, so the
+    branches below match a single error hierarchy.
     """
-    if isinstance(error, (ResourceDownloadError, supervisor_errors.ResourceDownloadError)):
+    if isinstance(error, ResourceDownloadError):
         logger.exception(error)
         raise HTTPBadRequest(reason="Code, runtime or data not available") from error
     if isinstance(error, (InsufficientResourcesError, supervisor_errors.InsufficientResourcesError)):
@@ -396,9 +396,9 @@ def _raise_http_for_program_error(error: Exception, vm_hash: ItemHash) -> None:
             reason="Insufficient capacity",
             text="This CRN cannot host the requested workload at this time.",
         ) from error
-    if isinstance(error, (FileTooLargeError, supervisor_errors.FileTooLargeError)):
+    if isinstance(error, FileTooLargeError):
         raise HTTPInternalServerError(reason=str(error) or "File too large") from error
-    if isinstance(error, (VmSetupError, supervisor_errors.VmSetupError)):
+    if isinstance(error, VmSetupError):
         logger.exception(error)
         raise HTTPInternalServerError(reason="Error during vm initialisation") from error
     if isinstance(error, (MicroVMFailedInitError, supervisor_errors.MicroVMInitError)):

--- a/src/aleph/vm/agent/translate.py
+++ b/src/aleph/vm/agent/translate.py
@@ -16,11 +16,9 @@ from aleph_message.models.execution.base import Encoding
 from aleph_message.models.execution.environment import HypervisorType
 from aleph_message.models.execution.instance import InstanceContent
 
+from aleph.vm.agent.vm.downloader import ProgramDownloader, QemuDownloader
 from aleph.vm.conf import settings
 from aleph.vm.storage import get_existing_file
-from aleph.vm.supervisor.controllers.firecracker.program import AlephProgramResources
-from aleph.vm.supervisor.controllers.qemu.cloudinit import get_hostname_from_hash
-from aleph.vm.supervisor.controllers.qemu.instance import AlephQemuResources
 from aleph.vm.supervisor_interface.errors import InvalidBackendError
 from aleph.vm.supervisor_interface.types import (
     Backend,
@@ -38,6 +36,7 @@ from aleph.vm.supervisor_interface.types import (
     TeeConfig,
     VmId,
 )
+from aleph.vm.utils import get_hostname_from_hash
 from aleph.vm.utils.runtime_channel import RUNTIME_CONTROL_PORT
 
 
@@ -97,7 +96,7 @@ async def build_create_vm_spec(
 
     # --- Materialise resources ---
 
-    resources = AlephQemuResources(message, namespace=str(vm_hash))
+    resources = QemuDownloader(message, namespace=str(vm_hash))
     await resources.download_all()
 
     # --- Confidential (TEE) ---
@@ -170,7 +169,7 @@ async def build_create_vm_spec(
 async def build_program_create_vm_spec(
     vm_hash: ItemHash,
     message: ExecutableContent,
-) -> tuple[CreateVmSpec, AlephProgramResources]:
+) -> tuple[CreateVmSpec, ProgramDownloader]:
     """Translate a program message into a CreateVmSpec, downloading resources.
 
     The agent half of the program create: code/runtime/data/volumes are
@@ -185,7 +184,7 @@ async def build_program_create_vm_spec(
     if not isinstance(message, ProgramContent):
         raise InvalidBackendError(f"Expected ProgramContent, got {type(message).__name__}")
 
-    resources = AlephProgramResources(message, namespace=str(vm_hash))
+    resources = ProgramDownloader(message, namespace=str(vm_hash))
     await resources.download_all()
 
     # The runtime image is the program's root filesystem: plain ROOTFS on the

--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -64,13 +64,7 @@ from aleph.vm.agent.views.host_status import (
 from aleph.vm.agent.views.operator import get_itemhash_or_400
 from aleph.vm.agent.vm_registry import AgentVmRecord, AgentVmRegistry
 from aleph.vm.conf import settings
-from aleph.vm.hypervisors.firecracker.microvm import MicroVMFailedInitError
 from aleph.vm.resources import InsufficientResourcesError
-from aleph.vm.supervisor.controllers.firecracker.executable import (
-    ResourceDownloadError,
-    VmSetupError,
-)
-from aleph.vm.supervisor.controllers.firecracker.program import FileTooLargeError
 from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.supervisor_interface.errors import (
     InsufficientResourcesError as BoundaryInsufficientResourcesError,
@@ -614,19 +608,18 @@ async def update_allocations(request: web.Request):
 
         # Second start persistent VMs and instances sequentially to limit resource usage.
 
-        # Exceptions that can be raised when starting a VM:
+        # Exceptions that can be raised when starting a VM. The create path now
+        # raises a single vocabulary: the agent download phase and the
+        # supervisor boundary both surface contract SupervisorError subclasses
+        # (ResourceDownloadError, FileTooLargeError, VmSetupError,
+        # MicroVMInitError, InsufficientResourcesError); SupervisorError catches
+        # them all. The remaining entries are agent-side foundation/HTTP errors.
         vm_creation_exceptions = (
             UnknownHashError,
-            ResourceDownloadError,
-            FileTooLargeError,
-            VmSetupError,
-            MicroVMFailedInitError,
+            SupervisorError,
             HostNotFoundError,
             HTTPNotFound,
             InsufficientResourcesError,
-            # The spec create path surfaces the boundary error (the engine's
-            # atomic admission, translated by LocalSupervisor.create_vm).
-            BoundaryInsufficientResourcesError,
         )
 
         scheduling_errors: dict[ItemHash, Exception] = {}
@@ -942,18 +935,14 @@ async def notify_allocation(request: web.Request):
     else:
         return web.HTTPBadRequest(reason="Invalid payment method")
 
-    # Exceptions that can be raised when starting a VM:
+    # Exceptions that can be raised when starting a VM. SupervisorError covers
+    # the full create-failure contract vocabulary (download, setup, init,
+    # capacity); see the matching tuple in update_allocations above.
     vm_creation_exceptions = (
         UnknownHashError,
-        ResourceDownloadError,
-        FileTooLargeError,
-        VmSetupError,
-        MicroVMFailedInitError,
+        SupervisorError,
         HostNotFoundError,
         InsufficientResourcesError,
-        # The spec create path surfaces the boundary error (the engine's
-        # atomic admission, translated by LocalSupervisor.create_vm).
-        BoundaryInsufficientResourcesError,
     )
 
     scheduling_errors: dict[ItemHash, Exception] = {}

--- a/src/aleph/vm/agent/views/operator.py
+++ b/src/aleph/vm/agent/views/operator.py
@@ -29,11 +29,8 @@ from aleph.vm.agent.views.authentication import (
     require_jwk_authentication,
 )
 from aleph.vm.agent.vm_registry import AgentVmRecord
+from aleph.vm.backup_staging import download_volume_by_ref, get_backup_directory
 from aleph.vm.conf import settings
-from aleph.vm.supervisor.controllers.qemu.backup import (
-    download_volume_by_ref,
-    get_backup_directory,
-)
 from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.supervisor_interface.errors import (
     BackupNotFoundError,

--- a/src/aleph/vm/agent/vm/downloader.py
+++ b/src/aleph/vm/agent/vm/downloader.py
@@ -122,14 +122,6 @@ class QemuDownloader:
         )
 
 
-class QemuConfidentialDownloader(QemuDownloader):
-    """A confidential QEMU instance downloader.
-
-    Firmware is resolved in ``translate.py`` (like the other TEE fields), so this
-    subclass adds no extra download step beyond the QEMU runtime + volumes.
-    """
-
-
 class ProgramDownloader:
     """Resolve a Firecracker program message's resources to on-host paths.
 

--- a/src/aleph/vm/agent/vm/downloader.py
+++ b/src/aleph/vm/agent/vm/downloader.py
@@ -1,0 +1,204 @@
+"""Agent-side resource downloaders.
+
+The create path resolves an Aleph message's resources (rootfs, code, runtime,
+data, extra volumes, firmware) into on-host paths *agent-side*, before the
+Supervisor boundary. The supervisor then boots from the resolved paths carried
+on the ``CreateVmSpec`` and never downloads.
+
+These downloaders *compose* the host-resource surface (they hold the
+``message_content`` and expose ``rootfs_path`` / ``volumes`` / the program code
+fields ``translate.py`` and ``program_client`` read); they deliberately do NOT
+subclass the supervisor's ``VmResources`` controller classes, which is what
+keeps the agent free of an ``aleph.vm.supervisor.controllers`` import.
+
+They raise the neutral contract vocabulary
+(``aleph.vm.supervisor_interface.errors``), not the controller exception
+classes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from os.path import isfile
+from pathlib import Path
+
+from aiohttp import ClientResponseError
+from aleph_message.models import InstanceContent, ProgramContent
+from aleph_message.models.execution.instance import RootfsVolume
+from aleph_message.models.execution.volume import PersistentVolume, VolumePersistence
+
+from aleph.vm.conf import settings
+from aleph.vm.host_volumes import HostVolume, host_volumes_from_message
+from aleph.vm.program_config import Interface
+from aleph.vm.storage import (
+    get_code_path,
+    get_data_path,
+    get_rootfs_base_path,
+    get_runtime_path,
+)
+from aleph.vm.supervisor_interface.errors import ResourceDownloadError, VmSetupError
+from aleph.vm.utils import run_in_subprocess
+
+
+async def _make_writable_volume(
+    parent_image_path: Path,
+    volume: PersistentVolume | RootfsVolume,
+    namespace: str,
+) -> Path:
+    """Create a new qcow2 image file based on the passed one, that we give to the VM to write onto."""
+    qemu_img_path: str | None = shutil.which("qemu-img")
+    if not qemu_img_path:
+        msg = "qemu-img not found in PATH"
+        raise VmSetupError(msg)
+
+    volume_name = volume.name if isinstance(volume, PersistentVolume) else "rootfs"
+
+    # detect the image format
+    out_json = await run_in_subprocess([qemu_img_path, "info", str(parent_image_path), "--output=json"])
+    out = json.loads(out_json)
+    parent_format = out.get("format", None)
+    if parent_format is None:
+        msg = f"Failed to detect format for {volume}: {out_json}"
+        raise VmSetupError(msg)
+    if parent_format not in ("qcow2", "raw"):
+        msg = f"Format {parent_format} for {volume} unhandled by QEMU hypervisor"
+        raise VmSetupError(msg)
+
+    dest_path = settings.PERSISTENT_VOLUMES_DIR / namespace / f"{volume_name}.qcow2"
+    # Do not override if user asked for host persistence.
+    if dest_path.exists() and volume.persistence == VolumePersistence.host:
+        return dest_path
+
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    size_in_bytes = int(volume.size_mib * 1024 * 1024)
+
+    await run_in_subprocess(
+        [
+            qemu_img_path,
+            "create",
+            "-f",  # Format
+            "qcow2",
+            "-F",
+            parent_format,
+            "-b",
+            str(parent_image_path),
+            str(dest_path),
+            str(size_in_bytes),
+        ]
+    )
+    return dest_path
+
+
+class QemuDownloader:
+    """Resolve a QEMU instance message's resources to on-host paths."""
+
+    message_content: InstanceContent
+    namespace: str
+    rootfs_path: Path
+    volumes: list[HostVolume]
+
+    def __init__(self, message_content: InstanceContent, namespace: str):
+        self.message_content = message_content
+        self.namespace = namespace
+        self.volumes = []
+
+    async def make_writable_volume(self, parent_image_path: Path, volume: PersistentVolume | RootfsVolume) -> Path:
+        return await _make_writable_volume(parent_image_path, volume, self.namespace)
+
+    async def download_runtime(self) -> None:
+        volume = self.message_content.rootfs
+        parent_image_path = await get_rootfs_base_path(volume.parent.ref)
+        self.rootfs_path = await self.make_writable_volume(parent_image_path, volume)
+
+    async def download_volumes(self) -> None:
+        self.volumes = await host_volumes_from_message(self.message_content, self.namespace)
+
+    async def download_all(self) -> None:
+        await asyncio.gather(
+            self.download_runtime(),
+            self.download_volumes(),
+        )
+
+
+class QemuConfidentialDownloader(QemuDownloader):
+    """A confidential QEMU instance downloader.
+
+    Firmware is resolved in ``translate.py`` (like the other TEE fields), so this
+    subclass adds no extra download step beyond the QEMU runtime + volumes.
+    """
+
+
+class ProgramDownloader:
+    """Resolve a Firecracker program message's resources to on-host paths.
+
+    Exposes the fields ``translate.py`` (rootfs/kernel/code/volumes) and the
+    agent program client (code_*/data_path/volumes) read.
+    """
+
+    message_content: ProgramContent
+    namespace: str
+    kernel_image_path: Path
+    rootfs_path: Path
+    volumes: list[HostVolume]
+    code_path: Path
+    code_entrypoint: str
+    code_interface: Interface
+    data_path: Path | None
+
+    def __init__(self, message_content: ProgramContent, namespace: str):
+        self.message_content = message_content
+        self.namespace = namespace
+        self.volumes = []
+        self.code_encoding = message_content.code.encoding
+        self.code_entrypoint = message_content.code.entrypoint
+        self.code_interface = Interface.from_entrypoint(
+            entrypoint=message_content.code.entrypoint,
+            interface_hint=message_content.code.interface,
+        )
+
+    async def download_kernel(self) -> None:
+        # Assumes kernel is already present on the host
+        self.kernel_image_path = Path(settings.LINUX_PATH)
+        assert isfile(self.kernel_image_path)
+
+    async def download_code(self) -> None:
+        code_ref: str = self.message_content.code.ref
+        try:
+            self.code_path = await get_code_path(code_ref)
+        except ClientResponseError as error:
+            raise ResourceDownloadError(str(error)) from error
+        assert self.code_path.is_file(), f"Code not found on '{self.code_path}'"
+
+    async def download_runtime(self) -> None:
+        runtime_ref: str = self.message_content.runtime.ref
+        try:
+            self.rootfs_path = await get_runtime_path(runtime_ref)
+        except ClientResponseError as error:
+            raise ResourceDownloadError(str(error)) from error
+        assert self.rootfs_path.is_file(), f"Runtime not found on {self.rootfs_path}"
+
+    async def download_volumes(self) -> None:
+        self.volumes = await host_volumes_from_message(self.message_content, self.namespace)
+
+    async def download_data(self) -> None:
+        if self.message_content.data:
+            data_ref: str = self.message_content.data.ref
+            try:
+                data_path = await get_data_path(data_ref)
+                self.data_path = data_path
+            except ClientResponseError as error:
+                raise ResourceDownloadError(str(error)) from error
+            assert data_path.is_file(), f"Data not found on {data_path}"
+        else:
+            self.data_path = None
+
+    async def download_all(self) -> None:
+        await asyncio.gather(
+            self.download_kernel(),
+            self.download_runtime(),
+            self.download_code(),
+            self.download_volumes(),
+            self.download_data(),
+        )

--- a/src/aleph/vm/agent/vm/program_client.py
+++ b/src/aleph/vm/agent/vm/program_client.py
@@ -31,23 +31,20 @@ import msgpack
 from aleph_message.models import ItemHash, ProgramContent
 from aleph_message.models.execution.base import Encoding
 
+from aleph.vm.agent.vm.downloader import ProgramDownloader
 from aleph.vm.conf import settings
 from aleph.vm.guest_api.__main__ import run_guest_api
 from aleph.vm.hypervisors.firecracker.microvm import RuntimeConfiguration
-from aleph.vm.storage import chown_to_jailman
-from aleph.vm.supervisor.controllers.firecracker.executable import (
-    VmInitNotConnectedError,
-    VmSetupError,
-    Volume,
-)
-from aleph.vm.supervisor.controllers.firecracker.program import (
-    AlephProgramResources,
+from aleph.vm.program_config import (
     ConfigurationResponse,
-    FileTooLargeError,
     ProgramConfiguration,
     RunCodePayload,
+    VmInitNotConnectedError,
+    Volume,
     read_input_data,
 )
+from aleph.vm.storage import chown_to_jailman
+from aleph.vm.supervisor_interface.errors import FileTooLargeError, VmSetupError
 from aleph.vm.supervisor_interface.types import VmId, VmInfo
 from aleph.vm.utils.runtime_channel import GUEST_API_PORT, RUNTIME_CONTROL_PORT
 
@@ -64,7 +61,7 @@ def _device_name(index: int) -> str:
     return f"vd{ascii_lowercase[index + 1]}"
 
 
-def build_code_and_volumes(resources: AlephProgramResources) -> tuple[bytes | None, list[Volume]]:
+def build_code_and_volumes(resources: ProgramDownloader) -> tuple[bytes | None, list[Volume]]:
     """The agent half of the old get_volumes_for_program: code bytes (inline
     encodings) or a CODE drive mount (squashfs), plus guest volume mappings."""
     if resources.code_encoding == Encoding.squashfs:
@@ -100,7 +97,7 @@ def runtime_config_from_ready_payload(payload: bytes) -> RuntimeConfiguration:
 
 
 def build_program_configuration(
-    info: VmInfo, message: ProgramContent, resources: AlephProgramResources
+    info: VmInfo, message: ProgramContent, resources: ProgramDownloader
 ) -> ProgramConfiguration:
     code, volumes = build_code_and_volumes(resources)
     input_data = read_input_data(resources.data_path)
@@ -167,7 +164,7 @@ class ProgramGuestClient:
         """True when this agent process configured the VM (safe to run code)."""
         return vm_id in self._configured
 
-    async def setup_program(self, info: VmInfo, message: ProgramContent, resources: AlephProgramResources) -> None:
+    async def setup_program(self, info: VmInfo, message: ProgramContent, resources: ProgramDownloader) -> None:
         """Bring a freshly-booted program VM to serving state: guest API up,
         configuration pushed. Must run exactly once per VM boot."""
         if not info.guest_channel_path:

--- a/src/aleph/vm/backup_staging.py
+++ b/src/aleph/vm/backup_staging.py
@@ -1,0 +1,41 @@
+"""Neutral backup staging helpers shared by the agent and the supervisor.
+
+The agent stages restore bytes (an upload or a downloaded volume) to a host
+path, then hands the disk/VM work to the supervisor over the boundary; the
+supervisor stores its backup archives in the same directory. These two helpers
+are the shared, neutral surface (they touch only ``settings`` and
+``aleph.vm.storage``), kept out of the QEMU backup controller so the agent does
+not import ``aleph.vm.supervisor.controllers``.
+"""
+
+from pathlib import Path
+
+from aleph.vm.conf import settings
+
+
+def get_backup_directory() -> Path:
+    """Return the directory used to store VM disk backups."""
+    path = settings.BACKUP_DIRECTORY or (settings.EXECUTION_ROOT / "backups")
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+async def download_volume_by_ref(
+    item_hash: str,
+    destination: Path,
+) -> Path:
+    """Download a volume from the aleph network by item hash.
+
+    Args:
+        item_hash: The aleph message item hash of the volume.
+        destination: Directory to save the downloaded file.
+
+    Returns:
+        Path to the downloaded file.
+    """
+    from aleph.vm.storage import _get_content_url, download_file
+
+    dest_path = destination / f"{item_hash}.qcow2"
+    url = await _get_content_url(item_hash)
+    await download_file(url, dest_path)
+    return dest_path

--- a/src/aleph/vm/host_volumes.py
+++ b/src/aleph/vm/host_volumes.py
@@ -1,0 +1,48 @@
+"""Shared host-volume types, neutral between the agent and the supervisor.
+
+A VM's extra (non-rootfs) volumes resolve to on-host paths the same way whether
+the VM runs under Firecracker or QEMU, and whether the resolution happens
+agent-side (download from an Aleph message) or supervisor-side (a message-free
+``CreateVmSpec``). This module holds that shared vocabulary so neither side has
+to import the other's package: it depends only on stdlib, ``aleph_message`` and
+``aleph.vm.storage``.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from aleph_message.models import ExecutableContent
+from aleph_message.models.execution.volume import MachineVolume, PersistentVolume
+
+from aleph.vm.storage import get_volume_path
+
+
+@dataclass
+class HostVolume:
+    mount: str
+    path_on_host: Path
+    read_only: bool
+    size_mib: int | None
+
+
+async def host_volumes_from_message(message_content: ExecutableContent, namespace: str) -> list[HostVolume]:
+    """Resolve the extra (non-rootfs) volumes declared in a message to on-host paths."""
+    volumes = []
+    # TODO: Download in parallel and prevent duplicated volume names
+    volume: MachineVolume
+    for i, volume in enumerate(message_content.volumes):
+        # only persistent volume has name and mount
+        if isinstance(volume, PersistentVolume):
+            if not volume.name:
+                volume.name = f"unamed_volume_{i}"
+            if not volume.mount:
+                volume.mount = f"/mnt/{volume.name}"
+        volumes.append(
+            HostVolume(
+                mount=volume.mount,
+                path_on_host=(await get_volume_path(volume=volume, namespace=namespace)),
+                read_only=volume.is_read_only(),
+                size_mib=getattr(volume, "size_mib", None),
+            )
+        )
+    return volumes

--- a/src/aleph/vm/program_config.py
+++ b/src/aleph/vm/program_config.py
@@ -1,0 +1,179 @@
+"""Program guest-protocol vocabulary, neutral between agent and supervisor.
+
+The configuration payloads, volume descriptors and run-code payload the Aleph
+runtime exchanges over its guest channel are needed on both sides of the
+Supervisor boundary:
+
+- the **agent** builds the configuration push and runs code from
+  ``aleph.vm.agent.vm.program_client``;
+- the **supervisor** runs code over the channel for persistent programs
+  (``aleph.vm.supervisor.local``).
+
+Keeping these types here (depending only on stdlib, ``aleph_message``,
+``aleph.vm.conf`` and the neutral ``RuntimeConfiguration``) lets neither side
+import the other's package.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os.path
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+from aleph_message.models.execution.base import Encoding
+
+from aleph.vm.conf import settings
+from aleph.vm.hypervisors.firecracker.microvm import RuntimeConfiguration
+from aleph.vm.utils import MsgpackSerializable
+
+logger = logging.getLogger(__name__)
+
+
+class VmInitNotConnectedError(Exception):
+    """Raised when the guest channel of a (micro)VM cannot be reached."""
+
+
+def read_input_data(path_to_data: Path | None) -> bytes | None:
+    if not path_to_data:
+        return None
+
+    if os.path.getsize(path_to_data) > settings.MAX_DATA_ARCHIVE_SIZE:
+        from aleph.vm.supervisor_interface.errors import FileTooLargeError
+
+        msg = "Data file too large to pass as an inline zip"
+        raise FileTooLargeError(msg)
+
+    return path_to_data.read_bytes()
+
+
+class Interface(str, Enum):
+    asgi = "asgi"
+    executable = "executable"
+
+    @classmethod
+    def from_entrypoint(cls, entrypoint: str, interface_hint: str | None = None):
+        """Determine the interface type (Python ASGI or executable HTTP service) from the entrypoint of the program.
+
+        If an explicit interface_hint is provided (from the message's code.interface field), it takes precedence.
+        Otherwise, we use the presence of ':' in the entrypoint to differentiate between Python ASGI and executable.
+        """
+        # Map aleph-message interface values to our enum values.
+        # aleph-message uses "binary" while our enum uses "executable".
+        _INTERFACE_MAP = {
+            "binary": cls.executable,
+        }
+
+        # If an explicit interface is specified in the message, use it
+        if interface_hint is not None:
+            if interface_hint in _INTERFACE_MAP:
+                return _INTERFACE_MAP[interface_hint]
+            try:
+                return cls(interface_hint)
+            except ValueError:
+                pass  # Fall back to auto-detection if invalid value
+
+        # Only Python ASGI entrypoints contain a colon `:` in their name.
+        # We use this to differentiate Python ASGI programs from executable HTTP service mode.
+        if ":" in entrypoint:
+            return cls.asgi
+        else:
+            return cls.executable
+
+
+@dataclass
+class Volume:
+    mount: str
+    device: str
+    read_only: bool
+
+
+@dataclass
+class ConfigurationPayload(MsgpackSerializable):
+    pass
+
+
+@dataclass
+class ConfigurationPayloadV1(ConfigurationPayload):
+    """
+    Configuration payload for runtime v1.
+    """
+
+    input_data: bytes | None
+    interface: Interface
+    vm_hash: str
+    encoding: Encoding
+    entrypoint: str
+    code: bytes | None
+    ip: str | None
+    route: str | None
+    dns_servers: list[str]
+    volumes: list[Volume]
+    variables: dict[str, str] | None
+
+    @classmethod
+    def from_program_config(cls, program_config: ProgramConfiguration) -> ConfigurationPayload:
+        """Converts a program configuration into a configuration payload
+        to be sent to a runtime.
+        """
+        field_names = {f.name for f in dataclasses.fields(cls)}
+        return cls(**{k: v for k, v in dataclasses.asdict(program_config).items() if k in field_names})
+
+
+@dataclass
+class ConfigurationPayloadV2(ConfigurationPayloadV1):
+    """
+    Configuration payload for runtime v2.
+    Adds support for IPv6.
+    """
+
+    ipv6: str | None
+    ipv6_gateway: str | None
+    authorized_keys: list[str] | None
+
+
+@dataclass
+class ProgramConfiguration:
+    """Configuration passed to the init of the virtual machine in order to start the program."""
+
+    input_data: bytes | None
+    interface: Interface
+    vm_hash: str
+    encoding: Encoding
+    entrypoint: str
+    code: bytes | None = None
+    ip: str | None = None
+    ipv6: str | None = None
+    route: str | None = None
+    ipv6_gateway: str | None = None
+    dns_servers: list[str] = field(default_factory=list)
+    volumes: list[Volume] = field(default_factory=list)
+    variables: dict[str, str] | None = None
+    authorized_keys: list[str] | None = None
+
+    def to_runtime_format(self, runtime_config: RuntimeConfiguration) -> ConfigurationPayload:
+        if runtime_config.version == "1.0.0":
+            return ConfigurationPayloadV1.from_program_config(self)
+
+        if runtime_config.version != "2.0.0":
+            logger.warning("This runtime version may be unsupported: %s", runtime_config.version)
+
+        return ConfigurationPayloadV2.from_program_config(self)
+
+
+@dataclass
+class ConfigurationResponse:
+    """Response received from the virtual machine in response to a request."""
+
+    success: bool
+    error: str | None = None
+    traceback: str | None = None
+
+
+@dataclass
+class RunCodePayload(MsgpackSerializable):
+    """Information passed to the init of the virtual machine to launch a function/path of the program."""
+
+    scope: dict

--- a/src/aleph/vm/supervisor/controllers/firecracker/executable.py
+++ b/src/aleph/vm/supervisor/controllers/firecracker/executable.py
@@ -18,16 +18,13 @@ from aleph.vm.guest_api.__main__ import run_guest_api
 from aleph.vm.hypervisors.firecracker.microvm import FirecrackerConfig, MicroVM
 from aleph.vm.network.firewall import teardown_nftables_for_vm
 from aleph.vm.network.interfaces import TapInterface
+from aleph.vm.program_config import Volume
 from aleph.vm.storage import chown_to_jailman
 from aleph.vm.supervisor.controllers.firecracker.snapshots import (
     CompressedDiskVolumeSnapshot,
 )
 from aleph.vm.supervisor.controllers.interface import AlephVmControllerInterface
-from aleph.vm.supervisor.controllers.resources import (
-    VmResources,
-    disk_usage_delta,
-    host_volumes_from_message,
-)
+from aleph.vm.supervisor.controllers.resources import VmResources, disk_usage_delta
 from aleph.vm.supervisor_interface.configuration import (
     Configuration,
     VMConfiguration,
@@ -66,13 +63,6 @@ class ResourceDownloadError(ClientResponseError):
 
 
 @dataclass
-class Volume:
-    mount: str
-    device: str
-    read_only: bool
-
-
-@dataclass
 class BaseConfiguration:
     vm_hash: ItemHash
     ip: str | None = None
@@ -106,21 +96,8 @@ class AlephFirecrackerResources(VmResources):
     def get_disk_usage_delta(self) -> int:
         return disk_usage_delta(self.message_content, self.rootfs_path, self.volumes)
 
-    async def download_volumes(self):
-        self.volumes = await host_volumes_from_message(self.message_content, self.namespace)
-
-    async def download_all(self):
-        await asyncio.gather(
-            self.download_kernel(),
-            self.download_volumes(),
-        )
-
 
 class VmSetupError(Exception):
-    pass
-
-
-class VmInitNotConnectedError(Exception):
     pass
 
 

--- a/src/aleph/vm/supervisor/controllers/firecracker/program.py
+++ b/src/aleph/vm/supervisor/controllers/firecracker/program.py
@@ -1,178 +1,56 @@
 from __future__ import annotations
 
-import asyncio
-import dataclasses
 import logging
-import os.path
-from dataclasses import dataclass, field
-from enum import Enum
-from pathlib import Path
 
-from aiohttp import ClientResponseError
 from aleph_message.models import ProgramContent
-from aleph_message.models.execution.base import Encoding
 
-from aleph.vm.conf import settings
-from aleph.vm.hypervisors.firecracker.microvm import RuntimeConfiguration
-from aleph.vm.storage import get_code_path, get_data_path, get_runtime_path
-from aleph.vm.utils import MsgpackSerializable
+# Guest-protocol vocabulary moved to the neutral foundation module so the agent
+# (program_client) and the supervisor (local) can share it without crossing the
+# import boundary. Re-exported here for the controllers and tests that import
+# these names from this module.
+from aleph.vm.program_config import (
+    ConfigurationPayload,
+    ConfigurationPayloadV1,
+    ConfigurationPayloadV2,
+    ConfigurationResponse,
+    Interface,
+    ProgramConfiguration,
+    RunCodePayload,
+    read_input_data,
+)
 
-from .executable import AlephFirecrackerResources, ResourceDownloadError, Volume
+from .executable import AlephFirecrackerResources
 
 logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ConfigurationPayload",
+    "ConfigurationPayloadV1",
+    "ConfigurationPayloadV2",
+    "ConfigurationResponse",
+    "FileTooLargeError",
+    "Interface",
+    "ProgramConfiguration",
+    "RunCodePayload",
+    "read_input_data",
+    "AlephProgramResources",
+]
 
 
 class FileTooLargeError(Exception):
     pass
 
 
-def read_input_data(path_to_data: Path | None) -> bytes | None:
-    if not path_to_data:
-        return None
-
-    if os.path.getsize(path_to_data) > settings.MAX_DATA_ARCHIVE_SIZE:
-        msg = "Data file too large to pass as an inline zip"
-        raise FileTooLargeError(msg)
-
-    return path_to_data.read_bytes()
-
-
-class Interface(str, Enum):
-    asgi = "asgi"
-    executable = "executable"
-
-    @classmethod
-    def from_entrypoint(cls, entrypoint: str, interface_hint: str | None = None):
-        """Determine the interface type (Python ASGI or executable HTTP service) from the entrypoint of the program.
-
-        If an explicit interface_hint is provided (from the message's code.interface field), it takes precedence.
-        Otherwise, we use the presence of ':' in the entrypoint to differentiate between Python ASGI and executable.
-        """
-        # Map aleph-message interface values to our enum values.
-        # aleph-message uses "binary" while our enum uses "executable".
-        _INTERFACE_MAP = {
-            "binary": cls.executable,
-        }
-
-        # If an explicit interface is specified in the message, use it
-        if interface_hint is not None:
-            if interface_hint in _INTERFACE_MAP:
-                return _INTERFACE_MAP[interface_hint]
-            try:
-                return cls(interface_hint)
-            except ValueError:
-                pass  # Fall back to auto-detection if invalid value
-
-        # Only Python ASGI entrypoints contain a colon `:` in their name.
-        # We use this to differentiate Python ASGI programs from executable HTTP service mode.
-        if ":" in entrypoint:
-            return cls.asgi
-        else:
-            return cls.executable
-
-
-@dataclass
-class ConfigurationPayload(MsgpackSerializable):
-    pass
-
-
-@dataclass
-class ConfigurationPayloadV1(ConfigurationPayload):
-    """
-    Configuration payload for runtime v1.
-    """
-
-    input_data: bytes | None
-    interface: Interface
-    vm_hash: str
-    encoding: Encoding
-    entrypoint: str
-    code: bytes | None
-    ip: str | None
-    route: str | None
-    dns_servers: list[str]
-    volumes: list[Volume]
-    variables: dict[str, str] | None
-
-    @classmethod
-    def from_program_config(cls, program_config: ProgramConfiguration) -> ConfigurationPayload:
-        """Converts a program configuration into a configuration payload
-        to be sent to a runtime.
-        """
-        field_names = {f.name for f in dataclasses.fields(cls)}
-        return cls(**{k: v for k, v in dataclasses.asdict(program_config).items() if k in field_names})
-
-
-@dataclass
-class ConfigurationPayloadV2(ConfigurationPayloadV1):
-    """
-    Configuration payload for runtime v2.
-    Adds support for IPv6.
-    """
-
-    ipv6: str | None
-    ipv6_gateway: str | None
-    authorized_keys: list[str] | None
-
-
-@dataclass
-class ProgramConfiguration:
-    """Configuration passed to the init of the virtual machine in order to start the program."""
-
-    input_data: bytes | None
-    interface: Interface
-    vm_hash: str
-    encoding: Encoding
-    entrypoint: str
-    code: bytes | None = None
-    ip: str | None = None
-    ipv6: str | None = None
-    route: str | None = None
-    ipv6_gateway: str | None = None
-    dns_servers: list[str] = field(default_factory=list)
-    volumes: list[Volume] = field(default_factory=list)
-    variables: dict[str, str] | None = None
-    authorized_keys: list[str] | None = None
-
-    def to_runtime_format(self, runtime_config: RuntimeConfiguration) -> ConfigurationPayload:
-        if runtime_config.version == "1.0.0":
-            return ConfigurationPayloadV1.from_program_config(self)
-
-        if runtime_config.version != "2.0.0":
-            logger.warning("This runtime version may be unsupported: %s", runtime_config.version)
-
-        return ConfigurationPayloadV2.from_program_config(self)
-
-
-@dataclass
-class ConfigurationResponse:
-    """Response received from the virtual machine in response to a request."""
-
-    success: bool
-    error: str | None = None
-    traceback: str | None = None
-
-
-@dataclass
-class RunCodePayload(MsgpackSerializable):
-    """Information passed to the init of the virtual machine to launch a function/path of the program."""
-
-    scope: dict
-
-
 class AlephProgramResources(AlephFirecrackerResources):
     """Resources required by the virtual machine in order to launch the program.
-    Extends the resources required by all Firecracker VMs."""
+
+    Extends the resources required by all Firecracker VMs. This is the
+    supervisor-side runtime holder; the Aleph-message download path lives
+    agent-side in ``aleph.vm.agent.vm.downloader.ProgramDownloader``.
+    """
 
     # A Firecracker program is always driven by a ProgramContent.
     message_content: ProgramContent
-
-    code_path: Path
-    code_encoding: Encoding
-    code_entrypoint: str
-    # Explicit interface type from message (asgi or executable)
-    code_interface: Interface
-    data_path: Path | None
 
     def __init__(self, message_content: ProgramContent, namespace: str):
         super().__init__(message_content, namespace)
@@ -181,41 +59,4 @@ class AlephProgramResources(AlephFirecrackerResources):
         # Get explicit interface if specified in the message
         self.code_interface = Interface.from_entrypoint(
             entrypoint=message_content.code.entrypoint, interface_hint=message_content.code.interface
-        )
-
-    async def download_code(self) -> None:
-        code_ref: str = self.message_content.code.ref
-        try:
-            self.code_path = await get_code_path(code_ref)
-        except ClientResponseError as error:
-            raise ResourceDownloadError(error) from error
-        assert self.code_path.is_file(), f"Code not found on '{self.code_path}'"
-
-    async def download_runtime(self) -> None:
-        runtime_ref: str = self.message_content.runtime.ref
-        try:
-            self.rootfs_path = await get_runtime_path(runtime_ref)
-        except ClientResponseError as error:
-            raise ResourceDownloadError(error) from error
-        assert self.rootfs_path.is_file(), f"Runtime not found on {self.rootfs_path}"
-
-    async def download_data(self) -> None:
-        if self.message_content.data:
-            data_ref: str = self.message_content.data.ref
-            try:
-                data_path = await get_data_path(data_ref)
-                self.data_path = data_path
-            except ClientResponseError as error:
-                raise ResourceDownloadError(error) from error
-            assert data_path.is_file(), f"Data not found on {data_path}"
-        else:
-            self.data_path = None
-
-    async def download_all(self):
-        await asyncio.gather(
-            self.download_kernel(),
-            self.download_runtime(),
-            self.download_code(),
-            self.download_volumes(),
-            self.download_data(),
         )

--- a/src/aleph/vm/supervisor/controllers/qemu/backup.py
+++ b/src/aleph/vm/supervisor/controllers/qemu/backup.py
@@ -8,7 +8,12 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-from aleph.vm.conf import settings
+# Neutral staging helpers shared with the agent; re-exported here for the
+# supervisor backup paths (and tests) that import them from this module.
+from aleph.vm.backup_staging import (  # noqa: F401
+    download_volume_by_ref,
+    get_backup_directory,
+)
 from aleph.vm.utils import run_in_subprocess
 
 logger = logging.getLogger(__name__)
@@ -26,13 +31,6 @@ def _require_qemu_img() -> str:
     if not path:
         msg = "qemu-img not found in PATH"
         raise FileNotFoundError(msg)
-    return path
-
-
-def get_backup_directory() -> Path:
-    """Return the directory used to store VM disk backups."""
-    path = settings.BACKUP_DIRECTORY or (settings.EXECUTION_ROOT / "backups")
-    path.mkdir(parents=True, exist_ok=True)
     return path
 
 
@@ -275,27 +273,6 @@ def backup_metadata(tar_path: Path) -> dict:
             meta["source_sizes"] = stored["source_sizes"]
 
     return meta
-
-
-async def download_volume_by_ref(
-    item_hash: str,
-    destination: Path,
-) -> Path:
-    """Download a volume from the aleph network by item hash.
-
-    Args:
-        item_hash: The aleph message item hash of the volume.
-        destination: Directory to save the downloaded file.
-
-    Returns:
-        Path to the downloaded file.
-    """
-    from aleph.vm.storage import _get_content_url, download_file
-
-    dest_path = destination / f"{item_hash}.qcow2"
-    url = await _get_content_url(item_hash)
-    await download_file(url, dest_path)
-    return dest_path
 
 
 def _restore_rootfs_sync(new_rootfs: Path, current_rootfs: Path) -> Path:

--- a/src/aleph/vm/supervisor/controllers/qemu/cloudinit.py
+++ b/src/aleph/vm/supervisor/controllers/qemu/cloudinit.py
@@ -13,19 +13,16 @@ https://cloudinit.readthedocs.io/en/latest/reference/datasources/nocloud.html
 See also the cloud-localds  man page (1)
 """
 
-import base64
 import json
 from tempfile import NamedTemporaryFile
 
 import yaml
-from aleph_message.models import ItemHash
 
-from aleph.vm.utils import run_in_subprocess
+# get_hostname_from_hash is the Aleph hostname convention, shared, neutral
+# vocabulary; re-exported here for the cloud-init builder that uses it.
+from aleph.vm.utils import get_hostname_from_hash, run_in_subprocess
 
-
-def get_hostname_from_hash(vm_hash: ItemHash) -> str:
-    item_hash_binary: bytes = base64.b16decode(vm_hash.encode().upper())
-    return base64.b32encode(item_hash_binary).decode().strip("=").lower()
+__all__ = ["get_hostname_from_hash", "encode_user_data"]
 
 
 def encode_user_data(

--- a/src/aleph/vm/supervisor/controllers/qemu/instance.py
+++ b/src/aleph/vm/supervisor/controllers/qemu/instance.py
@@ -1,31 +1,22 @@
-import asyncio
-import json
 import logging
-import shutil
 from asyncio.subprocess import Process
 from pathlib import Path
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 import psutil
 from aleph_message.models import InstanceContent, ItemHash
-from aleph_message.models.execution.instance import RootfsVolume
-from aleph_message.models.execution.volume import PersistentVolume, VolumePersistence
 
 from aleph.vm.conf import settings
 from aleph.vm.network.firewall import teardown_nftables_for_vm
 from aleph.vm.network.interfaces import TapInterface
 from aleph.vm.resources import HostGPU
-from aleph.vm.storage import get_rootfs_base_path
-from aleph.vm.supervisor.controllers.firecracker.executable import VmSetupError
 from aleph.vm.supervisor.controllers.interface import AlephVmControllerInterface
 from aleph.vm.supervisor.controllers.resources import (
     HostVolume,
     VmResources,
     disk_usage_delta,
-    host_volumes_from_message,
 )
 from aleph.vm.supervisor_interface.types import HardwareResources
-from aleph.vm.utils import run_in_subprocess
 
 if TYPE_CHECKING:
     from aleph.vm.supervisor_interface.types import CreateVmSpec
@@ -57,69 +48,6 @@ class AlephQemuResources(VmResources):
         # spec-built volumes carry no size_mib, so nothing is counted. Spec VMs
         # do not reserve disk through the pool; the agent sizes them upfront.
         return disk_usage_delta(self.message_content, self.rootfs_path, self.volumes)
-
-    async def download_runtime(self) -> None:
-        if self.message_content is None:
-            msg = "download_runtime called on a spec-built resources holder (no message to download from)"
-            raise VmSetupError(msg)
-        volume = self.message_content.rootfs
-        parent_image_path = await get_rootfs_base_path(volume.parent.ref)
-        self.rootfs_path = await self.make_writable_volume(parent_image_path, volume)
-
-    async def download_volumes(self) -> None:
-        if self.message_content is None:
-            return
-        self.volumes = await host_volumes_from_message(self.message_content, self.namespace)
-
-    async def download_all(self):
-        await asyncio.gather(
-            self.download_runtime(),
-            self.download_volumes(),
-        )
-
-    async def make_writable_volume(self, parent_image_path, volume: PersistentVolume | RootfsVolume):
-        """Create a new qcow2 image file based on the passed one, that we give to the VM to write onto"""
-        qemu_img_path: str | None = shutil.which("qemu-img")
-        if not qemu_img_path:
-            msg = "qemu-img not found in PATH"
-            raise VmSetupError(msg)
-
-        volume_name = volume.name if isinstance(volume, PersistentVolume) else "rootfs"
-
-        # detect the image format
-        out_json = await run_in_subprocess([qemu_img_path, "info", str(parent_image_path), "--output=json"])
-        out = json.loads(out_json)
-        parent_format = out.get("format", None)
-        if parent_format is None:
-            msg = f"Failed to detect format for {volume}: {out_json}"
-            raise VmSetupError(msg)
-        if parent_format not in ("qcow2", "raw"):
-            msg = f"Format {parent_format} for {volume} unhandled by QEMU hypervisor"
-            raise VmSetupError(msg)
-
-        dest_path = settings.PERSISTENT_VOLUMES_DIR / self.namespace / f"{volume_name}.qcow2"
-        # Do not override if user asked for host persistence.
-        if dest_path.exists() and volume.persistence == VolumePersistence.host:
-            return dest_path
-
-        dest_path.parent.mkdir(parents=True, exist_ok=True)
-        size_in_bytes = int(volume.size_mib * 1024 * 1024)
-
-        await run_in_subprocess(
-            [
-                qemu_img_path,
-                "create",
-                "-f",  # Format
-                "qcow2",
-                "-F",
-                parent_format,
-                "-b",
-                str(parent_image_path),
-                str(dest_path),
-                str(size_in_bytes),
-            ]
-        )
-        return dest_path
 
     @classmethod
     def from_spec(cls, spec: "CreateVmSpec", namespace: str) -> "AlephQemuResources":

--- a/src/aleph/vm/supervisor/controllers/qemu_confidential/instance.py
+++ b/src/aleph/vm/supervisor/controllers/qemu_confidential/instance.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 from aleph_message.models import ItemHash
 
 from aleph.vm.network.interfaces import TapInterface
-from aleph.vm.storage import get_existing_file
 from aleph.vm.supervisor.controllers.qemu import AlephQemuInstance
 from aleph.vm.supervisor.controllers.qemu.instance import (
     AlephQemuResources,
@@ -24,20 +23,6 @@ logger = logging.getLogger(__name__)
 
 class AlephQemuConfidentialResources(AlephQemuResources):
     firmware_path: Path
-
-    async def download_firmware(self):
-        # Message path only: the spec path resolves the firmware before create
-        # and uses from_spec (no download).
-        assert self.message_content is not None
-        firmware = self.message_content.environment.trusted_execution.firmware
-        self.firmware_path = await get_existing_file(firmware)
-
-    async def download_all(self):
-        await asyncio.gather(
-            self.download_runtime(),
-            self.download_firmware(),
-            self.download_volumes(),
-        )
 
     @classmethod
     def from_spec(cls, spec: "CreateVmSpec", namespace: str) -> "AlephQemuConfidentialResources":

--- a/src/aleph/vm/supervisor/controllers/resources.py
+++ b/src/aleph/vm/supervisor/controllers/resources.py
@@ -14,48 +14,22 @@ message contract without one inheriting the other's assumptions.
 """
 
 import logging
-from dataclasses import dataclass
 from os.path import isfile
 from pathlib import Path
 
 from aleph_message.models import ExecutableContent
-from aleph_message.models.execution.volume import MachineVolume, PersistentVolume
 
 from aleph.vm.conf import settings
-from aleph.vm.storage import get_volume_path
+
+# HostVolume and the message->host-path resolver are shared, neutral vocabulary
+# (agent download path and supervisor spec path both build them). They live in
+# the neutral foundation module; re-exported here for the controllers that
+# already import them from this module.
+from aleph.vm.host_volumes import HostVolume, host_volumes_from_message
 
 logger = logging.getLogger(__name__)
 
-
-@dataclass
-class HostVolume:
-    mount: str
-    path_on_host: Path
-    read_only: bool
-    size_mib: int | None
-
-
-async def host_volumes_from_message(message_content: ExecutableContent, namespace: str) -> list[HostVolume]:
-    """Resolve the extra (non-rootfs) volumes declared in a message to on-host paths."""
-    volumes = []
-    # TODO: Download in parallel and prevent duplicated volume names
-    volume: MachineVolume
-    for i, volume in enumerate(message_content.volumes):
-        # only persistent volume has name and mount
-        if isinstance(volume, PersistentVolume):
-            if not volume.name:
-                volume.name = f"unamed_volume_{i}"
-            if not volume.mount:
-                volume.mount = f"/mnt/{volume.name}"
-        volumes.append(
-            HostVolume(
-                mount=volume.mount,
-                path_on_host=(await get_volume_path(volume=volume, namespace=namespace)),
-                read_only=volume.is_read_only(),
-                size_mib=getattr(volume, "size_mib", None),
-            )
-        )
-    return volumes
+__all__ = ["HostVolume", "host_volumes_from_message", "disk_usage_delta", "VmResources"]
 
 
 def disk_usage_delta(message_content: ExecutableContent | None, rootfs_path: Path, volumes: list[HostVolume]) -> int:

--- a/src/aleph/vm/supervisor/local.py
+++ b/src/aleph/vm/supervisor/local.py
@@ -205,10 +205,7 @@ async def _run_code_over_channel(channel_path: str, scope: dict, *, timeout: flo
     from the supervisor process which owns the VM's guest channel UDS. Used by
     persistent programs (the agent cannot reach the channel across the boundary).
     """
-    from aleph.vm.supervisor.controllers.firecracker.executable import (
-        VmInitNotConnectedError,
-    )
-    from aleph.vm.supervisor.controllers.firecracker.program import RunCodePayload
+    from aleph.vm.program_config import RunCodePayload, VmInitNotConnectedError
     from aleph.vm.utils.runtime_channel import RUNTIME_CONTROL_PORT
 
     async def communicate(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> bytes:

--- a/src/aleph/vm/utils/__init__.py
+++ b/src/aleph/vm/utils/__init__.py
@@ -5,7 +5,7 @@ import hashlib
 import json
 import logging
 import subprocess
-from base64 import b16encode, b32decode
+from base64 import b16decode, b16encode, b32decode, b32encode
 from collections.abc import Callable, Coroutine
 from dataclasses import asdict as dataclass_as_dict
 from dataclasses import is_dataclass
@@ -16,11 +16,26 @@ from typing import Any, Optional
 import aiodns
 import msgpack
 from aiohttp_cors import ResourceOptions, custom_cors
-from aleph_message.models import ExecutableContent, InstanceContent, ProgramContent
+from aleph_message.models import (
+    ExecutableContent,
+    InstanceContent,
+    ItemHash,
+    ProgramContent,
+)
 from eth_typing import HexAddress, HexStr
 from eth_utils import hexstr_if_str, is_address, to_hex
 
 logger = logging.getLogger(__name__)
+
+
+def get_hostname_from_hash(vm_hash: ItemHash) -> str:
+    """Aleph's VM hostname convention: the base32 of the item hash.
+
+    Neutral vocabulary shared by the agent (CreateVmSpec.hostname) and the QEMU
+    cloud-init builder; defined here so neither side imports the other.
+    """
+    item_hash_binary: bytes = b16decode(vm_hash.encode().upper())
+    return b32encode(item_hash_binary).decode().strip("=").lower()
 
 
 def get_message_executable_content(message_dict: dict) -> ExecutableContent:

--- a/tests/migration/test_runner.py
+++ b/tests/migration/test_runner.py
@@ -665,7 +665,7 @@ async def test_import_spec_build_reuses_staged_overlay(tmp_path, monkeypatch):
     """
     from aleph_message.models.execution.volume import VolumePersistence
 
-    from aleph.vm.supervisor.controllers.qemu.instance import AlephQemuResources
+    from aleph.vm.agent.vm.downloader import QemuDownloader
 
     namespace = str(ItemHash(settings.FAKE_INSTANCE_ID))
     monkeypatch.setattr(settings, "PERSISTENT_VOLUMES_DIR", tmp_path)
@@ -688,15 +688,15 @@ async def test_import_spec_build_reuses_staged_overlay(tmp_path, monkeypatch):
         return b'{"format": "qcow2"}'
 
     monkeypatch.setattr(
-        "aleph.vm.supervisor.controllers.qemu.instance.run_in_subprocess",
+        "aleph.vm.agent.vm.downloader.run_in_subprocess",
         fake_run_in_subprocess,
     )
-    monkeypatch.setattr("aleph.vm.supervisor.controllers.qemu.instance.shutil.which", lambda _: "/usr/bin/qemu-img")
+    monkeypatch.setattr("aleph.vm.agent.vm.downloader.shutil.which", lambda _: "/usr/bin/qemu-img")
 
     # RootfsVolume is not a PersistentVolume, so volume_name resolves to "rootfs".
     from aleph_message.models.execution.instance import RootfsVolume
 
-    resources = AlephQemuResources(message_content=None, namespace=namespace)
+    resources = QemuDownloader(message_content=None, namespace=namespace)
     rootfs_volume = MagicMock(spec=RootfsVolume)
     rootfs_volume.persistence = VolumePersistence.host
 

--- a/tests/supervisor/test_pr2_neutral_modules.py
+++ b/tests/supervisor/test_pr2_neutral_modules.py
@@ -1,0 +1,406 @@
+"""Unit tests for the neutral modules extracted in the controller split (PR-2).
+
+These modules (``aleph.vm.host_volumes``, ``aleph.vm.backup_staging``,
+``aleph.vm.program_config`` and the agent-side ``aleph.vm.agent.vm.downloader``)
+sit on the shared, hardware-free side of the agent/supervisor boundary: the
+download paths resolve resources to on-host paths through ``aleph.vm.storage``,
+which is mocked here. No QEMU/Firecracker/SEV is exercised.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import ClientResponseError
+from aleph_message.models.execution.base import Encoding
+from aleph_message.models.execution.volume import PersistentVolume
+
+from aleph.vm import backup_staging, host_volumes, program_config
+from aleph.vm.agent.vm import downloader
+from aleph.vm.program_config import (
+    ConfigurationPayloadV1,
+    ConfigurationPayloadV2,
+    Interface,
+    ProgramConfiguration,
+    read_input_data,
+)
+from aleph.vm.supervisor_interface.errors import (
+    FileTooLargeError,
+    ResourceDownloadError,
+    VmSetupError,
+)
+
+
+def _client_response_error() -> ClientResponseError:
+    return ClientResponseError(request_info=MagicMock(), history=())
+
+
+# --------------------------------------------------------------------------- #
+# host_volumes.host_volumes_from_message
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_host_volumes_from_message_names_and_resolves(monkeypatch, tmp_path):
+    """An unnamed persistent volume gets a generated name/mount and resolves to a host path."""
+    volume = MagicMock()
+    volume.__class__ = PersistentVolume
+    volume.name = None  # falsy -> generated as unamed_volume_0
+    volume.mount = None  # falsy -> generated as /mnt/<name>
+    volume.is_read_only.return_value = True
+    volume.size_mib = 256
+
+    message_content = MagicMock()
+    message_content.volumes = [volume]
+
+    resolved = tmp_path / "vol.qcow2"
+    monkeypatch.setattr(host_volumes, "get_volume_path", AsyncMock(return_value=resolved))
+
+    result = await host_volumes.host_volumes_from_message(message_content, namespace="ns")
+
+    assert len(result) == 1
+    hv = result[0]
+    assert volume.name == "unamed_volume_0"
+    assert hv.mount == "/mnt/unamed_volume_0"
+    assert hv.path_on_host == resolved
+    assert hv.read_only is True
+    assert hv.size_mib == 256
+
+
+@pytest.mark.asyncio
+async def test_host_volumes_from_message_keeps_explicit_name(monkeypatch, tmp_path):
+    """A persistent volume that already carries a name/mount is left untouched."""
+    volume = MagicMock()
+    volume.__class__ = PersistentVolume
+    volume.name = "data"
+    volume.mount = "/srv/data"
+    volume.is_read_only.return_value = False
+    volume.size_mib = 512
+
+    message_content = MagicMock()
+    message_content.volumes = [volume]
+    monkeypatch.setattr(host_volumes, "get_volume_path", AsyncMock(return_value=tmp_path / "data.qcow2"))
+
+    result = await host_volumes.host_volumes_from_message(message_content, namespace="ns")
+
+    assert volume.name == "data"  # not regenerated
+    assert result[0].mount == "/srv/data"
+    assert result[0].read_only is False
+
+
+# --------------------------------------------------------------------------- #
+# backup_staging
+# --------------------------------------------------------------------------- #
+
+
+def test_get_backup_directory_default(monkeypatch, tmp_path):
+    """With no BACKUP_DIRECTORY set, backups live under EXECUTION_ROOT and the dir is created."""
+    monkeypatch.setattr(backup_staging.settings, "BACKUP_DIRECTORY", None, raising=False)
+    monkeypatch.setattr(backup_staging.settings, "EXECUTION_ROOT", tmp_path, raising=False)
+
+    path = backup_staging.get_backup_directory()
+
+    assert path == tmp_path / "backups"
+    assert path.is_dir()
+
+
+def test_get_backup_directory_explicit(monkeypatch, tmp_path):
+    explicit = tmp_path / "custom-backups"
+    monkeypatch.setattr(backup_staging.settings, "BACKUP_DIRECTORY", explicit, raising=False)
+
+    path = backup_staging.get_backup_directory()
+
+    assert path == explicit
+    assert path.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_download_volume_by_ref(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "aleph.vm.storage._get_content_url",
+        AsyncMock(return_value="http://example/volume"),
+    )
+    download_file = AsyncMock()
+    monkeypatch.setattr("aleph.vm.storage.download_file", download_file)
+
+    dest = await backup_staging.download_volume_by_ref("abc123", tmp_path)
+
+    assert dest == tmp_path / "abc123.qcow2"
+    download_file.assert_awaited_once_with("http://example/volume", dest)
+
+
+# --------------------------------------------------------------------------- #
+# downloader._make_writable_volume
+# --------------------------------------------------------------------------- #
+
+
+def _persistent_volume(name="vol1", size_mib=8, persistence="store"):
+    volume = MagicMock()
+    volume.__class__ = PersistentVolume
+    volume.name = name
+    volume.size_mib = size_mib
+    volume.persistence = persistence
+    return volume
+
+
+@pytest.mark.asyncio
+async def test_make_writable_volume_requires_qemu_img(monkeypatch):
+    monkeypatch.setattr(downloader.shutil, "which", lambda _: None)
+    with pytest.raises(VmSetupError, match="qemu-img not found"):
+        await downloader._make_writable_volume(Path("/parent.qcow2"), _persistent_volume(), "ns")
+
+
+@pytest.mark.asyncio
+async def test_make_writable_volume_unknown_format(monkeypatch):
+    monkeypatch.setattr(downloader.shutil, "which", lambda _: "/usr/bin/qemu-img")
+    monkeypatch.setattr(downloader, "run_in_subprocess", AsyncMock(return_value=json.dumps({})))
+    with pytest.raises(VmSetupError, match="Failed to detect format"):
+        await downloader._make_writable_volume(Path("/parent.qcow2"), _persistent_volume(), "ns")
+
+
+@pytest.mark.asyncio
+async def test_make_writable_volume_unhandled_format(monkeypatch):
+    monkeypatch.setattr(downloader.shutil, "which", lambda _: "/usr/bin/qemu-img")
+    monkeypatch.setattr(downloader, "run_in_subprocess", AsyncMock(return_value=json.dumps({"format": "vmdk"})))
+    with pytest.raises(VmSetupError, match="unhandled by QEMU"):
+        await downloader._make_writable_volume(Path("/parent.qcow2"), _persistent_volume(), "ns")
+
+
+@pytest.mark.asyncio
+async def test_make_writable_volume_creates_image(monkeypatch, tmp_path):
+    monkeypatch.setattr(downloader.shutil, "which", lambda _: "/usr/bin/qemu-img")
+    monkeypatch.setattr(downloader.settings, "PERSISTENT_VOLUMES_DIR", tmp_path, raising=False)
+    run = AsyncMock(return_value=json.dumps({"format": "qcow2"}))
+    monkeypatch.setattr(downloader, "run_in_subprocess", run)
+
+    dest = await downloader._make_writable_volume(Path("/parent.qcow2"), _persistent_volume(name="data"), "ns")
+
+    assert dest == tmp_path / "ns" / "data.qcow2"
+    assert dest.parent.is_dir()
+    # second call is the create; verify the destination is one of its args
+    create_args = run.await_args_list[-1].args[0]
+    assert "create" in create_args
+    assert str(dest) in create_args
+
+
+@pytest.mark.asyncio
+async def test_make_writable_volume_keeps_host_persisted(monkeypatch, tmp_path):
+    """A host-persisted volume that already exists is returned untouched (no create)."""
+    from aleph_message.models.execution.volume import VolumePersistence
+
+    monkeypatch.setattr(downloader.shutil, "which", lambda _: "/usr/bin/qemu-img")
+    monkeypatch.setattr(downloader.settings, "PERSISTENT_VOLUMES_DIR", tmp_path, raising=False)
+    run = AsyncMock(return_value=json.dumps({"format": "qcow2"}))
+    monkeypatch.setattr(downloader, "run_in_subprocess", run)
+
+    existing = tmp_path / "ns" / "vol1.qcow2"
+    existing.parent.mkdir(parents=True)
+    existing.write_bytes(b"keep me")
+
+    volume = _persistent_volume(name="vol1", persistence=VolumePersistence.host)
+    dest = await downloader._make_writable_volume(Path("/parent.qcow2"), volume, "ns")
+
+    assert dest == existing
+    assert dest.read_bytes() == b"keep me"  # untouched
+    # only the info call ran, never the create
+    assert run.await_count == 1
+
+
+# --------------------------------------------------------------------------- #
+# downloader.ProgramDownloader / QemuDownloader
+# --------------------------------------------------------------------------- #
+
+
+def _program_content(*, with_data: bool, entrypoint="main:app", interface=None):
+    content = MagicMock()
+    content.code.encoding = Encoding.zip
+    content.code.entrypoint = entrypoint
+    content.code.interface = interface
+    content.code.ref = "code-ref"
+    content.runtime.ref = "runtime-ref"
+    if with_data:
+        content.data.ref = "data-ref"
+    else:
+        content.data = None
+    return content
+
+
+@pytest.mark.asyncio
+async def test_program_downloader_kernel(monkeypatch, tmp_path):
+    kernel = tmp_path / "vmlinux.bin"
+    kernel.write_bytes(b"kernel")
+    monkeypatch.setattr(downloader.settings, "LINUX_PATH", str(kernel), raising=False)
+
+    pd = downloader.ProgramDownloader(_program_content(with_data=False), "ns")
+    await pd.download_kernel()
+
+    assert pd.kernel_image_path == kernel
+    assert pd.code_interface is Interface.asgi  # "main:app" -> colon -> asgi
+
+
+@pytest.mark.asyncio
+async def test_program_downloader_code_and_runtime(monkeypatch, tmp_path):
+    code = tmp_path / "code.zip"
+    code.write_bytes(b"code")
+    runtime = tmp_path / "runtime.squashfs"
+    runtime.write_bytes(b"runtime")
+    monkeypatch.setattr(downloader, "get_code_path", AsyncMock(return_value=code))
+    monkeypatch.setattr(downloader, "get_runtime_path", AsyncMock(return_value=runtime))
+
+    pd = downloader.ProgramDownloader(_program_content(with_data=False), "ns")
+    await pd.download_code()
+    await pd.download_runtime()
+
+    assert pd.code_path == code
+    assert pd.rootfs_path == runtime
+
+
+@pytest.mark.asyncio
+async def test_program_downloader_code_wraps_download_error(monkeypatch):
+    monkeypatch.setattr(downloader, "get_code_path", AsyncMock(side_effect=_client_response_error()))
+    pd = downloader.ProgramDownloader(_program_content(with_data=False), "ns")
+    with pytest.raises(ResourceDownloadError):
+        await pd.download_code()
+
+
+@pytest.mark.asyncio
+async def test_program_downloader_runtime_wraps_download_error(monkeypatch):
+    monkeypatch.setattr(downloader, "get_runtime_path", AsyncMock(side_effect=_client_response_error()))
+    pd = downloader.ProgramDownloader(_program_content(with_data=False), "ns")
+    with pytest.raises(ResourceDownloadError):
+        await pd.download_runtime()
+
+
+@pytest.mark.asyncio
+async def test_program_downloader_data_present(monkeypatch, tmp_path):
+    data = tmp_path / "data.zip"
+    data.write_bytes(b"data")
+    monkeypatch.setattr(downloader, "get_data_path", AsyncMock(return_value=data))
+
+    pd = downloader.ProgramDownloader(_program_content(with_data=True), "ns")
+    await pd.download_data()
+
+    assert pd.data_path == data
+
+
+@pytest.mark.asyncio
+async def test_program_downloader_data_absent():
+    pd = downloader.ProgramDownloader(_program_content(with_data=False), "ns")
+    await pd.download_data()
+    assert pd.data_path is None
+
+
+@pytest.mark.asyncio
+async def test_program_downloader_data_wraps_download_error(monkeypatch):
+    monkeypatch.setattr(downloader, "get_data_path", AsyncMock(side_effect=_client_response_error()))
+    pd = downloader.ProgramDownloader(_program_content(with_data=True), "ns")
+    with pytest.raises(ResourceDownloadError):
+        await pd.download_data()
+
+
+@pytest.mark.asyncio
+async def test_program_downloader_download_all(monkeypatch, tmp_path):
+    kernel = tmp_path / "vmlinux.bin"
+    kernel.write_bytes(b"kernel")
+    code = tmp_path / "code.zip"
+    code.write_bytes(b"code")
+    runtime = tmp_path / "runtime.squashfs"
+    runtime.write_bytes(b"runtime")
+    monkeypatch.setattr(downloader.settings, "LINUX_PATH", str(kernel), raising=False)
+    monkeypatch.setattr(downloader, "get_code_path", AsyncMock(return_value=code))
+    monkeypatch.setattr(downloader, "get_runtime_path", AsyncMock(return_value=runtime))
+    monkeypatch.setattr(downloader, "host_volumes_from_message", AsyncMock(return_value=["v"]))
+
+    pd = downloader.ProgramDownloader(_program_content(with_data=False), "ns")
+    await pd.download_all()
+
+    assert pd.rootfs_path == runtime
+    assert pd.code_path == code
+    assert pd.volumes == ["v"]
+    assert pd.data_path is None
+
+
+@pytest.mark.asyncio
+async def test_qemu_downloader_download_all(monkeypatch, tmp_path):
+    rootfs_parent = tmp_path / "base.qcow2"
+    rootfs_parent.write_bytes(b"base")
+    writable = tmp_path / "rootfs.qcow2"
+
+    content = MagicMock()
+    content.rootfs.parent.ref = "parent-ref"
+
+    monkeypatch.setattr(downloader, "get_rootfs_base_path", AsyncMock(return_value=rootfs_parent))
+    monkeypatch.setattr(downloader, "_make_writable_volume", AsyncMock(return_value=writable))
+    monkeypatch.setattr(downloader, "host_volumes_from_message", AsyncMock(return_value=["v"]))
+
+    qd = downloader.QemuDownloader(content, "ns")
+    await qd.download_all()
+
+    assert qd.rootfs_path == writable
+    assert qd.volumes == ["v"]
+
+
+# --------------------------------------------------------------------------- #
+# program_config
+# --------------------------------------------------------------------------- #
+
+
+def test_read_input_data_none():
+    assert read_input_data(None) is None
+
+
+def test_read_input_data_reads_bytes(tmp_path):
+    f = tmp_path / "data.bin"
+    f.write_bytes(b"payload")
+    assert read_input_data(f) == b"payload"
+
+
+def test_read_input_data_too_large(monkeypatch, tmp_path):
+    f = tmp_path / "big.bin"
+    f.write_bytes(b"x" * 100)
+    monkeypatch.setattr(program_config.settings, "MAX_DATA_ARCHIVE_SIZE", 10, raising=False)
+    with pytest.raises(FileTooLargeError):
+        read_input_data(f)
+
+
+@pytest.mark.parametrize(
+    "entrypoint, hint, expected",
+    [
+        ("main:app", None, Interface.asgi),
+        ("runnable", None, Interface.executable),
+        ("anything", "binary", Interface.executable),  # aleph-message alias
+        ("anything", "asgi", Interface.asgi),
+        ("main:app", "bogus", Interface.asgi),  # invalid hint -> auto-detect
+    ],
+)
+def test_interface_from_entrypoint(entrypoint, hint, expected):
+    assert Interface.from_entrypoint(entrypoint=entrypoint, interface_hint=hint) is expected
+
+
+def _program_configuration() -> ProgramConfiguration:
+    return ProgramConfiguration(
+        input_data=None,
+        interface=Interface.asgi,
+        vm_hash="vm",
+        encoding=Encoding.zip,
+        entrypoint="main:app",
+    )
+
+
+def test_to_runtime_format_v1():
+    payload = _program_configuration().to_runtime_format(MagicMock(version="1.0.0"))
+    assert isinstance(payload, ConfigurationPayloadV1)
+    assert not isinstance(payload, ConfigurationPayloadV2)
+
+
+def test_to_runtime_format_v2():
+    payload = _program_configuration().to_runtime_format(MagicMock(version="2.0.0"))
+    assert isinstance(payload, ConfigurationPayloadV2)
+
+
+def test_to_runtime_format_unknown_version_falls_back_to_v2():
+    payload = _program_configuration().to_runtime_format(MagicMock(version="9.9.9"))
+    assert isinstance(payload, ConfigurationPayloadV2)

--- a/tests/supervisor/test_program_client.py
+++ b/tests/supervisor/test_program_client.py
@@ -13,7 +13,7 @@ from aleph.vm.agent.vm.program_client import (
     build_program_configuration,
 )
 from aleph.vm.conf import settings
-from aleph.vm.supervisor.controllers.firecracker.program import FileTooLargeError
+from aleph.vm.supervisor_interface.errors import FileTooLargeError
 from aleph.vm.supervisor_interface.types import (
     Backend,
     IpAssignment,

--- a/tests/supervisor/test_qemu_backup.py
+++ b/tests/supervisor/test_qemu_backup.py
@@ -29,7 +29,7 @@ from aleph.vm.supervisor.controllers.qemu.backup import (
 def test_get_backup_directory_default(mocker, tmp_path):
     exec_root = tmp_path / "exec"
     exec_root.mkdir()
-    mock_settings = mocker.patch("aleph.vm.supervisor.controllers.qemu.backup.settings")
+    mock_settings = mocker.patch("aleph.vm.backup_staging.settings")
     mock_settings.BACKUP_DIRECTORY = None
     mock_settings.EXECUTION_ROOT = exec_root
 
@@ -41,7 +41,7 @@ def test_get_backup_directory_default(mocker, tmp_path):
 
 def test_get_backup_directory_custom(mocker, tmp_path):
     custom_dir = tmp_path / "my-backup-volume"
-    mock_settings = mocker.patch("aleph.vm.supervisor.controllers.qemu.backup.settings")
+    mock_settings = mocker.patch("aleph.vm.backup_staging.settings")
     mock_settings.BACKUP_DIRECTORY = custom_dir
 
     result = get_backup_directory()
@@ -54,7 +54,7 @@ def test_get_backup_directory_idempotent(mocker, tmp_path):
     """Calling twice doesn't raise even though the dir already exists."""
     exec_root = tmp_path / "exec"
     exec_root.mkdir()
-    mock_settings = mocker.patch("aleph.vm.supervisor.controllers.qemu.backup.settings")
+    mock_settings = mocker.patch("aleph.vm.backup_staging.settings")
     mock_settings.BACKUP_DIRECTORY = None
     mock_settings.EXECUTION_ROOT = exec_root
 

--- a/tests/supervisor/test_supervisor_backups.py
+++ b/tests/supervisor/test_supervisor_backups.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from test_supervisor_inprocess_query import FakePool, FakeSystemd, make_execution
 
-from aleph.vm.supervisor.controllers.qemu import backup as backup_module
+from aleph.vm import backup_staging as backup_module
 from aleph.vm.supervisor.local import LocalSupervisor
 from aleph.vm.supervisor_interface.errors import (
     BackupNotFoundError,

--- a/tests/supervisor/test_supervisor_grpc.py
+++ b/tests/supervisor/test_supervisor_grpc.py
@@ -306,7 +306,7 @@ async def test_unary_calls_carry_a_deadline(monkeypatch):
 async def test_backup_surface_round_trips_over_the_wire(tmp_path, monkeypatch):
     """Status, listing, download stream and delete against a real archive on
     disk, through the real server and client."""
-    from aleph.vm.supervisor.controllers.qemu import backup as backup_module
+    from aleph.vm import backup_staging as backup_module
     from aleph.vm.supervisor_interface.errors import BackupNotFoundError
     from aleph.vm.supervisor_interface.types import BackupId, BackupStatus
 

--- a/tests/supervisor/test_supervisor_spec_execution.py
+++ b/tests/supervisor/test_supervisor_spec_execution.py
@@ -73,13 +73,16 @@ def test_from_spec_sets_spec():
 async def test_prepare_builds_resources_without_download(monkeypatch):
     execution = VmExecution.from_spec(make_spec(), snapshot_manager=None, systemd_manager=None)
 
-    # download_all must never be called on the spec path.
+    # The agent downloader must never be invoked on the spec path (the holder
+    # is built from the spec via from_spec; download lives agent-side now).
+    from aleph.vm.agent.vm.downloader import QemuDownloader
+
     called = {"download": False}
 
     async def fail_download(_self):  # type: ignore[no-untyped-def]
         called["download"] = True
 
-    monkeypatch.setattr(AlephQemuResources, "download_all", fail_download)
+    monkeypatch.setattr(QemuDownloader, "download_all", fail_download)
 
     await execution.prepare()
 

--- a/tests/supervisor/test_supervisor_translate.py
+++ b/tests/supervisor/test_supervisor_translate.py
@@ -19,10 +19,11 @@ from aleph_message.models.execution.volume import ParentVolume, VolumePersistenc
 from aleph_message.utils import Mebibytes
 
 from aleph.vm.agent.translate import build_create_vm_spec, build_reservation_request
-from aleph.vm.supervisor.controllers.qemu.cloudinit import get_hostname_from_hash
-from aleph.vm.supervisor.controllers.resources import HostVolume
+from aleph.vm.agent.vm.downloader import QemuDownloader
+from aleph.vm.host_volumes import HostVolume
 from aleph.vm.supervisor_interface.errors import InvalidBackendError
 from aleph.vm.supervisor_interface.types import Backend, DiskRole
+from aleph.vm.utils import get_hostname_from_hash
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -82,9 +83,7 @@ async def test_build_create_vm_spec_happy_path(monkeypatch: pytest.MonkeyPatch) 
         self.rootfs_path = rootfs
         self.volumes = [vol]
 
-    from aleph.vm.supervisor.controllers.qemu.instance import AlephQemuResources
-
-    monkeypatch.setattr(AlephQemuResources, "download_all", fake_download_all)
+    monkeypatch.setattr(QemuDownloader, "download_all", fake_download_all)
 
     message = _make_qemu_instance_message(
         internet=True,
@@ -146,9 +145,7 @@ async def test_build_create_vm_spec_maps_gpu_requirements(monkeypatch: pytest.Mo
         self.rootfs_path = Path("/data/rootfs.qcow2")
         self.volumes = []
 
-    from aleph.vm.supervisor.controllers.qemu.instance import AlephQemuResources
-
-    monkeypatch.setattr(AlephQemuResources, "download_all", fake_download_all)
+    monkeypatch.setattr(QemuDownloader, "download_all", fake_download_all)
 
     message = _make_qemu_instance_message()
     message = message.model_copy(
@@ -181,9 +178,7 @@ async def test_authorized_keys_none_becomes_empty_list(monkeypatch: pytest.Monke
         self.rootfs_path = Path("/data/rootfs.qcow2")
         self.volumes = []
 
-    from aleph.vm.supervisor.controllers.qemu.instance import AlephQemuResources
-
-    monkeypatch.setattr(AlephQemuResources, "download_all", fake_download_all)
+    monkeypatch.setattr(QemuDownloader, "download_all", fake_download_all)
 
     message = _make_qemu_instance_message(authorized_keys=None)
     spec = await build_create_vm_spec(_VM_HASH, message)
@@ -213,9 +208,7 @@ async def test_non_instance_message_raises(monkeypatch: pytest.MonkeyPatch) -> N
         authorized_keys=None,
     )
 
-    from aleph.vm.supervisor.controllers.qemu.instance import AlephQemuResources
-
-    monkeypatch.setattr(AlephQemuResources, "download_all", should_not_be_called)
+    monkeypatch.setattr(QemuDownloader, "download_all", should_not_be_called)
 
     with pytest.raises(InvalidBackendError, match="InstanceContent"):
         await build_create_vm_spec(_VM_HASH, fake_message)  # type: ignore[arg-type]
@@ -232,9 +225,7 @@ async def test_firecracker_hypervisor_raises(monkeypatch: pytest.MonkeyPatch) ->
         nonlocal download_called
         download_called = True
 
-    from aleph.vm.supervisor.controllers.qemu.instance import AlephQemuResources
-
-    monkeypatch.setattr(AlephQemuResources, "download_all", should_not_be_called)
+    monkeypatch.setattr(QemuDownloader, "download_all", should_not_be_called)
 
     message = _make_qemu_instance_message(hypervisor=HypervisorType.firecracker)
 
@@ -263,9 +254,7 @@ async def test_confidential_instance_populates_tee(monkeypatch: pytest.MonkeyPat
     async def fake_get_existing_file(ref: Any) -> Path:
         return firmware_path
 
-    from aleph.vm.supervisor.controllers.qemu.instance import AlephQemuResources
-
-    monkeypatch.setattr(AlephQemuResources, "download_all", fake_download_all)
+    monkeypatch.setattr(QemuDownloader, "download_all", fake_download_all)
     monkeypatch.setattr("aleph.vm.agent.translate.get_existing_file", fake_get_existing_file)
 
     # The message requests a non-default policy: the spec must carry that
@@ -300,9 +289,7 @@ async def test_hypervisor_none_defaults_to_qemu(monkeypatch: pytest.MonkeyPatch)
         self.rootfs_path = rootfs
         self.volumes = []
 
-    from aleph.vm.supervisor.controllers.qemu.instance import AlephQemuResources
-
-    monkeypatch.setattr(AlephQemuResources, "download_all", fake_download_all)
+    monkeypatch.setattr(QemuDownloader, "download_all", fake_download_all)
     monkeypatch.setattr("aleph.vm.conf.settings.INSTANCE_DEFAULT_HYPERVISOR", HypervisorType.qemu)
 
     message = _make_qemu_instance_message(hypervisor=None)
@@ -323,9 +310,7 @@ async def test_hypervisor_none_defaults_to_firecracker_raises(monkeypatch: pytes
         nonlocal download_called
         download_called = True
 
-    from aleph.vm.supervisor.controllers.qemu.instance import AlephQemuResources
-
-    monkeypatch.setattr(AlephQemuResources, "download_all", should_not_be_called)
+    monkeypatch.setattr(QemuDownloader, "download_all", should_not_be_called)
     monkeypatch.setattr("aleph.vm.conf.settings.INSTANCE_DEFAULT_HYPERVISOR", HypervisorType.firecracker)
 
     message = _make_qemu_instance_message(hypervisor=None)

--- a/tests/supervisor/test_supervisor_translate_program.py
+++ b/tests/supervisor/test_supervisor_translate_program.py
@@ -45,7 +45,7 @@ def _fake_resources(tmp_path: Path):
 @pytest.mark.parametrize("persistent", [True, False])
 async def test_program_spec_threads_persistence(monkeypatch, tmp_path, persistent):
     resources = _fake_resources(tmp_path)
-    monkeypatch.setattr(translate, "AlephProgramResources", lambda *a, **k: resources)
+    monkeypatch.setattr(translate, "ProgramDownloader", lambda *a, **k: resources)
 
     spec, returned = await translate.build_program_create_vm_spec(_VM_HASH, _program_message(persistent=persistent))
 


### PR DESCRIPTION
## PR-2: controller split by concern

Stacked on **#988** (PR-3). Removes the `agent -> supervisor.controllers` import edge so the import-linter contract forbids it strictly. Design: `docs/plans/2026-06-19-controller-split-by-concern-design.md`; implementation plan (audit-grounded, with verified execution notes): `docs/plans/2026-06-19-controller-split-by-concern-implementation.md`.

### What changed
- **Agent-side downloaders** (`aleph.vm.agent.vm.downloader`: `QemuDownloader`, `QemuConfidentialDownloader`, `ProgramDownloader`) — *compose* the host-resource surface (do not subclass the controller `VmResources`), hold `message_content`, own the `download_*` / `make_writable_volume` logic, and raise the **contract** error vocabulary (`supervisor_interface.errors.{ResourceDownloadError,FileTooLargeError,VmSetupError}`). `translate.py` uses them.
- **Controller runtime holders** (`AlephQemuResources` / `AlephQemuConfidentialResources` / `AlephFirecrackerResources` / `AlephProgramResources`) lose their now-unused `download_*` / `make_writable_volume` (download is agent-only); `from_spec` stays.
- **Neutral foundation modules** (importable by both sides): `aleph.vm.host_volumes`, `aleph.vm.program_config`, `aleph.vm.backup_staging`; `get_hostname_from_hash` moved to `aleph.vm.utils`. Controllers re-export for their own importers.
- **Wire-error vocabulary:** `views/__init__.py`, `run.py`, `program_client.py` catch/raise the contract `SupervisorError` set; `operator.py` uses the neutral backup-staging utils.
- **pyproject:** `aleph.vm.supervisor.controllers` added to the agent contract's `forbidden_modules`; the PR-1 documented residual is gone.

### Scope note (review focus)
The literal "two residuals" understated the coupling: the edge was also used by `run.py` and `program_client.py` (shared program-config machinery), so removing it fully required migrating those too. That is the bulk of the diff and the part most worth reviewing.

### Decisions to double-check
1. `operator.py` backup utils relocated to a **neutral util** (`aleph.vm.backup_staging`), not a boundary method — they are pure `settings`/`storage` helpers with no tenant-isolation need.
2. **Confidential/SEV runtime path** is exercised by unit tests with mocks only; the real SEV path needs the testnet #27 run before merge (same gate as the confidential-init work).
3. Controller `FileTooLargeError` kept (still referenced by `error_mapping.py` + `test_supervisor_errors.py`); the agent path raises the contract `FileTooLargeError`. Both coexist, harmless.

### Verification (local; no GH CI until the stack reaches dev)
- import-linter: **4 contracts kept, 0 broken** (agent->controllers now forbidden).
- `tests/supervisor tests/migration tests/network`: **930 passed**, 3 expected env-only `test_interfaces` (pyroute2/root) failures, 1 skipped, 2 xfailed.
- whole-tree `--collect-only`: 956 collected, 0 errors.
- isort + ruff format clean.
- No test deleted/skipped/xfailed/weakened (0 assertions removed; test changes are symbol-retargeting only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)