### PR TITLE
ci: gate shellcheck for real and cover the measured-guest scripts (D4)

### DIFF
--- a/.github/scripts/test_runtime_on_droplet.sh
+++ b/.github/scripts/test_runtime_on_droplet.sh
@@ -44,6 +44,7 @@ wait_for_supervisor() {
 }
 
 echo "==> Configuring supervisor for runtime ${ITEM_HASH}"
+# shellcheck disable=SC2029  # ${ITEM_HASH} expands client-side on purpose (local value)
 ssh root@"${DROPLET_IPV4}" "sed -i '/^ALEPH_VM_CHECK_FASTAPI_VM_ID=/d' /etc/aleph-vm/supervisor.env && echo ALEPH_VM_CHECK_FASTAPI_VM_ID=${ITEM_HASH} >> /etc/aleph-vm/supervisor.env"
 ssh root@"${DROPLET_IPV4}" "systemctl restart aleph-vm-supervisor"
 wait_for_supervisor "${DROPLET_IPV4}"

--- a/.github/workflows/test-using-pytest.yml
+++ b/.github/workflows/test-using-pytest.yml
@@ -233,10 +233,17 @@ jobs:
       - name: Workaround github issue https://github.com/actions/runner-images/issues/7192
         run: sudo echo RESET grub-efi/install_devices | sudo debconf-communicate grub-pc
 
-      - name: Install required system packages only for Ubuntu Linux
+      - name: Install shellcheck (pinned)
         run: |
-          sudo apt-get update
-          sudo apt-get install -y shellcheck
+          # Pinned upstream release instead of apt: ubuntu-22.04 ships
+          # shellcheck 0.8.0 (2021), which emits SC2187 for the busybox
+          # `#!/bin/busybox sh` shebangs in the measured-guest scripts;
+          # modern shellcheck handles them. Checksum-verified.
+          curl -fsSL https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz -o /tmp/shellcheck.tar.xz
+          echo "8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198  /tmp/shellcheck.tar.xz" | sha256sum -c -
+          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+          sudo install /tmp/shellcheck-v0.11.0/shellcheck /usr/local/bin/shellcheck
+          shellcheck --version
 
       - name: Run Shellcheck on all shell scripts
         run: |-

--- a/.github/workflows/test-using-pytest.yml
+++ b/.github/workflows/test-using-pytest.yml
@@ -243,4 +243,9 @@ jobs:
           # Also lint the extensionless packaging launchers (supervisor-launcher /
           # controller-launcher): they carry no ".sh" suffix but ARE the scripts
           # that flip the production cutover, so they must be shellcheck-clean.
-          find ./ -type f \( -name "*.sh" -o -name "*-launcher" \) -exec shellcheck {} \;
+          # And the measured-guest scripts (*.script, e.g. nix/udhcpc.script):
+          # they run as PID-1-adjacent code inside SEV-SNP VMs.
+          # `-exec ... +` (not `\;`): with `\;` find swallows shellcheck's exit
+          # code, so findings never failed this job; `+` propagates a nonzero
+          # exit from any batch and makes the check an actual gate.
+          find ./ -type f \( -name "*.sh" -o -name "*-launcher" -o -name "*.script" \) -exec shellcheck {} +

--- a/docs/plans/rust-port-divergences.md
+++ b/docs/plans/rust-port-divergences.md
@@ -100,26 +100,21 @@ following are recorded here rather than fixed in this batch. All are guest-side
 or image-side; the attest-agent (initramfs) is unaffected, so attestation works
 today.
 
