### PR TITLE
refactor(agent): drop dead pool threading from the message path

### DIFF
--- a/src/aleph/vm/agent/reactor.py
+++ b/src/aleph/vm/agent/reactor.py
@@ -8,7 +8,6 @@ from aleph.vm.agent.expiry import ExpiryManager
 from aleph.vm.agent.update_watcher import UpdateWatcher
 from aleph.vm.agent.vm.program_client import ProgramGuestClient
 from aleph.vm.agent.vm_registry import AgentVmRegistry
-from aleph.vm.pool import VmPool
 from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.utils import create_task_log_exceptions
 
@@ -45,7 +44,6 @@ def subscription_matches(subscription: Subscription, message: AlephMessage) -> b
 
 class Reactor:
     pubsub: PubSub
-    pool: VmPool
     supervisor: Supervisor
     expiry: ExpiryManager
     update_watcher: UpdateWatcher
@@ -55,7 +53,6 @@ class Reactor:
     def __init__(
         self,
         pubsub: PubSub,
-        pool: VmPool,
         supervisor: Supervisor,
         expiry: ExpiryManager,
         update_watcher: UpdateWatcher,
@@ -63,7 +60,6 @@ class Reactor:
         program_client: ProgramGuestClient,
     ):
         self.pubsub = pubsub
-        self.pool = pool
         self.supervisor = supervisor
         self.expiry = expiry
         self.update_watcher = update_watcher

--- a/src/aleph/vm/agent/tasks.py
+++ b/src/aleph/vm/agent/tasks.py
@@ -36,7 +36,6 @@ from aleph.vm.agent.utils import (
 )
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
-from aleph.vm.pool import VmPool
 from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.supervisor_interface.errors import VmNotFoundError
 from aleph.vm.supervisor_interface.types import (
@@ -181,9 +180,7 @@ async def subscribe_via_ws(url) -> AsyncIterable[AlephMessage]:
                 break
 
 
-async def watch_for_messages(
-    dispatcher: PubSub, reactor: Reactor, pool: VmPool, supervisor: Supervisor, registry: AgentVmRegistry
-):
+async def watch_for_messages(dispatcher: PubSub, reactor: Reactor, supervisor: Supervisor, registry: AgentVmRegistry):
     """Watch for new Aleph messages"""
     logger.debug("watch_for_messages()")
     url = URL(f"{settings.API_SERVER}/api/ws0/messages").with_query({"startDate": math.floor(time.time())})
@@ -280,13 +277,9 @@ async def _handle_domains_aggregate(message: AggregateMessage, supervisor: Super
 async def start_watch_for_messages_task(app: web.Application):
     logger.debug("start_watch_for_messages_task()")
     pubsub = PubSub()
-    # Process-lifecycle wiring (not an agent request handler): the message
-    # listener and reactor are built once at startup and legitimately hold the
-    # embedded pool, like the daemon and CLI. None in split mode.
-    pool: VmPool | None = app.get("_engine_pool")
     supervisor = app["supervisor"]
     registry = app["vm_registry"]
-    reactor = Reactor(pubsub, pool, supervisor, app["expiry"], app["update_watcher"], registry, app["program_client"])
+    reactor = Reactor(pubsub, supervisor, app["expiry"], app["update_watcher"], registry, app["program_client"])
 
     # Register an hardcoded initial program
     # TODO: Register all programs with subscriptions
@@ -299,9 +292,7 @@ async def start_watch_for_messages_task(app: web.Application):
 
     app["pubsub"] = pubsub
     app["reactor"] = reactor
-    app["messages_listener"] = create_task_log_exceptions(
-        watch_for_messages(pubsub, reactor, pool, supervisor, registry)
-    )
+    app["messages_listener"] = create_task_log_exceptions(watch_for_messages(pubsub, reactor, supervisor, registry))
 
 
 async def stop_watch_for_messages_task(app: web.Application):


### PR DESCRIPTION
## Split-mode gap 4 of 4: dead pool threading on the message path

**Problem.** `Reactor` accepted and stored a `pool` it never used. The only thing that fed it was `start_watch_for_messages_task`, which fetched the embedded pool and threaded it into both `Reactor` and `watch_for_messages`. The pool is `None` in split mode and unused in in-process mode — pure dead weight that also kept an `agent → pool` import edge alive.

**Fix.** Remove the dead thread end to end:
- `Reactor`: drop the `pool` param and field.
- `watch_for_messages`: drop the `pool` param.
- `start_watch_for_messages_task`: drop the `_engine_pool` fetch.
- Remove the now-unused `VmPool` imports in `reactor.py` and `tasks.py`.

No behavior change (the value was never read). Drops one `agent → pool` import edge.

**Stacking.** Based on **#993** (`od/split-domains-haproxy`) — that PR is what frees `watch_for_messages` from the pool (it was the last real consumer, via the domains handler). Removing the thread off `dev` directly would orphan the builder line. **Retarget to `dev` once #993 merges.**

No new tests (dead-code removal); whole suite still collects (990 tests), `test_tasks_registry_reads.py` 11 passed. Verified: import-linter 4/0, mypy baseline unchanged (43/13), ruff+isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
