### PR TITLE
fix(supervisor): re-adopt a live controller on create instead of clobbering it

### DIFF
--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -309,6 +309,16 @@ class VmPool:
                 self._require_same_spec(current_execution, spec)
                 return current_execution
 
+            # The VM may already be running without a pool entry: a prior
+            # reattach failed and was isolated (#1001), leaving the live
+            # controller protected but untracked. Re-adopt it rather than
+            # building a fresh VM on top -- a fresh create reuses the index/tap
+            # and control sockets the live qemu still holds (it never wipes the
+            # disks, but it bounces or collides with a running instance).
+            readopted = await self._readopt_live_controller(vm_id)
+            if readopted is not None:
+                return readopted
+
             # Authoritative capacity admission, folded into the create path so
             # the check and the registration below are atomic under the lock.
             self.check_spec_admission(spec)
@@ -406,6 +416,35 @@ class VmPool:
 
             self._schedule_forget_on_stop(execution)
             return execution
+
+    async def _readopt_live_controller(self, vm_id: VmId) -> VmExecution | None:
+        """Re-adopt a VM whose controller is still running but is absent from the
+        pool (a reattach that failed and was isolated by load_persistent_executions).
+
+        Returns the re-adopted execution, or None when there is nothing live to
+        adopt -- no on-disk config, or the controller is not active -- in which
+        case the caller proceeds with a normal create (an inactive controller is
+        a clean restart-from-disk, which is safe).
+
+        Called under ``creation_lock``. If re-adoption itself fails (the original
+        transient cause persists), the exception propagates: the caller must NOT
+        fall through to a fresh create over the live controller. The VM stays
+        untracked until the next attempt -- never clobbered.
+        """
+        config = load_controller_configuration(str(vm_id))
+        if config is None:
+            return None
+        service_name = f"aleph-vm-controller@{vm_id}.service"
+        if not self.systemd_manager.get_services_active_states([service_name]).get(service_name, False):
+            return None
+
+        logger.warning(
+            "create requested for %s but its controller is already running and untracked "
+            "(a previous reattach failed); re-adopting it instead of creating a duplicate",
+            vm_id,
+        )
+        await self._restore_running_execution_from_config(config, config.vm_id, vm_id)
+        return self.executions[vm_id]
 
     async def _create_firecracker_from_spec(self, spec: CreateVmSpec) -> VmExecution:
         """Message-free Firecracker boot.

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -434,10 +434,11 @@ class VmPool:
         restart-from-disk, which is safe).
 
         Fail-closed: when systemd cannot report a definitive unit state (a
-        D-Bus error, or a transitional activating/deactivating state), this
-        raises InternalSupervisorError so the create fails and the agent
-        retries later, instead of falling through to a fresh create over a
-        possibly live controller.
+        D-Bus error, or a transitional activating/deactivating state), or when
+        the VM's on-disk vm_index is meanwhile claimed by another tracked
+        execution, this raises InternalSupervisorError so the create fails and
+        the agent retries later, instead of falling through to a fresh create
+        over a possibly live controller.
 
         Called under ``creation_lock``. If re-adoption itself fails (the original
         transient cause persists), the exception propagates: the caller must NOT
@@ -463,6 +464,23 @@ class VmPool:
             msg = (
                 f"Cannot determine the state of controller {service_name} (ActiveState: {state}); "
                 f"refusing to create VM {vm_id} over a possibly live controller, retry later"
+            )
+            raise InternalSupervisorError(msg)
+
+        # The on-disk vm_index may have been handed to a newer VM after the
+        # failed reattach (get_unique_vm_index only sees tracked executions).
+        # Restoring on it would rewire that VM's tap/nftables (the restore
+        # path trusts the index), and a fresh create over the live controller
+        # is forbidden, so the only safe outcome is to fail.
+        claimed_by = next(
+            (other_id for other_id, execution in self.executions.items() if execution.vm_index == config.vm_id),
+            None,
+        )
+        if claimed_by is not None:
+            msg = (
+                f"Cannot re-adopt VM {vm_id}: its on-disk vm_index {config.vm_id} is now claimed by "
+                f"running VM {claimed_by}; refusing to rewire that VM's networking or to create a "
+                f"duplicate, operator intervention required"
             )
             raise InternalSupervisorError(msg)
 

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -29,10 +29,12 @@ from aleph.vm.supervisor.qemu_build import (
 )
 from aleph.vm.supervisor_interface.configuration import (
     Configuration,
+    get_controller_configuration_path,
     load_controller_configuration,
     save_controller_configuration,
 )
 from aleph.vm.supervisor_interface.errors import (
+    InternalSupervisorError,
     InvalidBackendError,
     VmAlreadyExistsError,
 )
@@ -421,22 +423,44 @@ class VmPool:
         """Re-adopt a VM whose controller is still running but is absent from the
         pool (a reattach that failed and was isolated by load_persistent_executions).
 
