### PR TITLE
feat(supervisor): reattach confidential (SEV) VMs after a restart

### DIFF
--- a/src/aleph/vm/supervisor/qemu_build.py
+++ b/src/aleph/vm/supervisor/qemu_build.py
@@ -29,12 +29,15 @@ from aleph.vm.supervisor_interface.errors import InvalidBackendError
 from aleph.vm.supervisor_interface.types import (
     Backend,
     CreateVmSpec,
+    DirectoryPath,
     DiskFormat,
     DiskRole,
     DiskSpec,
     GpuSpec,
     NetworkConfig,
     PciAddress,
+    TeeBackend,
+    TeeConfig,
     VmId,
 )
 
@@ -282,13 +285,14 @@ async def build_qemu_confidential_configuration(
 def spec_from_controller_configuration(config: Configuration) -> CreateVmSpec:
     """Reconstruct a CreateVmSpec from an on-disk controller Configuration.
 
-    The inverse of build_qemu_configuration, used by reboot-recovery to
-    reattach a running VM message-free. Only non-confidential QEMU configs
-    are supported (QemuConfidentialVMConfiguration is a separate type).
+    The inverse of build_qemu_configuration / build_qemu_confidential_configuration,
+    used by reboot-recovery to reattach a running VM message-free. Plain and
+    confidential (SEV) QEMU configs are both supported; the difference is the
+    reconstructed TeeConfig.
     """
     vm_cfg = config.vm_configuration
-    if not isinstance(vm_cfg, QemuVMConfiguration):
-        msg = f"Reattach supports QemuVMConfiguration only, got {type(vm_cfg).__name__}"
+    if not isinstance(vm_cfg, QemuVMConfiguration | QemuConfidentialVMConfiguration):
+        msg = f"Reattach supports QEMU configurations only, got {type(vm_cfg).__name__}"
         raise InvalidBackendError(msg)
 
     disks: list[DiskSpec] = [
@@ -310,6 +314,22 @@ def spec_from_controller_configuration(config: Configuration) -> CreateVmSpec:
 
     gpus = [GpuSpec(pci_host=PciAddress(g.pci_host), supports_x_vga=g.supports_x_vga) for g in vm_cfg.gpus]
 
+    tee: TeeConfig | None = None
+    if isinstance(vm_cfg, QemuConfidentialVMConfiguration):
+        # Invert build_qemu_confidential_configuration: the on-disk OVMF path is
+        # the resolved firmware, the SEV policy crosses back as a hex string
+        # (matching the message path's hex(trusted_execution.policy)), and the
+        # session dir is where the owner's uploaded certs already live. Reattach
+        # only needs firmware_path (AlephQemuConfidentialResources.from_spec);
+        # the running controller already holds the measured launch -- we are not
+        # re-provisioning, so no fresh session upload is required.
+        tee = TeeConfig(
+            backend=TeeBackend.SEV,
+            policy=hex(vm_cfg.sev_policy),
+            session_dir=DirectoryPath(vm_cfg.sev_session_file.parent),
+            firmware_path=Path(vm_cfg.ovmf_path),
+        )
+
     return CreateVmSpec(
         vm_id=VmId(str(config.vm_hash)),
         backend=Backend.QEMU,
@@ -318,7 +338,7 @@ def spec_from_controller_configuration(config: Configuration) -> CreateVmSpec:
         disks=disks,
         vcpus=vm_cfg.vcpu_count,
         memory_mib=vm_cfg.mem_size_mb.count,
-        tee=None,
+        tee=tee,
         network=NetworkConfig(
             internet_access=bool(vm_cfg.interface_name),
             requested_ipv6="",

--- a/tests/supervisor/test_supervisor_spec_from_config.py
+++ b/tests/supervisor/test_supervisor_spec_from_config.py
@@ -12,12 +12,13 @@ from aleph.vm.supervisor.qemu_build import spec_from_controller_configuration
 from aleph.vm.supervisor_interface.configuration import (
     Configuration,
     HypervisorType,
+    QemuConfidentialVMConfiguration,
     QemuGPU,
     QemuVMConfiguration,
     QemuVMHostVolume,
 )
 from aleph.vm.supervisor_interface.errors import InvalidBackendError
-from aleph.vm.supervisor_interface.types import Backend, DiskRole
+from aleph.vm.supervisor_interface.types import Backend, DiskRole, TeeBackend
 
 _HASH = "deadbeef" * 8
 
@@ -64,6 +65,54 @@ def test_spec_from_config_roundtrips_core_fields():
 def test_spec_from_config_no_interface_means_no_internet():
     spec = spec_from_controller_configuration(_config(interface_name=None))
     assert spec.network.internet_access is False
+
+
+def _confidential_config() -> Configuration:
+    vm_cfg = QemuConfidentialVMConfiguration(
+        qemu_bin_path="/usr/bin/qemu-system-x86_64",
+        image_path="/data/rootfs.qcow2",
+        monitor_socket_path=Path("/run/m.socket"),
+        qmp_socket_path=Path("/run/q.socket"),
+        vcpu_count=4,
+        mem_size_mb=MiB(2048),
+        interface_name="tap7",
+        host_volumes=[QemuVMHostVolume(mount="/mnt/data", path_on_host=Path("/data/extra.img"), read_only=True)],
+        gpus=[QemuGPU(pci_host="0000:01:00.0", supports_x_vga=True)],
+        ovmf_path=Path("/opt/ovmf/OVMF.fd"),
+        sev_session_file=Path(f"/var/lib/aleph/sessions/{_HASH}/vm_session.b64"),
+        sev_dh_cert_file=Path(f"/var/lib/aleph/sessions/{_HASH}/vm_godh.b64"),
+        sev_policy=1,
+    )
+    return Configuration(
+        vm_id=7,
+        vm_hash=_HASH,
+        settings=real_settings,
+        vm_configuration=vm_cfg,
+        hypervisor=HypervisorType.qemu,
+    )
+
+
+def test_spec_from_config_reconstructs_confidential_tee():
+    """A confidential (SEV) controller config must reattach, not raise: the
+    TeeConfig is rebuilt so the execution stays confidential and create() can
+    take the AlephQemuConfidentialInstance path."""
+    spec = spec_from_controller_configuration(_confidential_config())
+
+    assert spec.tee is not None
+    assert spec.tee.backend is TeeBackend.SEV
+    # firmware_path is the only field AlephQemuConfidentialResources.from_spec
+    # requires; it must be the on-disk OVMF blob.
+    assert spec.tee.firmware_path == Path("/opt/ovmf/OVMF.fd")
+    # Policy round-trips through int(.., 0) exactly (create() converts it back).
+    assert int(spec.tee.policy, 0) == 1
+    # Session dir is where the owner's already-uploaded certs live.
+    assert spec.tee.session_dir == Path(f"/var/lib/aleph/sessions/{_HASH}")
+    # Core fields still reconstruct, same as the plain path.
+    assert spec.backend is Backend.QEMU
+    assert spec.vcpus == 4
+    assert spec.memory_mib == 2048
+    rootfs = [d for d in spec.disks if d.role is DiskRole.ROOTFS]
+    assert rootfs[0].path == Path("/data/rootfs.qcow2")
 
 
 def test_spec_from_config_rejects_non_qemu():


### PR DESCRIPTION
## Problem

`spec_from_controller_configuration` rejected `QemuConfidentialVMConfiguration` with `InvalidBackendError`, so a **running confidential (SEV) instance could not be re-adopted** on supervisor restart. This is a regression vs 1.13, which rebuilt the execution from the stored aleph message. Combined with the unguarded restore loop (#1001), one live SEV VM could take down reattach for the whole node — and crash in-process startup (#1002).

This is the **feature** half of the confidential-reattach problem: #1001/#1002 make a failure survivable; this makes confidential reattach actually *succeed*.

## Fix

Reconstruct a `TeeConfig` from the on-disk confidential config, inverting `build_qemu_confidential_configuration`:

| Spec field | ← source | Notes |
|---|---|---|
| `firmware_path` | `ovmf_path` | The **only** field reattach needs — `AlephQemuConfidentialResources.from_spec` requires just the resolved OVMF blob |
| `policy` | `hex(sev_policy)` | Matches the message path's `hex(trusted_execution.policy)`; `create()` converts back via `int(.., 0)` |
| `session_dir` | `sev_session_file.parent` | Where the owner's already-uploaded certs live |
| `backend` | `TeeBackend.SEV` | |

## Why it's safe

Reattach re-adopts an **already-running, already-measured** VM. `_restore_running_execution_from_config` calls `prepare()` + `create(prepare=False)` + `start_guest_api()` — it **never** calls `start()`, so it does not re-boot the guest, rewrite the controller config, or enable/start the systemd unit (the controller is already active). No fresh session-cert upload is required.

The SAFETY-CRITICAL "a confidential VM must never boot under a weaker configuration" invariant is untouched: this path doesn't boot anything, and a later reboot-recreate still goes through `build_qemu_confidential_configuration`, which re-validates firmware + session files and hard-stops if they're missing.

A reattached confidential VM is correctly reported as **running**, not awaiting-init: `is_awaiting_confidential_init` is False once the VM is running, and the reattach loop only restores controllers systemd reports active.

## Tests

- `test_spec_from_config_reconstructs_confidential_tee`: a confidential config rebuilds a `TeeConfig` (SEV backend, `firmware_path == ovmf_path`, `int(policy, 0)` round-trips the SEV policy, `session_dir == sev_session_file.parent`) and the core fields reconstruct as in the plain path.
- `test_spec_from_config_rejects_non_qemu` still holds — a Firecracker `VMConfiguration` is still rejected.

## Verification

`ruff==0.4.6` format + lint clean on changed files (the one new finding, `UP038`, fixed by using the `X | Y` isinstance form; remaining findings are pre-existing in `build_cloud_init_drive`/`build_qemu_confidential_configuration`); `isort` clean; `py_compile` clean. Full pytest deferred to CI (local env can't build `dbus-python`).

## Stacking

Independent of #1001 and #1002 (different files), all branched off `dev`; mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)