### PR TITLE
fix(nix): chroot DNS + secrets mount on the read-only measured rootfs (D3)

### DIFF
--- a/nix/init.sh
+++ b/nix/init.sh
@@ -92,9 +92,27 @@ prepare_chroot() {
     /bin/busybox mkdir -m 0700 -p /tmp/secrets
     /bin/busybox mkdir -m 0700 -p /mnt/root/tmp/secrets
     /bin/busybox mount --bind /tmp/secrets /mnt/root/tmp/secrets
-    # DNS: use gateway as nameserver (common for VM bridges).
-    if [ -n "$gateway" ]; then
-        echo "nameserver ${gateway}" > /mnt/root/etc/resolv.conf
+    # DNS for the chrooted workload. The rootfs is mounted read-only under
+    # dm-verity, so writing /mnt/root/etc/resolv.conf directly cannot work
+    # there (the old `echo >` only ever worked on legacy writable mounts).
+    # Instead, expose the initramfs /etc/resolv.conf (written by udhcpc.script
+    # from the DHCP option-6 nameservers) via a file bind-mount over the
+    # rootfs placeholder. On the static ip= path there is no DHCP lease, so
+    # seed the initramfs copy from the gateway first (common for VM bridges).
+    if [ ! -f /etc/resolv.conf ] && [ -n "$gateway" ]; then
+        /bin/busybox mkdir -p /etc
+        echo "nameserver ${gateway}" > /etc/resolv.conf
+    fi
+    if [ -f /etc/resolv.conf ]; then
+        if [ -f /mnt/root/etc/resolv.conf ]; then
+            /bin/busybox mount --bind /etc/resolv.conf /mnt/root/etc/resolv.conf \
+                || echo "init: WARNING: resolv.conf bind-mount failed; workload DNS unavailable"
+        else
+            # Legacy rootfs without the placeholder: best-effort copy (works
+            # only if the rootfs is mounted writable).
+            /bin/busybox cp /etc/resolv.conf /mnt/root/etc/resolv.conf 2>/dev/null \
+                || echo "init: WARNING: rootfs has no /etc/resolv.conf placeholder; workload DNS unavailable"
+        fi
     fi
     echo "init: chroot environment prepared (proc, sys, dev, secrets, DNS)"
 }

--- a/nix/rootfs.nix
+++ b/nix/rootfs.nix
@@ -21,8 +21,23 @@ pkgs.runCommand "rootfs.ext4" {
   SOURCE_DATE_EPOCH = "0";
 } ''
   # Create a minimal ext4 image with /sbin/init entrypoint.
-  mkdir -p rootfs/sbin rootfs/bin rootfs/srv
+  mkdir -p rootfs/sbin rootfs/bin rootfs/srv rootfs/etc
   cp ${staticBusybox}/bin/busybox rootfs/bin/
+
+  # Empty resolv.conf placeholder: the rootfs is mounted read-only under
+  # dm-verity, so init.sh cannot create files in it at boot. It instead
+  # bind-mounts the initramfs /etc/resolv.conf (the DHCP-provided nameservers
+  # written by udhcpc.script) over this placeholder so the chrooted workload
+  # gets DNS. A file bind-mount needs an existing target.
+  touch rootfs/etc/resolv.conf
+
+  # Same read-only constraint for the secrets bind-mount target: init.sh's
+  # `mkdir -p /mnt/root/tmp/secrets` cannot create directories on the verity
+  # mount, so ship them in the image (mkdir -p then no-ops and the bind-mount
+  # of the initramfs /tmp/secrets finds its target).
+  mkdir -p rootfs/tmp/secrets
+  chmod 1777 rootfs/tmp
+  chmod 0700 rootfs/tmp/secrets
 
   # Placeholder workload page served by busybox httpd.
   cat > rootfs/srv/index.html <<'HTML'

--- a/nix/udhcpc.script
+++ b/nix/udhcpc.script
@@ -42,6 +42,8 @@ case "$1" in
             /bin/busybox ip route add default via "$router" dev "$interface" 2>/dev/null
         fi
         if [ -n "$dns" ]; then
+            # The minimal initramfs ships no /etc; create it or the write fails.
+            /bin/busybox mkdir -p /etc
             : > /etc/resolv.conf
             for ns in $dns; do
                 echo "nameserver $ns" >> /etc/resolv.conf


### PR DESCRIPTION
## D3: give the chrooted workload DNS and a working secrets mount

Stacked on D2 (`od/phase3-d2-snp-dhcp`). Resolves the first D2-deferred follow-up (see `docs/plans/rust-port-divergences.md`).

### Why
The verity rootfs is mounted read-only, so `prepare_chroot`'s direct writes could never work on measured boots:
- the DNS `echo > /mnt/root/etc/resolv.conf` failed silently (and only ran on the static `ip=` path anyway, which the SNP image never takes), leaving the chrooted workload with no resolver;
- `mkdir -p /mnt/root/tmp/secrets` could not create the secrets bind-mount target, so injected secrets were invisible to the workload (same read-only failure, found while fixing the first).

Attestation was unaffected (the attest-agent runs in the initramfs), which is why the e2e validation passed regardless.

### What
- `nix/rootfs.nix`: ship `/etc/resolv.conf` (empty) and `/tmp/secrets` (0700, `/tmp` 1777) placeholders; a file bind-mount needs an existing target and `mkdir -p` then no-ops.
- `nix/init.sh` `prepare_chroot`: bind-mount the initramfs `/etc/resolv.conf` (DHCP option-6 nameservers written by `udhcpc.script`; gateway-seeded on the static `ip=` path) over the rootfs placeholder, with a best-effort copy fallback for legacy writable rootfs.
- `nix/udhcpc.script`: create `/etc` before writing `resolv.conf` (the minimal initramfs ships none, so the write previously failed silently).

Changes the launch measurement (expected; the client pins whatever the build emits). Verified: the built rootfs carries the placeholders (debugfs) and the initrd carries the fixed script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
