### PR TITLE
fix(agent): migration reaper works in split mode (agent-side, via list_vms)

### DIFF
--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -403,10 +403,16 @@ async def stop_program_client(app: web.Application) -> None:
 
 
 async def _run_migration_reaper(app: web.Application) -> None:
-    """on_startup hook: clean up orphan migration files left from a prior supervisor run."""
-    pool = app.get("_engine_pool")
-    if pool is not None:
-        await reap_orphan_migration_files(pool)
+    """on_startup hook: clean up orphan migration files from a prior agent run.
+
+    Cold migration staging is agent-owned, so this runs agent-side in both modes.
+    The live-VM set comes from the supervisor over the ABC (works in split mode,
+    where there is no in-process pool); it only guards against deleting a running
+    VM's volume directory.
+    """
+    supervisor = app["supervisor"]
+    known_vm_ids = {str(info.vm_id) for info in await supervisor.list_vms()}
+    await reap_orphan_migration_files(known_vm_ids)
 
 
 async def _rehydrate_vm_registry(app: web.Application) -> None:

--- a/src/aleph/vm/migration/reaper.py
+++ b/src/aleph/vm/migration/reaper.py
@@ -8,22 +8,27 @@ from aleph.vm.conf import settings
 logger = logging.getLogger(__name__)
 
 
-async def reap_orphan_migration_files(pool) -> None:
-    """Reap orphan export and partial-import files left behind by a prior supervisor run.
+async def reap_orphan_migration_files(known_vm_ids: set[str]) -> None:
+    """Reap orphan export and partial-import files left behind by a prior agent run.
+
+    Cold migration is agent-side: the agent stages the disk (the ``.part``
+    download and the ``.export.qcow2`` export) before asking the supervisor to
+    CreateVm, so this cleanup is owned by the agent. ``known_vm_ids`` is the set
+    of VMs the supervisor currently holds (from ``list_vms``); it is used only to
+    avoid touching a live VM's volume directory. Run at agent startup, where the
+    agent's own in-flight imports do not yet exist, so any ``.part`` is genuinely
+    an aborted prior run.
 
     On each <vm_hash> directory under PERSISTENT_VOLUMES_DIR:
