### PR TITLE
fix(restore): return 400 on invalid restore image (regression from #948)

### DIFF
--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -214,10 +214,10 @@ def setup_webapp(pool: VmPool | None):
 
     VmPool is None in two cases: tests that won't use it, and **split mode**
     (`ALEPH_VM_SUPERVISOR_GRPC_SOCKET` set), where the supervisor daemon owns
-    the pool and the agent reaches it over gRPC. In split mode the endpoints
-    that still require the in-process pool (backups, restore, confidential,
-    migration, network recreation, GPU reservation, persistent programs)
-    respond 501.
+    the pool and the agent reaches it over gRPC. Request handlers never touch
+    the pool directly: every VM operation (backups, restore, confidential,
+    migration, network recreation, GPU reservation, persistent programs) goes
+    through the `Supervisor` interface, so it works identically in split mode.
     """
     app = web.Application(middlewares=[drain_middleware, error_middleware])
     app.on_response_prepare.append(on_prepare_server_version)

--- a/src/aleph/vm/supervisor/local.py
+++ b/src/aleph/vm/supervisor/local.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 import os
 import shutil
+import subprocess
 import tarfile
 import time
 from collections.abc import AsyncIterator
@@ -953,9 +954,13 @@ class LocalSupervisor(Supervisor):
                 raise InternalSupervisorError(f"staged restore image {image} does not exist")
 
             # qemu-img rejects anything that is not a valid QCOW2 image with a
-            # non-zero exit code; let it bubble up (the agent maps the client
-            # error to a 400).
-            await verify_qemu_disk(image)
+            # non-zero exit code. That is a client error (a bad upload), so map
+            # it to InvalidBackendError; the agent turns that into a 400. A bare
+            # CalledProcessError would translate to InternalSupervisorError -> 500.
+            try:
+                await verify_qemu_disk(image)
+            except subprocess.CalledProcessError as exc:
+                raise InvalidBackendError(f"Restore image {image.name} is not a valid QCOW2 disk") from exc
             if max_virtual_size_bytes:
                 new_size = await get_qemu_disk_virtual_size(image)
                 if new_size > max_virtual_size_bytes:

--- a/tests/supervisor/test_supervisor_backups.py
+++ b/tests/supervisor/test_supervisor_backups.py
@@ -4,6 +4,7 @@ machinery, with the qemu-img calls stubbed out."""
 from __future__ import annotations
 
 import asyncio
+import subprocess
 import tarfile
 from pathlib import Path
 from types import SimpleNamespace
@@ -21,7 +22,13 @@ from aleph.vm.supervisor_interface.errors import (
     NotImplementedSupervisorError,
     VmNotFoundError,
 )
-from aleph.vm.supervisor_interface.types import BackupId, BackupStatus, VmId, VmStatus
+from aleph.vm.supervisor_interface.types import (
+    BackupId,
+    BackupStatus,
+    ErrorCode,
+    VmId,
+    VmStatus,
+)
 
 VM_ID = VmId("itemhash123")
 
@@ -445,6 +452,30 @@ async def test_restore_from_image_rejects_oversized_disk(backup_dir, tmp_path, m
     with pytest.raises(InvalidBackendError):
         await sup.restore_from_image(VM_ID, staged, max_virtual_size_bytes=100)
 
+    pool.stop_vm.assert_not_awaited()
+    assert rootfs.read_bytes() == original
+
+
+@pytest.mark.asyncio
+async def test_restore_from_image_rejects_invalid_qcow2(backup_dir, tmp_path, monkeypatch):
+    """A non-QCOW2 upload makes qemu-img exit non-zero (CalledProcessError).
+    That must surface as InvalidBackendError (a client error -> agent 400),
+    not InternalSupervisorError (-> 500). Regression test for aleph-vm#948."""
+    sup, pool, execution = _restorable_supervisor(backup_dir, tmp_path, monkeypatch)
+    rootfs = Path(execution.vm.resources.rootfs_path)
+    original = rootfs.read_bytes()
+    staged = tmp_path / "staged-upload.qcow2"
+    staged.write_bytes(b"not-a-qcow2-image")
+
+    async def boom(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, ["qemu-img", "check"])
+
+    monkeypatch.setattr("aleph.vm.supervisor.local.verify_qemu_disk", boom)
+
+    with pytest.raises(InvalidBackendError) as excinfo:
+        await sup.restore_from_image(VM_ID, staged, max_virtual_size_bytes=100)
+
+    assert excinfo.value.code is ErrorCode.INVALID_BACKEND
     pool.stop_vm.assert_not_awaited()
     assert rootfs.read_bytes() == original
 


### PR DESCRIPTION
## Summary

Two small fixes uncovered while gap-analysing `dev` against the 1.13 release on `main`.

### 1. Restore of an invalid image returns 500 again (regression of #948)
A malformed restore upload (e.g. a tar instead of a QCOW2) returns **HTTP 500** instead of 400.

`verify_qemu_disk()` raises `subprocess.CalledProcessError` on a bad image. Inside `LocalSupervisor.restore_from_image()` that runs under `translating_errors()`, which has no `CalledProcessError` case and falls through to `InternalSupervisorError` → the agent's generic handler → 500. The agent already maps `InvalidBackendError` → 400, so the fix is to catch the `CalledProcessError` at the validation call and raise `InvalidBackendError`.

Tightly scoped to the validation call rather than a broad `translate_exception` rule, so genuine internal subprocess failures still surface as 500. The oversized-disk path already raised `InvalidBackendError`; only the format-validation path regressed when disk validation moved into the supervisor during the split.

Adds `test_restore_from_image_rejects_invalid_qcow2` (a clone of the existing oversized-disk test).

### 2. Stale `setup_webapp` docstring
The docstring claimed backup/restore/confidential/migration/network/GPU/persistent-program endpoints "respond 501" in split mode. That predates Phase 1 — those endpoints now route through the `Supervisor` interface and work identically in split mode. Comment-only.

## Test plan
- [x] `ruff format` / `isort` clean
- [ ] CI runs the supervisor suite (couldn't run locally: env needs `libdbus-1-dev`/`libsystemd-dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)