### PR TITLE
fix(supervisor): isolate per-VM reattach failures and protect live VMs

### DIFF
--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -617,6 +617,13 @@ class VmPool:
         # avoid two VMs sharing a tap interface.
         claimed_vm_ids: set[int] = set()
 
+        # A controller that is alive but whose in-memory reattach failed. Its
+        # vm_index/hash are protected from the orphan sweep below: the VM is
+        # still running, so stopping its service or deleting its config would
+        # destroy a live instance -- far worse than not tracking it this cycle.
+        failed_vm_ids: set[int] = set()
+        failed_vm_hashes: set[str] = set()
+
         for config in configs:
             vm_id = VmId(str(config.vm_hash))
             vm_index = config.vm_id
@@ -638,9 +645,24 @@ class VmPool:
 
             logger.info("Reattaching execution %s for VM %d", vm_id, vm_index)
             claimed_vm_ids.add(vm_index)
-            await self._restore_running_execution_from_config(config, vm_index, vm_id)
+            try:
+                await self._restore_running_execution_from_config(config, vm_index, vm_id)
+            except Exception:
+                # One VM's reattach must never deny reattach to the rest of the
+                # node (and, in-process, must never crash startup). The
+                # controller is alive and the VM is running; only our in-memory
+                # rebuild failed -- e.g. an unsupported config (confidential),
+                # or a transient prepare/network error. Leave the live VM and
+                # its on-disk artifacts untouched and carry on with the others.
+                logger.exception(
+                    "Failed to reattach %s (vm_index %d); leaving its controller running and untracked this cycle",
+                    vm_id,
+                    vm_index,
+                )
+                failed_vm_ids.add(vm_index)
+                failed_vm_hashes.add(str(config.vm_hash))
 
-        self._cleanup_orphan_resources()
+        self._cleanup_orphan_resources(protected_vm_ids=failed_vm_ids, protected_vm_hashes=failed_vm_hashes)
 
         logger.info("Loaded %d executions", len(self.executions))
 
@@ -713,15 +735,28 @@ class VmPool:
         except Exception:
             logger.warning("Failed to stop/disable stale controller %s", service_name, exc_info=True)
 
-    def _cleanup_orphan_resources(self):
+    def _cleanup_orphan_resources(
+        self,
+        protected_vm_ids: set[int] | None = None,
+        protected_vm_hashes: set[str] | None = None,
+    ):
         """Remove orphan nft rules, nft chains, tap interfaces, and controller configs.
 
         Compares host resources against active executions in the pool
         and removes anything that doesn't belong to a running VM.
         Fetches the nftables ruleset once and passes it to both nft cleanup methods.
+
+        ``protected_vm_ids``/``protected_vm_hashes`` are VMs whose controllers
+        are alive but which are not in ``self.executions`` (a reattach that
+        failed): they are treated as active so the sweep does not stop their
+        services, delete their configs, or tear down their networking.
         """
         active_vm_ids = {execution.vm_index for execution in self.executions.values() if execution.vm_index is not None}
         active_vm_hashes = {str(vm_id) for vm_id in self.executions}
+        if protected_vm_ids:
+            active_vm_ids |= protected_vm_ids
+        if protected_vm_hashes:
+            active_vm_hashes |= protected_vm_hashes
 
         nft_ruleset = get_existing_nftables_ruleset()
         self._cleanup_orphan_port_redirects(nft_ruleset)

--- a/tests/supervisor/test_supervisor_reattach.py
+++ b/tests/supervisor/test_supervisor_reattach.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -69,8 +69,6 @@ async def test_handle_dead_controller_stops_service():
 async def test_failed_reattach_does_not_abort_the_rest(tmp_path):
     """A single VM whose restore raises (e.g. an unsupported confidential
     config) must not stop the other active VMs from reattaching."""
-    from unittest.mock import patch
-
     hash_ok = "a" * 64
     hash_bad = "b" * 64
     pool = _bare_pool()

--- a/tests/supervisor/test_supervisor_reattach.py
+++ b/tests/supervisor/test_supervisor_reattach.py
@@ -66,6 +66,69 @@ async def test_handle_dead_controller_stops_service():
 
 
 @pytest.mark.asyncio
