### PR TITLE
refactor(gpu): annotate GPU inventory agent-side; supervisor goes fully network-blind

### DIFF
--- a/src/aleph/vm/agent/aggregate.py
+++ b/src/aleph/vm/agent/aggregate.py
@@ -2,12 +2,22 @@ from logging import getLogger
 from typing import Any, TypedDict
 
 import aiohttp
+from pydantic import BaseModel, Field
 
 from aleph.vm.conf import settings
 from aleph.vm.utils.cache import AsyncTTLCache
 from aleph.vm.utils.http import get_session
 
 logger = getLogger(__name__)
+
+
+class CompatibleGPU(BaseModel):
+    """Shape of one ``compatible_gpus`` entry in the settings aggregate."""
+
+    vendor: str = Field(description="GPU vendor name")
+    model: str = Field(description="GPU model name")
+    name: str = Field(description="GPU full name")
+    device_id: str = Field(description="GPU device id code including vendor_id and model_id")
 
 
 class AggregateSettingsDict(TypedDict):

--- a/src/aleph/vm/agent/aggregate.py
+++ b/src/aleph/vm/agent/aggregate.py
@@ -2,7 +2,7 @@ from logging import getLogger
 from typing import Any, TypedDict
 
 import aiohttp
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from aleph.vm.conf import settings
 from aleph.vm.utils.cache import AsyncTTLCache
@@ -63,12 +63,22 @@ async def update_aggregate_settings() -> None:
     await get_aggregate_settings()
 
 
-def get_compatible_gpus() -> list[Any]:
-    """Return compatible GPUs from the cached settings aggregate."""
+def get_compatible_gpus() -> list[CompatibleGPU]:
+    """Return the validated GPU whitelist from the cached settings aggregate.
+
+    The aggregate is remote data: a malformed entry is skipped with a warning
+    rather than propagating (a raise here would take down every consumer,
+    e.g. the public usage endpoint) and older aggregates may omit the key."""
     cached = _settings_cache.get("settings")
     if not cached:
         return []
-    return cached["compatible_gpus"]
+    gpus = []
+    for entry in cached.get("compatible_gpus") or []:
+        try:
+            gpus.append(CompatibleGPU.model_validate(entry))
+        except ValidationError:
+            logger.warning(f"Skipping malformed compatible_gpus aggregate entry: {entry!r}")
+    return gpus
 
 
 async def get_user_aggregate(addr: str, keys_arg: list[str]) -> dict:

--- a/src/aleph/vm/agent/aggregate.py
+++ b/src/aleph/vm/agent/aggregate.py
@@ -21,7 +21,9 @@ class CompatibleGPU(BaseModel):
 
 
 class AggregateSettingsDict(TypedDict):
-    compatible_gpus: list[Any]
+    # Expected entry shape is CompatibleGPU; get_compatible_gpus validates
+    # each entry and skips violations, so this stays a raw-payload type.
+    compatible_gpus: list[dict[str, Any]]
     community_wallet_address: str
     community_wallet_timestamp: int
     # Optional in practice (older aggregates omit it); accessed via .get().

--- a/src/aleph/vm/agent/resources.py
+++ b/src/aleph/vm/agent/resources.py
@@ -18,6 +18,7 @@ from aleph.vm.utils import (
     check_amd_sev_supported,
     cors_allow_all,
 )
+from aleph.vm.utils.aggregate import get_compatible_gpus, update_aggregate_settings
 
 
 class Period(BaseModel):
@@ -112,16 +113,30 @@ class MachineCapability(BaseModel):
     memory: MemoryProperties
 
 
-def _gpus_from_host_info(host_info) -> GpuProperties:
+async def _gpus_from_host_info(host_info) -> GpuProperties:
     """Rebuild the rich GPU inventory from the supervisor's HostInfo.
 
     GetHostInfo carries the agent GpuDevice fields as plain dicts
-    (gpu_inventory / available_gpus); reconstruct the model so the public
-    usage endpoint keeps its full shape.
+    (gpu_inventory / available_gpus). The supervisor reports raw hardware
+    only (it never talks to the network): the network annotation, `model`
+    (the card's name on the Aleph network) and `compatible` (whether the
+    network's settings aggregate whitelists it), is applied here.
     """
