### PR TITLE
fix(supervisor): rebuild GPU attachments when reattaching running VMs

### DIFF
--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -769,6 +769,12 @@ class VmPool:
         spec = spec_from_controller_configuration(config)
         execution = VmExecution.from_spec(spec, systemd_manager=self.systemd_manager)
 
+        # Rebuild GPU attachments from the config. Without this, an adopted
+        # VM's cards look free: get_available_gpus re-offers them and
+        # _validate_spec_gpus lets a new create double-attach a card the
+        # running guest physically holds.
+        execution.gpus = self._rebuild_reattached_gpus(spec.gpus)
+
         execution.mapped_ports = await get_port_mappings(vm_id)
         logger.info("Loading existing mapped_ports %s", execution.mapped_ports)
 
@@ -1046,6 +1052,50 @@ class VmPool:
                 required={"memory_mib": required_memory_mib},
                 available={"memory_mib": max(memory_cap_mib - committed_memory_mib, 0)},
             )
+
+    def _rebuild_reattached_gpus(self, attached: list[GpuSpec]) -> list[HostGPU]:
+        """Rebuild the HostGPU attachments of a reattached VM from its on-disk
+        controller config.
+
+        Unlike ``_validate_spec_gpus`` this never rejects: the cards are
+        already passed through to a running guest, so the attachment is a
+        fact to record, not a request to admit. A pci_host still present in
+        the host inventory keeps its full device metadata (device_id, x-vga
+        support as the hardware reports it).
+
+        A pci_host absent from the inventory (card removed, or its vfio
+        binding changed while the supervisor was down) is still recorded, as
+        a bare HostGPU carrying only what the config knows (pci_host +
+        supports_x_vga, empty device_id). This is the least-surprising
+        representation the types allow: it is invisible to
+        ``get_available_gpus`` and ``_validate_spec_gpus`` (both only
+        offer/accept inventory cards, so accounting for the cards that DO
+        exist stays correct), while ``uses_gpu()`` keeps holding the address
+        and VM info keeps reporting the passthrough for as long as the VM
+        runs.
+        """
+        inventory = {gpu.pci_host: gpu for gpu in self.gpus}
+        rebuilt: list[HostGPU] = []
+        for gpu_spec in attached:
+            pci_host = str(gpu_spec.pci_host)
+            device = inventory.get(pci_host)
+            if device is not None:
+                rebuilt.append(
+                    HostGPU(
+                        pci_host=device.pci_host,
+                        supports_x_vga=device.has_x_vga_support,
+                        device_id=device.device_id,
+                        model=None,
+                    )
+                )
+            else:
+                logger.warning(
+                    "Reattached VM holds GPU %s which is absent from the host inventory; "
+                    "recording the attachment from the config alone",
+                    pci_host,
+                )
+                rebuilt.append(HostGPU(pci_host=pci_host, supports_x_vga=gpu_spec.supports_x_vga))
+        return rebuilt
 
     def _validate_spec_gpus(self, requested: list[GpuSpec]) -> list[HostGPU]:
         """GPU attach invariant: every spec entry names a pci_host that exists

--- a/tests/supervisor/test_supervisor_reattach.py
+++ b/tests/supervisor/test_supervisor_reattach.py
@@ -10,6 +10,21 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aleph.vm.pool import VmPool
+from aleph.vm.resources import (
+    GpuDevice,
+    GpuDeviceClass,
+    HostGPU,
+    InsufficientResourcesError,
+)
+from aleph.vm.supervisor_interface.configuration import (
+    Configuration,
+    ControllerSettings,
+    HypervisorType,
+    QemuGPU,
+    QemuVMConfiguration,
+    load_controller_configuration,
+    save_controller_configuration,
+)
 from aleph.vm.supervisor_interface.errors import (
     InternalSupervisorError,
     VmAlreadyExistsError,
@@ -20,7 +35,9 @@ from aleph.vm.supervisor_interface.types import (
     DiskFormat,
     DiskRole,
     DiskSpec,
+    GpuSpec,
     NetworkConfig,
+    PciAddress,
     VmId,
 )
 
@@ -56,6 +73,7 @@ def _bare_pool() -> VmPool:
     pool.executions = {}
     pool.network = None
     pool.systemd_manager = MagicMock()
+    pool.gpus = []
     pool._failed_reattach = {}
     return pool
 
@@ -475,6 +493,115 @@ async def test_retry_loop_returns_immediately_without_failures():
     pool = _bare_pool()
     pool._failed_reattach = {}
     await pool.run_reattach_retry_loop()  # must not hang
+
+
+# ── GPU accounting across reattach ──────────────────────────────────────────
+
+_DEVICE_ID = "10de:2504"
+
+
+def _gpu_device(pci_host: str) -> GpuDevice:
+    return GpuDevice(
+        vendor="NVIDIA",
+        device_name="GH100",
+        device_class=GpuDeviceClass.VGA_COMPATIBLE_CONTROLLER,
+        pci_host=pci_host,
+        device_id=_DEVICE_ID,
+    )
+
+
+def _controller_config_with_gpu(pci_host: str, supports_x_vga: bool = True) -> Configuration:
+    return Configuration(
+        vm_id=7,
+        vm_hash=_HASH,
+        settings=ControllerSettings(),
+        vm_configuration=QemuVMConfiguration(
+            qemu_bin_path="/usr/bin/qemu-system-x86_64",
+            image_path="/data/rootfs.qcow2",
+            monitor_socket_path=Path(f"{_HASH}-monitor.socket"),
+            qmp_socket_path=Path(f"{_HASH}-qmp.socket"),
+            vcpu_count=2,
+            mem_size_mb=1024,
+            host_volumes=[],
+            gpus=[QemuGPU(pci_host=pci_host, supports_x_vga=supports_x_vga)],
+        ),
+        hypervisor=HypervisorType.qemu,
+    )
+
+
+async def _restore_from_disk(pool: VmPool, monkeypatch, tmp_path, config: Configuration) -> None:
+    """Round-trip the config through the real on-disk JSON, then run the
+    restore exactly as load_persistent_executions would after a daemon
+    restart. Only the host-touching steps (resource prepare, controller
+    handle, port-mapping DB) are stubbed."""
+    from aleph.vm.conf import settings as vm_settings
+    from aleph.vm.models import VmExecution
+
+    monkeypatch.setattr(vm_settings, "EXECUTION_ROOT", tmp_path)
+    save_controller_configuration(_HASH, config)
+    loaded = load_controller_configuration(_HASH)
+    assert loaded is not None
+
+    monkeypatch.setattr(VmExecution, "prepare", AsyncMock())
+    fake_vm = SimpleNamespace(start_guest_api=AsyncMock())
+    monkeypatch.setattr(VmExecution, "create", MagicMock(return_value=fake_vm))
+    monkeypatch.setattr("aleph.vm.pool.get_port_mappings", AsyncMock(return_value={}))
+
+    await pool._restore_running_execution_from_config(loaded, vm_index=loaded.vm_id, vm_id=VmId(_HASH))
+
+
+@pytest.mark.asyncio
+async def test_reattach_rebuilds_gpu_attachments_from_config(monkeypatch, tmp_path):
+    """After a daemon restart, an adopted VM's GPUs must count as attached:
+    get_available_gpus must not re-offer them, and _validate_spec_gpus must
+    refuse a new spec claiming them (the card is physically passed through
+    to the running guest)."""
+    pool = _bare_pool()
+    free_card = _gpu_device("0000:02:00.0")
+    pool.gpus = [_gpu_device("0000:01:00.0"), free_card]
+
+    await _restore_from_disk(pool, monkeypatch, tmp_path, _controller_config_with_gpu("0000:01:00.0"))
+
+    execution = pool.executions[VmId(_HASH)]
+    # Full inventory metadata is preserved for a card that is still present.
+    assert execution.gpus == [HostGPU(pci_host="0000:01:00.0", supports_x_vga=True, device_id=_DEVICE_ID, model=None)]
+    # (a) the attached card is no longer offered; the free one still is.
+    assert pool.get_available_gpus() == [free_card]
+    # (b) a new create claiming the attached card is refused ...
+    with pytest.raises(InsufficientResourcesError) as excinfo:
+        pool._validate_spec_gpus([GpuSpec(pci_host=PciAddress("0000:01:00.0"), supports_x_vga=True)])
+    assert "already attached" in str(excinfo.value)
+    # ... while the free card still validates.
+    validated = pool._validate_spec_gpus([GpuSpec(pci_host=PciAddress("0000:02:00.0"), supports_x_vga=True)])
+    assert validated[0].pci_host == "0000:02:00.0"
+
+
+@pytest.mark.asyncio
+async def test_reattach_accounts_for_gpu_missing_from_inventory(monkeypatch, tmp_path):
+    """A config GPU absent from the current inventory (card removed or vfio
+    rebind while the daemon was down) is still recorded on the execution,
+    from the config's own data, without disturbing the accounting of the
+    cards that do exist."""
+    pool = _bare_pool()
+    remaining_card = _gpu_device("0000:02:00.0")
+    pool.gpus = [remaining_card]
+
+    await _restore_from_disk(
+        pool, monkeypatch, tmp_path, _controller_config_with_gpu("0000:01:00.0", supports_x_vga=False)
+    )
+
+    execution = pool.executions[VmId(_HASH)]
+    # Bare HostGPU built from the config alone: pci_host and supports_x_vga
+    # survive the JSON round-trip; the device metadata is unknown.
+    assert execution.gpus == [HostGPU(pci_host="0000:01:00.0", supports_x_vga=False, device_id="", model=None)]
+    assert execution.uses_gpu("0000:01:00.0")
+    # The inventory card is untouched: still offered and still admissible.
+    assert pool.get_available_gpus() == [remaining_card]
+    validated = pool._validate_spec_gpus([GpuSpec(pci_host=PciAddress("0000:02:00.0"), supports_x_vga=True)])
+    assert validated[0].pci_host == "0000:02:00.0"
+    # The absent card's address stays inadmissible (not in the inventory).
+    with pytest.raises(InsufficientResourcesError):
+        pool._validate_spec_gpus([GpuSpec(pci_host=PciAddress("0000:01:00.0"), supports_x_vga=True)])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
After a supervisor restart, `load_persistent_executions` reattaches running VMs but never rebuilt `VmExecution.gpus` from the controller config. Two consumers were wrong afterwards:

- `get_available_gpus` re-offered cards physically passed through to running guests, so `GetHostInfo.available_gpus` lied after every daemon restart.
- `_validate_spec_gpus` was blind to adopted VMs, so a new CreateVm could be handed a card a running VM owns (real double-attach harm).

The restore path now rebuilds attachments via `_rebuild_reattached_gpus`: inventory cards keep full device metadata; a card absent from the inventory (removed, or vfio binding changed while the supervisor was down) is recorded as a bare HostGPU from the config alone, with a warning, invisible to availability and admission (which only deal in inventory cards) but still held by `uses_gpu()`.

Found while building the Rust port's world view (its adoption already implements this exclusion; `docs/plans/rust-port-divergences.md` entry 14 on the increment branches tracks this as the matching Python fix).

Known limitation, out of scope: `build_qemu_confidential_configuration` persists `QemuGPU(pci_host=...)` only, so a confidential VM's 3D-controller card that is also missing from the inventory rebuilds with `supports_x_vga=True` from the pydantic default. When the card is present, hardware truth wins.

Tests: `tests/supervisor/test_supervisor_reattach.py` round-trips real Configuration models through disk and runs the real restore; asserts exclusion from availability, rejection at admission, and the inventory-missing variant. Full suite: 1035 passed, only the 4 known env-only failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)