### PR TITLE
ci(codeql): exclude non-shipped scripts/ tooling from analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,14 @@
+---
+name: "aleph-vm CodeQL config"
+
+# Exclude non-shipped developer tooling from analysis. scripts/ holds codegen
+# and test-fixture generators (e.g. generate_controller_argv_fixtures.py,
+# generate_rust_fixtures.py) plus one-off diagnostics, none of which is imported
+# by the runtime package or packaged. CodeQL taints the hardcoded dummy SEV
+# session/godh *paths* those generators write into fixtures as clear-text
+# secrets (py/clear-text-{storage,logging}-sensitive-data); on fixture data that
+# is a false positive, and it fails the CodeQL check on every PR that carries a
+# generator. Dropping scripts/ from the analysis scope removes the noise without
+# hiding any shipped code.
+paths-ignore:
+  - scripts

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,6 +49,9 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
+          # paths-ignore lives here (excludes non-shipped scripts/ tooling from
+          # the analysis scope; see the config for why).
+          config-file: ./.github/codeql/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
Resolves the Phase 3 CodeQL false positives (the pending "resolve CodeQL FPs" task) at the source.

## The problem

The `CodeQL` check fails on every PR that carries a fixture/codegen generator under `scripts/`. It first surfaced on a real incremental PR with #1031 (A2), whose `scripts/generate_controller_argv_fixtures.py` builds confidential argv fixtures. CodeQL taints the hardcoded dummy SEV `session`/`godh`/`dh_cert` **paths** those generators write into fixtures (e.g. `/var/lib/aleph/vm/testhash/vm_session.b64`) as clear-text secrets: `py/clear-text-storage-sensitive-data` and `py/clear-text-logging-sensitive-data`.

These are false positives on fixture data. The paths are test placeholders that do not point at real files (the fixtures exist precisely so the argv-parity tests run without real SEV material on disk), and no key bytes are stored or logged.

## The fix

`scripts/` is developer tooling: codegen, test-fixture generators (`generate_controller_argv_fixtures.py`, `generate_rust_fixtures.py`) and one-off diagnostics. Nothing in `src/aleph/` imports it and it is not packaged. So it does not belong in the security-analysis scope.

- Add `.github/codeql/codeql-config.yml` with `paths-ignore: [scripts]`.
- Wire `config-file: ./.github/codeql/codeql-config.yml` into the `codeql-action/init` step.

This removes the whole class of noise without hiding any shipped code, and it applies to every open PR through its merge commit once this lands on `dev` (both base and head then exclude `scripts/`, so the differential alert check comes back clean).

Standalone off `dev`, independent of the Rust stack (like the daemon `MiB` fix #1046).

🤖 Generated with [Claude Code](https://claude.com/claude-code)