### PR TITLE
fix(agent): graceful drain works in gRPC split mode

### DIFF
--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -95,14 +95,17 @@ logger = logging.getLogger(__name__)
 
 @web.middleware
 async def drain_middleware(request, handler) -> web.Response:
-    """Reject new VM execution requests while the pool is draining.
+    """Reject new VM execution requests while the agent is draining.
 
     Only blocks the paths that trigger on-demand VM creation
     (/vm/* and hostname-based routing). Status, control, and about
     endpoints remain accessible for monitoring and operations.
+
+    The draining flag is agent-owned (``app["draining"]``), so it works in split
+    mode where the in-process pool is absent: the agent fronts every request
+    regardless of which process owns the VMs.
     """
-    pool: VmPool | None = request.app.get("_engine_pool")
-    if pool and getattr(pool, "is_draining", False):
+    if request.app.get("draining"):
         path = request.path
         is_vm_request = path.startswith("/vm/") or (
             not path.startswith(("/about/", "/control/", "/status/", "/static/", "/debug/"))
@@ -223,6 +226,9 @@ def setup_webapp(pool: VmPool | None):
     # stop-all-on-shutdown, the migration reaper) still need the embedded pool;
     # they read this private key, which is None in split mode.
     app["_engine_pool"] = pool
+    # Agent-owned drain flag: drain_middleware rejects new VM requests when set.
+    # Works in both modes (no pool needed); flipped by drain_in_flight_requests.
+    app["draining"] = False
     app["supervisor"] = build_supervisor(settings, pool)
     app["expiry"] = ExpiryManager(app["supervisor"])
     app["vm_registry"] = AgentVmRegistry()
@@ -347,9 +353,17 @@ def setup_webapp(pool: VmPool | None):
 
 
 async def drain_in_flight_requests(app: web.Application):
-    """Drain in-flight requests before stopping VMs."""
+    """Stop accepting new VM requests, then wait for in-flight ones.
+
+    Setting the agent-owned draining flag makes drain_middleware reject new VM
+    requests in both modes. In-process, also drain the embedded pool (which waits
+    for in-flight ephemeral runs). In split mode the daemon owns the pool and
+    keeps VMs running across its own restart, so the agent only flips the flag and
+    lets aiohttp finish its in-flight handlers.
+    """
+    app["draining"] = True
     pool: VmPool | None = app.get("_engine_pool")
-    if pool:
+    if pool is not None:
         await pool.drain()
 
 

--- a/tests/supervisor/test_drain.py
+++ b/tests/supervisor/test_drain.py
@@ -24,20 +24,13 @@ def _make_execution(persistent: bool = False) -> VmExecution:
     return VmExecution.from_spec(spec, snapshot_manager=None, systemd_manager=None)
 
 
-class _DrainablePool:
-    """Minimal pool that supports drain state for middleware tests.
-
-    Uses only the attributes the drain middleware inspects, avoiding
-    the full VmPool constructor (which needs network/systemd).
-    """
-
-    def __init__(self, draining: bool = False):
-        self._draining = draining
-        self.executions: dict = {}
-
-    @property
-    def is_draining(self) -> bool:
-        return self._draining
+def _draining_app(draining: bool = True):
+    """A webapp with no in-process pool (split mode) and the agent-owned drain
+    flag set. The middleware reads app["draining"], not the pool, so this proves
+    drain works without an embedded pool."""
+    app = setup_webapp(pool=None)
+    app["draining"] = draining
+    return app
 
 
 # ---------------------------------------------------------------------------
@@ -50,8 +43,7 @@ class TestDrainMiddleware:
 
     @pytest.mark.asyncio
     async def test_vm_path_blocked_while_draining(self, aiohttp_client):
-        app = setup_webapp(pool=_DrainablePool(draining=True))
-        client = await aiohttp_client(app)
+        client = await aiohttp_client(_draining_app(draining=True))
 
         response = await client.get("/vm/abc123/some/path")
         assert response.status == 503
@@ -60,8 +52,7 @@ class TestDrainMiddleware:
 
     @pytest.mark.asyncio
     async def test_vm_path_allowed_when_not_draining(self, aiohttp_client):
-        app = setup_webapp(pool=_DrainablePool(draining=False))
-        client = await aiohttp_client(app)
+        client = await aiohttp_client(_draining_app(draining=False))
 
         response = await client.get("/vm/abc123/")
         # Will fail downstream (no real VM) but must NOT be 503
@@ -69,15 +60,14 @@ class TestDrainMiddleware:
 
     @pytest.mark.asyncio
     async def test_status_allowed_while_draining(self, aiohttp_client):
-        app = setup_webapp(pool=_DrainablePool(draining=True))
-        client = await aiohttp_client(app)
+        client = await aiohttp_client(_draining_app(draining=True))
 
         response = await client.get("/status/config")
         assert response.status == 200
 
     @pytest.mark.asyncio
     async def test_about_allowed_while_draining(self, aiohttp_client):
-        app = setup_webapp(pool=_DrainablePool(draining=True))
+        app = _draining_app(draining=True)
         app["secret_token"] = "test-token"
         client = await aiohttp_client(app)
 
@@ -86,8 +76,7 @@ class TestDrainMiddleware:
 
     @pytest.mark.asyncio
     async def test_control_allowed_while_draining(self, aiohttp_client):
-        app = setup_webapp(pool=_DrainablePool(draining=True))
-        client = await aiohttp_client(app)
+        client = await aiohttp_client(_draining_app(draining=True))
 
         response = await client.get("/control/nonexistent")
         # Unknown path → 404, but NOT 503
@@ -95,8 +84,7 @@ class TestDrainMiddleware:
 
     @pytest.mark.asyncio
     async def test_hostname_routing_blocked_while_draining(self, aiohttp_client):
-        app = setup_webapp(pool=_DrainablePool(draining=True))
-        client = await aiohttp_client(app)
+        client = await aiohttp_client(_draining_app(draining=True))
 
         with patch.object(settings, "DOMAIN_NAME", "supervisor.local"):
             response = await client.get("/", headers={"Host": "somevmhash.example.com"})
@@ -105,12 +93,41 @@ class TestDrainMiddleware:
     @pytest.mark.asyncio
     async def test_root_on_supervisor_domain_allowed(self, aiohttp_client):
         """Root path on the supervisor's own domain is NOT a VM request."""
-        app = setup_webapp(pool=_DrainablePool(draining=True))
-        client = await aiohttp_client(app)
+        client = await aiohttp_client(_draining_app(draining=True))
 
         with patch.object(settings, "DOMAIN_NAME", "127.0.0.1"):
             response = await client.get("/")
             assert response.status != 503
+
+
+# ---------------------------------------------------------------------------
+# drain_in_flight_requests — the on_shutdown hook, both modes
+# ---------------------------------------------------------------------------
+
+
+class TestDrainShutdownHook:
+    @pytest.mark.asyncio
+    async def test_split_mode_flips_flag_without_pool(self):
+        """Split mode (no embedded pool): the hook flips the flag and returns;
+        the daemon owns the pool and keeps VMs running across its own restart."""
+        from aleph.vm.agent.supervisor import drain_in_flight_requests
+
+        app = {"_engine_pool": None, "draining": False}
+        await drain_in_flight_requests(app)
+        assert app["draining"] is True
+
+    @pytest.mark.asyncio
+    async def test_in_process_flips_flag_and_drains_pool(self):
+        """In-process: the hook flips the flag AND drains the embedded pool."""
+        from unittest.mock import AsyncMock
+
+        from aleph.vm.agent.supervisor import drain_in_flight_requests
+
+        pool = AsyncMock()
+        app = {"_engine_pool": pool, "draining": False}
+        await drain_in_flight_requests(app)
+        assert app["draining"] is True
+        pool.drain.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Split-mode gap 2 of 4: graceful drain

**Problem.** `drain_middleware` rejected new VM requests based on `pool.is_draining`, and `drain_in_flight_requests` (the `on_shutdown` hook) called `pool.drain()`. Both reach the in-process pool, which is `None` in split mode — so during a shutdown/upgrade the agent kept accepting new VM-creation requests instead of shedding them.

**Fix.** Make the draining state **agent-owned** (`app["draining"]`):
- `drain_middleware` rejects new VM requests (`/vm/*` + hostname routing) based on the flag, in both modes. The pool is no longer consulted.
- `drain_in_flight_requests` flips the flag, then — in-process only — drains the embedded pool to wait for in-flight ephemeral runs. In split mode the daemon owns the pool and keeps VMs running across its own restart (its shutdown just stops the gRPC server), so the agent flips the flag and lets aiohttp finish in-flight handlers.

**No in-process behavior change:** the flag is set on the same `on_shutdown` hook that already called `pool.drain()`, so rejection timing is identical.

**Tests.** Middleware tests now drive the flag with `pool=None` (split-realistic, proving it works with no embedded pool); added `drain_in_flight_requests` tests for both modes (split flips the flag without a pool; in-process flips the flag *and* awaits `pool.drain()`). `test_drain.py`: 14 passed.

Verified: import-linter 4/0, mypy baseline unchanged (43/13), ruff+isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
