### PR TITLE
fix(agent): reattach failure must not crash in-process supervisor startup

### DIFF
--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -492,7 +492,16 @@ def run():
 
         if pool is not None:
             logger.info("Loading existing executions ...")
-            asyncio.run(pool.load_persistent_executions())
+            try:
+                asyncio.run(pool.load_persistent_executions())
+            except Exception:
+                # Reattach must never keep the agent down: a failed recovery of
+                # a leftover execution should still leave the supervisor serving,
+                # with the live VMs untouched. Mirrors the gRPC daemon's reattach
+                # guard (supervisor/daemon.py). Without this, the only handler
+                # below is `except OSError` (web-server port), so any other error
+                # here would crash startup into a restart loop.
+                logger.exception("Reattaching previous executions failed; continuing with the executions loaded so far")
         # Each asyncio.run() creates and destroys its own event loop.
         # Discard any HTTP session created during setup/loading so it
         # doesn't hold a reference to the dead loop.


### PR DESCRIPTION
## Problem

The in-process (default, non-split) startup path runs reattach at `agent/supervisor.py:495`:

```python
asyncio.run(pool.load_persistent_executions())
```

…inside a `try` whose **only** handler is `except OSError` (the web-server port-in-use case at line ~513); everything else is re-raised. So any error escaping reattach — an unsupported confidential config (`InvalidBackendError`), a `prepare()`/network failure, a systemd/D-Bus hiccup — **crashes agent startup**. With systemd auto-restart and the live controllers still keeping their configs "active", that's a **crash loop**.

The gRPC daemon path was already hardened (`supervisor/daemon.py:50` wraps the same call in `except Exception`). This PR removes the asymmetry.

## Fix

Wrap the in-process call in `except Exception`, log, and keep serving — mirroring the daemon guard. A botched recovery now leaves the supervisor **up** (live VMs untouched) instead of crash-looping.

## Relationship to the per-VM isolation PR

Defence in depth. The per-VM isolation change stops a *single* VM from aborting the reattach loop; this one stops *anything* still escaping `load_persistent_executions` (e.g. a failure in the batched systemd query or the orphan sweep itself) from taking down the process. Either alone helps; together the in-process path is as robust as the daemon path.

## Tests

No unit test: `run()` is the top-level process entrypoint (calls `web.run_app`, which blocks), with no clean seam to exercise — the daemon's equivalent guard is likewise not unit-tested. Verified by inspection; the behavior mirrors the already-reviewed `daemon.py` guard and is exercised end-to-end by the daemon-restart integration path. `ruff==0.4.6` format/lint clean (no new findings), `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)