### PR TITLE
refactor(db): split the DB per actor (supervisor port mappings vs agent records)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,10 +331,9 @@ allow_indirect_imports = "true"
 source_modules = [ "aleph.vm.supervisor", "aleph.vm.pool", "aleph.vm.models" ]
 forbidden_modules = [ "aleph.vm.agent" ]
 # Residuals removed by the VmExecution/VmPool cleave + DB-layer extraction.
+# The DB split (per-actor databases) removed the pool/daemon/local ->
+# agent.metrics residuals; only these two remain.
 ignore_imports = [
   "aleph.vm.models -> aleph.vm.agent.metrics",
-  "aleph.vm.pool -> aleph.vm.agent.metrics",
   "aleph.vm.pool -> aleph.vm.agent.utils",
-  "aleph.vm.supervisor.daemon -> aleph.vm.agent.metrics",
-  "aleph.vm.supervisor.local -> aleph.vm.agent.metrics",
 ]

--- a/src/aleph/vm/agent/cli.py
+++ b/src/aleph/vm/agent/cli.py
@@ -285,6 +285,9 @@ async def run_instances(instances: list[ItemHash]) -> None:
     logger.info(f"Instances to run: {instances}")
     loop = asyncio.get_event_loop()
     pool = VmPool()
+    # Bind the supervisor DB engine (port mappings) and set up the network;
+    # the create path hits that DB on its first port-mapping lookup.
+    await pool.setup()
     # The main program uses a singleton pubsub instance in order to watch for updates.
     # We create another instance here since that singleton is not initialized yet.
     # Watching for updates on this instance will therefore not work.

--- a/src/aleph/vm/agent/metrics.py
+++ b/src/aleph/vm/agent/metrics.py
@@ -4,7 +4,17 @@ from pathlib import Path
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import JSON, Boolean, Column, DateTime, Float, Integer, String, select
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    Integer,
+    String,
+    delete,
+    select,
+)
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -108,3 +118,15 @@ async def get_last_record_for_vm(vm_hash) -> ExecutionRecord | None:
             select(ExecutionRecord).where(ExecutionRecord.vm_hash == vm_hash).limit(1)
         )  # Use execute for querying
         return result.scalar()
+
+
+async def delete_records_for_vm(vm_hash: str) -> None:
+    """Delete every execution record for a VM.
+
+    The on-disk sibling of AgentVmRegistry.forget: called when the agent
+    permanently drops a VM (terminal dealloc, allocation removal, operator
+    erase) so its records do not linger and get re-hydrated on the next restart.
+    """
+    async with AsyncSessionMaker() as session:
+        await session.execute(delete(ExecutionRecord).where(ExecutionRecord.vm_hash == vm_hash))
+        await session.commit()

--- a/src/aleph/vm/agent/metrics.py
+++ b/src/aleph/vm/agent/metrics.py
@@ -1,22 +1,10 @@
 import logging
 from collections.abc import Iterable
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import (
-    JSON,
-    Boolean,
-    Column,
-    DateTime,
-    Float,
-    Index,
-    Integer,
-    String,
-    select,
-    update,
-)
+from sqlalchemy import JSON, Boolean, Column, DateTime, Float, Integer, String, select
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -120,120 +108,3 @@ async def get_last_record_for_vm(vm_hash) -> ExecutionRecord | None:
             select(ExecutionRecord).where(ExecutionRecord.vm_hash == vm_hash).limit(1)
         )  # Use execute for querying
         return result.scalar()
-
-
-class PortMapping(Base):
-    __tablename__ = "port_mappings"
-
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    vm_hash = Column(String, nullable=False, index=True)
-    vm_port = Column(Integer, nullable=False)
-    host_port = Column(Integer, nullable=False)
-    tcp = Column(Boolean, default=False, nullable=False)
-    udp = Column(Boolean, default=False, nullable=False)
-    created_at = Column(DateTime, nullable=False)
-    deleted_at = Column(DateTime, nullable=True)
-
-    __table_args__ = (
-        Index(
-            "ix_port_mappings_host_port_active",
-            host_port,
-            unique=True,
-            sqlite_where=deleted_at.is_(None),
-        ),
-    )
-
-    def __repr__(self):
-        return f"<PortMapping(vm_hash={self.vm_hash}, " f"vm_port={self.vm_port}, host_port={self.host_port})>"
-
-
-async def save_port_mappings(vm_hash: str, mapped_ports: dict[int, dict]) -> None:
-    """Persist port mappings for a VM.
-
-    Only touches rows that actually changed — unchanged mappings are
-    left in place so the audit trail stays meaningful.
-    SQLite serializes writes, so concurrent calls for the same vm_hash
-    are safe.
-    """
-    now = datetime.now(tz=timezone.utc)
-    async with AsyncSessionMaker() as session:
-        result = await session.execute(
-            select(PortMapping).where(
-                PortMapping.vm_hash == vm_hash,
-                PortMapping.deleted_at.is_(None),
-            )
-        )
-        existing = {row.vm_port: row for row in result.scalars().all()}
-
-        new_mappings: list[dict] = []
-        for vm_port, details in mapped_ports.items():
-            port = int(vm_port)
-            host_port = int(details["host"])
-            tcp = bool(details.get("tcp", False))
-            udp = bool(details.get("udp", False))
-
-            old = existing.pop(port, None)
-            if old and old.host_port == host_port and old.tcp == tcp and old.udp == udp:
-                continue
-            # Soft-delete the stale row if it existed
-            if old:
-                old.deleted_at = now
-            new_mappings.append({"vm_port": port, "host_port": host_port, "tcp": tcp, "udp": udp})
-
-        # Soft-delete mappings that are no longer present
-        for old in existing.values():
-            old.deleted_at = now
-
-        # Flush soft-deletes first so the partial unique index on
-        # host_port (WHERE deleted_at IS NULL) is freed before
-        # inserting new rows that may reuse the same host_port.
-        await session.flush()
-
-        for mapping in new_mappings:
-            session.add(
-                PortMapping(
-                    vm_hash=vm_hash,
-                    vm_port=mapping["vm_port"],
-                    host_port=mapping["host_port"],
-                    tcp=mapping["tcp"],
-                    udp=mapping["udp"],
-                    created_at=now,
-                )
-            )
-
-        await session.commit()
-
-
-async def get_port_mappings(vm_hash: str) -> dict[int, dict]:
-    """Load active port mappings for a VM.
-
-    Returns dict mapping vm_port -> {host, tcp, udp}.
-    """
-    async with AsyncSessionMaker() as session:
-        result = await session.execute(
-            select(PortMapping).where(
-                PortMapping.vm_hash == vm_hash,
-                PortMapping.deleted_at.is_(None),
-            )
-        )
-        rows = result.scalars().all()
-        return {
-            row.vm_port: {
-                "host": row.host_port,
-                "tcp": row.tcp,
-                "udp": row.udp,
-            }
-            for row in rows
-        }
-
-
-async def delete_port_mappings(vm_hash: str) -> None:
-    """Soft-delete all active port mappings for a VM."""
-    now = datetime.now(tz=timezone.utc)
-    async with AsyncSessionMaker() as session:
-        await session.execute(
-            update(PortMapping)
-            .where(PortMapping.vm_hash == vm_hash, PortMapping.deleted_at.is_(None))
-            .values(deleted_at=now)
-        )
-        await session.commit()

