### PR TITLE
revert(supervisor): fail startup on systemic reattach errors (revert #1002)

### DIFF
--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -492,16 +492,13 @@ def run():
 
         if pool is not None:
             logger.info("Loading existing executions ...")
-            try:
-                asyncio.run(pool.load_persistent_executions())
-            except Exception:
-                # Reattach must never keep the agent down: a failed recovery of
-                # a leftover execution should still leave the supervisor serving,
-                # with the live VMs untouched. Mirrors the gRPC daemon's reattach
-                # guard (supervisor/daemon.py). Without this, the only handler
-                # below is `except OSError` (web-server port), so any other error
-                # here would crash startup into a restart loop.
-                logger.exception("Reattaching previous executions failed; continuing with the executions loaded so far")
+            # No guard here on purpose: per-VM reattach failures are isolated
+            # inside load_persistent_executions (one bad VM is skipped, its live
+            # controller protected). Anything that still escapes is systemic --
+            # an unparseable controller config (a supervisor bug) or a broken
+            # systemd/D-Bus -- and must abort startup rather than bring the agent
+            # up with a pool that does not reflect what is actually running.
+            asyncio.run(pool.load_persistent_executions())
         # Each asyncio.run() creates and destroys its own event loop.
         # Discard any HTTP session created during setup/loading so it
         # doesn't hold a reference to the dead loop.

--- a/src/aleph/vm/supervisor/daemon.py
+++ b/src/aleph/vm/supervisor/daemon.py
@@ -46,13 +46,14 @@ async def run_daemon(socket_path: Path) -> None:
     await pool.setup()
 
     logger.info("Reattaching executions that survived a previous run ...")
-    try:
-        await pool.load_persistent_executions()
-    except Exception:
-        # Reattach must not keep the daemon down: a failed recovery of one
-        # leftover (or a host without the expected nftables base chains)
-        # should still leave the contract reachable for the agent.
-        logger.exception("Reattaching previous executions failed; continuing with an empty pool")
+    # No guard here on purpose (kept symmetric with the in-process agent path):
+    # per-VM reattach failures -- including a host missing the expected nftables
+    # base chains -- are isolated inside load_persistent_executions, which marks
+    # the VM failed and protects its live controller. Anything that still escapes
+    # is systemic (an unparseable controller config, or a broken systemd/D-Bus)
+    # and must abort startup rather than serve gRPC from a pool that does not
+    # reflect what is actually running.
+    await pool.load_persistent_executions()
 
     socket_path.parent.mkdir(parents=True, exist_ok=True)
     if socket_path.exists():


### PR DESCRIPTION
## Why

#1002 wrapped the in-process reattach in `except Exception` so a failed recovery never kept the agent down. Now that #1001 isolates **per-VM** failures *inside* `load_persistent_executions` (skip the bad VM, protect its live controller), that outer guard only ever catches **systemic** failures — and swallowing those is the wrong call.

A systemic failure means an unparseable `controller.json` (a supervisor bug / schema regression) or a broken systemd/D-Bus. If we swallow it and come up anyway, the supervisor serves capacity admission and `list_vms` from a pool that **doesn't reflect what's actually running**: it oversubscribes the host (admits new VMs on top of live ones it can't see → OOM) and the agent treats live VMs as gone (→ recreate attempts). Refusing to start is safer and surfaces the bug to a human.

## Taxonomy adopted

| Failure | Behavior |
|---|---|
| systemd / D-Bus | abort startup — the service restart *is* the recovery |
| unparseable controller config | abort startup — don't operate on a corrupt source of truth |
| per-VM runtime failure (network, etc.) | isolated by #1001 — skip + protect the live VM; never escapes; startup proceeds |

## Change

Remove the `except Exception` guard in **both** reattach callers so split and monolith modes behave identically:
- `agent/supervisor.py` — the literal #1002 revert (in-process path).
- `supervisor/daemon.py` — the same pre-existing guard (gRPC split path). Leaving it would re-create the split/in-process asymmetry #1002 set out to fix, just inverted.

The daemon comment's old "host missing nftables base chains" worry is now a **per-VM** failure (`_restore_network` raises inside the loop) absorbed by #1001, not something the outer guard needs to catch — so nothing systemic-but-benign starts crashing as a result.

## Follow-ups (this is step 1 of 3)

2. Make `create_vm_from_spec` idempotent against a live-but-untracked controller (prevents the agent from clobbering a VM whose reattach failed).
3. Retry + bounded escalation for protected-but-failed VMs (heal transient failures in place; never leave a VM in limbo).

## Verification

`ruff==0.4.6` format clean; `py_compile` clean. No new tests (removes a guard; behavior is "let it propagate"). Full pytest deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)