-- **Workload chroot has no DNS on the DHCP path.** `nix/init.sh`
-  `prepare_chroot` writes `/mnt/root/etc/resolv.conf` only in the static `ip=`
-  branch (which the SNP image never takes, its cmdline omits `ip=`), and
-  `nix/udhcpc.script` writes `resolv.conf` only inside the initramfs
-  (`/etc/resolv.conf`), not into the workload chroot at `/mnt/root`. The
-  attest-agent runs in the initramfs so attestation resolves fine, but a real
-  workload pivoted into `/mnt/root` gets no resolver. FIX LATER (needs a `nix/`
-  change): seed `/mnt/root/etc/resolv.conf` from the DHCP-learned nameservers
-  (the `$dns` the udhcpc script already has) on the DHCP path.
+- **Workload chroot has no DNS on the DHCP path.** RESOLVED (increment D3,
+  `od/phase3-d3-guest-dns`): the verity rootfs is mounted read-only, so the
+  old `echo > /mnt/root/etc/resolv.conf` could never work on measured boots
+  (and `mkdir -p /mnt/root/tmp/secrets` could not create the secrets
+  bind-mount target either, the same read-only failure). The rootfs now ships
+  `/etc/resolv.conf` and `/tmp/secrets` placeholders, and `prepare_chroot`
+  bind-mounts the initramfs `/etc/resolv.conf` (DHCP option-6 nameservers
+  written by `udhcpc.script`, gateway-seeded on the static `ip=` path) over
+  the placeholder. Changes the launch measurement (expected).
 
-- **`nix/udhcpc.script` is not shellcheck-clean (SC2154).** shellcheck 0.10.0
-  flags `SC2154` twice (`interface` and `ip` referenced but not assigned):
-  they are lease variables udhcpc injects via the environment, invisible to
-  shellcheck. Because these are real findings, the aleph-vm shellcheck CI job
-  (`.github/workflows/test-using-pytest.yml`) was DELIBERATELY NOT extended to
-  cover `*.script` in this batch (wiring it would surface the warnings on a
-  file we cannot edit under the `nix/` constraint). NOTE the current CI `find
-  ... -exec shellcheck {} \;` swallows per-file exit codes (find returns 0
-  regardless), so shellcheck findings do not actually fail that job today; that
-  is a separate pre-existing CI weakness. FIX LATER (needs a `nix/` change):
-  add `# shellcheck disable=SC2154` (or declare the udhcpc-injected lease
-  variables) in `nix/udhcpc.script`, THEN add `-o -name "*.script"` to the CI
-  find pattern so the guest lease script is covered going forward.
+- **`nix/udhcpc.script` shellcheck + the non-gating CI job.** RESOLVED
+  (increment D4, `od/phase3-d4-shellcheck-gate`): `# shellcheck
+  disable=SC2154` documents the udhcpc-injected lease variables; the CI find
+  pattern now includes `*.script`; and the job switched from `-exec shellcheck
+  {} \;` (which swallowed exit codes, so shellcheck never actually failed CI)
+  to `-exec ... +`, making it a real gate. The 8 pre-existing findings this
+  uncovered across 5 scripts were fixed (quoting) or annotated (SC1091
+  runtime source, SC2029 intentional client-side expansion).

--- a/examples/example_confidential_image/build_debian_image.sh
+++ b/examples/example_confidential_image/build_debian_image.sh
@@ -99,13 +99,13 @@ fi
 if [ -z "${DISK_PASSWORD}" ]; then
   echo "No disk password provided. Generating one..."
   DISK_PASSWORD=$(
-    tr </dev/urandom -dc _A-Z-a-z-0-9 | head -c${1:-16}
+    tr </dev/urandom -dc _A-Z-a-z-0-9 | head -c"${1:-16}"
     echo
   )
 fi
 
 if [ -z "${IMAGE_FILE}" ]; then
-  IMAGE_FILE="$(basename ${ROOTFS_DIR}).img"
+  IMAGE_FILE="$(basename "${ROOTFS_DIR}").img"
 fi
 
 BOOT_PARTITION_SIZE=100MiB
