### PR TITLE
fix(storage): don't cap large runtime/image downloads at 300s, retry on timeout

### DIFF
--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -37,6 +37,12 @@ from aleph.vm.utils import fix_message_validation, run_in_subprocess
 logger = logging.getLogger(__name__)
 DEVICE_MAPPER_DIRECTORY = "/dev/mapper"
 
+# Runtimes and base images can be several hundred MiB and are sometimes served by slow
+# gateways (e.g. IPFS). We must not cap the *total* transfer time, or large-but-steady
+# downloads get killed mid-stream; instead guard against genuine stalls with sock timeouts.
+DOWNLOAD_SOCKET_CONNECT_TIMEOUT_SECONDS = 30
+DOWNLOAD_SOCKET_READ_TIMEOUT_SECONDS = 120
+
 
 class CorruptedFilesystemError(Exception):
     """Raised when a file containing a filesystem is corrupted."""
@@ -63,7 +69,14 @@ async def file_downloaded_by_another_task(final_path: Path) -> None:
 
 
 async def download_file_in_chunks(url: str, tmp_path: Path) -> None:
-    async with aiohttp.ClientSession() as session:
+    # No total timeout: a 500+ MiB image over a slow gateway is a legitimate multi-minute
+    # download. sock_read makes the request fail fast only if the transfer truly stalls.
+    timeout = aiohttp.ClientTimeout(
+        total=None,
+        sock_connect=DOWNLOAD_SOCKET_CONNECT_TIMEOUT_SECONDS,
+        sock_read=DOWNLOAD_SOCKET_READ_TIMEOUT_SECONDS,
+    )
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         resp = await session.get(url)
         resp.raise_for_status()
 
@@ -126,6 +139,8 @@ async def download_file(url: str, local_path: Path) -> None:
             aiohttp.ClientConnectionError,
             aiohttp.ClientResponseError,
             aiohttp.ClientPayloadError,
+            # A stalled transfer raises asyncio.TimeoutError (sock_read); retry it too.
+            asyncio.TimeoutError,
         ) as error:
             if attempt < (download_attempts - 1):
                 logger.warning(f"Download failed, retrying attempt {attempt + 1}/{download_attempts}...")

--- a/tests/supervisor/test_storage.py
+++ b/tests/supervisor/test_storage.py
@@ -1,8 +1,10 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 
-from aleph.vm.storage import get_latest_amend
+from aleph.vm.storage import download_file, download_file_in_chunks, get_latest_amend
 
 ORIGINAL_HASH = "a" * 64
 AMEND_HASH = "b" * 64
@@ -125,3 +127,74 @@ async def test_get_latest_amend_queries_by_owner_not_sender():
     amend_lookup_url = captured_urls[1]
     assert f"owners={OWNER}" in amend_lookup_url
     assert "addresses=" not in amend_lookup_url
+
+
+def _empty_body_session_mock() -> MagicMock:
+    """Mock aiohttp.ClientSession that serves an immediately-empty response body."""
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.content = MagicMock()
+    response.content.read = AsyncMock(return_value=b"")  # empty -> loop ends immediately
+    session.get = AsyncMock(return_value=response)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_download_file_in_chunks_does_not_cap_total_time(tmp_path):
+    """A large but steady download must not be killed by aiohttp's default total=300s timeout.
+
+    The session must be built with no total cap and a sock_read stall guard instead, so a
+    legitimately slow multi-hundred-MB download from a slow gateway can still complete.
+    """
+    captured_timeout: list = []
+
+    def _session_factory(**kwargs):
+        captured_timeout.append(kwargs.get("timeout"))
+        return _empty_body_session_mock()
+
+    with patch("aleph.vm.storage.aiohttp.ClientSession", side_effect=_session_factory):
+        await download_file_in_chunks("http://example.com/file", tmp_path / "out.part")
+
+    timeout = captured_timeout[0]
+    assert isinstance(timeout, aiohttp.ClientTimeout)
+    assert timeout.total is None, "total time must be uncapped for large downloads"
+    assert timeout.sock_read is not None, "a sock_read stall guard must be set"
+
+
+@pytest.mark.asyncio
+async def test_download_file_retries_on_timeout(tmp_path):
+    """A timed-out chunk download must be retried, not aborted on the first failure."""
+    local_path = tmp_path / "runtime"
+    calls = {"n": 0}
+
+    async def _flaky(_url, _target_path):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise TimeoutError
+        # success: download_file already created the .part file via touch()
+
+    with patch("aleph.vm.storage.download_file_in_chunks", side_effect=_flaky):
+        await download_file("http://example.com/runtime", local_path)
+
+    assert calls["n"] == 3
+    assert local_path.is_file()
+
+
+@pytest.mark.asyncio
+async def test_download_file_aborts_after_exhausting_retries_on_timeout(tmp_path):
+    """If every attempt times out, the error propagates after the retries are exhausted."""
+    local_path = tmp_path / "runtime"
+
+    async def _always_timeout(_url, _target_path):
+        raise TimeoutError
+
+    with patch("aleph.vm.storage.download_file_in_chunks", side_effect=_always_timeout):
+        with pytest.raises(asyncio.TimeoutError):
+            await download_file("http://example.com/runtime", local_path)
+
+    assert not local_path.is_file()
+    assert not (tmp_path / "runtime.part").exists()


### PR DESCRIPTION
Backport of #1004 to `dev`, so the fix ships with the agent / supervisor split release.

Cherry-pick of the same commit; the diff is identical to #1004 (`storage.py` and `test_storage.py` are identical between `main` and `dev`, so it applied cleanly).

## Problem

A CRN operator's node wouldn't dispatch instances — it appeared "stuck downloading a runtime." Every instance failed with `asyncio.TimeoutError` at `storage.py` `resp.content.read()`, on a strict ~5-minute cadence.

### Root cause

`download_file_in_chunks` used a bare `aiohttp.ClientSession()`, inheriting aiohttp's default `ClientTimeout(total=300s)` — a hard cap on the *whole* transfer. Runtimes / instance base images are routinely several hundred MiB and are sometimes served by slow gateways (the affected base image was a 582 MiB IPFS file on `ipfs.aleph.im`, delivered at a steady ~300 KB/s ≈ 34 min). Every attempt was guillotined at 300s, so the instance never started.

Compounded by `download_file`'s retry loop not catching `asyncio.TimeoutError`, so a timed-out download got zero retries.

## Fix

- `download_file_in_chunks`: build the session with `total=None` plus `sock_read`/`sock_connect` stall guards — slow-but-steady large downloads complete; genuine stalls still fail fast.
- `download_file`: add `asyncio.TimeoutError` to the retry tuple.

## Tests

TDD, added to `tests/supervisor/test_storage.py` (each watched failing first):
- `test_download_file_in_chunks_does_not_cap_total_time`
- `test_download_file_retries_on_timeout`
- `test_download_file_aborts_after_exhausting_retries_on_timeout`

All 7 tests in the file pass; ruff clean on the changed lines.