### PR TITLE
feat(supervisor): retry failed reattachments, give up loudly after a bound

### DIFF
--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -7,6 +7,7 @@ evolve in the future.
 """
 
 import asyncio
+import contextlib
 import logging
 import sys
 from pathlib import Path
@@ -367,6 +368,27 @@ async def drain_in_flight_requests(app: web.Application):
         await pool.drain()
 
 
+async def start_reattach_retry_task(app: web.Application) -> None:
+    """on_startup: retry VMs whose reattach failed at load time (in-process mode).
+
+    No-op in split mode -- the daemon owns the pool and runs its own retry loop.
+    The loop self-terminates once nothing is left to retry.
+    """
+    pool: VmPool | None = app.get("_engine_pool")
+    if pool is None:
+        return
+    app["_reattach_retry_task"] = asyncio.create_task(pool.run_reattach_retry_loop())
+
+
+async def stop_reattach_retry_task(app: web.Application) -> None:
+    """on_cleanup: cancel the reattach retry loop."""
+    task = app.get("_reattach_retry_task")
+    if task is not None:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
 async def stop_all_vms(app: web.Application):
     pool: VmPool | None = app.get("_engine_pool")
     if pool is None:
@@ -457,7 +479,9 @@ def run():
     app.on_startup.append(_run_migration_reaper)
     app.on_startup.append(_rehydrate_vm_registry)
     app.on_startup.append(start_node_hash_discovery)
+    app.on_startup.append(start_reattach_retry_task)
     app.on_cleanup.append(stop_node_hash_discovery)
+    app.on_cleanup.append(stop_reattach_retry_task)
 
     # Store sevctl app singleton only if confidential feature is enabled
     if settings.ENABLE_CONFIDENTIAL_COMPUTING:

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -27,6 +27,7 @@ from aleph.vm.pool import VmPool
 from aleph.vm.sevclient import SevClient
 from aleph.vm.supervisor.grpc_client import GrpcSupervisor
 from aleph.vm.supervisor.local import LocalSupervisor
+from aleph.vm.utils import create_task_log_exceptions
 from aleph.vm.version import __version__
 
 from .node_identity import (
@@ -377,7 +378,7 @@ async def start_reattach_retry_task(app: web.Application) -> None:
     pool: VmPool | None = app.get("_engine_pool")
     if pool is None:
         return
-    app["_reattach_retry_task"] = asyncio.create_task(pool.run_reattach_retry_loop())
+    app["_reattach_retry_task"] = create_task_log_exceptions(pool.run_reattach_retry_loop(), name="reattach-retry-loop")
 
 
 async def stop_reattach_retry_task(app: web.Application) -> None:

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import shutil
 from collections.abc import Iterable
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -60,6 +60,27 @@ from .network.interfaces import remove_orphan_tap_interfaces
 
 logger = logging.getLogger(__name__)
 
+# Background retry of VMs whose reattach failed at startup (their controller is
+# still running but the supervisor could not rebuild its in-memory state). A
+# transient cause (e.g. host networking not ready yet) heals on a later pass.
+REATTACH_RETRY_INTERVAL_SECONDS = 30
+REATTACH_RETRY_MAX_ATTEMPTS = 5
+
+
+@dataclass
+class _FailedReattach:
+    """A VM left running-but-untracked after a failed reattach, pending retry.
+
+    ``attempts`` starts at 1 (the startup attempt). Once it reaches
+    ``REATTACH_RETRY_MAX_ATTEMPTS`` the VM is ``exhausted``: the supervisor stops
+    retrying and leaves the live controller alone (operator intervention needed).
+    """
+
+    config: Configuration
+    vm_index: int
+    attempts: int = 1
+    exhausted: bool = False
+
 
 class VmPool:
     """Pool of existing VMs
@@ -79,12 +100,16 @@ class VmPool:
     """Resources reserved by an user, before launching (only GPU atm)"""
 
     _draining: bool
+    # VMs whose reattach failed and that are awaiting background retry. Keyed by
+    # vm_id; entries are removed once re-adopted, kept (exhausted) once given up.
+    _failed_reattach: dict[VmId, _FailedReattach]
 
     def __init__(self):
         self.executions = {}
         self.reservations = {}
         self.gpus = []
         self._draining = False
+        self._failed_reattach = {}
 
         self.creation_lock = asyncio.Lock()
 
@@ -746,10 +771,68 @@ class VmPool:
                 )
                 failed_vm_ids.add(vm_index)
                 failed_vm_hashes.add(str(config.vm_hash))
+                # Queue it for background retry (run_reattach_retry_loop): a
+                # transient cause may clear and let us adopt it without downtime.
+                self._failed_reattach[vm_id] = _FailedReattach(config=config, vm_index=vm_index)
 
         self._cleanup_orphan_resources(protected_vm_ids=failed_vm_ids, protected_vm_hashes=failed_vm_hashes)
 
         logger.info("Loaded %d executions", len(self.executions))
