### PR TITLE
refactor(supervisor)!: controller configs embed only the controller's settings slice

### DIFF
--- a/src/aleph/vm/supervisor/controllers/__main__.py
+++ b/src/aleph/vm/supervisor/controllers/__main__.py
@@ -123,9 +123,13 @@ def main():
     )
 
     if args.print_settings:
-        print(config.settings.display())
+        print(config.settings.model_dump_json(indent=4))
 
-    config.settings.check()
+    # The config predates this process (written at VM creation, possibly by
+    # an older aleph-vm): validate the one field Network cannot default.
+    if not config.settings.NETWORK_INTERFACE:
+        logger.error("Controller config %s carries no NETWORK_INTERFACE", config_path)
+        sys.exit(1)
 
     network = Network(
         vm_ipv4_address_pool_range=config.settings.IPV4_ADDRESS_POOL,

--- a/src/aleph/vm/supervisor_interface/configuration.py
+++ b/src/aleph/vm/supervisor_interface/configuration.py
@@ -152,11 +152,7 @@ def save_controller_configuration(vm_hash: str, configuration: Configuration) ->
     """Save VM configuration to be used by the controller service"""
     config_file_path = get_controller_configuration_path(vm_hash)
     with config_file_path.open("w") as controller_config_file:
-        controller_config_file.write(
-            configuration.model_dump_json(
-                by_alias=True, exclude_none=True, indent=4, exclude={"settings": {"USE_DEVELOPER_SSH_KEYS"}}
-            )
-        )
+        controller_config_file.write(configuration.model_dump_json(by_alias=True, exclude_none=True, indent=4))
     config_file_path.chmod(0o644)
     return config_file_path
 

--- a/src/aleph/vm/supervisor_interface/configuration.py
+++ b/src/aleph/vm/supervisor_interface/configuration.py
@@ -3,15 +3,9 @@ from enum import Enum
 from pathlib import Path
 from typing import Annotated
 
-from pydantic import (
-    BaseModel,
-    BeforeValidator,
-    ConfigDict,
-    PlainSerializer,
-    field_validator,
-)
+from pydantic import BaseModel, BeforeValidator, ConfigDict, PlainSerializer
 
-from aleph.vm.conf import Settings, settings
+from aleph.vm.conf import IPv6AllocationPolicy, settings
 from aleph.vm.sizes import MiB
 
 logger = logging.getLogger(__name__)
@@ -93,37 +87,44 @@ class HypervisorType(str, Enum):
     firecracker = "firecracker"
 
 
+class ControllerSettings(BaseModel):
+    """The slice of node settings a VM controller actually needs.
+
+    Controller configs used to embed a FULL Settings dump, which coupled the
+    on-disk format to every one of the ~200 settings: any rename or removal
+    broke parsing of configs written by the previous version and crash-looped
+    the supervisor daemon on upgrade (the 1.13.0 CONNECTIVITY_DNS_HOSTNAME
+    incident). Only the fields below were ever read controller-side
+    (supervisor/controllers/__main__.py); nothing else belongs here.
+
+    Validation is deliberately lax in both directions:
+    - ``extra="ignore"``: configs written by older versions carry the full
+      dump; the surplus keys are ignored on read. No file migration needed.
+    - ``from_attributes=True``: writers pass the live Settings object and
+      pydantic extracts just this slice.
+    - Defaults mirror conf.py so a key absent from an old dump (or removed
+      from a future one) falls back instead of failing.
+    Known keys with invalid values still fail loudly."""
+
+    model_config = ConfigDict(extra="ignore", from_attributes=True)
+
+    JAILER_BASE_DIR: Path | None = None
+    NETWORK_INTERFACE: str | None = None
+    IPV4_ADDRESS_POOL: str = "172.16.0.0/12"
+    IPV4_NETWORK_PREFIX_LENGTH: int = 24
+    IPV6_ADDRESS_POOL: str = "fc00:1:2:3::/64"
+    IPV6_ALLOCATION_POLICY: IPv6AllocationPolicy = IPv6AllocationPolicy.static
+    IPV6_SUBNET_PREFIX: int = 124
+    IPV6_FORWARDING_ENABLED: bool = True
+    USE_NDP_PROXY: bool = True
+
+
 class Configuration(BaseModel):
     vm_id: int
     vm_hash: str
-    settings: Settings
+    settings: ControllerSettings
     vm_configuration: QemuConfidentialVMConfiguration | QemuVMConfiguration | VMConfiguration
     hypervisor: HypervisorType = HypervisorType.firecracker
-
-    @field_validator("settings", mode="before")
-    @classmethod
-    def _drop_unknown_settings_keys(cls, value: object) -> object:
-        """Tolerate settings keys this version does not know.
-
-        Controller configs on disk embed a full Settings dump from whichever
-        aleph-vm version created the VM. Settings itself is extra=forbid, so
-        a key that has since been renamed or removed (e.g. 1.13.0's
-        CONNECTIVITY_DNS_HOSTNAME, now CONNECTIVITY_DNS_HOSTNAMES) would
-        reject the whole config; load_persistent_executions would then abort
-        the supervisor daemon on startup, turning a routine package upgrade
-        of a node with live VMs into a crash loop. Unknown keys are dropped
-        (a renamed setting falls back to its current default); known keys
-        with invalid values still fail loudly."""
-        if not isinstance(value, dict):
-            return value
-        unknown = value.keys() - Settings.model_fields.keys()
-        if unknown:
-            logger.warning(
-                "Ignoring unknown settings keys in controller config (written by another aleph-vm version): %s",
-                ", ".join(sorted(unknown)),
-            )
-            return {key: item for key, item in value.items() if key not in unknown}
-        return value
 
 
 def get_controller_configuration_path(vm_hash: str) -> Path:

--- a/tests/supervisor/test_controller_config_forward_compat.py
+++ b/tests/supervisor/test_controller_config_forward_compat.py
@@ -1,12 +1,14 @@
-"""Controller configs written by an older aleph-vm must still parse after a
-settings rename or removal.
+"""Controller configs must survive settings schema drift in both directions.
 
-Every <vm_hash>-controller.json embeds a full Settings dump. Settings uses
-extra=forbid, so without a lenient parse a key that a NEWER version renamed
-(e.g. 1.13.0's CONNECTIVITY_DNS_HOSTNAME, now CONNECTIVITY_DNS_HOSTNAMES)
-makes the embedded parse raise, load_persistent_executions propagates it, and
-the supervisor daemon aborts startup BY DESIGN on unparseable controller
-configs: an in-place package upgrade with live VMs crash-loops the node."""
+Historically every <vm_hash>-controller.json embedded a FULL Settings dump
+parsed with extra=forbid, so any settings rename broke parsing of configs
+written by the previous version (1.13.0's CONNECTIVITY_DNS_HOSTNAME, renamed
+in #974) and the supervisor daemon aborted startup: an in-place upgrade with
+live VMs crash-looped the node.
+
+The config now embeds only ControllerSettings, the slice the controller
+process actually reads, and ignores unknown keys: old full dumps keep
+parsing with no file migration, and future removals from the slice do too."""
 
 import pytest
 from pydantic import ValidationError
@@ -14,16 +16,17 @@ from pydantic import ValidationError
 from aleph.vm.conf import Settings
 from aleph.vm.supervisor_interface.configuration import (
     Configuration,
+    ControllerSettings,
     HypervisorType,
     VMConfiguration,
 )
 
 
-def _controller_config_dict(settings_dict: dict) -> dict:
+def _controller_config_dict(settings_value) -> dict:
     return {
         "vm_id": 3,
         "vm_hash": "cafe" * 16,
-        "settings": settings_dict,
+        "settings": settings_value,
         "vm_configuration": {
             "use_jailer": False,
             "firecracker_bin_path": "/opt/firecracker",
@@ -35,22 +38,24 @@ def _controller_config_dict(settings_dict: dict) -> dict:
     }
 
 
-def test_settings_dump_with_renamed_key_still_parses():
-    """A 1.13.0-era dump carries CONNECTIVITY_DNS_HOSTNAME (renamed since):
-    unknown keys must be dropped, not rejected."""
+def test_full_1_13_0_style_settings_dump_still_parses():
+    """Old configs carry a full Settings dump including keys that no longer
+    exist (CONNECTIVITY_DNS_HOSTNAME): the surplus is ignored, the slice the
+    controller needs is extracted."""
     settings_dict = Settings().model_dump(exclude_none=True)
     settings_dict.pop("CONNECTIVITY_DNS_HOSTNAMES", None)
     settings_dict["CONNECTIVITY_DNS_HOSTNAME"] = "example.org"
+    settings_dict["NETWORK_INTERFACE"] = "eth0"
 
     config = Configuration.model_validate(_controller_config_dict(settings_dict))
 
-    # The legacy key is dropped; the current setting falls back to its default.
-    assert config.settings.CONNECTIVITY_DNS_HOSTNAMES == Settings().CONNECTIVITY_DNS_HOSTNAMES
+    assert config.settings.NETWORK_INTERFACE == "eth0"
+    assert config.settings.IPV4_NETWORK_PREFIX_LENGTH == 24
     assert not hasattr(config.settings, "CONNECTIVITY_DNS_HOSTNAME")
     assert isinstance(config.vm_configuration, VMConfiguration)
 
 
-def test_settings_dump_with_arbitrary_unknown_key_still_parses():
+def test_arbitrary_unknown_settings_key_is_ignored():
     """The guard is structural: any future rename/removal must not break
     reattach across an upgrade."""
     settings_dict = Settings().model_dump(exclude_none=True)
@@ -61,11 +66,31 @@ def test_settings_dump_with_arbitrary_unknown_key_still_parses():
     assert config.vm_id == 3
 
 
-def test_known_key_with_wrong_type_still_rejected():
-    """Leniency is only about unknown keys: a corrupt value for a live
-    setting must still fail loudly rather than misconfigure a VM."""
-    settings_dict = Settings().model_dump(exclude_none=True)
-    settings_dict["CONNECTIVITY_DNS_HOSTNAMES"] = 42
+def test_missing_slice_keys_fall_back_to_defaults():
+    """A key absent from an old dump (or dropped from a future slice) takes
+    the conf.py default instead of failing."""
+    config = Configuration.model_validate(_controller_config_dict({"NETWORK_INTERFACE": "eth0"}))
 
+    assert config.settings.IPV4_ADDRESS_POOL == "172.16.0.0/12"
+    assert config.settings.USE_NDP_PROXY is True
+
+
+def test_known_key_with_wrong_type_still_rejected():
+    """Leniency is only about unknown keys: a corrupt value for a setting the
+    controller reads must fail loudly rather than misconfigure a VM."""
     with pytest.raises(ValidationError):
-        Configuration.model_validate(_controller_config_dict(settings_dict))
+        Configuration.model_validate(_controller_config_dict({"IPV4_NETWORK_PREFIX_LENGTH": "not-a-number"}))
+
+
+def test_writers_pass_the_live_settings_object():
+    """Configuration builders pass the full Settings instance; pydantic
+    extracts the controller slice (from_attributes), so the file on disk
+    carries only what the controller reads."""
+    source = Settings()
+    source.NETWORK_INTERFACE = "enp3s0"
+
+    config = Configuration.model_validate(_controller_config_dict(source))
+
+    assert config.settings.NETWORK_INTERFACE == "enp3s0"
+    dumped = config.model_dump()["settings"]
+    assert set(dumped) == set(ControllerSettings.model_fields)

--- a/tests/supervisor/test_controller_main.py
+++ b/tests/supervisor/test_controller_main.py
@@ -1,0 +1,65 @@
+"""The controller process entry point (supervisor/controllers/__main__.py):
+config-file loading, the NETWORK_INTERFACE guard, and --print-settings."""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+import aleph.vm.supervisor.controllers.__main__ as controller_main
+
+
+def _write_config(tmp_path, settings_dict: dict):
+    config = {
+        "vm_id": 3,
+        "vm_hash": "cafe" * 16,
+        "settings": settings_dict,
+        "vm_configuration": {
+            "use_jailer": False,
+            "firecracker_bin_path": "/opt/firecracker",
+            "jailer_bin_path": "/opt/jailer",
+            "config_file_path": "/tmp/config.json",
+            "init_timeout": 30.0,
+        },
+        "hypervisor": "firecracker",
+    }
+    path = tmp_path / "controller.json"
+    path.write_text(json.dumps(config))
+    return path
+
+
+def test_main_exits_when_config_has_no_network_interface(tmp_path, mocker):
+    """A config with no NETWORK_INTERFACE (never written by a healthy
+    supervisor, conceivable in a hand-edited or truncated file) must exit
+    with a clear error instead of crashing inside Network()."""
+    config_path = _write_config(tmp_path, {})
+    mocker.patch("sys.argv", ["controller", "-c", str(config_path)])
+
+    with pytest.raises(SystemExit) as excinfo:
+        controller_main.main()
+
+    assert excinfo.value.code == 1
+
+
+def test_main_print_settings_shows_the_controller_slice(tmp_path, mocker, capsys):
+    config_path = _write_config(tmp_path, {"NETWORK_INTERFACE": "eth0"})
+    mocker.patch("sys.argv", ["controller", "-c", str(config_path), "--print-settings"])
+    mocker.patch.object(controller_main, "Network")
+    mocker.patch.object(controller_main, "run_persistent_vm", new=AsyncMock())
+
+    controller_main.main()
+
+    printed = capsys.readouterr().out
+    assert '"NETWORK_INTERFACE": "eth0"' in printed
+    # Only the controller slice, not a full node-settings dump.
+    assert "CONNECTIVITY" not in printed
+    assert "SUPERVISOR_GRPC_SOCKET" not in printed
+
+
+def test_main_exits_when_config_file_is_missing(tmp_path, mocker):
+    mocker.patch("sys.argv", ["controller", "-c", str(tmp_path / "nope.json")])
+
+    with pytest.raises(SystemExit) as excinfo:
+        controller_main.main()
+
+    assert excinfo.value.code == 1


### PR DESCRIPTION
Follow-up to #1014, removing the design smell it papered over: controller configs embedded a full ~200-field `Settings` dump, of which the controller process ever read **nine** (`JAILER_BASE_DIR` + the eight network fields consumed by `supervisor/controllers/__main__.py`). The full dump coupled the on-disk format to every settings rename (the 1.13.0 `CONNECTIVITY_DNS_HOSTNAME` crash-loop) and shipped ~190 stale values as dead weight in per-VM state.

## What

- **`ControllerSettings`**: a new model in `supervisor_interface/configuration.py` carrying exactly the slice the controller reads, with `extra="ignore"` and per-field defaults mirroring `conf.py`. `Configuration.settings` is now this type.
- **No file migration needed, in either direction of schema drift**:
  - configs written by ANY older version (full dumps, legacy keys like `CONNECTIVITY_DNS_HOSTNAME` included) parse by ignoring the surplus;
  - a key missing from an old dump, or dropped from the slice in the future, falls back to its default;
  - files rewrite themselves to the minimal form on the VM's next reconfigure.
- **Writers unchanged**: `from_attributes=True` lets the three `Configuration(...)` build sites keep passing the live `Settings` object; pydantic extracts the slice.
- **Controller `__main__`** no longer calls `Settings.check()` (full-host validation: KVM, firecracker binaries, fake-data paths — meaningless against a stale snapshot, redundant with the supervisor's own startup check). It validates the one field `Network` cannot default (`NETWORK_INTERFACE`) with a clear error, and `--print-settings` prints the actual slice.
- **Supersedes #1014's unknown-key validator**: the smaller model's `extra="ignore"` absorbs it; the forward-compat test file now pins both directions (1.13.0-style full dump, arbitrary future key, missing keys → defaults, corrupt known key still rejected, writer round-trip is minimal).

## Compatibility

- Reading: any old config parses (verified against a real 1.13.0-style `Settings` dump with the legacy key in tests).
- Rollback: a node rolled back to a version older than #1014 cannot parse minimal configs, same asymmetry #1014 already documented; rollback to a #1014-or-later version works (its validator drops the unknown... nothing: minimal is a strict subset, and missing keys were never rejected — the full-`Settings` model has defaults for all nine fields).
- Marked breaking (`!`) for the on-disk format change, though no operator action is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
