### PR TITLE
refactor(boundary): remove dead controller error branches and classes

### DIFF
--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -353,9 +353,6 @@ async def create_vm_execution_or_raise_http_error(
     except VmSetupError as error:
         logger.exception(error)
         raise HTTPInternalServerError(reason="Error during vm initialisation") from error
-    except MicroVMFailedInitError as error:
-        logger.exception(error)
-        raise HTTPInternalServerError(reason="Error during runtime initialisation") from error
     except HostNotFoundError as error:
         logger.exception(error)
         raise HTTPInternalServerError(reason="Host did not respond to ping") from error

--- a/src/aleph/vm/supervisor/controllers/firecracker/executable.py
+++ b/src/aleph/vm/supervisor/controllers/firecracker/executable.py
@@ -10,7 +10,6 @@ from os.path import exists
 from pathlib import Path
 from typing import Generic, TypeVar
 
-from aiohttp import ClientResponseError
 from aleph_message.models import ExecutableContent, ItemHash
 
 from aleph.vm.conf import settings
@@ -49,19 +48,6 @@ except RuntimeError as error:
         raise error
 
 
-class ResourceDownloadError(ClientResponseError):
-    """An error occurred while downloading a VM resource file"""
-
-    def __init__(self, error: ClientResponseError):
-        super().__init__(
-            request_info=error.request_info,
-            history=error.history,
-            status=error.status,
-            message=error.message,
-            headers=error.headers,
-        )
-
-
 @dataclass
 class BaseConfiguration:
     vm_hash: ItemHash
@@ -95,10 +81,6 @@ class AlephFirecrackerResources(VmResources):
 
     def get_disk_usage_delta(self) -> int:
         return disk_usage_delta(self.message_content, self.rootfs_path, self.volumes)
-
-
-class VmSetupError(Exception):
-    pass
 
 
 ConfigurationType = TypeVar("ConfigurationType")

--- a/src/aleph/vm/supervisor/error_mapping.py
+++ b/src/aleph/vm/supervisor/error_mapping.py
@@ -17,9 +17,7 @@ from aleph.vm.supervisor_interface.errors import (
     InsufficientResourcesError,
     InternalSupervisorError,
     MicroVMInitError,
-    ResourceDownloadError,
     SupervisorError,
-    VmSetupError,
 )
 
 
@@ -38,12 +36,6 @@ def translate_exception(exc: BaseException) -> SupervisorError:
     from aleph.vm.resources import (
         InsufficientResourcesError as _InsufficientResourcesError,
     )
-    from aleph.vm.supervisor.controllers.firecracker.executable import (
-        ResourceDownloadError as _ResourceDownloadError,
-    )
-    from aleph.vm.supervisor.controllers.firecracker.executable import (
-        VmSetupError as _VmSetupError,
-    )
     from aleph.vm.supervisor.controllers.firecracker.program import (
         FileTooLargeError as _FileTooLargeError,
     )
@@ -52,12 +44,8 @@ def translate_exception(exc: BaseException) -> SupervisorError:
     message = str(exc)
     if isinstance(exc, _InsufficientResourcesError):
         return InsufficientResourcesError(message)
-    if isinstance(exc, _ResourceDownloadError):
-        return ResourceDownloadError(message)
     if isinstance(exc, _FileTooLargeError):
         return FileTooLargeError(message)
-    if isinstance(exc, _VmSetupError):
-        return VmSetupError(message)
     if isinstance(exc, _MicroVMFailedInitError):
         return MicroVMInitError(message)
     if isinstance(exc, _HostNotFoundError):


### PR DESCRIPTION
Follow-up cleanup after the agent/supervisor boundary split (PR-1..PR-3). Stacked on **#990** (`od/supervisor-vm-id-rename-impl`) — retarget to `dev` once #990 merges.

With the download phase running agent-side and raising the contract vocabulary (`supervisor_interface.errors`), several controller-side exception paths are now unreachable. This removes the verified-dead ones.

### Removed
- **`run.py`** — instance-path `except MicroVMFailedInitError`. Instances are QEMU, not Firecracker microVMs, so that path never raises a MicroVM init error (local or contract). The program path still catches both forms; the import stays (used there).
- **`error_mapping.py`** — `translate_exception` branches for the controller `ResourceDownloadError` and `VmSetupError`, plus their now-unused contract imports. Every raiser of those errors is agent-side and raises the *contract* class; no supervisor-side op (the only thing `translating_errors` wraps) raises the controller class.
- **`executable.py`** — the orphaned `ResourceDownloadError` and `VmSetupError` class defs (never raised, no importers) and the now-unused `ClientResponseError` import.

### Deliberately NOT touched (needs a decision)
The controller **`program.FileTooLargeError`** class and its `error_mapping` branch are kept, because `tests/supervisor/test_supervisor_errors.py::test_translate_file_too_large` pins that controller→contract mapping. Retiring it requires editing that test, which I won't do unilaterally under the "don't denature tests" rule. Options for a follow-up:
- **(X)** retire it and change *only* the test's import to the contract `FileTooLargeError` (assertions unchanged; the test then verifies the `SupervisorError` pass-through, which is real and still passes), or
- **(Y)** leave it permanently as the single documented exception to the consolidation.

### Verification
- import-linter: **4 kept / 0 broken**
- mypy: **baseline unchanged (43 errors / 13 files)**
- full supervisor suite: **936 passed** (only the 3 env-only pyroute2 `test_interfaces` failures)
- ruff format + isort: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
