### PR TITLE
fix(agent): domains->HAProxy sync works in gRPC split mode

### DIFF
--- a/src/aleph/vm/agent/tasks.py
+++ b/src/aleph/vm/agent/tasks.py
@@ -39,7 +39,13 @@ from aleph.vm.conf import settings
 from aleph.vm.pool import VmPool
 from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.supervisor_interface.errors import VmNotFoundError
-from aleph.vm.supervisor_interface.types import ConfidentialMode, VmId, VmInfo, VmStatus
+from aleph.vm.supervisor_interface.types import (
+    Backend,
+    ConfidentialMode,
+    VmId,
+    VmInfo,
+    VmStatus,
+)
 from aleph.vm.utils import create_task_log_exceptions
 
 # Terminal statuses that confirm a message is no longer valid.
@@ -201,7 +207,7 @@ async def watch_for_messages(
                 if key == "port-forwarding":
                     await _handle_port_forwarding_aggregate(message, supervisor, registry)
                 elif key == "domains":
-                    await _handle_domains_aggregate(message, pool, supervisor, registry)
+                    await _handle_domains_aggregate(message, supervisor, registry)
 
 
 async def _handle_port_forwarding_aggregate(
@@ -233,34 +239,34 @@ async def _handle_port_forwarding_aggregate(
             logger.exception("Failed to update port redirects for %s", vm_hash)
 
 
-async def _handle_domains_aggregate(
-    message: AggregateMessage, pool: VmPool, supervisor: Supervisor, registry: AgentVmRegistry
-):
+async def _handle_domains_aggregate(message: AggregateMessage, supervisor: Supervisor, registry: AgentVmRegistry):
     """Update HAProxy domain mapping when a domains aggregate changes.
 
     The aggregate content maps domain names to instance configs:
     {"testd.example.com": {"message_id": "<item_hash>", "type": "instance"}}
 
-    Only trigger if any referenced message_id matches a locally running instance.
+    Only trigger if the address owns an instance present on this node. The owner
+    address comes from the agent registry, not the hypervisor object: spec-built
+    and restored executions carry no message. Enumerating through the registry
+    and ``supervisor.get_vm`` (instead of the in-process pool's executions) keeps
+    this working in split mode, where the daemon owns the pool. This covers both
+    additions (new domain pointing to a local instance) and deletions (domain
+    removed, the map must be rebuilt).
     """
     address = message.content.address
 
-    # Trigger if the address owns any running instance on this node. The owner
-    # address comes from the agent registry, not the hypervisor object —
-    # spec-built and restored executions carry no message.
-    # This covers both additions (new domain pointing to local instance)
-    # and deletions (domain removed — need to clean up the map).
-    if pool is None:
-        # Split mode: the domains/HAProxy path still needs the in-process
-        # pool; deferred.
-        return
-    has_local_instance = any(
-        execution.is_instance
-        and execution.vm
-        and (record := registry.get(execution.vm_id)) is not None
-        and record.message.address == address
-        for execution in pool.executions.values()
-    )
+    has_local_instance = False
+    for vm_hash, record in registry.items():
+        if record.message.address != address:
+            continue
+        try:
+            info = await supervisor.get_vm(VmId(str(vm_hash)))
+        except VmNotFoundError:
+            continue
+        # QEMU is the instance backend (the old execution.is_instance check).
+        if info.backend is Backend.QEMU:
+            has_local_instance = True
+            break
     if not has_local_instance:
         return
 

--- a/tests/supervisor/test_tasks_registry_reads.py
+++ b/tests/supervisor/test_tasks_registry_reads.py
@@ -11,6 +11,7 @@ from aleph_message.models import Chain, ItemHash, Payment, PaymentType
 from aleph.vm.agent.tasks import _group_executions_by_payment, _handle_domains_aggregate
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
+from aleph.vm.supervisor_interface.errors import VmNotFoundError
 from aleph.vm.supervisor_interface.types import (
     Backend,
     ConfidentialMode,
@@ -23,14 +24,14 @@ from aleph.vm.supervisor_interface.types import (
 _HASH = ItemHash("deadbeef" * 8)
 
 
-def _info(vm_hash: ItemHash, *, running: bool = True, confidential=False) -> VmInfo:
+def _info(vm_hash: ItemHash, *, running: bool = True, confidential=False, backend: Backend = Backend.QEMU) -> VmInfo:
     return VmInfo(
         vm_id=VmId(str(vm_hash)),
         status=VmStatus.RUNNING if running else VmStatus.STOPPED,
         ipv4=IpAssignment(),
         ipv6=IpAssignment(),
         uptime_secs=0,
-        backend=Backend.QEMU,
+        backend=backend,
         numa_node=None,
         status_message="",
         confidential_mode=ConfidentialMode.SEV if confidential else ConfidentialMode.NONE,
@@ -87,18 +88,31 @@ def test_grouping_skips_stopped_and_diagnostic_executions():
     assert _group_executions_by_payment(infos, registry, PaymentType.hold) == {}
 
 
+def _supervisor_returning(*infos: VmInfo):
+    """A supervisor stub whose get_vm answers from the given VmInfos by vm_id,
+    raising VmNotFoundError for anything else. No in-process pool involved, so
+    this exercises the split-mode path (the daemon owns the VMs)."""
+    by_id = {info.vm_id: info for info in infos}
+
+    async def get_vm(vm_id):
+        if vm_id in by_id:
+            return by_id[vm_id]
+        raise VmNotFoundError(str(vm_id))
+
+    return SimpleNamespace(get_vm=get_vm)
+
+
 @pytest.mark.asyncio
 async def test_domains_aggregate_triggers_for_registry_recorded_instance(mocker):
     """A message-less (spec-built / restored) instance must still trigger the
-    HAProxy domain-mapping refresh when its registry record matches the owner."""
+    HAProxy domain-mapping refresh when its registry record matches the owner,
+    sourced through the supervisor (works in split mode, no pool)."""
     sync = mocker.patch("aleph.vm.agent.tasks.sync_domain_mappings", new=AsyncMock())
     registry = _registry_with(_HASH, payment=None, address="0xowner")
-    execution = SimpleNamespace(vm_id=_HASH, is_instance=True, vm=object())
-    pool = SimpleNamespace(executions={_HASH: execution})
-    supervisor = object()
+    supervisor = _supervisor_returning(_info(_HASH))
     aggregate = SimpleNamespace(content=SimpleNamespace(address="0xowner"))
 
-    await _handle_domains_aggregate(aggregate, pool, supervisor, registry)
+    await _handle_domains_aggregate(aggregate, supervisor, registry)
 
     sync.assert_awaited_once_with(supervisor)
 
@@ -107,11 +121,10 @@ async def test_domains_aggregate_triggers_for_registry_recorded_instance(mocker)
 async def test_domains_aggregate_ignores_unrelated_address(mocker):
     sync = mocker.patch("aleph.vm.agent.tasks.sync_domain_mappings", new=AsyncMock())
     registry = _registry_with(_HASH, payment=None, address="0xowner")
-    execution = SimpleNamespace(vm_id=_HASH, is_instance=True, vm=object())
-    pool = SimpleNamespace(executions={_HASH: execution})
+    supervisor = _supervisor_returning(_info(_HASH))
     aggregate = SimpleNamespace(content=SimpleNamespace(address="0xsomeoneelse"))
 
-    await _handle_domains_aggregate(aggregate, pool, object(), registry)
+    await _handle_domains_aggregate(aggregate, supervisor, registry)
 
     sync.assert_not_awaited()
 
@@ -121,25 +134,38 @@ async def test_domains_aggregate_ignores_unrecorded_execution(mocker):
     """A matching-owner instance the agent has no record for must NOT trigger a
     refresh (no registry record -> short-circuits before the address compare)."""
     sync = mocker.patch("aleph.vm.agent.tasks.sync_domain_mappings", new=AsyncMock())
-    execution = SimpleNamespace(vm_id=_HASH, is_instance=True, vm=object())
-    pool = SimpleNamespace(executions={_HASH: execution})
+    supervisor = _supervisor_returning(_info(_HASH))
     aggregate = SimpleNamespace(content=SimpleNamespace(address="0xowner"))
 
-    await _handle_domains_aggregate(aggregate, pool, object(), AgentVmRegistry())
+    await _handle_domains_aggregate(aggregate, supervisor, AgentVmRegistry())
 
     sync.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_domains_aggregate_ignores_non_instance(mocker):
-    """A program (not an instance) owned by the address must NOT trigger a refresh."""
+    """A program (FIRECRACKER, not a QEMU instance) owned by the address must
+    NOT trigger a refresh."""
     sync = mocker.patch("aleph.vm.agent.tasks.sync_domain_mappings", new=AsyncMock())
     registry = _registry_with(_HASH, payment=None, address="0xowner")
-    execution = SimpleNamespace(vm_id=_HASH, is_instance=False, vm=object())
-    pool = SimpleNamespace(executions={_HASH: execution})
+    supervisor = _supervisor_returning(_info(_HASH, backend=Backend.FIRECRACKER))
     aggregate = SimpleNamespace(content=SimpleNamespace(address="0xowner"))
 
-    await _handle_domains_aggregate(aggregate, pool, object(), registry)
+    await _handle_domains_aggregate(aggregate, supervisor, registry)
+
+    sync.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_domains_aggregate_ignores_owner_instance_absent_from_supervisor(mocker):
+    """An owner-matching registry record whose VM the supervisor does not know
+    (deleted, never created) must NOT trigger a refresh."""
+    sync = mocker.patch("aleph.vm.agent.tasks.sync_domain_mappings", new=AsyncMock())
+    registry = _registry_with(_HASH, payment=None, address="0xowner")
+    supervisor = _supervisor_returning()  # get_vm always raises VmNotFoundError
+    aggregate = SimpleNamespace(content=SimpleNamespace(address="0xowner"))
+
+    await _handle_domains_aggregate(aggregate, supervisor, registry)
 
     sync.assert_not_awaited()
 


### PR DESCRIPTION
## Split-mode gap 1 of 4: domains → HAProxy sync

**Problem.** In split (two-process gRPC) mode the agent has no in-process `VmPool`. `_handle_domains_aggregate` short-circuited on `pool is None`, so a `domains` aggregate change never refreshed the HAProxy domain map. Custom-domain instances stop being routed after a mapping change. (In-process mode was unaffected — and, as it turns out, the only mode our integration tests have ever exercised.)

**Fix.** Source the owner's instances from the agent registry + `supervisor.get_vm()` instead of `pool.executions`, mirroring the already-split-safe `_handle_port_forwarding_aggregate`:
- registry record's `message.address == aggregate.address` (owner match, as before),
- `supervisor.get_vm(...)` succeeding stands in for "present in the pool",
- `VmInfo.backend is Backend.QEMU` is the wire equivalent of the old `execution.is_instance`.

Works identically in-process and over gRPC. No behavior change in-process.

**Scope note.** `pool` is now unused by `watch_for_messages`. Removing that dead threading (plus the unused `Reactor` pool param) is the separate **Reactor pool-param cleanup PR**, kept out of here to stay surgical.

**Tests.** The four `_handle_domains_aggregate` tests are rewritten to drive `supervisor.get_vm` (no pool), and a new case covers an owner-matching registry record whose VM the supervisor doesn't know. `test_tasks_registry_reads.py`: 11 passed.

Verified: import-linter 4/0, mypy baseline unchanged (43/13), ruff+isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
