### PR TITLE
refactor(rust): read the daemon's mem_size_mb as memsizes::MiB

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2875,6 +2875,7 @@ dependencies = [
  "clap",
  "hyper-util",
  "libc",
+ "memsizes",
  "prost",
  "rmpv",
  "rusqlite",

--- a/rust/crates/supervisor-daemon/Cargo.toml
+++ b/rust/crates/supervisor-daemon/Cargo.toml
@@ -16,6 +16,7 @@ supervisor-proto.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 libc.workspace = true
+memsizes.workspace = true
 prost.workspace = true
 rmpv.workspace = true
 rusqlite.workspace = true

--- a/rust/crates/supervisor-daemon/src/controller_config.rs
+++ b/rust/crates/supervisor-daemon/src/controller_config.rs
@@ -29,7 +29,8 @@
 
 use std::path::PathBuf;
 
-use serde::{Deserialize, Deserializer};
+use memsizes::MiB;
+use serde::Deserialize;
 
 /// A parse failure for one controller config file. The world view logs it
 /// and skips the VM; it never aborts the daemon (the Python crash-loop
@@ -152,8 +153,7 @@ pub struct QemuVmConfig {
     #[serde(default)]
     pub qga_socket_path: Option<String>,
     pub vcpu_count: u32,
-    #[serde(deserialize_with = "deserialize_mem_size_mib")]
-    pub mem_size_mb: u64,
+    pub mem_size_mb: MiB,
     #[serde(default)]
     pub interface_name: Option<String>,
     pub host_volumes: Vec<QemuHostVolume>,
@@ -209,7 +209,8 @@ impl QemuVmConfig {
             qmp_socket_path: String::new(),
             qga_socket_path: None,
             vcpu_count: 0,
-            mem_size_mb,
+            // The caller holds a raw MiB count from the request/proto edge.
+            mem_size_mb: MiB::from(mem_size_mb),
             interface_name,
             host_volumes: Vec::new(),
             gpus: Vec::new(),
@@ -274,26 +275,6 @@ impl QemuVmConfig {
             _ => None,
         }
     }
-}
-
-/// `MemSizeMib` reads with the coercion of the Python `_coerce_mib`
-/// (`MiB(int(value))`): an integer, a float JSON number (Python's `int()`
-/// truncates) or an INTEGER string. A float STRING like "2048.5" raises in
-/// Python's `int(value)` and makes the whole config unparseable; it is
-/// rejected here too.
-fn deserialize_mem_size_mib<'de, D>(deserializer: D) -> Result<u64, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let value = serde_json::Value::deserialize(deserializer)?;
-    let parsed = match &value {
-        serde_json::Value::Number(number) => number
-            .as_u64()
-            .or_else(|| number.as_f64().map(|float| float as u64)),
-        serde_json::Value::String(text) => text.trim().parse::<u64>().ok(),
-        _ => None,
-    };
-    parsed.ok_or_else(|| serde::de::Error::custom(format!("cannot coerce {value} to MiB")))
 }
 
 /// The resolved `vm_configuration` union member.
@@ -608,7 +589,7 @@ mod tests {
             panic!("expected a QEMU configuration");
         };
         assert_eq!(vm.vcpu_count, 2);
-        assert_eq!(vm.mem_size_mb, 2048);
+        assert_eq!(vm.mem_size_mb, MiB::from(2048));
         assert_eq!(vm.interface_name.as_deref(), Some("vmtap3"));
         assert!(vm.image_path.ends_with("rootfs.qcow2"));
         assert_eq!(vm.host_volumes.len(), 1);
@@ -791,21 +772,26 @@ mod tests {
     }
 
     #[test]
