### PR TITLE
fix(packaging): declare the deb Architecture as amd64

### DIFF
--- a/packaging/aleph-vm/DEBIAN/control
+++ b/packaging/aleph-vm/DEBIAN/control
@@ -1,6 +1,6 @@
 Package: aleph-vm
 Version: 0.1.8
-Architecture: all
+Architecture: amd64
 Maintainer: Aleph.im
 Description: Aleph.im VM execution engine
 Depends: python3,python3-pip,python3-aiohttp,python3-msgpack,python3-aiodns,python3-alembic,python3-sqlalchemy,python3-setproctitle,redis,python3-psutil,sudo,acl,curl,systemd-container,squashfs-tools,debootstrap,python3-packaging,python3-cpuinfo,python3-nftables,python3-jsonschema,cloud-image-utils,ndppd,python3-yaml,python3-dotenv,python3-schedule,qemu-system-x86,qemu-utils,python3-systemd,python3-dbus,btrfs-progs,nftables,lshw,python3-jwcrypto,python3-netifaces,haproxy (>= 2.4),python3-setuptools


### PR DESCRIPTION
Follow-up from #1024's review. The package has shipped native x86_64 binaries for a long time (firecracker, jailer, sevctl, and now the Rust supervisor daemon) while declaring `Architecture: all`, so dpkg would happily install it on arm64 where nothing runs. One line: `all` becomes `amd64`.

No artifact ripple: the deb filename is set explicitly by `dpkg-deb --build aleph-vm target/aleph-vm.deb` and the per-distro renames in CI, so nothing downstream keys off an architecture suffix. The only behavior change is dpkg now refusing to install on non-amd64 hosts, which is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)