@@ -148,7 +148,7 @@ sudo mount "${MAPPED_DEVICE_ID}" "${MOUNT_POINT}"
 sudo cp --archive "${ROOTFS_DIR}"/* "${MOUNT_POINT}"
 
 echo "Configuring root file system..."
-for m in run sys proc dev; do sudo mount --bind /$m ${MOUNT_POINT}/$m; done
+for m in run sys proc dev; do sudo mount --bind /$m "${MOUNT_POINT}/$m"; done
 sudo cp "${SCRIPT_DIR}/setup_debian_rootfs.sh" "${KEY_FILE}" "${MOUNT_POINT}"
 sudo chroot "${MOUNT_POINT}" bash setup_debian_rootfs.sh --loop-device-id "${LOOP_DEVICE_ID}" --mapper-name "${MAPPER_NAME}"
 sudo rm "${MOUNT_POINT}/setup_debian_rootfs.sh" "${KEY_FILE}"

--- a/kernels/build-kernel.sh
+++ b/kernels/build-kernel.sh
@@ -25,7 +25,7 @@ cd "linux-$kversion/"
 make olddefconfig
 make menuconfig
 
-make -j$(nproc) vmlinux
+make -j"$(nproc)" vmlinux
 
 # Copy the updated config locally for documentation
 cd ../

--- a/nix/udhcpc.script
+++ b/nix/udhcpc.script
@@ -29,6 +29,9 @@ mask2prefix() {
     echo "$prefix"
 }
 
+# udhcpc passes the lease via environment variables ($interface, $ip,
+# $subnet, $router, $dns), which shellcheck cannot see assigned.
+# shellcheck disable=SC2154
 case "$1" in
     deconfig)
         /bin/busybox ip addr flush dev "$interface" 2>/dev/null

--- a/runtimes/ovmf/build_ovmf.sh
+++ b/runtimes/ovmf/build_ovmf.sh
@@ -24,12 +24,12 @@ apt-get install -y autoconf autopoint binutils bison flex gcc gettext git make p
 # Packages for OVMF (there are some duplicates with Grub, kept for documentation)
 apt-get install -y bison build-essential dosfstools flex iasl libgmp3-dev libmpfr-dev mtools nasm subversion texinfo uuid-dev
 
-cd $GRUB_DIR
+cd "$GRUB_DIR"
 ./bootstrap
 ./configure --prefix /usr/ --with-platform=efi --target=x86_64
 make
 make install
 
 # Build OVMF
-cd $EDK2_DIR
+cd "$EDK2_DIR"
 OvmfPkg/build.sh -b RELEASE -p OvmfPkg/AmdSev/AmdSevX64.dsc

--- a/scripts/crn_upgrade.sh
+++ b/scripts/crn_upgrade.sh
@@ -35,6 +35,7 @@ detect_os() {
         echo "Cannot detect OS: /etc/os-release not found" >&2
         exit 1
     fi
+    # shellcheck disable=SC1091  # runtime file, not available to the linter
     . /etc/os-release
     case "${ID}-${VERSION_ID}" in
         debian-12*)  echo "debian-12" ;;


### PR DESCRIPTION
## D4: make the shellcheck CI job a real gate, widen it to guest scripts

Stacked on D3 (`od/phase3-d3-guest-dns`). Resolves the second D2-deferred follow-up (see `docs/plans/rust-port-divergences.md`).

### Why
Two related gaps:
- `nix/udhcpc.script` (the measured guest's lease-application script) was invisible to the shellcheck CI job (the find pattern only matches `*.sh` and `*-launcher`), and flagged SC2154 for the udhcpc-injected lease variables.
- The job ran `find ... -exec shellcheck {} \;`, which swallows shellcheck's exit code: **shellcheck findings never actually failed CI** for any script.

### What
- `nix/udhcpc.script`: `# shellcheck disable=SC2154` documenting that `$interface`/`$ip`/`$subnet`/`$router`/`$dns` are injected by udhcpc via the environment. (Touches the initrd, so the launch measurement changes; expected.)
- `.github/workflows/test-using-pytest.yml`: add `-o -name "*.script"` and switch to `-exec shellcheck {} +` so a nonzero exit from any batch fails the job.
- Fix the 8 pre-existing findings the now-real gate uncovers across 5 scripts: quoting in `kernels/build-kernel.sh`, `runtimes/ovmf/build_ovmf.sh`, `examples/example_confidential_image/build_debian_image.sh`; an SC1091 directive for the runtime `/etc/os-release` source in `scripts/crn_upgrade.sh`; an SC2029 directive for an intentional client-side expansion in `.github/scripts/test_runtime_on_droplet.sh`.

Dry-ran the exact CI command locally (shellcheck 0.11.0): exit 0 across all matched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