+    await update_aggregate_settings()
+    network_models = {gpu["device_id"]: gpu["model"] for gpu in get_compatible_gpus()}
+
+    def annotate(gpu: dict) -> GpuDevice:
+        return GpuDevice.model_validate(
+            gpu
+            | {
+                "model": network_models.get(gpu["device_id"]),
+                "compatible": gpu["device_id"] in network_models,
+            }
+        )
+
     return GpuProperties(
-        devices=[GpuDevice.model_validate(gpu) for gpu in host_info.gpu_inventory],
-        available_devices=[GpuDevice.model_validate(gpu) for gpu in host_info.available_gpus],
+        devices=[annotate(gpu) for gpu in host_info.gpu_inventory],
+        available_devices=[annotate(gpu) for gpu in host_info.available_gpus],
     )
 
 
@@ -221,7 +236,7 @@ async def about_system_usage(request: web.Request):
             duration_seconds=60,
         ),
         properties=machine_properties,
-        gpu=_gpus_from_host_info(host_info),
+        gpu=await _gpus_from_host_info(host_info),
     )
 
     return web.json_response(text=usage.model_dump_json(exclude_none=True))

--- a/src/aleph/vm/agent/resources.py
+++ b/src/aleph/vm/agent/resources.py
@@ -7,6 +7,7 @@ from aleph_message.models import ItemHash
 from aleph_message.models.execution.environment import CpuProperties
 from pydantic import BaseModel, Field
 
+from aleph.vm.agent.aggregate import get_compatible_gpus, update_aggregate_settings
 from aleph.vm.agent.machine import get_cpu_info, get_hardware_info, get_memory_info
 from aleph.vm.conf import settings
 from aleph.vm.resources import GpuDevice
@@ -18,7 +19,6 @@ from aleph.vm.utils import (
     check_amd_sev_supported,
     cors_allow_all,
 )
-from aleph.vm.utils.aggregate import get_compatible_gpus, update_aggregate_settings
 
 
 class Period(BaseModel):

--- a/src/aleph/vm/agent/resources.py
+++ b/src/aleph/vm/agent/resources.py
@@ -75,9 +75,20 @@ class MachineProperties(BaseModel):
     cpu: CpuProperties
 
 
+class AnnotatedGpuDevice(GpuDevice):
+    """A host GPU annotated with what the network says about it.
+
+    The supervisor reports raw hardware (GpuDevice); the network-derived
+    fields are the agent's to add, from the settings aggregate's
+    compatible_gpus whitelist."""
+
+    model: str | None = Field(description="GPU model name on Aleph Network", default=None)
+    compatible: bool = Field(description="GPU compatibility with Aleph Network", default=False)
+
+
 class GpuProperties(BaseModel):
-    devices: list[GpuDevice] | None = None
-    available_devices: list[GpuDevice] | None = None
+    devices: list[AnnotatedGpuDevice] | None = None
+    available_devices: list[AnnotatedGpuDevice] | None = None
 
 
 class MachineUsage(BaseModel):
@@ -116,17 +127,16 @@ class MachineCapability(BaseModel):
 async def _gpus_from_host_info(host_info) -> GpuProperties:
     """Rebuild the rich GPU inventory from the supervisor's HostInfo.
 
-    GetHostInfo carries the agent GpuDevice fields as plain dicts
-    (gpu_inventory / available_gpus). The supervisor reports raw hardware
-    only (it never talks to the network): the network annotation, `model`
-    (the card's name on the Aleph network) and `compatible` (whether the
-    network's settings aggregate whitelists it), is applied here.
+    GetHostInfo carries raw GpuDevice fields as plain dicts (gpu_inventory /
+    available_gpus): the supervisor never talks to the network, so the
+    network annotation (AnnotatedGpuDevice: `model`, `compatible`) is
+    applied here from the settings aggregate.
     """
     await update_aggregate_settings()
     network_models = {gpu["device_id"]: gpu["model"] for gpu in get_compatible_gpus()}
 