+async def test_failed_reattach_does_not_abort_the_rest(tmp_path):
+    """A single VM whose restore raises (e.g. an unsupported confidential
+    config) must not stop the other active VMs from reattaching."""
+    from unittest.mock import patch
+
+    hash_ok = "a" * 64
+    hash_bad = "b" * 64
+    pool = _bare_pool()
+    pool.systemd_manager.get_services_active_states = MagicMock(
+        return_value={
+            f"aleph-vm-controller@{hash_ok}.service": True,
+            f"aleph-vm-controller@{hash_bad}.service": True,
+        }
+    )
+    for h in (hash_ok, hash_bad):
+        (tmp_path / f"{h}-controller.json").write_text("{}")
+    configs = {hash_ok: SimpleNamespace(vm_hash=hash_ok, vm_id=1), hash_bad: SimpleNamespace(vm_hash=hash_bad, vm_id=2)}
+
+    async def fake_restore(config, vm_index, vm_id):
+        if str(config.vm_hash) == hash_bad:
+            msg = "reattach supports QemuVMConfiguration only"
+            raise RuntimeError(msg)
+        pool.executions[vm_id] = SimpleNamespace(vm_index=vm_index)
+
+    with (
+        patch("aleph.vm.pool.settings", SimpleNamespace(EXECUTION_ROOT=tmp_path)),
+        patch("aleph.vm.pool.load_controller_configuration", side_effect=lambda h: configs[h]),
+        patch.object(pool, "_restore_running_execution_from_config", side_effect=fake_restore),
+        patch.object(pool, "_handle_dead_controller", new_callable=AsyncMock) as dead,
+        patch.object(pool, "_cleanup_orphan_resources") as cleanup,
+    ):
+        await pool.load_persistent_executions()
+
+    # The healthy VM reattached despite the other one failing.
+    assert VmId(hash_ok) in pool.executions
+    # The failed VM's live controller is left running, not killed as "dead".
+    dead.assert_not_called()
+    # And it is protected from the orphan sweep so cleanup cannot delete its
+    # config or tear down its networking while the VM is still running.
+    _, kwargs = cleanup.call_args
+    assert kwargs["protected_vm_ids"] == {2}
+    assert kwargs["protected_vm_hashes"] == {hash_bad}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_orphan_resources_treats_protected_as_active(monkeypatch):
+    """A protected (failed-reattach) VM must not be swept: its vm_index and
+    hash are unioned into the active sets the cleanup helpers receive."""
+    pool = _bare_pool()
+    seen: dict[str, object] = {}
+    monkeypatch.setattr("aleph.vm.pool.get_existing_nftables_ruleset", lambda: [])
+    monkeypatch.setattr(pool, "_cleanup_orphan_port_redirects", lambda _ruleset: None)
+    monkeypatch.setattr(pool, "_cleanup_orphan_nft_chains", lambda ids, _ruleset: seen.update(ids=ids))
+    monkeypatch.setattr(pool, "_cleanup_orphan_tap_interfaces", lambda _ids: None)
+    monkeypatch.setattr(pool, "_cleanup_orphan_controller_configs", lambda hashes: seen.update(hashes=hashes))
+
+    pool._cleanup_orphan_resources(protected_vm_ids={5}, protected_vm_hashes={"c" * 64})
+
+    assert seen["ids"] == {5}
+    assert seen["hashes"] == {"c" * 64}
+
+
+@pytest.mark.asyncio
 async def test_restore_running_execution_from_config_registers_execution(monkeypatch):
     pool = _bare_pool()
     config = SimpleNamespace(vm_hash=_HASH, vm_id=7)


### PR DESCRIPTION
## Problem

`load_persistent_executions` awaited each VM's restore with **no try/except** (`pool.py:642`), so a single failure aborted the entire reattach loop. The realistic trigger is a live **confidential (SEV)** instance: `spec_from_controller_configuration` rejects `QemuConfidentialVMConfiguration` with `InvalidBackendError`, and any `prepare()`/network error raises too.

Consequences on a node hosting even one such VM:
- **Split mode**: the daemon survives (its caller wraps `load_persistent_executions` in `except Exception`), but every VM after the failure in that pass is left un-reattached.
- **In-process mode (the default)**: the caller at `agent/supervisor.py:489` only catches `OSError`, so the exception crashes agent startup — a crash loop, since the live controller keeps the config "active".

## Fix

Wrap the per-VM restore in `try/except`: one VM's failure is logged (`logger.exception`) and skipped while the rest reattach.

The subtle part: a skipped VM must **not** be treated as a dead controller. Its controller is still running, so stopping the service or deleting `controller.json` would **destroy a live instance** — worse than the original crash. `_cleanup_orphan_resources()` runs right after the loop and does exactly that to any VM absent from `self.executions` (stops+disables the service, deletes the config, tears down tap/nft). So the failed VM's `vm_index`/`hash` are now passed to `_cleanup_orphan_resources` as **protected** sets, unioned into the "active" sets the sweep uses. The live VM and its on-disk artifacts are left fully intact; it's simply untracked in-memory for this cycle.

## Scope

This is the **robustness** half of the confidential-reattach problem — it stops one VM from taking down reattach for the whole node and stops the startup crash. Making confidential reattach actually *succeed* (so SEV instances are re-adopted, not just left running-but-untracked) is a separate follow-up.

## Tests

- `test_failed_reattach_does_not_abort_the_rest`: with two active configs where one restore raises, the healthy VM still reattaches, the failed VM is **not** killed as a dead controller, and its index/hash are handed to cleanup as protected.
- `test_cleanup_orphan_resources_treats_protected_as_active`: protected ids/hashes are unioned into the active sets passed to the cleanup helpers.

## Verification

`ruff==0.4.6` format + lint clean on changed files (no new findings); `py_compile` clean. Full pytest deferred to CI (local env can't build `dbus-python`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)