-        Returns the re-adopted execution, or None when there is nothing live to
-        adopt -- no on-disk config, or the controller is not active -- in which
-        case the caller proceeds with a normal create (an inactive controller is
-        a clean restart-from-disk, which is safe).
+        Returns the re-adopted execution, or None when there is positively
+        nothing live to adopt (no on-disk config, or the controller unit is
+        inactive, failed, or not loaded), in which case the caller proceeds
+        with a normal create (an inactive controller is a clean
+        restart-from-disk, which is safe).
+
+        Fail-closed: when systemd cannot report a definitive unit state (a
+        D-Bus error, or a transitional activating/deactivating state), this
+        raises InternalSupervisorError so the create fails and the agent
+        retries later, instead of falling through to a fresh create over a
+        possibly live controller.
 
         Called under ``creation_lock``. If re-adoption itself fails (the original
         transient cause persists), the exception propagates: the caller must NOT
         fall through to a fresh create over the live controller. The VM stays
-        untracked until the next attempt -- never clobbered.
+        untracked until the next attempt, never clobbered.
         """
+        # Probe for the config file before calling the loader: for a genuinely
+        # new VM there is no file and load_controller_configuration would log
+        # a spurious "not found" warning on every create.
+        if not get_controller_configuration_path(str(vm_id)).exists():
+            return None
         config = load_controller_configuration(str(vm_id))
         if config is None:
             return None
         service_name = f"aleph-vm-controller@{vm_id}.service"
-        if not self.systemd_manager.get_services_active_states([service_name]).get(service_name, False):
+        state = self.systemd_manager.get_service_active_state(service_name)
+        if state in ("inactive", "failed", "not-loaded"):
+            # Positively not running: a fresh create is a clean restart.
             return None
+        if state != "active":
+            # "unknown" (a D-Bus failure) or a transitional state: we cannot
+            # tell whether the controller is live, so refuse to create.
+            msg = (
+                f"Cannot determine the state of controller {service_name} (ActiveState: {state}); "
+                f"refusing to create VM {vm_id} over a possibly live controller, retry later"
+            )
+            raise InternalSupervisorError(msg)
 
         logger.warning(
             "create requested for %s but its controller is already running and untracked "

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -319,6 +319,10 @@ class VmPool:
             # disks, but it bounces or collides with a running instance).
             readopted = await self._readopt_live_controller(vm_id)
             if readopted is not None:
+                # Same idempotency contract as the tracked-running branch
+                # above: a retry with the identical spec returns the live VM,
+                # a different spec is a conflict, never a silent old-spec VM.
+                self._require_same_spec(readopted, spec)
                 return readopted
 
             # Authoritative capacity admission, folded into the create path so

--- a/tests/supervisor/test_supervisor_reattach.py
+++ b/tests/supervisor/test_supervisor_reattach.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -148,3 +149,57 @@ async def test_restore_running_execution_from_config_registers_execution(monkeyp
     assert execution.vm_spec is execution.spec
     fake_vm.start_guest_api.assert_awaited_once()
     assert execution.ready_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_readopt_live_controller_readopts_when_active(monkeypatch):
+    """A create for a VM whose controller is still running but untracked
+    re-adopts it (retries the reattach) instead of creating a duplicate."""
+    pool = _bare_pool()
+    config = SimpleNamespace(vm_hash=_HASH, vm_id=7)
+    monkeypatch.setattr("aleph.vm.pool.load_controller_configuration", lambda _h: config)
+    pool.systemd_manager.get_services_active_states = MagicMock(
+        return_value={f"aleph-vm-controller@{_HASH}.service": True}
+    )
+    adopted = SimpleNamespace()
+
+    async def fake_restore(_cfg, vm_index, vm_id):
+        assert vm_index == 7  # config.vm_id is the vm_index
+        pool.executions[vm_id] = adopted
+
+    monkeypatch.setattr(pool, "_restore_running_execution_from_config", fake_restore)
+
+    assert await pool._readopt_live_controller(VmId(_HASH)) is adopted
+
+
+@pytest.mark.asyncio
+async def test_readopt_live_controller_none_without_config(monkeypatch):
+    """No on-disk config -> nothing to re-adopt -> normal create proceeds."""
+    pool = _bare_pool()
+    monkeypatch.setattr("aleph.vm.pool.load_controller_configuration", lambda _h: None)
+    assert await pool._readopt_live_controller(VmId(_HASH)) is None
+
+
+@pytest.mark.asyncio
+async def test_readopt_live_controller_none_when_inactive(monkeypatch):
+    """Config exists but the controller is down -> no live VM to clobber, so a
+    normal create (a clean restart-from-disk) is allowed to proceed."""
+    pool = _bare_pool()
+    config = SimpleNamespace(vm_hash=_HASH, vm_id=7)
+    monkeypatch.setattr("aleph.vm.pool.load_controller_configuration", lambda _h: config)
+    pool.systemd_manager.get_services_active_states = MagicMock(return_value={})
+    assert await pool._readopt_live_controller(VmId(_HASH)) is None
+
+
+@pytest.mark.asyncio
+async def test_create_vm_from_spec_short_circuits_to_readopt(monkeypatch):
+    """create_vm_from_spec returns the re-adopted execution and never reaches
+    fresh-create admission when a live untracked controller is found."""
+    pool = _bare_pool()
+    pool.creation_lock = asyncio.Lock()
+    sentinel = SimpleNamespace()
+    monkeypatch.setattr(pool, "_readopt_live_controller", AsyncMock(return_value=sentinel))
+    pool.check_spec_admission = MagicMock(side_effect=AssertionError("must not reach fresh create"))
+
+    assert await pool.create_vm_from_spec(_spec()) is sentinel
+    pool.check_spec_admission.assert_not_called()

--- a/tests/supervisor/test_supervisor_reattach.py
+++ b/tests/supervisor/test_supervisor_reattach.py
@@ -10,6 +10,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aleph.vm.pool import VmPool
+from aleph.vm.supervisor_interface.errors import (
+    InternalSupervisorError,
+    VmAlreadyExistsError,
+)
 from aleph.vm.supervisor_interface.types import (
     Backend,
     CreateVmSpec,
@@ -151,16 +155,23 @@ async def test_restore_running_execution_from_config_registers_execution(monkeyp
     assert execution.ready_event.is_set()
 
 
+def _fake_existing_config(monkeypatch, tmp_path) -> SimpleNamespace:
+    """Point the on-disk config probe at an existing file and stub the loader."""
+    config_path = tmp_path / f"{_HASH}-controller.json"
+    config_path.write_text("{}")
+    config = SimpleNamespace(vm_hash=_HASH, vm_id=7)
+    monkeypatch.setattr("aleph.vm.pool.get_controller_configuration_path", lambda _h: config_path)
+    monkeypatch.setattr("aleph.vm.pool.load_controller_configuration", lambda _h: config)
+    return config
+
+
 @pytest.mark.asyncio
-async def test_readopt_live_controller_readopts_when_active(monkeypatch):
+async def test_readopt_live_controller_readopts_when_active(monkeypatch, tmp_path):
     """A create for a VM whose controller is still running but untracked
     re-adopts it (retries the reattach) instead of creating a duplicate."""
     pool = _bare_pool()
-    config = SimpleNamespace(vm_hash=_HASH, vm_id=7)
-    monkeypatch.setattr("aleph.vm.pool.load_controller_configuration", lambda _h: config)
-    pool.systemd_manager.get_services_active_states = MagicMock(
-        return_value={f"aleph-vm-controller@{_HASH}.service": True}
-    )
+    _fake_existing_config(monkeypatch, tmp_path)
+    pool.systemd_manager.get_service_active_state = MagicMock(return_value="active")
     adopted = SimpleNamespace()
 
     async def fake_restore(_cfg, vm_index, vm_id):
@@ -170,25 +181,47 @@ async def test_readopt_live_controller_readopts_when_active(monkeypatch):
     monkeypatch.setattr(pool, "_restore_running_execution_from_config", fake_restore)
 
     assert await pool._readopt_live_controller(VmId(_HASH)) is adopted
+    pool.systemd_manager.get_service_active_state.assert_called_once_with(f"aleph-vm-controller@{_HASH}.service")
 
 
 @pytest.mark.asyncio
-async def test_readopt_live_controller_none_without_config(monkeypatch):
-    """No on-disk config -> nothing to re-adopt -> normal create proceeds."""
+async def test_readopt_live_controller_none_without_config(monkeypatch, tmp_path):
+    """No on-disk config -> nothing to re-adopt -> normal create proceeds.
+    The loader is never called, so it cannot log a spurious warning."""
     pool = _bare_pool()
-    monkeypatch.setattr("aleph.vm.pool.load_controller_configuration", lambda _h: None)
+    monkeypatch.setattr(
+        "aleph.vm.pool.get_controller_configuration_path", lambda _h: tmp_path / f"{_HASH}-controller.json"
+    )
+    loader = MagicMock(side_effect=AssertionError("loader must not run when the config file is absent"))
+    monkeypatch.setattr("aleph.vm.pool.load_controller_configuration", loader)
+
+    assert await pool._readopt_live_controller(VmId(_HASH)) is None
+    loader.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["inactive", "failed", "not-loaded"])
+async def test_readopt_live_controller_none_when_positively_down(monkeypatch, tmp_path, state):
+    """Config exists but the controller is positively down -> no live VM to
+    clobber, so a normal create (a clean restart-from-disk) is allowed to
+    proceed."""
+    pool = _bare_pool()
+    _fake_existing_config(monkeypatch, tmp_path)
+    pool.systemd_manager.get_service_active_state = MagicMock(return_value=state)
     assert await pool._readopt_live_controller(VmId(_HASH)) is None
 
 
 @pytest.mark.asyncio
-async def test_readopt_live_controller_none_when_inactive(monkeypatch):
-    """Config exists but the controller is down -> no live VM to clobber, so a
-    normal create (a clean restart-from-disk) is allowed to proceed."""
+@pytest.mark.parametrize("state", ["unknown", "activating", "deactivating"])
+async def test_readopt_live_controller_raises_when_state_indeterminate(monkeypatch, tmp_path, state):
+    """When systemd cannot tell whether the controller is live (a D-Bus error
+    or a transitional state), the create must fail so the agent retries later,
+    instead of falling through to a fresh create over a live controller."""
     pool = _bare_pool()
-    config = SimpleNamespace(vm_hash=_HASH, vm_id=7)
-    monkeypatch.setattr("aleph.vm.pool.load_controller_configuration", lambda _h: config)
-    pool.systemd_manager.get_services_active_states = MagicMock(return_value={})
-    assert await pool._readopt_live_controller(VmId(_HASH)) is None
+    _fake_existing_config(monkeypatch, tmp_path)
+    pool.systemd_manager.get_service_active_state = MagicMock(return_value=state)
+    with pytest.raises(InternalSupervisorError):
+        await pool._readopt_live_controller(VmId(_HASH))
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_supervisor_reattach.py
+++ b/tests/supervisor/test_supervisor_reattach.py
@@ -230,9 +230,25 @@ async def test_create_vm_from_spec_short_circuits_to_readopt(monkeypatch):
     fresh-create admission when a live untracked controller is found."""
     pool = _bare_pool()
     pool.creation_lock = asyncio.Lock()