-    def annotate(gpu: dict) -> GpuDevice:
-        return GpuDevice.model_validate(
+    def annotate(gpu: dict) -> AnnotatedGpuDevice:
+        return AnnotatedGpuDevice.model_validate(
             gpu
             | {
                 "model": network_models.get(gpu["device_id"]),

--- a/src/aleph/vm/agent/resources.py
+++ b/src/aleph/vm/agent/resources.py
@@ -133,7 +133,7 @@ async def _gpus_from_host_info(host_info) -> GpuProperties:
     applied here from the settings aggregate.
     """
     await update_aggregate_settings()
-    network_models = {gpu["device_id"]: gpu["model"] for gpu in get_compatible_gpus()}
+    network_models = {gpu.device_id: gpu.model for gpu in get_compatible_gpus()}
 
     def annotate(gpu: dict) -> AnnotatedGpuDevice:
         return AnnotatedGpuDevice.model_validate(

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -16,6 +16,7 @@ from aleph_message.models import InstanceContent, ItemHash, ProgramContent
 from msgpack import UnpackValueError
 from multidict import CIMultiDict
 
+from aleph.vm.agent.aggregate import get_user_settings
 from aleph.vm.agent.expiry import ExpiryManager
 from aleph.vm.agent.translate import build_create_vm_spec, build_program_create_vm_spec
 from aleph.vm.agent.update_watcher import UpdateWatcher
@@ -43,7 +44,6 @@ from aleph.vm.supervisor_interface.types import (
     VmStatus,
 )
 from aleph.vm.utils import HostNotFoundError
-from aleph.vm.utils.aggregate import get_user_settings
 
 from .messages import load_updated_message
 from .pubsub import PubSub

--- a/src/aleph/vm/agent/utils.py
+++ b/src/aleph/vm/agent/utils.py
@@ -2,8 +2,8 @@ from datetime import datetime, timezone
 from decimal import ROUND_FLOOR, Decimal
 from logging import getLogger
 
+from aleph.vm.agent.aggregate import get_aggregate_settings
 from aleph.vm.conf import settings
-from aleph.vm.utils.aggregate import get_aggregate_settings
 
 logger = getLogger(__name__)
 

--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -21,6 +21,7 @@ from pydantic import ValidationError
 
 from aleph.vm import haproxy
 from aleph.vm.agent import payment, status
+from aleph.vm.agent.aggregate import update_aggregate_settings
 from aleph.vm.agent.custom_logs import set_vm_for_logging
 from aleph.vm.agent.haproxy_sync import sync_domain_mappings
 from aleph.vm.agent.messages import try_get_message
@@ -87,7 +88,6 @@ from aleph.vm.utils import (
     dumps_for_json,
     get_ref_from_dns,
 )
-from aleph.vm.utils.aggregate import update_aggregate_settings
 from aleph.vm.version import __version__
 from aleph.vm.vm_type import VmType
 

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -51,7 +51,6 @@ from aleph.vm.supervisor_interface.types import (
     VmId,
 )
 from aleph.vm.systemd import SystemDManager
-from aleph.vm.utils.aggregate import update_aggregate_settings
 from aleph.vm.vm_type import VmType
 
 from .models import VmExecution
@@ -156,8 +155,8 @@ class VmPool:
             logger.debug("Initializing SnapshotManager ...")
             self.snapshot_manager.run_in_thread()
         if settings.ENABLE_GPU_SUPPORT:
-            # Refresh and get latest settings aggregate
-            await update_aggregate_settings()
+            # Raw hardware inventory (lspci): network annotation (model name,
+            # compatibility) is applied agent-side from the settings aggregate.
             logger.debug("Detecting GPU devices ...")
             self.gpus = get_gpu_devices()
 

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -377,7 +377,12 @@ class VmPool:
             # skips reservations still held by OTHER users.
             resolved_host_gpus: list[HostGPU] = []
             if spec.gpus:
+                # _resolve_spec_gpus resolves in request order, so requests and
+                # devices zip index-aligned. `model` is a network-derived name
+                # the supervisor does not know: echo whatever the agent
+                # requested rather than inventing one.
                 resolved_devices = self._resolve_spec_gpus(spec.gpus, owner=spec.owner_id)
+                resolved_pairs = list(zip(spec.gpus, resolved_devices, strict=True))
                 spec = replace(
                     spec,
                     gpus=[
@@ -385,9 +390,9 @@ class VmPool:
                             pci_host=PciAddress(device.pci_host),
                             supports_x_vga=device.has_x_vga_support,
                             device_id=device.device_id,
-                            model=device.model or "",
+                            model=request.model,
                         )
-                        for device in resolved_devices
+                        for request, device in resolved_pairs
                     ],
                 )
                 resolved_host_gpus = [
@@ -395,9 +400,9 @@ class VmPool:
                         pci_host=device.pci_host,
                         supports_x_vga=device.has_x_vga_support,
                         device_id=device.device_id,
-                        model=device.model,
+                        model=request.model or None,
                     )
-                    for device in resolved_devices
+                    for request, device in resolved_pairs
                 ]
 
             execution = VmExecution.from_spec(

--- a/src/aleph/vm/resources.py
+++ b/src/aleph/vm/resources.py
@@ -33,17 +33,20 @@ class GpuDeviceClass(str, Enum):
 
 
 class GpuDevice(HashableModel):
-    """GPU properties."""
+    """A GPU as the host hardware reports it (lspci): no network knowledge.
+
+    The card's name on the Aleph network and whether the network supports it
+    are properties of the settings aggregate, not of the hardware; the agent
+    layers them on via AnnotatedGpuDevice (agent/resources.py). The
+    supervisor stays network-blind."""
 
     vendor: str = Field(description="GPU vendor name")
-    model: str | None = Field(description="GPU model name on Aleph Network", default=None)
     device_name: str = Field(description="GPU vendor card name")
     device_class: GpuDeviceClass = Field(
         description="GPU device class. Look at https://admin.pci-ids.ucw.cz/read/PD/03"
     )
     pci_host: str = Field(description="Host PCI bus for this device")
     device_id: str = Field(description="GPU vendor & device ids")
-    compatible: bool = Field(description="GPU compatibility with Aleph Network", default=False)
 
     @property
     def has_x_vga_support(self) -> bool:
@@ -113,18 +116,12 @@ def parse_gpu_device_info(line: str) -> GpuDevice | None:
     model_id = model_id[:-1]
     device_id = f"{vendor_id}:{model_id}"
 
-    # Raw hardware knowledge only: `model` (the network name for the card) and
-    # `compatible` (whether the network supports it) come from the settings
-    # aggregate and are filled in agent-side (agent/resources.py); the
-    # supervisor stays network-blind.
     return GpuDevice(
         pci_host=pci_host,
         vendor=vendor_name,
-        model=None,
         device_name=device_name,
         device_class=device_class,
         device_id=device_id,
-        compatible=False,
     )
 
 

--- a/src/aleph/vm/resources.py
+++ b/src/aleph/vm/resources.py
@@ -4,8 +4,6 @@ from enum import Enum
 from aleph_message.models import HashableModel
 from pydantic import BaseModel, ConfigDict, Field
 
-from aleph.vm.utils.aggregate import get_compatible_gpus
-
 
 class InsufficientResourcesError(Exception):
     """Raised when there are insufficient resources to create a VM."""
@@ -77,21 +75,6 @@ def is_gpu_device_class(device_class: str) -> bool:
         return False
 
 
-def get_gpu_model(device_id: str) -> bool | None:
-    """Returns a GPU model name if it's found from the compatible ones."""
-    model_gpu_set = {gpu["device_id"]: gpu["model"] for gpu in get_compatible_gpus()}
-    try:
-        return model_gpu_set[device_id]
-    except KeyError:
-        return None
-
-
-def is_gpu_compatible(device_id: str) -> bool:
-    """Checks if a GPU is compatible based on vendor and model IDs."""
-    compatible_gpu_set = {gpu["device_id"] for gpu in get_compatible_gpus()}
-    return device_id in compatible_gpu_set
-
-
 def get_vendor_name(vendor_id: str) -> str:
     match vendor_id:
         case "10de":
@@ -138,17 +121,19 @@ def parse_gpu_device_info(line: str) -> GpuDevice | None:
     device_name, model_id = device_name.rsplit(" [", maxsplit=1)
     model_id = model_id[:-1]
     device_id = f"{vendor_id}:{model_id}"
-    model = get_gpu_model(device_id=device_id)
-    compatible = is_gpu_compatible(device_id=device_id)
 
+    # Raw hardware knowledge only: `model` (the network name for the card) and
+    # `compatible` (whether the network supports it) come from the settings
+    # aggregate and are filled in agent-side (agent/resources.py); the
+    # supervisor stays network-blind.
     return GpuDevice(
         pci_host=pci_host,
         vendor=vendor_name,
-        model=model,
+        model=None,
         device_name=device_name,
         device_class=device_class,
         device_id=device_id,
-        compatible=compatible,
+        compatible=False,
     )
 
 

--- a/src/aleph/vm/resources.py
+++ b/src/aleph/vm/resources.py
@@ -58,15 +58,6 @@ class GpuDevice(HashableModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class CompatibleGPU(BaseModel):
-    """Compatible GPU properties detail."""
-
-    vendor: str = Field(description="GPU vendor name")
-    model: str = Field(description="GPU model name")
-    name: str = Field(description="GPU full name")
-    device_id: str = Field(description="GPU device id code including vendor_id and model_id")
-
-
 def is_gpu_device_class(device_class: str) -> bool:
     try:
         GpuDeviceClass(device_class)

--- a/src/aleph/vm/supervisor/local.py
+++ b/src/aleph/vm/supervisor/local.py
@@ -407,9 +407,10 @@ class LocalSupervisor(Supervisor):
     async def get_host_info(self) -> HostInfo:
         with translating_errors():
             network = getattr(self.pool, "network", None)
-            # Rich GPU inventory (vendor / device_name / device_class /
-            # compatible) the public usage endpoint exposes. Carried as plain
-            # dicts so the boundary stays GpuDevice-agnostic.
+            # Rich GPU inventory (vendor / device_name / device_class) the
+            # public usage endpoint exposes. Raw hardware only: the agent
+            # annotates model / compatible from the settings aggregate.
+            # Carried as plain dicts so the boundary stays GpuDevice-agnostic.
             inventory = [gpu.model_dump() for gpu in getattr(self.pool, "gpus", None) or []]
             get_available = getattr(self.pool, "get_available_gpus", None)
             available_gpus = [gpu.model_dump() for gpu in get_available()] if get_available else []

--- a/src/aleph/vm/supervisor_interface/types.py
+++ b/src/aleph/vm/supervisor_interface/types.py
@@ -430,9 +430,10 @@ class HostInfo:
     # Reservation-aware figures the agent's /about endpoints surface. The
     # embedded engine fills them from the pool. ``gpu_inventory`` /
     # ``available_gpus`` carry the rich agent GpuDevice (vendor, device_name,
-    # device_class, compatible) as plain dicts so the public usage endpoint does
-    # not regress to the narrow boundary GpuDevice; they ride the proto as JSON
-    # strings.
+    # device_class) as plain dicts so the public usage endpoint does not
+    # regress to the narrow boundary GpuDevice; they ride the proto as JSON
+    # strings. Raw hardware only: the network annotation (model name,
+    # aggregate-whitelist compatibility) is the agent's job.
     available_disk_bytes: int = 0
     gpu_inventory: list[dict] = field(default_factory=list)
     available_gpus: list[dict] = field(default_factory=list)

--- a/tests/supervisor/test_agent_gpu_annotation.py
+++ b/tests/supervisor/test_agent_gpu_annotation.py
@@ -1,0 +1,67 @@
+"""The agent, not the supervisor, annotates the GPU inventory with network
+knowledge: `model` (the card's name on the Aleph network) and `compatible`
+(whether the settings aggregate whitelists the device_id). The supervisor
+reports raw hardware over GetHostInfo."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from aleph.vm.agent.resources import _gpus_from_host_info
+
+
+def _raw_gpu(device_id: str, pci_host: str) -> dict:
+    """A GPU dict as the supervisor reports it: no network annotation."""
+    return {
+        "vendor": "NVIDIA",
+        "model": None,
+        "device_name": f"Device {device_id}",
+        "device_class": "0300",
+        "pci_host": pci_host,
+        "device_id": device_id,
+        "compatible": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_agent_annotates_gpus_from_aggregate(mocker):
+    mocker.patch("aleph.vm.agent.resources.update_aggregate_settings")
+    mocker.patch(
+        "aleph.vm.agent.resources.get_compatible_gpus",
+        return_value=[
+            {"device_id": "10de:27b0", "model": "RTX 4000 ADA", "vendor": "NVIDIA", "name": "AD104GL"},
+        ],
+    )
+    host_info = SimpleNamespace(
+        gpu_inventory=[_raw_gpu("10de:27b0", "01:00.0"), _raw_gpu("10de:ffff", "02:00.0")],
+        available_gpus=[_raw_gpu("10de:27b0", "01:00.0")],
+    )
+
+    gpu = await _gpus_from_host_info(host_info)
+
+    whitelisted, unlisted = gpu.devices
+    assert whitelisted.model == "RTX 4000 ADA"
+    assert whitelisted.compatible is True
+    # A card the network does not support stays in the inventory, unannotated.
+    assert unlisted.model is None
+    assert unlisted.compatible is False
+    assert gpu.available_devices[0].model == "RTX 4000 ADA"
+    assert gpu.available_devices[0].compatible is True
+
+
+@pytest.mark.asyncio
+async def test_agent_annotation_survives_missing_aggregate(mocker):
+    """Aggregate unreachable: the cache stays empty and every card reports
+    incompatible, but the endpoint keeps working."""
+    mocker.patch("aleph.vm.agent.resources.update_aggregate_settings")
+    mocker.patch("aleph.vm.agent.resources.get_compatible_gpus", return_value=[])
+    host_info = SimpleNamespace(
+        gpu_inventory=[_raw_gpu("10de:27b0", "01:00.0")],
+        available_gpus=[],
+    )
+
+    gpu = await _gpus_from_host_info(host_info)
+
+    assert gpu.devices[0].model is None
+    assert gpu.devices[0].compatible is False
+    assert gpu.available_devices == []

--- a/tests/supervisor/test_agent_gpu_annotation.py
+++ b/tests/supervisor/test_agent_gpu_annotation.py
@@ -7,6 +7,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from aleph.vm.agent import aggregate
+from aleph.vm.agent.aggregate import CompatibleGPU
 from aleph.vm.agent.resources import _gpus_from_host_info
 
 
@@ -28,7 +30,7 @@ async def test_agent_annotates_gpus_from_aggregate(mocker):
     mocker.patch(
         "aleph.vm.agent.resources.get_compatible_gpus",
         return_value=[
-            {"device_id": "10de:27b0", "model": "RTX 4000 ADA", "vendor": "NVIDIA", "name": "AD104GL"},
+            CompatibleGPU(device_id="10de:27b0", model="RTX 4000 ADA", vendor="NVIDIA", name="AD104GL"),
         ],
     )
     host_info = SimpleNamespace(
@@ -64,3 +66,29 @@ async def test_agent_annotation_survives_missing_aggregate(mocker):
     assert gpu.devices[0].model is None
     assert gpu.devices[0].compatible is False
     assert gpu.available_devices == []
+
+
+def test_get_compatible_gpus_skips_malformed_entries(mocker):
+    """The whitelist is remote data: one bad aggregate entry must not take
+    down every consumer (e.g. the public usage endpoint)."""
+    valid = {"device_id": "10de:27b0", "model": "RTX 4000 ADA", "vendor": "NVIDIA", "name": "AD104GL"}
+    mocker.patch.object(
+        aggregate._settings_cache,
+        "get",
+        return_value={"compatible_gpus": [valid, {"device_id": "10de:2204"}, "not-a-dict"]},
+    )
+
+    gpus = aggregate.get_compatible_gpus()
+
+    assert [gpu.device_id for gpu in gpus] == ["10de:27b0"]
+
+
+def test_get_compatible_gpus_tolerates_missing_key(mocker):
+    """Older aggregates omit compatible_gpus entirely."""
+    mocker.patch.object(
+        aggregate._settings_cache,
+        "get",
+        return_value={"community_wallet_address": "0x0"},
+    )
+
+    assert aggregate.get_compatible_gpus() == []

--- a/tests/supervisor/test_agent_gpu_annotation.py
+++ b/tests/supervisor/test_agent_gpu_annotation.py
@@ -11,15 +11,14 @@ from aleph.vm.agent.resources import _gpus_from_host_info
 
 
 def _raw_gpu(device_id: str, pci_host: str) -> dict:
-    """A GPU dict as the supervisor reports it: no network annotation."""
+    """A GPU dict as the supervisor reports it: raw hardware, no `model` or
+    `compatible` key at all (GpuDevice does not carry them)."""
     return {
         "vendor": "NVIDIA",
-        "model": None,
         "device_name": f"Device {device_id}",
         "device_class": "0300",
         "pci_host": pci_host,
         "device_id": device_id,
-        "compatible": False,
     }
 
 

--- a/tests/supervisor/test_supervisor_spec_gpu_create.py
+++ b/tests/supervisor/test_supervisor_spec_gpu_create.py
@@ -37,12 +37,10 @@ _DEVICE_ID = "10de:2504"
 def _gpu_device(pci_host: str, *, device_id: str = _DEVICE_ID) -> ResourceGpuDevice:
     return ResourceGpuDevice(
         vendor="NVIDIA",
-        model="RTX 4000",
         device_name="GH100",
         device_class=GpuDeviceClass.VGA_COMPATIBLE_CONTROLLER,
         pci_host=pci_host,
         device_id=device_id,
-        compatible=True,
     )
 
 

--- a/tests/supervisor/test_supervisor_spec_pool_create.py
+++ b/tests/supervisor/test_supervisor_spec_pool_create.py
@@ -254,12 +254,10 @@ async def test_create_vm_from_spec_confidential_with_gpu_carries_resolved_gpu(mo
 
     gpu = ResourceGpuDevice(
         vendor="NVIDIA",
-        model="RTX 4000",
         device_name="GH100",
         device_class=GpuDeviceClass.VGA_COMPATIBLE_CONTROLLER,
         pci_host="0000:01:00.0",
         device_id=_DEVICE_ID,
-        compatible=True,
     )
     pool = _bare_pool()
     pool.gpus = [gpu]
@@ -321,12 +319,10 @@ def _gpu_device(device_id: str = _DEVICE_ID, pci_host: str = "0000:01:00.0"):
 
     return ResourceGpuDevice(
         vendor="NVIDIA",
-        model="RTX 4000",
         device_name="GH100",
         device_class=GpuDeviceClass.VGA_COMPATIBLE_CONTROLLER,
         pci_host=pci_host,
         device_id=device_id,
-        compatible=True,
     )
 
 

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -670,7 +670,7 @@ async def test_about_certificates(aiohttp_client):
 @pytest.fixture
 def mock_aggregate_settings(mocker: MockerFixture):
     mocker.patch(
-        "aleph.vm.utils.aggregate.fetch_aggregate_settings",
+        "aleph.vm.agent.aggregate.fetch_aggregate_settings",
         return_value={
             "compatible_gpus": [
                 {"name": "AD102GL [L40S]", "model": "L40S", "vendor": "NVIDIA", "device_id": "10de:26b9"},


### PR DESCRIPTION
Follow-up to #1012 (now merged; rebased onto dev).

## Why

The supervisor consulted the settings aggregate for exactly one thing: annotating its lspci GPU inventory with the network's model name and `compatible` flag. Allocation never depended on it (GPU requests are matched by `device_id`; incompatible cards were inventoried and reservable all the same), so this was pure display annotation for `/about/usage/system`, and the supervisor's last remaining reason to talk to the CCN API.

## What

- **Supervisor reports raw hardware.** `parse_gpu_device_info` no longer looks up the aggregate: `model` stays unset and `compatible` false. `pool.setup()` no longer refreshes the aggregate.
- **The agent annotates.** `_gpus_from_host_info` (behind `/about/usage/system`) fills in `model` / `compatible` from the aggregate's `compatible_gpus` whitelist. Whitelist updates now apply on the agent's 60 s cache refresh instead of requiring a supervisor restart.
- **The aggregate module moves into the agent package** (`aleph.vm.utils.aggregate` → `aleph.vm.agent.aggregate`). Every consumer is agent-side now, so the existing import-linter contract ("the supervisor side does not import the agent") statically guarantees the supervisor never talks to the CCN API. The supervisor is fully network-blind.

## Behavior notes

- The wire format is unchanged: `gpu_inventory` / `available_gpus` already ride `GetHostInfo` as plain dicts; only who fills `model`/`compatible` changes.
- `VmInfo.gpus[].model` (attached-GPU info) is now empty; the agent only uses `info.gpus` as a has-GPUs gate, and QEMU passthrough only consumes `pci_host` / `x-vga`.
- Covered by the existing end-to-end test (`test_system_usage_gpu_ressources`: mocked lspci + mocked aggregate → annotated usage payload) plus new unit tests for the annotation itself (whitelisted vs unlisted device, unreachable aggregate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