+
+    @property
+    def unmanaged_vm_ids(self) -> set[VmId]:
+        """VMs whose controller is running but which the supervisor gave up
+        reattaching (Option B). Surfaced for operators; these need manual action."""
+        return {vm_id for vm_id, state in self._failed_reattach.items() if state.exhausted}
+
+    async def run_reattach_retry_loop(self) -> None:
+        """Background loop: retry VMs whose reattach failed at startup.
+
+        Each pass re-attempts adoption for every VM not yet exhausted; a VM that
+        succeeds is dropped, one that fails has its attempt count bumped. After
+        REATTACH_RETRY_MAX_ATTEMPTS the VM is marked exhausted and left alone --
+        its controller keeps running, the supervisor just cannot manage it
+        (operator intervention required). The loop exits once nothing is left to
+        retry, so a clean startup (no failures) returns immediately.
+        """
+        while any(not state.exhausted for state in self._failed_reattach.values()):
+            await asyncio.sleep(REATTACH_RETRY_INTERVAL_SECONDS)
+            await self._retry_failed_reattachments_once()
+
+    async def _retry_failed_reattachments_once(self) -> None:
+        for vm_id, state in list(self._failed_reattach.items()):
+            if state.exhausted:
+                continue
+            # Serialize with create_vm_from_spec so the two adoption paths never
+            # rebuild the same VM concurrently.
+            async with self.creation_lock:
+                if vm_id in self.executions:
+                    # Adopted in the meantime (e.g. by an on-demand create).
+                    del self._failed_reattach[vm_id]
+                    continue
+                try:
+                    await self._restore_running_execution_from_config(state.config, state.vm_index, vm_id)
+                except Exception:
+                    state.attempts += 1
+                    if state.attempts >= REATTACH_RETRY_MAX_ATTEMPTS:
+                        state.exhausted = True
+                        logger.error(
+                            "Giving up reattaching %s after %d attempts. Its controller is still "
+                            "running but the supervisor cannot manage it; the VM is NOT auto-stopped "
+                            "-- operator intervention required.",
+                            vm_id,
+                            state.attempts,
+                        )
+                    else:
+                        logger.warning(
+                            "Reattach retry %d/%d for %s failed; will retry",
+                            state.attempts,
+                            REATTACH_RETRY_MAX_ATTEMPTS,
+                            vm_id,
+                        )
+                else:
+                    del self._failed_reattach[vm_id]
+                    logger.info("Re-adopted previously-failed VM %s on retry", vm_id)
 
     async def _restore_network(self, vm_index: int, vm_id: VmId) -> TapInterface | None:
         """Restore tap interface, NDP proxy, and nftables rules for a VM."""

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -841,13 +841,19 @@ class VmPool:
 
     async def _retry_failed_reattachments_once(self) -> None:
         for vm_id, state in list(self._failed_reattach.items()):
+            if vm_id in self.executions:
+                # Adopted in the meantime (e.g. by an on-demand create). Checked
+                # before the exhausted skip so even a given-up entry is dropped
+                # once another path tracks the VM.
+                del self._failed_reattach[vm_id]
+                continue
             if state.exhausted:
                 continue
             # Serialize with create_vm_from_spec so the two adoption paths never
             # rebuild the same VM concurrently.
             async with self.creation_lock:
                 if vm_id in self.executions:
-                    # Adopted in the meantime (e.g. by an on-demand create).
+                    # Adopted while we waited for the lock.
                     del self._failed_reattach[vm_id]
                     continue
                 # Liveness gate: the controller was alive at startup, but it may