-    sentinel = SimpleNamespace()
+    sentinel = SimpleNamespace(vm_spec=_spec())
     monkeypatch.setattr(pool, "_readopt_live_controller", AsyncMock(return_value=sentinel))
     pool.check_spec_admission = MagicMock(side_effect=AssertionError("must not reach fresh create"))
 
     assert await pool.create_vm_from_spec(_spec()) is sentinel
     pool.check_spec_admission.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_vm_from_spec_readopt_requires_same_spec(monkeypatch):
+    """A create whose spec differs from the re-adopted VM's spec is a
+    conflict, same as the tracked-running idempotency branch: the caller must
+    not silently get a VM with the old vcpus/memory."""
+    pool = _bare_pool()
+    pool.creation_lock = asyncio.Lock()
+    readopted = SimpleNamespace(vm_spec=_spec())
+    monkeypatch.setattr(pool, "_readopt_live_controller", AsyncMock(return_value=readopted))
+
+    from dataclasses import replace
+
+    with pytest.raises(VmAlreadyExistsError):
+        await pool.create_vm_from_spec(replace(_spec(), vcpus=4))

--- a/tests/supervisor/test_supervisor_reattach.py
+++ b/tests/supervisor/test_supervisor_reattach.py
@@ -252,3 +252,36 @@ async def test_create_vm_from_spec_readopt_requires_same_spec(monkeypatch):
 
     with pytest.raises(VmAlreadyExistsError):
         await pool.create_vm_from_spec(replace(_spec(), vcpus=4))
