### PR TITLE
fix(supervisor): survive settings renames in on-disk controller configs (1.13.0 upgrade blocker)

### DIFF
--- a/src/aleph/vm/supervisor_interface/configuration.py
+++ b/src/aleph/vm/supervisor_interface/configuration.py
@@ -3,7 +3,13 @@ from enum import Enum
 from pathlib import Path
 from typing import Annotated
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, PlainSerializer
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    PlainSerializer,
+    field_validator,
+)
 
 from aleph.vm.conf import Settings, settings
 from aleph.vm.sizes import MiB
@@ -93,6 +99,31 @@ class Configuration(BaseModel):
     settings: Settings
     vm_configuration: QemuConfidentialVMConfiguration | QemuVMConfiguration | VMConfiguration
     hypervisor: HypervisorType = HypervisorType.firecracker
+
+    @field_validator("settings", mode="before")
+    @classmethod
+    def _drop_unknown_settings_keys(cls, value: object) -> object:
+        """Tolerate settings keys this version does not know.
+
+        Controller configs on disk embed a full Settings dump from whichever
+        aleph-vm version created the VM. Settings itself is extra=forbid, so
+        a key that has since been renamed or removed (e.g. 1.13.0's
+        CONNECTIVITY_DNS_HOSTNAME, now CONNECTIVITY_DNS_HOSTNAMES) would
+        reject the whole config; load_persistent_executions would then abort
+        the supervisor daemon on startup, turning a routine package upgrade
+        of a node with live VMs into a crash loop. Unknown keys are dropped
+        (a renamed setting falls back to its current default); known keys
+        with invalid values still fail loudly."""
+        if not isinstance(value, dict):
+            return value
+        unknown = value.keys() - Settings.model_fields.keys()
+        if unknown:
+            logger.warning(
+                "Ignoring unknown settings keys in controller config (written by another aleph-vm version): %s",
+                ", ".join(sorted(unknown)),
+            )
+            return {key: item for key, item in value.items() if key not in unknown}
+        return value
 
 
 def get_controller_configuration_path(vm_hash: str) -> Path:

--- a/tests/supervisor/test_controller_config_forward_compat.py
+++ b/tests/supervisor/test_controller_config_forward_compat.py
@@ -1,0 +1,71 @@
+"""Controller configs written by an older aleph-vm must still parse after a
+settings rename or removal.
+
+Every <vm_hash>-controller.json embeds a full Settings dump. Settings uses
+extra=forbid, so without a lenient parse a key that a NEWER version renamed
+(e.g. 1.13.0's CONNECTIVITY_DNS_HOSTNAME, now CONNECTIVITY_DNS_HOSTNAMES)
+makes the embedded parse raise, load_persistent_executions propagates it, and
+the supervisor daemon aborts startup BY DESIGN on unparseable controller
+configs: an in-place package upgrade with live VMs crash-loops the node."""
+
+import pytest
+from pydantic import ValidationError
+
+from aleph.vm.conf import Settings
+from aleph.vm.supervisor_interface.configuration import (
+    Configuration,
+    HypervisorType,
+    VMConfiguration,
+)
+
+
+def _controller_config_dict(settings_dict: dict) -> dict:
+    return {
+        "vm_id": 3,
+        "vm_hash": "cafe" * 16,
+        "settings": settings_dict,
+        "vm_configuration": {
+            "use_jailer": False,
+            "firecracker_bin_path": "/opt/firecracker",
+            "jailer_bin_path": "/opt/jailer",
+            "config_file_path": "/tmp/config.json",
+            "init_timeout": 30.0,
+        },
+        "hypervisor": HypervisorType.firecracker,
+    }
+
+
+def test_settings_dump_with_renamed_key_still_parses():
+    """A 1.13.0-era dump carries CONNECTIVITY_DNS_HOSTNAME (renamed since):
+    unknown keys must be dropped, not rejected."""
+    settings_dict = Settings().model_dump(exclude_none=True)
+    settings_dict.pop("CONNECTIVITY_DNS_HOSTNAMES", None)
+    settings_dict["CONNECTIVITY_DNS_HOSTNAME"] = "example.org"
+
+    config = Configuration.model_validate(_controller_config_dict(settings_dict))
+
+    # The legacy key is dropped; the current setting falls back to its default.
+    assert config.settings.CONNECTIVITY_DNS_HOSTNAMES == Settings().CONNECTIVITY_DNS_HOSTNAMES
+    assert not hasattr(config.settings, "CONNECTIVITY_DNS_HOSTNAME")
+    assert isinstance(config.vm_configuration, VMConfiguration)
+
+
+def test_settings_dump_with_arbitrary_unknown_key_still_parses():
+    """The guard is structural: any future rename/removal must not break
+    reattach across an upgrade."""
+    settings_dict = Settings().model_dump(exclude_none=True)
+    settings_dict["SOME_SETTING_REMOVED_IN_THE_FUTURE"] = {"nested": True}
+
+    config = Configuration.model_validate(_controller_config_dict(settings_dict))
+
+    assert config.vm_id == 3
+
+
+def test_known_key_with_wrong_type_still_rejected():
+    """Leniency is only about unknown keys: a corrupt value for a live
+    setting must still fail loudly rather than misconfigure a VM."""
+    settings_dict = Settings().model_dump(exclude_none=True)
+    settings_dict["CONNECTIVITY_DNS_HOSTNAMES"] = 42
+
+    with pytest.raises(ValidationError):
+        Configuration.model_validate(_controller_config_dict(settings_dict))


### PR DESCRIPTION
Fixes the release blocker found in the 1.13.0 → dev gap analysis: **an in-place package upgrade of a node with live VMs crash-loops the supervisor daemon.**

## Mechanism

- Every `<vm_hash>-controller.json` embeds a full `Settings` dump from the aleph-vm version that created the VM, and `Settings` validates with `extra=forbid`.
- 1.13.0 wrote `CONNECTIVITY_DNS_HOSTNAME`; #974 renamed it to `CONNECTIVITY_DNS_HOSTNAMES` (the example.org probe was flaky, replaced by a dual-stack fallback list). The old key is now an unknown extra → `ValidationError`.
- `load_persistent_executions` parses controller configs unguarded, and the daemon intentionally aborts startup on an unparseable config (`daemon.py`: a pool that does not reflect what is running must not serve gRPC). Upgrade a 1.13.0 node with live VMs → daemon crash-loop, no gRPC socket, node unmanageable; a controller restart re-parses the same JSON and kills its VM.

## Fix

A `mode="before"` validator on `Configuration.settings` drops keys the running version does not know, logging a warning that names them. A renamed setting falls back to its current default. The guard is structural: any future settings rename/removal survives the upgrade, not just this one. Known keys with invalid values still fail loudly; leniency applies only to unknown keys.

Covered by tests: 1.13.0-style dump with the legacy key parses (and the renamed setting takes its default), an arbitrary future unknown key parses, and a corrupt value for a known key is still rejected.

## Not in this PR

- Rollback (dev → 1.13.0) remains broken for VMs reconfigured under dev: 1.13.0's parser is strict and cannot be fixed retroactively.
- A 1.13.0→candidate upgrade job in droplet CI (current CI only tests fresh installs, which is why this slipped through) is deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