-      - Always delete *.qcow2.export.qcow2 (orphan exports — pool can't claim them).
-      - If pool has no execution for this vm_hash AND the dir contains *.part files:
+      - Always delete *.qcow2.export.qcow2 (orphan exports — never reused).
+      - If the vm_hash is not a known live VM AND the dir contains *.part files:
           → rmtree the directory (clear evidence of an aborted import).
-      - If pool has no execution AND the dir has only completed .qcow2 files:
+      - If not known AND the dir has only completed .qcow2 files:
           → keep, log warning. A subsequent import retry can detect the existing files.
     """
     base = settings.PERSISTENT_VOLUMES_DIR
     if not base.exists():
         return
-
-    # Pool keys may be strings or ItemHash objects; normalise to strings for matching.
-    known = {str(k) for k in pool.executions}
 
     n_exports = 0
     n_dirs = 0
@@ -42,7 +47,7 @@ async def reap_orphan_migration_files(pool) -> None:
                 logger.warning("Failed to delete orphan export %s: %s", export_file, e)
 
         # Pass 2: orphan dest dirs.
-        if entry.name in known:
+        if entry.name in known_vm_ids:
             continue
 
         part_files = list(entry.glob("*.part"))

--- a/tests/migration/test_reaper.py
+++ b/tests/migration/test_reaper.py
@@ -1,6 +1,11 @@
-"""Tests for the startup migration reaper."""
+"""Tests for the startup migration reaper.
 
-from unittest.mock import MagicMock
+The reaper takes the set of live vm_ids (sourced from supervisor.list_vms by the
+agent hook), not a pool, so it works in both in-process and split mode.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -17,11 +22,8 @@ async def test_reaper_deletes_export_files(tmp_path, monkeypatch):
     (vm_dir / "rootfs.qcow2.export.qcow2").write_bytes(b"orphan")
     (vm_dir / "data.qcow2.export.qcow2").write_bytes(b"orphan2")
 
-    pool = MagicMock()
-    # Pretend the VM is in the pool — directory itself stays.
-    pool.executions = {"abc123": MagicMock()}
-
-    await reap_orphan_migration_files(pool)
+    # The VM is live — the directory itself stays, only orphan exports go.
+    await reap_orphan_migration_files({"abc123"})
 
     assert (vm_dir / "rootfs.qcow2").exists()
     assert not (vm_dir / "rootfs.qcow2.export.qcow2").exists()
@@ -35,26 +37,55 @@ async def test_reaper_removes_orphan_dest_dir_with_part_files(tmp_path, monkeypa
     vm_dir.mkdir()
     (vm_dir / "rootfs.qcow2.part").write_bytes(b"partial")
 
-    pool = MagicMock()
-    pool.executions = {}
-
-    await reap_orphan_migration_files(pool)
+    await reap_orphan_migration_files(set())
 
     assert not vm_dir.exists()
 
 
 @pytest.mark.asyncio
+async def test_reaper_keeps_part_dir_of_live_vm(tmp_path, monkeypatch):
+    """A .part dir whose vm_hash IS a live VM must be left alone (no rmtree)."""
+    monkeypatch.setattr(settings, "PERSISTENT_VOLUMES_DIR", tmp_path)
+    vm_dir = tmp_path / "live"
+    vm_dir.mkdir()
+    (vm_dir / "rootfs.qcow2.part").write_bytes(b"partial")
+
+    await reap_orphan_migration_files({"live"})
+
+    assert vm_dir.exists()
+
+
+@pytest.mark.asyncio
 async def test_reaper_keeps_complete_orphan_volumes(tmp_path, monkeypatch):
-    """Directory with completed qcow2 files but no execution: keep, log a warning."""
+    """Directory with completed qcow2 files but no live VM: keep, log a warning."""
     monkeypatch.setattr(settings, "PERSISTENT_VOLUMES_DIR", tmp_path)
     vm_dir = tmp_path / "complete-but-orphan"
     vm_dir.mkdir()
     (vm_dir / "rootfs.qcow2").write_bytes(b"complete")
 
-    pool = MagicMock()
-    pool.executions = {}
-
-    await reap_orphan_migration_files(pool)
+    await reap_orphan_migration_files(set())
 
     assert vm_dir.exists()
     assert (vm_dir / "rootfs.qcow2").exists()
+
+
+@pytest.mark.asyncio
+async def test_agent_hook_sources_live_ids_from_supervisor(mocker):
+    """The agent on_startup hook builds the live-VM set from supervisor.list_vms
+    (over the ABC, so it works in split mode with no in-process pool) and hands
+    it to the reaper."""
+    from aleph.vm.agent.supervisor import _run_migration_reaper
+
+    captured = {}
+
+    async def fake_reap(known_vm_ids):
+        captured["known"] = known_vm_ids
+
+    mocker.patch("aleph.vm.agent.supervisor.reap_orphan_migration_files", new=fake_reap)
+    supervisor = SimpleNamespace(
+        list_vms=AsyncMock(return_value=[SimpleNamespace(vm_id="vm1"), SimpleNamespace(vm_id="vm2")])
+    )
+
+    await _run_migration_reaper({"supervisor": supervisor})
+
+    assert captured["known"] == {"vm1", "vm2"}


### PR DESCRIPTION
## Split-mode gap: orphan migration-file reaper (corrected — agent-side)

> Redone after review. The first version moved the reaper to the daemon; that was wrong. Cold migration is **agent-side**, and a daemon-side reaper is actively unsafe — see below.

**Problem.** The orphan-migration-file reaper ran as an agent `on_startup` hook but read `pool.executions`, which is `None` for the agent in split mode, so it no-op'd and orphan `.part` / `.export.qcow2` files accumulated.

**Why it stays agent-side.** Cold migration is entirely agent-owned: `migration/runner.py` (`run_import`/`run_export`) is agent code (it imports `agent.translate`), launched as an agent background task from `agent/views/migration.py`, and it does all the file work — the `.part` download (`helpers.download_disk_from_source`), the `.export.qcow2` export, and the in-flight `import_jobs` map. It stages the disk, *then* calls `supervisor.create_vm(spec)`. The supervisor never reads or writes these files.

**Why the daemon version was unsafe.** During an active import, `.part` exists but the VM does not yet (CreateVm happens *after* the download). In split mode the daemon is an independent process — a daemon restart mid-import would see `.part` + no execution and `rmtree` the agent's **live** import, since the daemon has no view of `import_jobs`.

**Fix.** Keep the reaper agent-side; source the live-VM set from `supervisor.list_vms()` over the ABC instead of `pool.executions`. This mirrors `_handle_domains_aggregate` (#993) and the `_vm_exists` check the migration runner already uses. The set only guards against deleting a running VM's volume dir. Run at agent startup, the agent's own `import_jobs` is empty, so any `.part` is genuinely an aborted prior run. The daemon is untouched.

**Tests.** `reap_orphan_migration_files` now takes the id set (tests driven by a set, plus a new "live VM's `.part` dir is kept" case), and a new test covers the agent hook sourcing ids from `list_vms`. 5 passed.

Verified: import-linter 4/0, mypy baseline unchanged (43/13), ruff+isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)