+
+
+@pytest.mark.asyncio
+async def test_readopt_live_controller_raises_on_vm_index_conflict(monkeypatch, tmp_path):
+    """The untracked VM's on-disk vm_index may have been handed to a newer VM
+    after the failed reattach. Re-adopting on it would rewire the other VM's
+    tap/nftables (the restore path trusts the index), and a fresh create over
+    the live controller is forbidden, so the only safe outcome is to fail."""
+    pool = _bare_pool()
+    _fake_existing_config(monkeypatch, tmp_path)  # config.vm_id (vm_index) == 7
+    pool.executions[VmId("f" * 64)] = SimpleNamespace(vm_index=7)
+    pool.systemd_manager.get_service_active_state = MagicMock(return_value="active")
+    restore = AsyncMock(side_effect=AssertionError("must not restore on a conflicting vm_index"))
+    monkeypatch.setattr(pool, "_restore_running_execution_from_config", restore)
+
+    with pytest.raises(InternalSupervisorError):
+        await pool._readopt_live_controller(VmId(_HASH))
+    restore.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_vm_from_spec_readopt_failure_does_not_fall_through(monkeypatch):
+    """The fail-closed contract of _readopt_live_controller: when re-adoption
+    fails (the original transient cause persists), the exception propagates
+    out of create_vm_from_spec and the fresh-create path is never reached."""
+    pool = _bare_pool()
+    pool.creation_lock = asyncio.Lock()
+    monkeypatch.setattr(pool, "_readopt_live_controller", AsyncMock(side_effect=RuntimeError("reattach still failing")))
+    pool.check_spec_admission = MagicMock(side_effect=AssertionError("must not reach fresh create"))
+
+    with pytest.raises(RuntimeError, match="reattach still failing"):
+        await pool.create_vm_from_spec(_spec())
+    pool.check_spec_admission.assert_not_called()