--- a/src/aleph/vm/agent/tasks.py
+++ b/src/aleph/vm/agent/tasks.py
@@ -27,6 +27,7 @@ from aleph_message.status import MessageStatus
 from yarl import URL
 
 from aleph.vm.agent.haproxy_sync import sync_domain_mappings
+from aleph.vm.agent.metrics import delete_records_for_vm
 from aleph.vm.agent.run import reconcile_port_forwards
 from aleph.vm.agent.utils import (
     format_cost,
@@ -393,6 +394,7 @@ async def check_payment(supervisor: Supervisor, registry: AgentVmRegistry):
             del _terminal_strike_count[key]
             await supervisor.delete_vm(VmId(str(vm_hash)))
             registry.forget(vm_hash)
+            await delete_records_for_vm(str(vm_hash))
         else:
             # Status is healthy — reset any previous strikes
             _terminal_strike_count.pop(str(vm_hash), None)

--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -25,7 +25,7 @@ from aleph.vm.agent.chain import STREAM_CHAINS
 from aleph.vm.agent.custom_logs import set_vm_for_logging
 from aleph.vm.agent.haproxy_sync import sync_domain_mappings
 from aleph.vm.agent.messages import try_get_message
-from aleph.vm.agent.metrics import get_execution_records
+from aleph.vm.agent.metrics import delete_records_for_vm, get_execution_records
 from aleph.vm.agent.node_identity import NodeIdentity
 from aleph.vm.agent.payment import (
     InvalidAddressError,
@@ -601,6 +601,7 @@ async def update_allocations(request: web.Request):
                 except VmNotFoundError:
                     pass
                 registry.forget(vm_hash)
+                await delete_records_for_vm(str(vm_hash))
                 stopped_vms.append(vm_hash)
 
         # Second start persistent VMs and instances sequentially to limit resource usage.

--- a/src/aleph/vm/agent/views/operator.py
+++ b/src/aleph/vm/agent/views/operator.py
@@ -661,6 +661,7 @@ async def operate_erase(request: web.Request, authenticated_sender: str) -> web.
         except VmNotFoundError:
             raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_hash}") from None
         request.app["vm_registry"].forget(vm_hash)
+        await metrics.delete_records_for_vm(str(vm_hash))
         return web.Response(status=200, body=f"Erased VM with ref {vm_hash}")
 
 

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -255,7 +255,10 @@ class Settings(BaseSettings):
     EXECUTION_ROOT: Path = Path("/var/lib/aleph/vm")
     JAILER_BASE_DIRECTORY: Path | None = Field(None, description="Default to EXECUTION_ROOT/jailer")
     EXECUTION_DATABASE: Path | None = Field(
-        None, description="Location of database file. Default to EXECUTION_ROOT/executions.sqlite3"
+        None, description="Agent database file (executions/records). Default to EXECUTION_ROOT/executions.sqlite3"
+    )
+    SUPERVISOR_DATABASE: Path | None = Field(
+        None, description="Supervisor database file (port mappings). Default to EXECUTION_ROOT/supervisor.sqlite3"
     )
     EXECUTION_LOG_ENABLED: bool = False
     EXECUTION_LOG_DIRECTORY: Path | None = Field(
@@ -699,6 +702,8 @@ class Settings(BaseSettings):
             self.PERSISTENT_VOLUMES_DIR = self.EXECUTION_ROOT / "volumes" / "persistent"
         if not self.EXECUTION_DATABASE:
             self.EXECUTION_DATABASE = self.EXECUTION_ROOT / "executions.sqlite3"
+        if not self.SUPERVISOR_DATABASE:
+            self.SUPERVISOR_DATABASE = self.EXECUTION_ROOT / "supervisor.sqlite3"
         if not self.EXECUTION_LOG_DIRECTORY:
             self.EXECUTION_LOG_DIRECTORY = self.EXECUTION_ROOT / "executions"
         if not self.JAILER_BASE_DIR:
@@ -718,6 +723,14 @@ def make_db_url():
 
 def make_sync_db_url():
     return f"sqlite:///{settings.EXECUTION_DATABASE}"
+
+
+def make_supervisor_db_url():
+    return f"sqlite+aiosqlite:///{settings.SUPERVISOR_DATABASE}"
+
+
+def make_supervisor_sync_db_url():
+    return f"sqlite:///{settings.SUPERVISOR_DATABASE}"
 
 
 # Settings singleton

--- a/src/aleph/vm/models.py
+++ b/src/aleph/vm/models.py
@@ -6,11 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 
-from aleph.vm.agent.metrics import (
-    delete_port_mappings,
-    save_execution_data,
-    save_port_mappings,
-)
+from aleph.vm.agent.metrics import save_execution_data
 from aleph.vm.conf import settings
 from aleph.vm.network.firewall import (
     add_entities_if_not_present,
@@ -46,6 +42,7 @@ from aleph.vm.supervisor.controllers.qemu_confidential.instance import (
     AlephQemuConfidentialInstance,
     AlephQemuConfidentialResources,
 )
+from aleph.vm.supervisor.networking_db import delete_port_mappings, save_port_mappings
 from aleph.vm.supervisor_interface.types import (
     Backend,
     CreateVmSpec,

--- a/src/aleph/vm/network/port_availability_checker.py
+++ b/src/aleph/vm/network/port_availability_checker.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import OperationalError
 
-from aleph.vm.conf import make_sync_db_url
+from aleph.vm.conf import make_supervisor_sync_db_url
 from aleph.vm.network.firewall import check_nftables_redirections
 
 logger = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ class _SyncEngineHolder:
     @classmethod
     def get(cls) -> Engine:
         if cls._instance is None:
-            cls._instance = create_engine(make_sync_db_url())
+            cls._instance = create_engine(make_supervisor_sync_db_url())
         return cls._instance
 
     @classmethod

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -10,7 +10,6 @@ from typing import Any
 
 import psutil
 
-from aleph.vm.agent.metrics import get_port_mappings
 from aleph.vm.agent.utils import update_aggregate_settings
 from aleph.vm.conf import settings
 from aleph.vm.network.hostnetwork import Network, make_ipv6_allocator
@@ -22,6 +21,12 @@ from aleph.vm.resources import (
     get_gpu_devices,
 )
 from aleph.vm.supervisor.controllers.firecracker.snapshot_manager import SnapshotManager
+from aleph.vm.supervisor.networking_db import (
+    create_supervisor_tables,
+    get_port_mappings,
+    migrate_port_mappings_from_legacy_db,
+    setup_supervisor_engine,
+)
 from aleph.vm.supervisor.qemu_build import (
     build_qemu_confidential_configuration,
     build_qemu_configuration,
@@ -136,6 +141,14 @@ class VmPool:
 
     async def setup(self) -> None:
         """Set up the VM pool and the network."""
+        # This process runs the pool, so it owns the supervisor DB (port
+        # mappings). Set up its engine, create the schema, and on first start
+        # after the agent/supervisor DB split, migrate any pre-split rows so
+        # live VMs keep their host-port forwards.
+        engine = setup_supervisor_engine()
+        await create_supervisor_tables(engine)
+        migrate_port_mappings_from_legacy_db()
+
         if self.network:
             self.network.setup()
 

--- a/src/aleph/vm/supervisor/daemon.py
+++ b/src/aleph/vm/supervisor/daemon.py
@@ -35,15 +35,13 @@ def default_socket_path() -> Path:
 async def run_daemon(socket_path: Path) -> None:
     # Local imports: pulling the pool imports the controller/networking stack,
     # which must happen after settings.setup().
-    from aleph.vm.agent import metrics
     from aleph.vm.pool import VmPool
     from aleph.vm.supervisor.grpc_server import serve_unix
     from aleph.vm.supervisor.local import LocalSupervisor
     from aleph.vm.utils import create_task_log_exceptions
 
-    engine = metrics.setup_engine()
-    await metrics.create_tables(engine)
-
+    # The supervisor owns only its own DB (port mappings); pool.setup() sets it
+    # up. The agent's executions DB is the agent process's concern.
     pool = VmPool()
     await pool.setup()
 

--- a/src/aleph/vm/supervisor/local.py
+++ b/src/aleph/vm/supervisor/local.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING
 import psutil
 from aleph_message.models.execution.environment import AMDSEVPolicy
 
-from aleph.vm.agent.metrics import delete_port_mappings, get_port_mappings
 from aleph.vm.conf import settings
 from aleph.vm.network.firewall import (
     initialize_nftables,
@@ -45,6 +44,7 @@ from aleph.vm.supervisor.controllers.qemu.backup import (
 )
 from aleph.vm.supervisor.controllers.qemu.client import QemuVmClient
 from aleph.vm.supervisor.error_mapping import translating_errors
+from aleph.vm.supervisor.networking_db import delete_port_mappings, get_port_mappings
 from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.supervisor_interface.configuration import remove_controller_configuration
 from aleph.vm.supervisor_interface.errors import (

--- a/src/aleph/vm/supervisor/networking_db.py
+++ b/src/aleph/vm/supervisor/networking_db.py
@@ -25,7 +25,6 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
     create_async_engine,
 )
-
 from sqlalchemy.orm import declarative_base
 
 from aleph.vm.conf import make_supervisor_db_url, settings

--- a/src/aleph/vm/supervisor/networking_db.py
+++ b/src/aleph/vm/supervisor/networking_db.py
@@ -26,10 +26,7 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
-try:
-    from sqlalchemy.orm import declarative_base
-except ImportError:
-    from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from aleph.vm.conf import make_supervisor_db_url, settings
 
@@ -174,8 +171,10 @@ def migrate_port_mappings_from_legacy_db() -> int:
     agent DB into the supervisor DB so live VMs keep their host-port forwards.
 
     Idempotent and self-skipping: does nothing when the two DBs are the same
-    file, the legacy DB is absent, the legacy table is missing, or the
-    supervisor table already holds rows. Returns the number of rows copied.
+    file, the legacy DB is absent, either table is missing, or the supervisor
+    table already holds rows. Returns the number of rows copied. The supervisor
+    schema is expected to exist (created in ``VmPool.setup``) for the copy to
+    happen; without it the migration skips.
 
     Both stores are SQLite files, so this copies rows verbatim (sync sqlite3),
     preserving created_at; ``id`` is left to autoincrement fresh.
@@ -186,8 +185,11 @@ def migrate_port_mappings_from_legacy_db() -> int:
         return 0
 
     with closing(sqlite3.connect(target)) as tgt:
-        if tgt.execute("SELECT 1 FROM port_mappings LIMIT 1").fetchone():
-            return 0  # already migrated / populated
+        try:
+            if tgt.execute("SELECT 1 FROM port_mappings LIMIT 1").fetchone():
+                return 0  # already migrated / populated
+        except sqlite3.OperationalError:
+            return 0  # supervisor schema not created yet, nothing to copy into
         with closing(sqlite3.connect(f"file:{legacy}?mode=ro", uri=True)) as src:
             try:
                 rows = src.execute(

--- a/src/aleph/vm/supervisor/networking_db.py
+++ b/src/aleph/vm/supervisor/networking_db.py
@@ -1,0 +1,209 @@
+"""Supervisor-owned persistence: the host port-mapping store.
+
+Port mappings are hypervisor state (host DNAT forwards), so they live in the
+supervisor's own database (``settings.SUPERVISOR_DATABASE``), separate from the
+agent's executions database. This module owns the engine, the schema, and the
+CRUD the pool/controllers use.
+
+The process that runs the VM pool (the gRPC daemon, or the agent in-process)
+sets the engine up via :func:`setup_supervisor_engine` inside ``VmPool.setup``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from contextlib import closing
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import Boolean, Column, DateTime, Index, Integer, String, select, update
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+try:
+    from sqlalchemy.orm import declarative_base
+except ImportError:
+    from sqlalchemy.ext.declarative import declarative_base
+
+from aleph.vm.conf import make_supervisor_db_url, settings
+
+logger = logging.getLogger(__name__)
+
+SupervisorSessionMaker: async_sessionmaker[AsyncSession]
+
+Base: Any = declarative_base()
+
+
+def setup_supervisor_engine() -> AsyncEngine:
+    global SupervisorSessionMaker
+    engine = create_async_engine(make_supervisor_db_url(), echo=False)
+    SupervisorSessionMaker = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    return engine
+
+
+async def create_supervisor_tables(engine: AsyncEngine) -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+class PortMapping(Base):
+    __tablename__ = "port_mappings"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    vm_hash = Column(String, nullable=False, index=True)
+    vm_port = Column(Integer, nullable=False)
+    host_port = Column(Integer, nullable=False)
+    tcp = Column(Boolean, default=False, nullable=False)
+    udp = Column(Boolean, default=False, nullable=False)
+    created_at = Column(DateTime, nullable=False)
+    deleted_at = Column(DateTime, nullable=True)
+
+    __table_args__ = (
+        Index(
+            "ix_port_mappings_host_port_active",
+            host_port,
+            unique=True,
+            sqlite_where=deleted_at.is_(None),
+        ),
+    )
+
+    def __repr__(self):
+        return f"<PortMapping(vm_hash={self.vm_hash}, vm_port={self.vm_port}, host_port={self.host_port})>"
+
+
+async def save_port_mappings(vm_hash: str, mapped_ports: dict[int, dict]) -> None:
+    """Persist port mappings for a VM.
+
+    Only touches rows that actually changed — unchanged mappings are
+    left in place so the audit trail stays meaningful.
+    SQLite serializes writes, so concurrent calls for the same vm_hash
+    are safe.
+    """
+    now = datetime.now(tz=timezone.utc)
+    async with SupervisorSessionMaker() as session:
+        result = await session.execute(
+            select(PortMapping).where(
+                PortMapping.vm_hash == vm_hash,
+                PortMapping.deleted_at.is_(None),
+            )
+        )
+        existing = {row.vm_port: row for row in result.scalars().all()}
+
+        new_mappings: list[dict] = []
+        for vm_port, details in mapped_ports.items():
+            port = int(vm_port)
+            host_port = int(details["host"])
+            tcp = bool(details.get("tcp", False))
+            udp = bool(details.get("udp", False))
+
+            old = existing.pop(port, None)
+            if old and old.host_port == host_port and old.tcp == tcp and old.udp == udp:
+                continue
+            # Soft-delete the stale row if it existed
+            if old:
+                old.deleted_at = now
+            new_mappings.append({"vm_port": port, "host_port": host_port, "tcp": tcp, "udp": udp})
+
+        # Soft-delete mappings that are no longer present
+        for old in existing.values():
+            old.deleted_at = now
+
+        # Flush soft-deletes first so the partial unique index on
+        # host_port (WHERE deleted_at IS NULL) is freed before
+        # inserting new rows that may reuse the same host_port.
+        await session.flush()
+
+        for mapping in new_mappings:
+            session.add(
+                PortMapping(
+                    vm_hash=vm_hash,
+                    vm_port=mapping["vm_port"],
+                    host_port=mapping["host_port"],
+                    tcp=mapping["tcp"],
+                    udp=mapping["udp"],
+                    created_at=now,
+                )
+            )
+
+        await session.commit()
+
+
+async def get_port_mappings(vm_hash: str) -> dict[int, dict]:
+    """Load active port mappings for a VM.
+
+    Returns dict mapping vm_port -> {host, tcp, udp}.
+    """
+    async with SupervisorSessionMaker() as session:
+        result = await session.execute(
+            select(PortMapping).where(
+                PortMapping.vm_hash == vm_hash,
+                PortMapping.deleted_at.is_(None),
+            )
+        )
+        rows = result.scalars().all()
+        return {
+            row.vm_port: {
+                "host": row.host_port,
+                "tcp": row.tcp,
+                "udp": row.udp,
+            }
+            for row in rows
+        }
+
+
+async def delete_port_mappings(vm_hash: str) -> None:
+    """Soft-delete all active port mappings for a VM."""
+    now = datetime.now(tz=timezone.utc)
+    async with SupervisorSessionMaker() as session:
+        await session.execute(
+            update(PortMapping)
+            .where(PortMapping.vm_hash == vm_hash, PortMapping.deleted_at.is_(None))
+            .values(deleted_at=now)
+        )
+        await session.commit()
+
+
+def migrate_port_mappings_from_legacy_db() -> int:
+    """One-time upgrade migration: copy active port mappings from the pre-split
+    agent DB into the supervisor DB so live VMs keep their host-port forwards.
+
+    Idempotent and self-skipping: does nothing when the two DBs are the same
+    file, the legacy DB is absent, the legacy table is missing, or the
+    supervisor table already holds rows. Returns the number of rows copied.
+
+    Both stores are SQLite files, so this copies rows verbatim (sync sqlite3),
+    preserving created_at; ``id`` is left to autoincrement fresh.
+    """
+    legacy = Path(settings.EXECUTION_DATABASE)
+    target = Path(settings.SUPERVISOR_DATABASE)
+    if legacy == target or not legacy.exists():
+        return 0
+
+    with closing(sqlite3.connect(target)) as tgt:
+        if tgt.execute("SELECT 1 FROM port_mappings LIMIT 1").fetchone():
+            return 0  # already migrated / populated
+        with closing(sqlite3.connect(f"file:{legacy}?mode=ro", uri=True)) as src:
+            try:
+                rows = src.execute(
+                    "SELECT vm_hash, vm_port, host_port, tcp, udp, created_at, deleted_at "
+                    "FROM port_mappings WHERE deleted_at IS NULL"
+                ).fetchall()
+            except sqlite3.OperationalError:
+                return 0  # legacy DB predates the port_mappings table
+        if not rows:
+            return 0
+        tgt.executemany(
+            "INSERT INTO port_mappings (vm_hash, vm_port, host_port, tcp, udp, created_at, deleted_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        tgt.commit()
+
+    logger.info("Migrated %d port mapping(s) from the legacy agent DB into the supervisor DB", len(rows))
+    return len(rows)

--- a/tests/supervisor/test_agent_vm_registry.py
+++ b/tests/supervisor/test_agent_vm_registry.py
@@ -222,3 +222,42 @@ async def test_persist_then_rehydrate_round_trip(monkeypatch):
     assert rec.message is parsed
     assert rec.original is parsed
     assert rec.persistent is True
+
+
+@pytest.mark.asyncio
+async def test_delete_records_for_vm_removes_only_that_vm(monkeypatch):
+    """delete_records_for_vm drops every record for one vm_hash and no other."""
+    from datetime import datetime, timezone
+
+    from sqlalchemy.ext.asyncio import (
+        AsyncSession,
+        async_sessionmaker,
+        create_async_engine,
+    )
+
+    import aleph.vm.agent.metrics as metrics_mod
+    from aleph.vm.agent.metrics import (
+        Base,
+        delete_records_for_vm,
+        get_last_record_for_vm,
+        save_record,
+    )
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    monkeypatch.setattr(
+        metrics_mod,
+        "AsyncSessionMaker",
+        async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession),
+        raising=False,
+    )
+    now = datetime.now(tz=timezone.utc)
+    for uuid_, vm_hash in (("u1", "h1"), ("u2", "h1"), ("u3", "other")):
+        await save_record(ExecutionRecord(uuid=uuid_, vm_hash=vm_hash, time_defined=now, vcpus=1, memory=1))
+
+    await delete_records_for_vm("h1")
+
+    assert await get_last_record_for_vm("h1") is None
+    assert await get_last_record_for_vm("other") is not None
+    await engine.dispose()

--- a/tests/supervisor/test_checkpayment.py
+++ b/tests/supervisor/test_checkpayment.py
@@ -258,6 +258,7 @@ async def test_removed_message_status(mocker, fake_instance_content):
     mocker.patch("aleph.vm.agent.tasks.get_community_wallet_address", return_value=mock_community_wallet_address)
     mocker.patch("aleph.vm.agent.tasks.get_message_status", return_value=MessageStatus.REMOVED)
     mocker.patch("aleph.vm.agent.tasks.compute_required_flow", return_value=5)
+    mock_delete_records = mocker.patch("aleph.vm.agent.tasks.delete_records_for_vm", new_callable=mocker.AsyncMock)
     message = InstanceContent.model_validate(fake_instance_content)
 
     hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadece"
@@ -278,7 +279,8 @@ async def test_removed_message_status(mocker, fake_instance_content):
 
     await check_payment(supervisor=supervisor, registry=registry)
     # Terminal-status dealloc: supervisor.delete_vm (which owns port-mapping
-    # cleanup hypervisor-side) + registry.forget.
+    # cleanup hypervisor-side) + registry.forget + delete the persisted record.
     supervisor.delete_vm.assert_awaited_once_with(VmId(str(hash)))
+    mock_delete_records.assert_awaited_once_with(hash)
     assert ItemHash(hash) not in registry
     # pool.stop_vm and pool.forget_vm must NOT be called

--- a/tests/supervisor/test_cli_run_instances.py
+++ b/tests/supervisor/test_cli_run_instances.py
@@ -1,0 +1,47 @@
+"""Regression tests for the --run-test-instance / --run-fake-instance CLI path."""
+
+import asyncio
+import contextlib
+from unittest.mock import AsyncMock
+
+import pytest
+from aleph_message.models import ItemHash
+
+from aleph.vm.agent import cli
+from aleph.vm.conf import settings
+
+FAKE_INSTANCE_ID = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
+
+
+@pytest.mark.asyncio
+async def test_run_instances_sets_up_pool(monkeypatch):
+    """run_instances must await VmPool.setup() before starting instances:
+    the pool setup binds the supervisor DB engine (port mappings), and the
+    create path hits that DB on its first port-mapping lookup."""
+    calls: list[str] = []
+
+    async def fake_setup(self) -> None:
+        calls.append("pool.setup")
+
+    async def fake_start_instance(item_hash, pubsub, pool) -> None:
+        calls.append("start_instance")
+
+    # Keep VmPool() construction host-independent.
+    monkeypatch.setattr(settings, "ALLOW_VM_NETWORKING", False)
+    monkeypatch.setattr(settings, "SNAPSHOT_FREQUENCY", 0)
+    monkeypatch.setattr(cli.VmPool, "setup", fake_setup)
+    monkeypatch.setattr(cli, "start_instance", AsyncMock(side_effect=fake_start_instance))
+
+    # run_instances waits forever after starting the instances; run it as a
+    # task and cancel it once the startup sequence has been observed.
+    task = asyncio.create_task(cli.run_instances([FAKE_INSTANCE_ID]))
+    try:
+        for _ in range(100):
+            if "start_instance" in calls:
+                break
+            await asyncio.sleep(0.01)
+        assert calls == ["pool.setup", "start_instance"]
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task

--- a/tests/supervisor/test_port_mappings.py
+++ b/tests/supervisor/test_port_mappings.py
@@ -242,6 +242,33 @@ def test_migrate_port_mappings_copies_active_rows(tmp_path, monkeypatch):
     assert migrate_port_mappings_from_legacy_db() == 0
 
 
+def test_migrate_port_mappings_noop_when_target_table_missing(tmp_path, monkeypatch):
+    """A target DB file without the port_mappings table (schema not created
+    yet) must make the migration skip cleanly instead of crashing."""
+    import sqlite3
+
+    from aleph.vm.conf import settings
+    from aleph.vm.supervisor.networking_db import migrate_port_mappings_from_legacy_db
+
+    legacy = tmp_path / "executions.sqlite3"
+    target = tmp_path / "supervisor.sqlite3"
+    with closing(sqlite3.connect(legacy)) as c:
+        c.execute(_PM_SCHEMA)
+        c.execute(
+            "INSERT INTO port_mappings (vm_hash, vm_port, host_port, tcp, udp, created_at) VALUES (?,?,?,?,?,?)",
+            ("abc", 80, 30000, 1, 0, "2026-01-01"),
+        )
+        c.commit()
+    # Create the target DB file without any tables.
+    with closing(sqlite3.connect(target)):
+        pass
+
+    monkeypatch.setattr(settings, "EXECUTION_DATABASE", legacy)
+    monkeypatch.setattr(settings, "SUPERVISOR_DATABASE", target)
+
+    assert migrate_port_mappings_from_legacy_db() == 0
+
+
 def test_migrate_port_mappings_noop_when_same_file(tmp_path, monkeypatch):
     from aleph.vm.conf import settings
     from aleph.vm.supervisor.networking_db import migrate_port_mappings_from_legacy_db

--- a/tests/supervisor/test_port_mappings.py
+++ b/tests/supervisor/test_port_mappings.py
@@ -259,3 +259,32 @@ def test_migrate_port_mappings_noop_when_legacy_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "EXECUTION_DATABASE", tmp_path / "nope.sqlite3")
     monkeypatch.setattr(settings, "SUPERVISOR_DATABASE", tmp_path / "supervisor.sqlite3")
     assert migrate_port_mappings_from_legacy_db() == 0
+
+
+@pytest.mark.asyncio
+async def test_vm_pool_setup_binds_supervisor_engine(tmp_path, monkeypatch):
+    """VmPool.setup() must bind SupervisorSessionMaker and create the schema:
+    any process that runs the pool without it hits a NameError on the first
+    port-mapping access (regression: the run-instances CLI path)."""
+    import sqlite3
+
+    from aleph.vm.conf import settings
+    from aleph.vm.pool import VmPool
+    from aleph.vm.supervisor import networking_db
+
+    monkeypatch.setattr(settings, "ALLOW_VM_NETWORKING", False)
+    monkeypatch.setattr(settings, "SNAPSHOT_FREQUENCY", 0)
+    monkeypatch.setattr(settings, "ENABLE_GPU_SUPPORT", False)
+    monkeypatch.setattr(settings, "EXECUTION_DATABASE", tmp_path / "executions.sqlite3")
+    monkeypatch.setattr(settings, "SUPERVISOR_DATABASE", tmp_path / "supervisor.sqlite3")
+    monkeypatch.delattr(networking_db, "SupervisorSessionMaker", raising=False)
+
+    pool = VmPool()
+    await pool.setup()
+
+    # The session maker is bound and usable.
+    assert isinstance(networking_db.SupervisorSessionMaker, async_sessionmaker)
+    assert await networking_db.get_port_mappings("no-such-vm") == {}
+    # The schema exists in the supervisor DB file.
+    with closing(sqlite3.connect(tmp_path / "supervisor.sqlite3")) as c:
+        assert c.execute("SELECT COUNT(*) FROM port_mappings").fetchone() == (0,)

--- a/tests/supervisor/test_port_mappings.py
+++ b/tests/supervisor/test_port_mappings.py
@@ -1,5 +1,6 @@
 """Tests for port mapping DB logic and port availability checker."""
 
+from contextlib import closing
 from unittest.mock import patch
 
 import pytest
@@ -7,7 +8,7 @@ import pytest_asyncio
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from aleph.vm.agent.metrics import Base, save_port_mappings
+from aleph.vm.supervisor.networking_db import Base, save_port_mappings
 
 
 @pytest_asyncio.fixture
@@ -23,13 +24,13 @@ async def async_session():
 
 @pytest_asyncio.fixture
 async def _patch_session_maker(async_session, monkeypatch):
-    """Redirect AsyncSessionMaker in metrics module to the in-memory DB."""
-    import aleph.vm.agent.metrics as metrics_mod
+    """Redirect SupervisorSessionMaker in the networking_db module to the in-memory DB."""
+    from aleph.vm.supervisor import networking_db
 
-    # raising=False: AsyncSessionMaker is a bare module annotation until
-    # setup_engine() binds it, so whether the attribute already exists depends
-    # on test order. Redirect it regardless of any prior setup_engine() call.
-    monkeypatch.setattr(metrics_mod, "AsyncSessionMaker", async_session, raising=False)
+    # raising=False: SupervisorSessionMaker is a bare module annotation until
+    # setup_supervisor_engine() binds it, so whether the attribute already exists
+    # depends on test order. Redirect it regardless of any prior setup call.
+    monkeypatch.setattr(networking_db, "SupervisorSessionMaker", async_session, raising=False)
 
 
 @pytest.mark.asyncio
@@ -140,7 +141,10 @@ def test_get_active_host_ports_missing_table(tmp_path):
     _SyncEngineHolder.reset()
     try:
         db_path = tmp_path / "empty.db"
-        with patch("aleph.vm.network.port_availability_checker.make_sync_db_url", return_value=f"sqlite:///{db_path}"):
+        with patch(
+            "aleph.vm.network.port_availability_checker.make_supervisor_sync_db_url",
+            return_value=f"sqlite:///{db_path}",
+        ):
             result = _get_active_host_ports()
         assert result == set()
     finally:
@@ -184,8 +188,74 @@ def test_get_active_host_ports_with_data(tmp_path):
 
     _SyncEngineHolder.reset()
     try:
-        with patch("aleph.vm.network.port_availability_checker.make_sync_db_url", return_value=f"sqlite:///{db_path}"):
+        with patch(
+            "aleph.vm.network.port_availability_checker.make_supervisor_sync_db_url",
+            return_value=f"sqlite:///{db_path}",
+        ):
             result = _get_active_host_ports()
         assert result == {30000}  # deleted row excluded
     finally:
         _SyncEngineHolder.reset()
+
+
+_PM_SCHEMA = (
+    "CREATE TABLE port_mappings ("
+    "id INTEGER PRIMARY KEY, vm_hash TEXT, vm_port INTEGER, host_port INTEGER, "
+    "tcp BOOLEAN, udp BOOLEAN, created_at DATETIME, deleted_at DATETIME)"
+)
+
+
+def test_migrate_port_mappings_copies_active_rows(tmp_path, monkeypatch):
+    """The upgrade migration copies active rows from the legacy agent DB into
+    the supervisor DB, skips soft-deleted rows, and is idempotent."""
+    import sqlite3
+
+    from aleph.vm.conf import settings
+    from aleph.vm.supervisor.networking_db import migrate_port_mappings_from_legacy_db
+
+    legacy = tmp_path / "executions.sqlite3"
+    target = tmp_path / "supervisor.sqlite3"
+    with closing(sqlite3.connect(legacy)) as c:
+        c.execute(_PM_SCHEMA)
+        c.execute(
+            "INSERT INTO port_mappings (vm_hash, vm_port, host_port, tcp, udp, created_at) VALUES (?,?,?,?,?,?)",
+            ("abc", 80, 30000, 1, 0, "2026-01-01"),
+        )
+        c.execute(
+            "INSERT INTO port_mappings (vm_hash, vm_port, host_port, tcp, udp, created_at, deleted_at) "
+            "VALUES (?,?,?,?,?,?,?)",
+            ("abc", 443, 30001, 1, 0, "2026-01-01", "2026-01-02"),
+        )
+        c.commit()
+    with closing(sqlite3.connect(target)) as c:
+        c.execute(_PM_SCHEMA)
+        c.commit()
+
+    monkeypatch.setattr(settings, "EXECUTION_DATABASE", legacy)
+    monkeypatch.setattr(settings, "SUPERVISOR_DATABASE", target)
+
+    assert migrate_port_mappings_from_legacy_db() == 1
+    with closing(sqlite3.connect(target)) as c:
+        rows = c.execute("SELECT vm_hash, host_port FROM port_mappings WHERE deleted_at IS NULL").fetchall()
+    assert rows == [("abc", 30000)]
+    # Idempotent: the target is now populated, so a second run copies nothing.
+    assert migrate_port_mappings_from_legacy_db() == 0
+
+
+def test_migrate_port_mappings_noop_when_same_file(tmp_path, monkeypatch):
+    from aleph.vm.conf import settings
+    from aleph.vm.supervisor.networking_db import migrate_port_mappings_from_legacy_db
+
+    same = tmp_path / "db.sqlite3"
+    monkeypatch.setattr(settings, "EXECUTION_DATABASE", same)
+    monkeypatch.setattr(settings, "SUPERVISOR_DATABASE", same)
+    assert migrate_port_mappings_from_legacy_db() == 0
+
+
+def test_migrate_port_mappings_noop_when_legacy_missing(tmp_path, monkeypatch):
+    from aleph.vm.conf import settings
+    from aleph.vm.supervisor.networking_db import migrate_port_mappings_from_legacy_db
+
+    monkeypatch.setattr(settings, "EXECUTION_DATABASE", tmp_path / "nope.sqlite3")
+    monkeypatch.setattr(settings, "SUPERVISOR_DATABASE", tmp_path / "supervisor.sqlite3")
+    assert migrate_port_mappings_from_legacy_db() == 0

--- a/tests/supervisor/test_qemu_instance.py
+++ b/tests/supervisor/test_qemu_instance.py
@@ -19,6 +19,10 @@ from aleph.vm.supervisor.controllers.__main__ import (
     execute_persistent_vm,
 )
 from aleph.vm.supervisor.controllers.qemu import AlephQemuInstance
+from aleph.vm.supervisor.networking_db import (
+    create_supervisor_tables,
+    setup_supervisor_engine,
+)
 from aleph.vm.supervisor.qemu_build import build_qemu_configuration
 from aleph.vm.supervisor_interface.configuration import save_controller_configuration
 from aleph.vm.systemd import SystemDManager
@@ -101,6 +105,8 @@ async def test_create_qemu_instance(mocker):
     # The database is required for the metrics and is currently not optional.
     engine = metrics.setup_engine()
     await metrics.create_tables(engine)
+    # The VM lifecycle persists port mappings to the supervisor DB.
+    await create_supervisor_tables(setup_supervisor_engine())
 
     vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
     message = await get_message(ref=vm_hash)
@@ -177,6 +183,8 @@ async def test_create_qemu_instance_online(mocker):
     # The database is required for the metrics and is currently not optional.
     engine = metrics.setup_engine()
     await metrics.create_tables(engine)
+    # The VM lifecycle persists port mappings to the supervisor DB.
+    await create_supervisor_tables(setup_supervisor_engine())
 
     vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
     message = await get_message(ref=vm_hash)

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -1279,7 +1279,7 @@ async def test_restore_rejects_invalid_image_format(aiohttp_client, mocker, tmp_
 
 
 @pytest.mark.asyncio
-async def test_update_allocations_stop_loop_uses_supervisor(aiohttp_client):
+async def test_update_allocations_stop_loop_uses_supervisor(aiohttp_client, mocker):
     """update_allocations stop loop must call supervisor.delete_vm + registry.forget
     (permanent dealloc) for executions no longer in the allocation. Port-mapping
     cleanup is owned by supervisor.delete_vm (hypervisor-side).
@@ -1342,6 +1342,7 @@ async def test_update_allocations_stop_loop_uses_supervisor(aiohttp_client):
     fake_supervisor = MagicMock(delete_vm=AsyncMock(), list_vms=AsyncMock(return_value=[vm_info]))
     app["supervisor"] = fake_supervisor
 
+    mock_delete_records = mocker.patch("aleph.vm.agent.views.delete_records_for_vm", new_callable=AsyncMock)
     settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
     client = await aiohttp_client(app)
 
@@ -1357,7 +1358,8 @@ async def test_update_allocations_stop_loop_uses_supervisor(aiohttp_client):
 
     # Verify the supervisor path was taken.
     fake_supervisor.delete_vm.assert_awaited_once_with(VmId(str(vm_hash)))
-    # Permanent dealloc: registry.forget must be called.
+    # Permanent dealloc: registry.forget + delete the persisted record.
+    mock_delete_records.assert_awaited_once_with(vm_hash)
     assert vm_hash not in app["vm_registry"]
 
 
@@ -1671,7 +1673,7 @@ def _running_vm_info(
 
 
 @pytest.mark.asyncio
-async def test_stop_loop_stops_eligible_vm(aiohttp_client):
+async def test_stop_loop_stops_eligible_vm(aiohttp_client, mocker):
     """A running, persistent, hold-tier VM not in the allocation must be stopped.
 
     Behavior 1: registry has record, persistent=True, status=RUNNING, no GPUs,
@@ -1686,6 +1688,7 @@ async def test_stop_loop_stops_eligible_vm(aiohttp_client):
     )
     app = _make_app_with_supervisor(fake_supervisor)
     app["vm_registry"].record(VM_HASH, message=message, original=message, persistent=True)
+    mock_delete_records = mocker.patch("aleph.vm.agent.views.delete_records_for_vm", new_callable=AsyncMock)
 
     client = await aiohttp_client(app)
     response = await client.post(
@@ -1698,6 +1701,7 @@ async def test_stop_loop_stops_eligible_vm(aiohttp_client):
 
     assert str(VM_HASH) in resp_json["stopped"]
     fake_supervisor.delete_vm.assert_awaited_once_with(VmId(str(VM_HASH)))
+    mock_delete_records.assert_awaited_once_with(str(VM_HASH))
     assert VM_HASH not in app["vm_registry"]
 
 

--- a/tests/supervisor/views/test_operator.py
+++ b/tests/supervisor/views/test_operator.py
@@ -951,6 +951,7 @@ async def test_operator_erase_with_delegation(aiohttp_client, mocker):
     )
     fake_sup = _fake_supervisor()
     app["supervisor"] = fake_sup
+    mock_delete_records = mocker.patch("aleph.vm.agent.metrics.delete_records_for_vm", new_callable=mocker.AsyncMock)
     client: TestClient = await aiohttp_client(app)
     response = await client.post(
         f"/control/machine/{vm_hash}/erase",
@@ -959,8 +960,9 @@ async def test_operator_erase_with_delegation(aiohttp_client, mocker):
     assert response.status == 200
     assert await response.text() == f"Erased VM with ref {vm_hash}"
     fake_sup.delete_vm.assert_awaited_once_with(VmId(str(vm_hash)), wipe=True)
-    # registry record must be forgotten after erase
+    # registry record must be forgotten after erase, and its DB records deleted
     assert app["vm_registry"].get(vm_hash) is None
+    mock_delete_records.assert_awaited_once_with(str(vm_hash))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Second of two PRs toward **one DB per actor** (stacks on #1009). The agent keeps `executions.sqlite3` (executions/records); the supervisor gets its own `supervisor.sqlite3` (port mappings).

> Was stacked on #1009; now rebased directly onto `dev` after its merge. The boundary cleanup there is what makes splitting the files safe (no code crosses actors anymore).

## What moved

- **New `supervisor/networking_db.py`** owns the `PortMapping` model, its own engine + `SupervisorSessionMaker`, schema creation, the CRUD (`save`/`get`/`delete_port_mappings`, moved verbatim), and the upgrade migration. This also fixes the boundary wrinkle where `pool.py` imported port-mapping code from `aleph.vm.agent.metrics`.
- **`metrics.py`** loses `PortMapping` and its functions — the agent DB now holds only `executions`.
- **`conf.py`**: new `SUPERVISOR_DATABASE` setting (default `EXECUTION_ROOT/supervisor.sqlite3`) + `make_supervisor_db_url` / `make_supervisor_sync_db_url`.
- **`port_availability_checker.py`** (a sync `port_mappings` reader) now points at the supervisor DB.

## Engine wiring

Centralised in **`VmPool.setup()`**: the process that runs the pool (the gRPC daemon, or the agent in-process) sets up the supervisor engine, creates the schema, and runs the migration — so daemon, agent-in-process, and cli bench/test all get it without touching each entrypoint. `daemon.py` no longer sets up the agent DB (it doesn't use `executions`); the agent's `cli.py` still sets up `executions`.

## Upgrade safety

`migrate_port_mappings_from_legacy_db()` copies **active** rows from the pre-split `executions.sqlite3` into `supervisor.sqlite3` on first start, so live VMs keep their host-port forwards (otherwise the supervisor would come up blind to existing forwards → orphaned nft rules + port-reuse conflicts). Idempotent and self-skipping: same file, missing legacy DB/table, or an already-populated target all no-op. Both stores are SQLite, so rows are copied verbatim (preserving `created_at`; `id` autoincrements fresh).

The agent DB's now-vestigial `port_mappings` table (still created by the agent Alembic chain) is left in place; dropping it is a later cleanup.

## Tests

- `test_port_mappings` imports/patches the new module; new cases cover the migration (copies active rows, skips soft-deleted, idempotent, same-file / missing-legacy no-ops).
- `test_qemu_instance` sets up the supervisor engine for the real VM lifecycle (it calls `execution.stop()` → `record_usage`).
- Mock targets like `aleph.vm.pool.get_port_mappings` / `local.delete_port_mappings` still resolve (the names are imported into those namespaces), so the many tests patching by string are unaffected.

## Verification

`ruff==0.4.6` format clean, `isort` clean, `py_compile` clean across all 10 files. No new lint categories — `networking_db`'s `PLW0603` mirrors `metrics.py`'s existing `setup_engine` idiom; the other findings are pre-existing. Full pytest in CI (local env can't build `dbus-python`).

## Follow-ups (noted)

- Drop the vestigial `port_mappings` table from the agent DB via an Alembic migration.
- The execution-record GC gap from #1009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