-    fn mem_size_accepts_pydantic_lax_forms() {
+    fn a_non_integer_mem_size_fails_the_whole_config() {
+        // mem_size_mb reads as memsizes::MiB, which deserializes only from a
+        // bare integer. No producer writes anything else (pydantic MiB is an
+        // int subclass; the daemon writer holds a u64), so a float, negative
+        // or string is a parse error and the world view skips the VM. This is
+        // strictly safer than the former coercion, whose `float as u64` path
+        // saturated a negative like -2048 to `-m 0`.
         let name = format!("{}-controller.json", crate::test_fixtures::QEMU_HASH);
-        let mut value: serde_json::Value = serde_json::from_str(&fixture(&name)).unwrap();
-        for lax in [
-            serde_json::Value::from("2048"),
-            serde_json::Value::from(2048.0),
-            // Python's int() truncates a float JSON number.
+        let base: serde_json::Value = serde_json::from_str(&fixture(&name)).unwrap();
+        for bad in [
             serde_json::Value::from(2048.7),
+            serde_json::Value::from(-2048),
+            serde_json::Value::from("2048"),
         ] {
-            value["vm_configuration"]["mem_size_mb"] = lax;
-            let config = parse_controller_config(&value.to_string()).unwrap();
-            let VmConfiguration::Qemu(vm) = &config.vm else {
-                panic!("expected a QEMU configuration");
-            };
-            assert_eq!(vm.mem_size_mb, 2048);
+            let mut value = base.clone();
+            value["vm_configuration"]["mem_size_mb"] = bad.clone();
+            assert!(
+                parse_controller_config(&value.to_string()).is_err(),
+                "{bad} must be rejected"
+            );
         }
     }
 
@@ -940,18 +926,5 @@ mod tests {
         std::fs::write(tmp.path().join("ab-qmp.socket"), b"dead").unwrap();
         remove_controller_configuration(tmp.path(), hash).unwrap();
         assert_eq!(std::fs::read_dir(tmp.path()).unwrap().count(), 0);
-    }
-
-    #[test]
-    fn a_float_string_mem_size_fails_the_whole_config() {
-        // Python parity: _coerce_mib does MiB(int(value)) and
-        // int("2048.5") raises, so the whole Configuration is unparseable
-        // (the world view then skips the VM, ledger entry 12). The payload
-        // does not fit the Firecracker shape either, so the shape-based
-        // union cannot rescue it.
-        let name = format!("{}-controller.json", crate::test_fixtures::QEMU_HASH);
-        let mut value: serde_json::Value = serde_json::from_str(&fixture(&name)).unwrap();
-        value["vm_configuration"]["mem_size_mb"] = "2048.5".into();
-        assert!(parse_controller_config(&value.to_string()).is_err());
     }
 }

--- a/rust/crates/supervisor-daemon/src/lifecycle.rs
+++ b/rust/crates/supervisor-daemon/src/lifecycle.rs
@@ -225,7 +225,7 @@ fn apply_numa_dropin(
 /// allocator selected (`None` for regular pages). Used to return the exact
 /// pages a VM reserved on release and to re-register them at adoption.
 fn config_hugepage_backing(config: &QemuVmConfig) -> (u32, Option<crate::numa::HugePageSize>) {
-    let memory_mb = config.mem_size_mb.min(u32::MAX as u64) as u32;
+    let memory_mb = config.mem_size_mb.count().min(u32::MAX as u64) as u32;
     let hugepage_size = config
         .hugepage_size
         .as_deref()
@@ -1779,7 +1779,7 @@ fn check_memory_backstop(state: &DaemonState, required_memory_mib: u64) -> Resul
         .blocking_read()
         .entries
         .values()
-        .map(|entry| entry.config.mem_size_mb)
+        .map(|entry| entry.config.mem_size_mb.count())
         .sum();
     let physical =
         crate::host::memory_total_mib().map_err(|error| RpcError::Internal(error.to_string()))?;
@@ -3723,7 +3723,7 @@ mod tests {
             panic!("the written config must be QEMU");
         };
         assert_eq!(qemu.interface_name.as_deref(), Some("vmtap4"));
-        assert_eq!(qemu.mem_size_mb, 256);
+        assert_eq!(qemu.mem_size_mb, memsizes::MiB::from(256));
 
         // GetVmSpec serves the ORIGINAL spec (live-daemon behavior).
         assert_eq!(vm_spec_message(&entry), request);

--- a/rust/crates/supervisor-daemon/src/service.rs
+++ b/rust/crates/supervisor-daemon/src/service.rs
@@ -538,7 +538,7 @@ pub fn vm_spec_message(entry: &VmEntry) -> pb::VmSpec {
         initrd_path: String::new(),
         disks,
         vcpus: config.vcpu_count,
-        memory_mib: config.mem_size_mb,
+        memory_mib: config.mem_size_mb.count(),
         tee,
         network: Some(pb::NetworkConfig {
             // Python: bool(vm_cfg.interface_name).


### PR DESCRIPTION
Follow-up to the #1030 review. The daemon's `controller_config` reader carried the same lax `_coerce_mib` emulation as the A1 controller: a custom deserializer that accepted a float or string `mem_size_mb`.

No producer ever writes those forms:
- pydantic `MiB` is an `int` subclass, so `.json()` emits a bare integer;
- the Rust daemon writer holds a `u64`.

The daemon's variant was in fact the more dangerous of the two. Its float path (`number.as_f64().map(|float| float as u64)`) had no negative/non-finite guard, so a hand-corrupted config with `mem_size_mb: -2048` failed `as_u64()`, fell through to `-2048.0 as u64`, and **saturated to 0**, launching QEMU with `-m 0`.

## Change

Read the field as [`memsizes::MiB`](https://crates.io/crates/memsizes) (the aleph-rs newtype the CVM scheduler agent already uses), which serde deserializes only from a bare integer. A float, negative or string is now a parse error; the world view then skips the VM, which is the intended fail-closed behaviour. The ~15-line custom deserializer and its now-moot lax-form test are gone.

- Read struct `QemuVmConfig.mem_size_mb`: `u64` + custom deserializer → `MiB`.
- Proto/accounting edges take `.count()` at the boundary (`memory_mib` in the world spec, the `check_memory_backstop` sum).
- The write struct `WrittenQemuVmConfiguration.mem_size_mb` stays `u64`: it never coerced and its value comes from a `u64` in code, so there is no footgun to close there.
- Tests: the lax-form test becomes a strict-rejection test (float/negative/string); the standalone float-string test is subsumed and removed.

Net −11 lines; all 238 daemon tests, fmt and clippy green.

## Note

This branches off `dev` (the daemon lives there via #1026-#1028, not on the Phase 3 stack) and, like #1030, adds `memsizes` to the workspace `Cargo.toml`. Whichever of the two lands second will need a one-line rebase to drop the duplicate dependency line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)