### PR DESCRIPTION
## Problem

After a failed reattach, #1001 leaves the VM's controller **running but untracked** (absent from `self.executions`). The agent sees the VM missing from `list_vms` and calls create for it. But `create_vm_from_spec`'s idempotency check (`pool.py:308`) only fires for VMs already in the pool — so it falls through to a **fresh create over the live controller**:

- `get_unique_vm_index` treats the old index as free;
- `prepare_tap`/`create_tap` tears down the tap the running qemu still uses;
- `enable_and_start` targets the already-active unit, with monitor/qmp socket conflicts.

It never wipes the disks (the rootfs is *referenced*, not recreated — verified: `build_qemu_configuration` sets `image_path = spec.require_rootfs().path`), but it **bounces or collides with a live instance**.

## Fix

`_readopt_live_controller`, called under `creation_lock` before the fresh-create path: if a controller config for this `vm_id` is on disk **and** its systemd unit is **active** but the VM isn't in the pool, re-adopt it through the reattach path instead of creating a duplicate.

- **Re-adopt succeeds** → return the adopted execution (the agent's create "just works", and a transient failure that has since cleared heals here).
- **Re-adopt fails** (original cause persists) → the exception propagates. The caller must **never** fall through to a fresh create over a live controller; the VM stays untracked until the next attempt — never clobbered.
- **Controller inactive** → returns `None`, so the normal create proceeds. That's a clean restart-from-disk, which is the intended "restartable without losing disks" behavior.

## Scope

QEMU instances — the reattach-eligible, persistent path. Firecracker dispatches early to `_create_firecracker_from_spec` and isn't reattach-backed.

This nudges `create_vm_from_spec`'s already-flagged `C901` complexity from 11→12 (a pre-existing, CI-tolerated finding, not a new category); I deliberately didn't refactor that large method in this focused PR.

## Tests

- `test_readopt_live_controller_readopts_when_active` — live untracked controller → re-adopts (calls the reattach path, returns the adopted execution).
- `test_readopt_live_controller_none_without_config` / `_none_when_inactive` — no config / inactive controller → returns `None`, normal create proceeds.
- `test_create_vm_from_spec_short_circuits_to_readopt` — create returns the re-adopt result and never reaches admission.

## Stacking

Step 2 of 3 (after the #1002 revert, #1006). Independent of step 3 (proactive retry + bounded escalation), which makes recovery not depend on the agent poking create. `ruff==0.4.6` format/lint clean (no new findings), `isort` clean, `py_compile` clean; full pytest in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)