### PR TITLE
ci(droplets): stop apt-daily before provisioning instead of racing its lock

### DIFF
--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -223,8 +223,14 @@ jobs:
           # Wait a few seconds for DigitalOcean to setup the Droplet using apt, which conflicts with our comands:
           sleep 5
 
-          # Wait for /var/lib/apt/lists/lock to be unlocked on the remote host via SSH.
-          while ssh root@${DROPLET_IPV4} lsof /var/lib/apt/lists/lock; do sleep 1; done
+          # Fresh droplets run apt-daily / unattended-upgrades at boot, which
+          # grabs /var/lib/apt/lists/lock. DPkg::Lock::Timeout does not cover
+          # that lock reliably, and a check-then-run wait loop races (the
+          # timer can re-fire between the check and our apt-get). Stop the
+          # contender for good, then wait out any run already in flight.
+          ssh root@${DROPLET_IPV4} "systemctl disable --now apt-daily.timer apt-daily-upgrade.timer 2>/dev/null || true"
+          ssh root@${DROPLET_IPV4} "systemctl stop unattended-upgrades.service apt-daily.service apt-daily-upgrade.service 2>/dev/null || true"
+          while ssh root@${DROPLET_IPV4} lsof /var/lib/apt/lists/lock /var/lib/dpkg/lock-frontend 2>/dev/null; do sleep 1; done
 
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 update"
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 upgrade -y"
@@ -385,6 +391,12 @@ jobs:
           ssh  root@${DROPLET_IPV4} mkdir -p /etc/aleph-vm/
           scp supervisor.env root@${DROPLET_IPV4}:/etc/aleph-vm/supervisor.env
           scp packaging/target/aleph-vm.debian-12.deb root@${DROPLET_IPV4}:/opt
+
+          # Same apt-daily mitigation as the matrix job above: stop the boot-time
+          # apt timers and wait out any run already holding the locks.
+          ssh root@${DROPLET_IPV4} "systemctl disable --now apt-daily.timer apt-daily-upgrade.timer 2>/dev/null || true"
+          ssh root@${DROPLET_IPV4} "systemctl stop unattended-upgrades.service apt-daily.service apt-daily-upgrade.service 2>/dev/null || true"
+          while ssh root@${DROPLET_IPV4} lsof /var/lib/apt/lists/lock /var/lib/dpkg/lock-frontend 2>/dev/null; do sleep 1; done
 
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 update"
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 upgrade -y"

--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -230,7 +230,7 @@ jobs:
           # contender for good, then wait out any run already in flight.
           ssh root@${DROPLET_IPV4} "systemctl disable --now apt-daily.timer apt-daily-upgrade.timer 2>/dev/null || true"
           ssh root@${DROPLET_IPV4} "systemctl stop unattended-upgrades.service apt-daily.service apt-daily-upgrade.service 2>/dev/null || true"
-          while ssh root@${DROPLET_IPV4} lsof /var/lib/apt/lists/lock /var/lib/dpkg/lock-frontend 2>/dev/null; do sleep 1; done
+          while ssh root@${DROPLET_IPV4} "lsof /var/lib/apt/lists/lock || lsof /var/lib/dpkg/lock-frontend" 2>/dev/null; do sleep 1; done
 
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 update"
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 upgrade -y"
@@ -396,7 +396,7 @@ jobs:
           # apt timers and wait out any run already holding the locks.
           ssh root@${DROPLET_IPV4} "systemctl disable --now apt-daily.timer apt-daily-upgrade.timer 2>/dev/null || true"
           ssh root@${DROPLET_IPV4} "systemctl stop unattended-upgrades.service apt-daily.service apt-daily-upgrade.service 2>/dev/null || true"
-          while ssh root@${DROPLET_IPV4} lsof /var/lib/apt/lists/lock /var/lib/dpkg/lock-frontend 2>/dev/null; do sleep 1; done
+          while ssh root@${DROPLET_IPV4} "lsof /var/lib/apt/lists/lock || lsof /var/lib/dpkg/lock-frontend" 2>/dev/null; do sleep 1; done
 
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 update"
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 upgrade -y"


### PR DESCRIPTION
Three droplet-CI flakes today (on #1014, #1015 and #1016) with the identical signature:

```
E: Could not get lock /var/lib/apt/lists/lock. It is held by process NNNN (apt-get)
```

on fresh Ubuntu 24.04 droplets, in the "Install Aleph-VM on the Droplet" step — despite every apt-get already passing `-o DPkg::Lock::Timeout=-1`. That option reliably guards the dpkg locks but empirically not the lists lock, and the existing `lsof` wait loop is check-then-run: the boot-time `apt-daily` timer can re-fire between the check and the next ssh command.

Fix: remove the contender instead of racing it.

- `systemctl disable --now apt-daily.timer apt-daily-upgrade.timer` and stop any in-flight `unattended-upgrades` / `apt-daily` run before the first apt command (fine on a throwaway CI droplet).
- Extend the wait loop to cover both `/var/lib/apt/lists/lock` and `/var/lib/dpkg/lock-frontend`, so a run already holding a lock is waited out.
- Apply the same treatment to the fake-instance (debian-12) job, which had no wait at all.

Fail-open by design: every mitigation command is `|| true`, so on an image without these units the behavior is exactly today's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
