### PR TITLE
refactor(supervisor): drop vestigial message-built (spec=None) guards

### DIFF
--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -476,8 +476,7 @@ class VmPool:
     @staticmethod
     def _require_same_spec(current_execution: VmExecution, spec: CreateVmSpec) -> None:
         """CreateVm idempotency: a retry with the identical spec returns the
-        live VM; a different spec for a live vm_index is a conflict (also covers
-        colliding with a message-built execution, whose vm_spec is None)."""
+        live VM; a different spec for a live vm_index is a conflict."""
         if current_execution.vm_spec != spec:
             msg = f"VM {spec.vm_id} already exists with a different spec"
             raise VmAlreadyExistsError(msg)

--- a/src/aleph/vm/supervisor/local.py
+++ b/src/aleph/vm/supervisor/local.py
@@ -460,11 +460,7 @@ class LocalSupervisor(Supervisor):
     async def get_vm_spec(self, vm_id: VmId) -> CreateVmSpec:
         with translating_errors():
             execution = self._require(vm_id)
-            spec = execution.vm_spec
-            if spec is None:
-                msg = f"VM {vm_id} was created outside the spec path (message-built); no spec is held"
-                raise NotImplementedSupervisorError(msg)
-            return spec
+            return execution.vm_spec
 
     async def delete_vm(self, vm_id: VmId, wipe: bool = False) -> None:
         with translating_errors():
@@ -540,17 +536,13 @@ class LocalSupervisor(Supervisor):
             if execution.vm_id in self.pool.executions:
                 self.pool.forget_vm(vm_id)
             self._emit_event(vm_id, old_status, VmStatus.STOPPED)
-            if spec is not None:
-                # A real reboot: the supervisor holds the spec, so it can
-                # recreate the VM itself instead of returning a stopped husk
-                # and expecting the client to know it must re-create.
-                new_execution = await self.pool.create_vm_from_spec(spec)
-                info = _to_vm_info(new_execution, _is_running(new_execution, self.pool))
-                self._emit_event(vm_id, VmStatus.STOPPED, info.status)
-                return info
-            # Message-built (legacy) ephemeral VMs: the agent owns the
-            # message and re-creates through its own path.
-            return _to_vm_info(execution, _is_running(execution, self.pool))
+            # A real reboot: the supervisor holds the spec, so it can
+            # recreate the VM itself instead of returning a stopped husk
+            # and expecting the client to know it must re-create.
+            new_execution = await self.pool.create_vm_from_spec(spec)
+            info = _to_vm_info(new_execution, _is_running(new_execution, self.pool))
+            self._emit_event(vm_id, VmStatus.STOPPED, info.status)
+            return info
 
     async def reinstall_vm(self, vm_id: VmId, wipe_volumes: bool = True) -> VmInfo:
         with translating_errors():

--- a/tests/supervisor/test_supervisor_inprocess_lifecycle.py
+++ b/tests/supervisor/test_supervisor_inprocess_lifecycle.py
@@ -233,22 +233,6 @@ async def test_reboot_ephemeral_spec_vm_recreates_from_held_spec():
 
 
 @pytest.mark.asyncio
-async def test_reboot_ephemeral_message_vm_stops_only():
-    """Message-built (legacy) ephemeral VMs keep the old contract: the agent
-    owns the message and re-creates through its own path."""
-    execution = _make_execution(persistent=False)
-    execution.vm_spec = None
-    pool = _make_pool(executions={"itemhash123": execution})
-    pool.create_vm_from_spec = AsyncMock()
-    sup = LocalSupervisor(pool=pool)
-
-    await sup.reboot_vm(VM_ID)
-
-    pool.stop_vm.assert_awaited_once_with(VM_ID)
-    pool.create_vm_from_spec.assert_not_awaited()
-
-
-@pytest.mark.asyncio
 async def test_get_vm_spec_returns_held_spec():
     spec = _spec_for("itemhash123")
     execution = make_execution()
@@ -263,16 +247,6 @@ async def test_get_vm_spec_unknown_vm_raises_not_found():
     sup = LocalSupervisor(pool=FakePool())
     with pytest.raises(VmNotFoundError):
         await sup.get_vm_spec(VmId("nope"))
-
-
-@pytest.mark.asyncio
-async def test_get_vm_spec_message_built_vm_raises_unimplemented():
-    from aleph.vm.supervisor_interface.errors import NotImplementedSupervisorError
-
-    execution = make_execution()  # vm_spec=None: legacy, message-built
-    sup = LocalSupervisor(pool=FakePool(executions={"itemhash123": execution}))
-    with pytest.raises(NotImplementedSupervisorError):
-        await sup.get_vm_spec(VM_ID)
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_supervisor_inprocess_query.py
+++ b/tests/supervisor/test_supervisor_inprocess_query.py
@@ -52,7 +52,6 @@ def make_execution(
         is_confidential=confidential,
         is_awaiting_confidential_init=False,
         hypervisor=hypervisor,
-        vm_spec=None,
         vm=vm,
         gpus=[],
         wait_for_controller_ready=AsyncMock(),

--- a/tests/supervisor/test_supervisor_spec_pool_create.py
+++ b/tests/supervisor/test_supervisor_spec_pool_create.py
@@ -311,24 +311,6 @@ async def test_create_vm_from_spec_conflicting_spec_raises_already_exists():
         await pool.create_vm_from_spec(replace(spec, memory_mib=4096))
 
 
-@pytest.mark.asyncio
-async def test_create_vm_from_spec_collision_with_message_built_vm_raises():
-    """A live message-built execution (vm_spec=None) for the same hash is a
-    conflict too: the pool cannot prove the spec matches."""
-    from types import SimpleNamespace
-
-    from aleph_message.models import ItemHash
-
-    from aleph.vm.supervisor_interface.errors import VmAlreadyExistsError
-
-    pool = _bare_pool()
-    live = SimpleNamespace(is_running=True, is_stopping=False, vm_spec=None)
-    pool.executions[ItemHash(_HASH)] = live
-
-    with pytest.raises(VmAlreadyExistsError):
-        await pool.create_vm_from_spec(_spec())
-
-
 # ── pool.reserve_gpus — message-free GPU reservation ───────────────────────
 
 


### PR DESCRIPTION
## What

`VmExecution.spec` is a required, non-optional field (`spec: CreateVmSpec`), and every construction path now goes through `VmExecution.from_spec` — `create_vm_from_spec` for new VMs and the restart-recovery path via `spec_from_controller_configuration`. No code path produces a spec-less execution, so `vm_spec` is never `None` in production. The remaining `spec is None` checks are leftovers from the now-removed message-built construction path.

This removes the unreachable defensive branches and the tests that only exercised them by faking the impossible `vm_spec=None` state via mocks.

## Changes

- **`LocalSupervisor.get_vm_spec`** — drop the `spec is None` → `NotImplementedSupervisorError` guard; return the held spec directly.
- **`LocalSupervisor.reboot_vm`** — drop the `if spec is not None:` wrapper and the "message-built ephemeral, stop only" fallback. Spec-built ephemeral VMs already reboot via `create_vm_from_spec`; that path stays and is covered by `test_reboot_ephemeral_spec_vm_recreates_from_held_spec`.
- **`VmPool._require_same_spec`** — fix the stale docstring referencing a `vm_spec=None` collision that can no longer occur.
- Remove three tests that fabricated `vm_spec=None` through mocks: the reboot stop-only test, the `get_vm_spec` NotImplemented test, and the pool-collision test.

## Why it's safe

Behaviour-neutral: the type system already guarantees `spec` is present, so the removed branches were dead. The reachable behaviour stays fully covered by the surviving tests. `NotImplementedSupervisorError` is still used by the deliberate ephemeral-lifecycle guards (stop/start/restore), so the import remains.

## Verification

- `ruff==0.4.6` format: all touched files already formatted; lint introduces no new findings (only deletes code).
- `py_compile` clean on all four files.
- Full pytest deferred to CI: the local env can't build `dbus-python`/`systemd-python` (no `libdbus-1-dev`, sudo unavailable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)