@@ -897,7 +903,7 @@ class VmPool:
             )
         else:
             logger.warning(
-                "Reattach retry %d/%d for %s failed; will retry",
+                "Reattach attempt %d/%d for %s failed; will retry",
                 state.attempts,
                 REATTACH_RETRY_MAX_ATTEMPTS,
                 vm_id,

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -810,29 +810,58 @@ class VmPool:
                     # Adopted in the meantime (e.g. by an on-demand create).
                     del self._failed_reattach[vm_id]
                     continue
+                # Liveness gate: the controller was alive at startup, but it may
+                # have died since. Restoring a dead one would register a phantom
+                # "running" execution (the restore never talks to the guest).
+                service_name = f"aleph-vm-controller@{vm_id}.service"
+                active_state = self.systemd_manager.get_service_active_state(service_name)
+                if active_state in ("inactive", "failed", "not-loaded"):
+                    # Positively dead: clean up the stale unit and stop retrying.
+                    logger.warning(
+                        "Controller of queued VM %s is %s; it died since startup. "
+                        "Cleaning it up and dropping it from reattach retries.",
+                        vm_id,
+                        active_state,
+                    )
+                    await self._handle_dead_controller(state.config)
+                    del self._failed_reattach[vm_id]
+                    continue
+                if active_state != "active":
+                    # "unknown" (D-Bus error) or a transitional state
+                    # (activating/deactivating): not proof of death, so treat it
+                    # exactly like a failed restore attempt and retry later.
+                    self._note_reattach_retry_failure(vm_id, state)
+                    continue
                 try:
                     await self._restore_running_execution_from_config(state.config, state.vm_index, vm_id)
                 except Exception:
-                    state.attempts += 1
-                    if state.attempts >= REATTACH_RETRY_MAX_ATTEMPTS:
-                        state.exhausted = True
-                        logger.error(
-                            "Giving up reattaching %s after %d attempts. Its controller is still "
-                            "running but the supervisor cannot manage it; the VM is NOT auto-stopped "
-                            "-- operator intervention required.",
-                            vm_id,
-                            state.attempts,
-                        )
-                    else:
-                        logger.warning(
-                            "Reattach retry %d/%d for %s failed; will retry",
-                            state.attempts,
-                            REATTACH_RETRY_MAX_ATTEMPTS,
-                            vm_id,
-                        )
+                    self._note_reattach_retry_failure(vm_id, state)
                 else:
                     del self._failed_reattach[vm_id]
                     logger.info("Re-adopted previously-failed VM %s on retry", vm_id)
+
+    def _note_reattach_retry_failure(self, vm_id: VmId, state: _FailedReattach) -> None:
+        """Spend one reattach attempt for ``vm_id``; mark it exhausted at the cap.
+
+        ``attempts`` counts TOTAL attempts, including the one made at startup.
+        """
+        state.attempts += 1
+        if state.attempts >= REATTACH_RETRY_MAX_ATTEMPTS:
+            state.exhausted = True
+            logger.error(
+                "Giving up reattaching %s after %d attempts. Its controller is still "
+                "running but the supervisor cannot manage it; the VM is NOT auto-stopped "
+                "-- operator intervention required.",
+                vm_id,
+                state.attempts,
+            )
+        else:
+            logger.warning(
+                "Reattach retry %d/%d for %s failed; will retry",
+                state.attempts,
+                REATTACH_RETRY_MAX_ATTEMPTS,
+                vm_id,
+            )
 
     async def _restore_network(self, vm_index: int, vm_id: VmId) -> TapInterface | None:
         """Restore tap interface, NDP proxy, and nftables rules for a VM."""

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -31,6 +31,7 @@ from aleph.vm.supervisor_interface.configuration import (
     Configuration,
     get_controller_configuration_path,
     load_controller_configuration,
+    remove_controller_configuration,
     save_controller_configuration,
 )
 from aleph.vm.supervisor_interface.errors import (
@@ -784,6 +785,41 @@ class VmPool:
         """VMs whose controller is running but which the supervisor gave up
         reattaching (Option B). Surfaced for operators; these need manual action."""
         return {vm_id for vm_id, state in self._failed_reattach.items() if state.exhausted}
+
+    async def discard_failed_reattach(self, vm_id: VmId) -> bool:
+        """Dequeue a failed-reattach VM (pending or exhausted) and stop its controller.
+
+        The delete path for a VM the supervisor never re-adopted: its
+        controller is running but the VM is not in ``self.executions``.
+        Without this, a delete raises VmNotFoundError while the retry loop
+        (or the next startup) resurrects the controller as an unmanageable,
+        still-billed VM.
+
+        Returns True if an entry was discarded (the controller was stopped
+        and its on-disk definition removed), False if nothing was queued.
+
+        Deliberately takes ``creation_lock``: the retry pass holds it around
+        its liveness check + restore, so acquiring it here guarantees we
+        never stop a controller that a concurrent retry pass is halfway
+        through adopting. If that pass wins the lock and adopts the VM
+        first, the entry is already gone and this returns False; the caller
+        then falls back to its not-found handling and a follow-up delete
+        goes through the tracked path.
+        """
+        async with self.creation_lock:
+            state = self._failed_reattach.pop(vm_id, None)
+            if state is None:
+                return False
+            logger.info(
+                "Discarding failed-reattach VM %s on delete: stopping its untracked controller",
+                vm_id,
+            )
+            # Same cleanup as a dead controller found at startup: stop and
+            # disable the unit, then drop the on-disk definition so neither
+            # the next startup nor systemd revives it.
+            await self._handle_dead_controller(state.config)
+            remove_controller_configuration(str(vm_id))
+            return True
 
     async def run_reattach_retry_loop(self) -> None:
         """Background loop: retry VMs whose reattach failed at startup.

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -516,6 +516,10 @@ class VmPool:
             vm_id,
         )
         await self._restore_running_execution_from_config(config, config.vm_id, vm_id)
+        # The VM may also be queued for background retry (or given up on):
+        # both paths run under creation_lock, so drop the entry here instead
+        # of leaving it to linger in unmanaged_vm_ids and hold its vm_index.
+        self._failed_reattach.pop(vm_id, None)
         return self.executions[vm_id]
 
     async def _create_firecracker_from_spec(self, spec: CreateVmSpec) -> VmExecution:

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -598,8 +598,12 @@ class VmPool:
         This identifier is used to name the network interface and in the IPv4 range
         dedicated to the VM.
         """
-        # Take the first id that is not already taken
+        # Take the first id that is not already taken. Failed-reattach VMs are
+        # not in self.executions but their live controllers still own their
+        # vm_index (tap interface, nft chains): handing one of those to a new
+        # create would let it delete the live VM's networking.
         currently_used_vm_ids = {execution.vm_index for execution in self.executions.values()}
+        currently_used_vm_ids |= {state.vm_index for state in self._failed_reattach.values()}
         for i in range(settings.START_ID_INDEX, 255**2):
             if i not in currently_used_vm_ids:
                 return i

--- a/src/aleph/vm/supervisor/daemon.py
+++ b/src/aleph/vm/supervisor/daemon.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import logging
 import signal
 from pathlib import Path
@@ -60,6 +61,10 @@ async def run_daemon(socket_path: Path) -> None:
         # A previous daemon left its socket behind; a fresh bind needs it gone.
         socket_path.unlink()
 
+    # Retry VMs whose reattach failed above (e.g. host networking not ready yet);
+    # self-terminates once nothing is left to retry.
+    retry_task = asyncio.create_task(pool.run_reattach_retry_loop())
+
     supervisor = LocalSupervisor(pool)
     server = await serve_unix(supervisor, socket_path)
 
@@ -72,6 +77,9 @@ async def run_daemon(socket_path: Path) -> None:
     await stop_event.wait()
 
     logger.info("Stopping the supervisor gRPC server (VMs keep running) ...")
+    retry_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await retry_task
     await server.stop(grace=5)
     socket_path.unlink(missing_ok=True)
 

--- a/src/aleph/vm/supervisor/daemon.py
+++ b/src/aleph/vm/supervisor/daemon.py
@@ -39,6 +39,7 @@ async def run_daemon(socket_path: Path) -> None:
     from aleph.vm.pool import VmPool
     from aleph.vm.supervisor.grpc_server import serve_unix
     from aleph.vm.supervisor.local import LocalSupervisor
+    from aleph.vm.utils import create_task_log_exceptions
 
     engine = metrics.setup_engine()
     await metrics.create_tables(engine)
@@ -63,7 +64,7 @@ async def run_daemon(socket_path: Path) -> None:
 
     # Retry VMs whose reattach failed above (e.g. host networking not ready yet);
     # self-terminates once nothing is left to retry.
-    retry_task = asyncio.create_task(pool.run_reattach_retry_loop())
+    retry_task = create_task_log_exceptions(pool.run_reattach_retry_loop(), name="reattach-retry-loop")
 
     supervisor = LocalSupervisor(pool)
     server = await serve_unix(supervisor, socket_path)

--- a/src/aleph/vm/supervisor/local.py
+++ b/src/aleph/vm/supervisor/local.py
@@ -464,7 +464,18 @@ class LocalSupervisor(Supervisor):
 
     async def delete_vm(self, vm_id: VmId, wipe: bool = False) -> None:
         with translating_errors():
-            execution = self._require(vm_id)
+            execution = self.pool.executions.get(vm_id)
+            if execution is None:
+                # Not tracked, but possibly queued (or given up) for reattach
+                # retry: its controller is still running. Honor the delete by
+                # stopping that controller and dequeuing it; raising
+                # VmNotFoundError here would make the agent forget the VM
+                # while the retry loop resurrects it as an unmanageable,
+                # still-billed instance.
+                if await self.pool.discard_failed_reattach(vm_id):
+                    logger.info("Deleted queued failed-reattach VM %s (untracked controller stopped)", vm_id)
+                    return
+                raise VmNotFoundError(vm_id)
             old_status = self._status_snapshot(execution)
             await self.pool.stop_vm(vm_id)
             self._emit_event(vm_id, old_status, VmStatus.STOPPED)

--- a/tests/supervisor/test_supervisor_grpc.py
+++ b/tests/supervisor/test_supervisor_grpc.py
@@ -47,6 +47,10 @@ class FakePool:
     def __init__(self):
         self.executions = {}
 
+    async def discard_failed_reattach(self, vm_id) -> bool:
+        # Nothing is ever queued for reattach retry in these tests.
+        return False
+
 
 class _ServerHarness:
     """Server + client pair on a short-lived UDS path."""

--- a/tests/supervisor/test_supervisor_inprocess_lifecycle.py
+++ b/tests/supervisor/test_supervisor_inprocess_lifecycle.py
@@ -57,6 +57,35 @@ async def test_delete_unknown_vm_raises():
 
 
 @pytest.mark.asyncio
+async def test_delete_vm_queued_for_reattach_retry_stops_and_dequeues():
+    """A VM whose reattach failed is untracked (not in pool.executions) but
+    its controller is still running and the retry loop would resurrect it.
+    Delete must honor the request: stop the controller and drop the entry
+    instead of raising VmNotFoundError."""
+    import asyncio
+
+    from unittest.mock import patch
+
+    from aleph.vm.pool import VmPool, _FailedReattach
+
+    pool = VmPool.__new__(VmPool)
+    pool.executions = {}
+    pool.network = None
+    pool.snapshot_manager = None
+    pool.systemd_manager = MagicMock()
+    pool.creation_lock = asyncio.Lock()
+    pool._failed_reattach = {VM_ID: _FailedReattach(config=SimpleNamespace(vm_hash=str(VM_ID), vm_id=7), vm_index=7)}
+    sup = LocalSupervisor(pool=pool)
+
+    with patch("aleph.vm.pool.remove_controller_configuration") as remove_config:
+        await sup.delete_vm(VM_ID)  # must not raise
+
+    assert VM_ID not in pool._failed_reattach
+    pool.systemd_manager.stop_and_disable.assert_called_once_with(f"aleph-vm-controller@{VM_ID}.service")
+    remove_config.assert_called_once_with(str(VM_ID))
+
+
+@pytest.mark.asyncio
 async def test_reboot_persistent_vm_restarts_systemd_and_returns_info():
     """RestartUnit only queues a job: reboot must confirm the unit is back
     up before reporting, or callers see BOOTING for a healthy reboot."""

--- a/tests/supervisor/test_supervisor_inprocess_lifecycle.py
+++ b/tests/supervisor/test_supervisor_inprocess_lifecycle.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from test_supervisor_inprocess_query import FakePool, FakeSystemd, make_execution
@@ -63,8 +63,6 @@ async def test_delete_vm_queued_for_reattach_retry_stops_and_dequeues():
     Delete must honor the request: stop the controller and drop the entry
     instead of raising VmNotFoundError."""
     import asyncio
-
-    from unittest.mock import patch
 
     from aleph.vm.pool import VmPool, _FailedReattach
 

--- a/tests/supervisor/test_supervisor_inprocess_query.py
+++ b/tests/supervisor/test_supervisor_inprocess_query.py
@@ -72,6 +72,10 @@ class FakePool:
         self.systemd_manager = systemd or FakeSystemd()
         self.network = network
 
+    async def discard_failed_reattach(self, vm_id):
+        # Mirrors VmPool.discard_failed_reattach: nothing queued by default.
+        return False
+
 
 @pytest.mark.asyncio
 async def test_get_vm_maps_a_running_qemu_instance():

--- a/tests/supervisor/test_supervisor_inprocess_query.py
+++ b/tests/supervisor/test_supervisor_inprocess_query.py
@@ -72,7 +72,7 @@ class FakePool:
         self.systemd_manager = systemd or FakeSystemd()
         self.network = network
 
-    async def discard_failed_reattach(self, vm_id):
+    async def discard_failed_reattach(self, _vm_id):
         # Mirrors VmPool.discard_failed_reattach: nothing queued by default.
         return False
 

--- a/tests/supervisor/test_supervisor_reattach.py
+++ b/tests/supervisor/test_supervisor_reattach.py
@@ -406,6 +406,37 @@ async def test_retry_drops_vm_adopted_elsewhere(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_discard_failed_reattach_stops_unit_and_removes_config():
+    """Deleting a queued (here: even exhausted) failed-reattach VM stops its
+    controller, removes its on-disk definition and dequeues it for good."""
+    from aleph.vm.pool import _FailedReattach
+
+    pool = _bare_pool()
+    pool.creation_lock = asyncio.Lock()
+    state = _FailedReattach(config=SimpleNamespace(vm_hash=_HASH, vm_id=7), vm_index=7, exhausted=True)
+    pool._failed_reattach = {VmId(_HASH): state}
+
+    with patch("aleph.vm.pool.remove_controller_configuration") as remove_config:
+        discarded = await pool.discard_failed_reattach(VmId(_HASH))
+
+    assert discarded is True
+    assert VmId(_HASH) not in pool._failed_reattach
+    pool.systemd_manager.stop_and_disable.assert_called_once_with(f"aleph-vm-controller@{_HASH}.service")
+    remove_config.assert_called_once_with(_HASH)
+
+
+@pytest.mark.asyncio
+async def test_discard_failed_reattach_without_entry_is_a_noop():
+    pool = _bare_pool()
+    pool.creation_lock = asyncio.Lock()
+
+    discarded = await pool.discard_failed_reattach(VmId(_HASH))
+
+    assert discarded is False
+    pool.systemd_manager.stop_and_disable.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_retry_loop_returns_immediately_without_failures():
     """A clean startup (no failed reattachments) makes the loop a no-op."""
     pool = _bare_pool()

--- a/tests/supervisor/test_supervisor_reattach.py
+++ b/tests/supervisor/test_supervisor_reattach.py
@@ -476,3 +476,25 @@ async def test_retry_loop_returns_immediately_without_failures():
     pool = _bare_pool()
     pool._failed_reattach = {}
     await pool.run_reattach_retry_loop()  # must not hang
+
+
+@pytest.mark.asyncio
+async def test_readopt_live_controller_dequeues_failed_reattach(monkeypatch, tmp_path):
+    """A successful re-adopt via create drops the VM from the retry set
+    directly (both paths run under creation_lock), so a queued or exhausted
+    entry does not linger in unmanaged_vm_ids or block its vm_index."""
+    from aleph.vm.pool import _FailedReattach
+
+    pool = _bare_pool()
+    config = _fake_existing_config(monkeypatch, tmp_path)
+    pool._failed_reattach = {VmId(_HASH): _FailedReattach(config=config, vm_index=7, exhausted=True)}
+    pool.systemd_manager.get_service_active_state = MagicMock(return_value="active")
+
+    async def fake_restore(_cfg, vm_index, vm_id):
+        pool.executions[vm_id] = SimpleNamespace(vm_index=vm_index)
+
+    monkeypatch.setattr(pool, "_restore_running_execution_from_config", fake_restore)
+
+    await pool._readopt_live_controller(VmId(_HASH))
+
+    assert VmId(_HASH) not in pool._failed_reattach

--- a/tests/supervisor/test_supervisor_reattach.py
+++ b/tests/supervisor/test_supervisor_reattach.py
@@ -406,6 +406,26 @@ async def test_retry_drops_vm_adopted_elsewhere(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_retry_drops_exhausted_vm_adopted_elsewhere(monkeypatch):
+    """Even a given-up (exhausted) entry is dropped once another path tracks
+    the VM: the adopted-elsewhere cleanup runs before the exhausted skip."""
+    from aleph.vm.pool import _FailedReattach
+
+    pool = _bare_pool()
+    pool.creation_lock = asyncio.Lock()
+    state = _FailedReattach(config=SimpleNamespace(vm_hash=_HASH, vm_id=7), vm_index=7, exhausted=True)
+    pool._failed_reattach = {VmId(_HASH): state}
+    pool.executions[VmId(_HASH)] = SimpleNamespace(vm_index=7)
+    restore = AsyncMock()
+    monkeypatch.setattr(pool, "_restore_running_execution_from_config", restore)
+
+    await pool._retry_failed_reattachments_once()
+
+    assert VmId(_HASH) not in pool._failed_reattach
+    restore.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_discard_failed_reattach_stops_unit_and_removes_config():
     """Deleting a queued (here: even exhausted) failed-reattach VM stops its
     controller, removes its on-disk definition and dequeues it for good."""

--- a/tests/supervisor/test_supervisor_reattach.py
+++ b/tests/supervisor/test_supervisor_reattach.py
@@ -436,6 +436,20 @@ async def test_discard_failed_reattach_without_entry_is_a_noop():
     pool.systemd_manager.stop_and_disable.assert_not_called()
 
 
+def test_get_unique_vm_index_skips_failed_reattach_indexes(monkeypatch):
+    """A queued/exhausted failed-reattach VM still owns its vm_index (tap,
+    nft chains): handing it to a fresh create would let that create tear
+    down the live VM's networking."""
+    from aleph.vm.pool import _FailedReattach
+
+    pool = _bare_pool()
+    monkeypatch.setattr("aleph.vm.pool.settings.START_ID_INDEX", 4, raising=False)
+    pool.executions = {VmId("a" * 64): SimpleNamespace(vm_index=4)}
+    pool._failed_reattach = {VmId(_HASH): _FailedReattach(config=SimpleNamespace(vm_hash=_HASH, vm_id=5), vm_index=5)}
+
+    assert pool.get_unique_vm_index() == 6
+
+
 @pytest.mark.asyncio
 async def test_retry_loop_returns_immediately_without_failures():
     """A clean startup (no failed reattachments) makes the loop a no-op."""

--- a/tests/supervisor/test_supervisor_reattach.py
+++ b/tests/supervisor/test_supervisor_reattach.py
@@ -57,6 +57,7 @@ def _bare_pool() -> VmPool:
     pool.network = None
     pool.snapshot_manager = None
     pool.systemd_manager = MagicMock()
+    pool._failed_reattach = {}
     return pool
 
 

--- a/tests/supervisor/test_supervisor_reattach.py
+++ b/tests/supervisor/test_supervisor_reattach.py
@@ -295,6 +295,7 @@ async def test_retry_readopts_a_failed_vm(monkeypatch):
 
     pool = _bare_pool()
     pool.creation_lock = asyncio.Lock()
+    pool.systemd_manager.get_service_active_state = MagicMock(return_value="active")
     pool._failed_reattach = {VmId(_HASH): _FailedReattach(config=SimpleNamespace(vm_hash=_HASH, vm_id=7), vm_index=7)}
 
     async def fake_restore(_cfg, vm_index, vm_id):
@@ -309,6 +310,56 @@ async def test_retry_readopts_a_failed_vm(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_retry_drops_dead_controller(monkeypatch):
+    """A controller that died since startup must not be re-adopted as a
+    phantom running execution: it is cleaned up and dequeued for good."""
+    from aleph.vm.pool import _FailedReattach
+
+    pool = _bare_pool()
+    pool.creation_lock = asyncio.Lock()
+    pool.systemd_manager.get_service_active_state = MagicMock(return_value="inactive")
+    state = _FailedReattach(config=SimpleNamespace(vm_hash=_HASH, vm_id=7), vm_index=7)
+    pool._failed_reattach = {VmId(_HASH): state}
+    restore = AsyncMock()
+    monkeypatch.setattr(pool, "_restore_running_execution_from_config", restore)
+    dead = AsyncMock()
+    monkeypatch.setattr(pool, "_handle_dead_controller", dead)
+
+    await pool._retry_failed_reattachments_once()
+
+    assert VmId(_HASH) not in pool._failed_reattach
+    assert VmId(_HASH) not in pool.executions
+    dead.assert_awaited_once_with(state.config)
+    restore.assert_not_awaited()
+    pool.systemd_manager.get_service_active_state.assert_called_once_with(f"aleph-vm-controller@{_HASH}.service")
+
+
+@pytest.mark.asyncio
+async def test_retry_unknown_state_counts_as_failed_attempt(monkeypatch):
+    """A D-Bus error ("unknown") is not proof the controller is dead: the
+    entry stays queued, no restore or cleanup happens, one attempt is spent."""
+    from aleph.vm.pool import _FailedReattach
+
+    pool = _bare_pool()
+    pool.creation_lock = asyncio.Lock()
+    pool.systemd_manager.get_service_active_state = MagicMock(return_value="unknown")
+    state = _FailedReattach(config=SimpleNamespace(vm_hash=_HASH, vm_id=7), vm_index=7)
+    pool._failed_reattach = {VmId(_HASH): state}
+    restore = AsyncMock()
+    monkeypatch.setattr(pool, "_restore_running_execution_from_config", restore)
+    dead = AsyncMock()
+    monkeypatch.setattr(pool, "_handle_dead_controller", dead)
+
+    await pool._retry_failed_reattachments_once()
+
+    assert VmId(_HASH) in pool._failed_reattach
+    assert state.attempts == 2
+    assert state.exhausted is False
+    restore.assert_not_awaited()
+    dead.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_retry_exhausts_and_leaves_vm_running(monkeypatch):
     """After MAX attempts the VM is exhausted, kept as unmanaged, and NOT
     auto-stopped (Option B)."""
@@ -316,6 +367,7 @@ async def test_retry_exhausts_and_leaves_vm_running(monkeypatch):
 
     pool = _bare_pool()
     pool.creation_lock = asyncio.Lock()
+    pool.systemd_manager.get_service_active_state = MagicMock(return_value="active")
     state = _FailedReattach(config=SimpleNamespace(vm_hash=_HASH, vm_id=7), vm_index=7)
     pool._failed_reattach = {VmId(_HASH): state}
 

--- a/tests/supervisor/test_supervisor_reattach.py
+++ b/tests/supervisor/test_supervisor_reattach.py
@@ -285,3 +285,76 @@ async def test_create_vm_from_spec_readopt_failure_does_not_fall_through(monkeyp
     with pytest.raises(RuntimeError, match="reattach still failing"):
         await pool.create_vm_from_spec(_spec())
     pool.check_spec_admission.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_retry_readopts_a_failed_vm(monkeypatch):
+    """A queued failed VM is dropped from the retry set once it re-adopts."""
+    from aleph.vm.pool import _FailedReattach
+
+    pool = _bare_pool()
+    pool.creation_lock = asyncio.Lock()
+    pool._failed_reattach = {VmId(_HASH): _FailedReattach(config=SimpleNamespace(vm_hash=_HASH, vm_id=7), vm_index=7)}
+
+    async def fake_restore(_cfg, vm_index, vm_id):
+        pool.executions[vm_id] = SimpleNamespace(vm_index=vm_index)
+
+    monkeypatch.setattr(pool, "_restore_running_execution_from_config", fake_restore)
+
+    await pool._retry_failed_reattachments_once()
+
+    assert VmId(_HASH) not in pool._failed_reattach
+    assert VmId(_HASH) in pool.executions
+
+
+@pytest.mark.asyncio
+async def test_retry_exhausts_and_leaves_vm_running(monkeypatch):
+    """After MAX attempts the VM is exhausted, kept as unmanaged, and NOT
+    auto-stopped (Option B)."""
+    from aleph.vm.pool import REATTACH_RETRY_MAX_ATTEMPTS, _FailedReattach
+
+    pool = _bare_pool()
+    pool.creation_lock = asyncio.Lock()
+    state = _FailedReattach(config=SimpleNamespace(vm_hash=_HASH, vm_id=7), vm_index=7)
+    pool._failed_reattach = {VmId(_HASH): state}
+
+    async def always_fail(_cfg, _vm_index, _vm_id):
+        msg = "still broken"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(pool, "_restore_running_execution_from_config", always_fail)
+
+    for _ in range(REATTACH_RETRY_MAX_ATTEMPTS):
+        await pool._retry_failed_reattachments_once()
+
+    assert state.exhausted is True
+    assert VmId(_HASH) in pool._failed_reattach
+    assert VmId(_HASH) in pool.unmanaged_vm_ids
+    pool.systemd_manager.stop_and_disable.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_retry_drops_vm_adopted_elsewhere(monkeypatch):
+    """If the VM is already in the pool (adopted by an on-demand create), the
+    retry drops it without attempting another restore."""
+    from aleph.vm.pool import _FailedReattach
+
+    pool = _bare_pool()
+    pool.creation_lock = asyncio.Lock()
+    pool._failed_reattach = {VmId(_HASH): _FailedReattach(config=SimpleNamespace(vm_hash=_HASH, vm_id=7), vm_index=7)}
+    pool.executions[VmId(_HASH)] = SimpleNamespace(vm_index=7)
+    restore = AsyncMock()
+    monkeypatch.setattr(pool, "_restore_running_execution_from_config", restore)
+
+    await pool._retry_failed_reattachments_once()
+
+    assert VmId(_HASH) not in pool._failed_reattach
+    restore.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_retry_loop_returns_immediately_without_failures():
+    """A clean startup (no failed reattachments) makes the loop a no-op."""
+    pool = _bare_pool()
+    pool._failed_reattach = {}
+    await pool.run_reattach_retry_loop()  # must not hang

--- a/tests/supervisor/test_supervisor_spec_gpu_create.py
+++ b/tests/supervisor/test_supervisor_spec_gpu_create.py
@@ -79,6 +79,7 @@ def _spec(gpus: list[GpuSpec], *, owner_id: str = "") -> CreateVmSpec:
 def _bare_pool(gpus: list[ResourceGpuDevice]) -> VmPool:
     pool = VmPool.__new__(VmPool)
     pool.executions = {}
+    pool._failed_reattach = {}
     pool.reservations = {}
     pool.gpus = gpus
     pool.network = None

--- a/tests/supervisor/test_supervisor_spec_pool_create.py
+++ b/tests/supervisor/test_supervisor_spec_pool_create.py
@@ -74,6 +74,7 @@ def _bare_pool() -> VmPool:
 
     pool = VmPool.__new__(VmPool)
     pool.executions = {}
+    pool._failed_reattach = {}
     pool.reservations = {}
     pool.network = None  # exercise the no-network branch
     pool.snapshot_manager = None


### PR DESCRIPTION
## What

A VM whose reattach fails at startup is isolated (#1001) — its controller keeps running but the supervisor doesn't manage it. Until now, recovery only happened if the agent later called create (#1007). This adds **proactive** recovery so a VM never sits in limbo waiting to be poked.

## How

- `load_persistent_executions` queues each failed VM in `_failed_reattach`.
- A background loop, `run_reattach_retry_loop`, retries adoption every `REATTACH_RETRY_INTERVAL_SECONDS` (30s). A **transient** cause — host networking not ready yet, a brief D-Bus hiccup — clears and the VM is re-adopted **in place, no downtime, no controller bounce**.
- Retries are serialized with `create_vm_from_spec` via `creation_lock`, so the two adoption paths (proactive retry here, on-demand re-adopt in #1007) never rebuild the same VM at once; whichever adopts first wins and the other drops it from the retry set.

## Bounded escalation — Option B

After `REATTACH_RETRY_MAX_ATTEMPTS` (5) the VM is marked **exhausted**: the supervisor logs an `ERROR` and stops retrying, but **does not auto-stop the live VM**. Rationale (your call): auto-stopping would bounce a running customer instance, and a host-wide failure (e.g. missing nft base chains affecting every VM) would cascade a recoverable glitch into a mass outage. The VM keeps running; recovery then needs operator action. `unmanaged_vm_ids` exposes the give-up set for observability.

Mass-failure detection was intentionally left out (kept simple, per discussion).

## Placement

The loop runs where the pool lives and self-terminates once nothing is left to retry (a clean startup is a no-op):
- **in-process agent** — an aiohttp `on_startup` task (`start_reattach_retry_task`), cancelled on cleanup;
- **gRPC daemon** — a task in `run_daemon`, cancelled on shutdown.

## Tests

- `test_retry_readopts_a_failed_vm` — a queued VM is re-adopted and dropped from the retry set.
- `test_retry_exhausts_and_leaves_vm_running` — after MAX attempts: exhausted, kept as unmanaged, and **not** auto-stopped (`stop_and_disable` never called).
- `test_retry_drops_vm_adopted_elsewhere` — a VM already in the pool is dropped without another restore.
- `test_retry_loop_returns_immediately_without_failures` — clean startup is a no-op (doesn't hang).

## Stacking

Step 3 of 3. Independent of step 1 (#1006 revert) and step 2 (#1007 re-adopt-on-create) — all off `dev`; step 2 and step 3 touch different methods in `pool.py` and compose (on-demand + proactive adoption). `ruff==0.4.6` format/lint clean (no new findings), `isort` clean, `py_compile` clean; full pytest in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)