### PR TITLE
feat(storage): multi-disk volume pools for VM storage

### DIFF
--- a/doc/multi-disk-storage.md
+++ b/doc/multi-disk-storage.md
@@ -1,0 +1,44 @@
+# Using multiple disks on a CRN
+
+aleph-vm can spread VM volumes (instance rootfs overlays and persistent
+volumes) across several fast disks, and use slow disks for caches.
+
+## Fast disks (NVMe / SATA SSD): volume pools
+
+Mount each extra disk, then declare the mountpoints in
+`/etc/aleph-vm/supervisor.env`:
+
+    ALEPH_VM_VOLUME_POOLS=["/mnt/nvme1/aleph-volumes", "/mnt/sata1/aleph-volumes=ssd"]
+
+- The value is a JSON list. Each entry is a directory on the extra disk.
+- `PERSISTENT_VOLUMES_DIR` (default `/var/lib/aleph/vm/volumes/persistent`)
+  is always the first pool; existing nodes need no migration.
+- The media class (`nvme`/`ssd`/`hdd`) is detected from the backing block
+  device. Append `=nvme`/`=ssd` to override a wrong detection.
+- New volumes land on the eligible pool with the most free space. A volume
+  never spans pools. The capacity advertised to the network is the sum of
+  all pools.
+- Rotational disks (HDD) are refused as volume pools: VMs need fast storage.
+
+On first use the agent writes a `.aleph-vm-pool` marker into the pool and
+records the adoption under `EXECUTION_ROOT`. If the marker later disappears
+(typically: the disk is not mounted), the agent refuses to start rather than
+silently writing to the filesystem underneath the mountpoint.
+
+If one pooled disk fails, only the VMs whose volumes live on it are lost;
+the other pools keep serving their VMs. This is the main advantage over
+LVM/RAID0 striping, which loses the whole pool with one disk. If you prefer
+operating a single filesystem (LVM, btrfs multi-device, ZFS, mdraid), that
+still works: leave `VOLUME_POOLS` unset and mount the pooled filesystem at
+`PERSISTENT_VOLUMES_DIR`.
+
+## Slow disks (HDD): caches and backups
+
+HDDs must not hold running VMs, but they are fine for re-downloadable
+content and backups. Point the existing settings at them:
+
+    ALEPH_VM_CACHE_ROOT=/mnt/hdd0/aleph-cache
+    ALEPH_VM_BACKUP_DIRECTORY=/mnt/hdd0/aleph-backups
+
+`CACHE_ROOT` holds runtime/rootfs base images, program code archives,
+message JSON and data volumes — all safe on slow media.

--- a/doc/multi-disk-storage.md
+++ b/doc/multi-disk-storage.md
@@ -14,16 +14,40 @@ Mount each extra disk, then declare the mountpoints in
 - `PERSISTENT_VOLUMES_DIR` (default `/var/lib/aleph/vm/volumes/persistent`)
   is always the first pool; existing nodes need no migration.
 - The media class (`nvme`/`ssd`/`hdd`) is detected from the backing block
-  device. Append `=nvme`/`=ssd` to override a wrong detection.
+  device. Append `=nvme`/`=ssd` to override a wrong detection. Stacked or
+  unnamed-device setups (LVM, btrfs multi-device, mdraid, ZFS, network
+  filesystems) may detect as *undetectable*, which is a startup error: give
+  those pools an explicit `=nvme`/`=ssd` override.
 - New volumes land on the eligible pool with the most free space. A volume
   never spans pools. The capacity advertised to the network is the sum of
   all pools.
-- Rotational disks (HDD) are refused as volume pools: VMs need fast storage.
+- Rotational disks (HDD) are refused as *extra* volume pools: VMs need fast
+  storage. The first pool (`PERSISTENT_VOLUMES_DIR`) is the exception: on an
+  HDD it only logs a warning and stays eligible, so existing nodes keep
+  working unchanged.
 
 On first use the agent writes a `.aleph-vm-pool` marker into the pool and
 records the adoption under `EXECUTION_ROOT`. If the marker later disappears
 (typically: the disk is not mounted), the agent refuses to start rather than
 silently writing to the filesystem underneath the mountpoint.
+
+### Firecracker programs
+
+Writable volumes of Firecracker programs always stay on the first pool,
+regardless of free space. The Firecracker jailer hardlinks drive files into
+its chroot, and a hardlink across filesystems silently becomes a copy: guest
+writes would land in the copy and be lost. Read-only program files (runtime,
+code, data squashfs) are unaffected. Size the first pool accordingly if the
+node runs many programs with persistent volumes.
+
+### Removing a pool
+
+Once a pool has been adopted (its `.aleph-vm-pool` marker written), the agent
+refuses to start if the pool is later dropped from `VOLUME_POOLS`: the pool
+holds (or held) VM volumes, and silently forgetting it would orphan them. To
+really remove a pool: migrate or delete the volumes it holds, then remove the
+pool's entry from `{EXECUTION_ROOT}/volume-pools.json` (default
+`/var/lib/aleph/vm/volume-pools.json`).
 
 If one pooled disk fails, only the VMs whose volumes live on it are lost;
 the other pools keep serving their VMs. This is the main advantage over

--- a/rust/crates/supervisor-daemon/src/config.rs
+++ b/rust/crates/supervisor-daemon/src/config.rs
@@ -34,6 +34,11 @@ pub struct Settings {
     pub supervisor_grpc_socket: PathBuf,
     /// conf.py PERSISTENT_VOLUMES_DIR, default {EXECUTION_ROOT}/volumes/persistent.
     pub persistent_volumes_dir: PathBuf,
+    /// conf.py VOLUME_POOLS, default []: extra VM volume pool directories.
+    /// JSON list like the other pydantic list settings; entries may carry a
+    /// "=class" suffix the daemon strips — media-class eligibility is agent
+    /// policy, the daemon only needs the paths for available-disk accounting.
+    pub volume_pools: Vec<PathBuf>,
     /// conf.py BACKUP_DIRECTORY, default {EXECUTION_ROOT}/backups (increment 5).
     pub backup_directory: PathBuf,
     /// conf.py CONFIDENTIAL_SESSION_DIRECTORY, default {EXECUTION_ROOT}/sessions
@@ -185,6 +190,23 @@ impl Settings {
             Some(path) if !path.is_empty() => PathBuf::from(path),
             _ => execution_root.join("volumes").join("persistent"),
         };
+        let volume_pools = match env.get("VOLUME_POOLS") {
+            None => Vec::new(),
+            Some(value) => serde_json::from_str::<Vec<String>>(&value)
+                .map_err(|_| DaemonError::InvalidSetting {
+                    key: format!("{ENV_PREFIX}VOLUME_POOLS"),
+                    value,
+                    expected: "a JSON list of pool directories",
+                })?
+                .into_iter()
+                .map(|entry| {
+                    let path = entry
+                        .split_once('=')
+                        .map_or(entry.as_str(), |(path, _)| path);
+                    PathBuf::from(path.trim())
+                })
+                .collect(),
+        };
         // conf.py setup(): BACKUP_DIRECTORY defaults to EXECUTION_ROOT/backups,
         // CONFIDENTIAL_SESSION_DIRECTORY to EXECUTION_ROOT/sessions, when unset
         // (or emptied, matching the empty-string-is-unset family, entry 4).
@@ -323,6 +345,7 @@ impl Settings {
             execution_root,
             supervisor_grpc_socket,
             persistent_volumes_dir,
+            volume_pools,
             backup_directory,
             confidential_session_directory,
             enable_confidential_computing,
@@ -357,6 +380,14 @@ impl Settings {
             systemd_unit_dir,
             numa_hugepages,
         })
+    }
+
+    /// Every volume pool: PERSISTENT_VOLUMES_DIR (pool 0) plus the extras,
+    /// in declaration order — the statvfs targets for available-disk.
+    pub fn all_volume_pools(&self) -> Vec<PathBuf> {
+        std::iter::once(self.persistent_volumes_dir.clone())
+            .chain(self.volume_pools.iter().cloned())
+            .collect()
     }
 }
 
@@ -542,6 +573,7 @@ mod tests {
         );
         assert!(settings.developer_ssh_keys.is_empty());
         assert!(!settings.use_developer_ssh_keys);
+        assert!(settings.volume_pools.is_empty());
     }
 
     #[test]
@@ -756,6 +788,38 @@ mod tests {
         let settings =
             Settings::from_vars(vars(&[("ALEPH_VM_NETWORK_INTERFACE", "eth0")])).unwrap();
         assert_eq!(settings.network_interface.as_deref(), Some("eth0"));
+    }
+
+    #[test]
+    fn volume_pools_parse_json_and_strip_class_suffixes() {
+        let settings = Settings::from_vars(vars(&[(
+            "ALEPH_VM_VOLUME_POOLS",
+            r#"["/mnt/nvme1/aleph", "/mnt/sata1/aleph=ssd"]"#,
+        )]))
+        .unwrap();
+        assert_eq!(
+            settings.volume_pools,
+            vec![
+                PathBuf::from("/mnt/nvme1/aleph"),
+                PathBuf::from("/mnt/sata1/aleph"),
+            ]
+        );
+        // all_volume_pools prepends pool 0 (PERSISTENT_VOLUMES_DIR).
+        assert_eq!(
+            settings.all_volume_pools()[0],
+            PathBuf::from("/var/lib/aleph/vm/volumes/persistent")
+        );
+        assert_eq!(settings.all_volume_pools().len(), 3);
+
+        // Default: no extras, all_volume_pools is pool 0 alone.
+        let settings = Settings::from_vars(vars(&[])).unwrap();
+        assert!(settings.volume_pools.is_empty());
+        assert_eq!(settings.all_volume_pools().len(), 1);
+
+        // pydantic list parsing: a non-JSON value is a startup error.
+        let error =
+            Settings::from_vars(vars(&[("ALEPH_VM_VOLUME_POOLS", "/mnt/a,/mnt/b")])).unwrap_err();
+        assert!(error.to_string().contains("VOLUME_POOLS"));
     }
 
     #[test]

--- a/rust/crates/supervisor-daemon/src/host.rs
+++ b/rust/crates/supervisor-daemon/src/host.rs
@@ -7,9 +7,12 @@
 //!   truncated to MiB like `int(total / (1024 * 1024))`
 //! - kernel_version / hostname: uname(2) release / nodename, like os.uname()
 //! - available_disk_bytes: statvfs f_bavail * f_frsize, what
-//!   shutil.disk_usage().free reports for PERSISTENT_VOLUMES_DIR
+//!   shutil.disk_usage().free reports for PERSISTENT_VOLUMES_DIR;
+//!   available_disk_bytes_pooled sums this across every volume pool
 
+use std::os::unix::fs::MetadataExt;
 use std::path::Path;
+use std::path::PathBuf;
 
 use crate::error::DaemonError;
 
@@ -87,9 +90,61 @@ pub fn available_disk_bytes(path: &Path) -> Result<u64, DaemonError> {
     Ok(stat.f_bavail as u64 * stat.f_frsize as u64)
 }
 
+/// Free disk space for new volumes across every volume pool, in bytes:
+/// the statvfs sum with filesystems deduplicated by st_dev (two pool
+/// directories on one filesystem count once), matching the agent's
+/// pools_disk_usage. Unreachable pools contribute zero instead of failing
+/// GetHostInfo: a dead disk must not take Health down.
+pub fn available_disk_bytes_pooled(paths: &[PathBuf]) -> u64 {
+    let mut seen_devices = std::collections::HashSet::new();
+    let mut free = 0u64;
+    for path in paths {
+        let device = match std::fs::metadata(path) {
+            Ok(metadata) => metadata.dev(),
+            Err(error) => {
+                tracing::warn!(path = %path.display(), %error, "volume pool inaccessible, ignoring");
+                continue;
+            }
+        };
+        if !seen_devices.insert(device) {
+            continue;
+        }
+        match available_disk_bytes(path) {
+            Ok(bytes) => free += bytes,
+            Err(error) => {
+                tracing::warn!(path = %path.display(), %error, "statvfs failed, ignoring pool");
+            }
+        }
+    }
+    free
+}
+
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
+
+    #[test]
+    fn pooled_disk_dedups_same_filesystem_and_skips_dead_pools() {
+        let root = PathBuf::from("/");
+        // The same filesystem listed twice counts once...
+        let once = available_disk_bytes_pooled(&[root.clone()]);
+        let twice = available_disk_bytes_pooled(&[root.clone(), PathBuf::from("/etc")]);
+        // ("/" and "/etc" are usually one filesystem; when they are, the sums
+        // match. Different-filesystem hosts still satisfy the >= invariant.)
+        assert!(twice >= once);
+        assert_eq!(
+            available_disk_bytes_pooled(&[root.clone(), root.clone()]),
+            once
+        );
+        // A nonexistent pool contributes zero instead of erroring.
+        assert_eq!(
+            available_disk_bytes_pooled(&[root, PathBuf::from("/nonexistent-pool")]),
+            once
+        );
+        assert_eq!(available_disk_bytes_pooled(&[]), 0);
+    }
 
     #[test]
     fn meminfo_total_is_parsed_and_truncated() {

--- a/rust/crates/supervisor-daemon/src/host.rs
+++ b/rust/crates/supervisor-daemon/src/host.rs
@@ -129,7 +129,7 @@ mod tests {
     fn pooled_disk_dedups_same_filesystem_and_skips_dead_pools() {
         let root = PathBuf::from("/");
         // The same filesystem listed twice counts once...
-        let once = available_disk_bytes_pooled(&[root.clone()]);
+        let once = available_disk_bytes_pooled(std::slice::from_ref(&root));
         let twice = available_disk_bytes_pooled(&[root.clone(), PathBuf::from("/etc")]);
         // ("/" and "/etc" are usually one filesystem; when they are, the sums
         // match. Different-filesystem hosts still satisfy the >= invariant.)

--- a/rust/crates/supervisor-daemon/src/service.rs
+++ b/rust/crates/supervisor-daemon/src/service.rs
@@ -298,13 +298,13 @@ impl SupervisorService {
         // execution's get_disk_usage_delta, which is 0 for every adopted
         // (spec-built, message-free) execution, so free space alone is
         // still the exact post-restart figure.
-        let volumes_dir = self.state.host.settings.persistent_volumes_dir.clone();
+        let volume_pools = self.state.host.settings.all_volume_pools();
         let available_disk_bytes =
-            tokio::task::spawn_blocking(move || host::available_disk_bytes(&volumes_dir))
+            tokio::task::spawn_blocking(move || host::available_disk_bytes_pooled(&volume_pools))
                 .await
                 .map_err(|error| {
                     DaemonError::Internal(format!("the statvfs task failed: {error}"))
-                })??;
+                })?;
         // NUMA topology (increment C1): one proto NumaNode per detected node.
         // Empty when detection was unavailable, as it was before C1.
         let numa_nodes = numa_nodes_proto(&self.state.numa);

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import shutil
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
@@ -23,6 +22,7 @@ import psutil
 from aleph_message.models import ExecutableContent, ItemHash
 from aleph_message.models.execution.instance import InstanceContent
 
+from aleph.vm import storage_pools
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 from aleph.vm.resources import GpuDevice, InsufficientResourcesError
@@ -44,22 +44,24 @@ class ResourceRequirements:
     vcpus: int
     memory_mib: int
     disk_mib: int
-    is_instance: bool
+    max_volume_mib: int = 0
+    is_instance: bool = False
     gpu_device_ids: list[str] = field(default_factory=list)
 
 
 def requirements_from_message(content: ExecutableContent) -> ResourceRequirements:
     """Extract the resources a message requests into a message-free DTO."""
     is_instance = isinstance(content, InstanceContent)
-    disk_mib = 0
+    volume_sizes_mib: list[int] = []
     if isinstance(content, InstanceContent) and content.rootfs:
-        disk_mib += content.rootfs.size_mib
+        volume_sizes_mib.append(content.rootfs.size_mib)
     for volume in content.volumes or []:
-        disk_mib += getattr(volume, "size_mib", 0) or 0
+        volume_sizes_mib.append(getattr(volume, "size_mib", 0) or 0)
     return ResourceRequirements(
         vcpus=content.resources.vcpus,
         memory_mib=content.resources.memory,
-        disk_mib=disk_mib,
+        disk_mib=sum(volume_sizes_mib),
+        max_volume_mib=max(volume_sizes_mib, default=0),
         is_instance=is_instance,
         gpu_device_ids=requested_gpu_ids(content),
     )
@@ -104,6 +106,7 @@ class CapacityManager:
         memory_mib: int,
         vcpus: int,
         disk_mib: int,
+        max_volume_mib: int = 0,
         is_instance: bool,
         exclude_vm_hash: ItemHash | None = None,
     ) -> None:
@@ -124,22 +127,9 @@ class CapacityManager:
         required_vcpus = vcpus
         required_disk_mib = disk_mib
 
-        committed_instance_memory_mib = 0
-        committed_program_memory_mib = 0
-        committed_vcpus = 0
-        for vm_hash, record in tuple(self.registry.items()):
-            if exclude_vm_hash is not None and vm_hash == exclude_vm_hash:
-                continue
-            resources = record.message.resources
-            memory = resources.memory
-            record_vcpus = resources.vcpus
-            if not memory and not record_vcpus:
-                continue
-            if isinstance(record.message, InstanceContent):
-                committed_instance_memory_mib += memory
-            else:
-                committed_program_memory_mib += memory
-            committed_vcpus += record_vcpus
+        committed_instance_memory_mib, committed_program_memory_mib, committed_vcpus = self._committed_resources(
+            exclude_vm_hash
+        )
 
         physical_memory_mib = psutil.virtual_memory().total // (1024 * 1024)
         physical_cores = psutil.cpu_count() or 1
@@ -190,6 +180,10 @@ class CapacityManager:
         if required_disk_mib > 0 and required_disk_mib > available_disk_mib:
             errors.append(f"Disk: required {required_disk_mib} MiB, " f"available {available_disk_mib} MiB")
 
+        max_volume_error = self._check_max_volume(max_volume_mib)
+        if max_volume_error:
+            errors.append(max_volume_error)
+
         if errors:
             detail = "Insufficient capacity to create VM. " + "; ".join(errors)
             available_memory_mib = max(memory_cap_mib - committed_memory_mib, 0)
@@ -208,21 +202,52 @@ class CapacityManager:
                 },
             )
 
+    def _committed_resources(self, exclude_vm_hash: ItemHash | None) -> tuple[int, int, int]:
+        """(committed_instance_memory_mib, committed_program_memory_mib,
+        committed_vcpus) summed over the registry, skipping
+        ``exclude_vm_hash``'s own record (see ``check_capacity``)."""
+        committed_instance_memory_mib = 0
+        committed_program_memory_mib = 0
+        committed_vcpus = 0
+        for vm_hash, record in tuple(self.registry.items()):
+            if exclude_vm_hash is not None and vm_hash == exclude_vm_hash:
+                continue
+            resources = record.message.resources
+            memory = resources.memory
+            record_vcpus = resources.vcpus
+            if not memory and not record_vcpus:
+                continue
+            if isinstance(record.message, InstanceContent):
+                committed_instance_memory_mib += memory
+            else:
+                committed_program_memory_mib += memory
+            committed_vcpus += record_vcpus
+        return committed_instance_memory_mib, committed_program_memory_mib, committed_vcpus
+
+    @staticmethod
+    def _check_max_volume(max_volume_mib: int) -> str | None:
+        """None when ``max_volume_mib`` fits the roomiest eligible pool, else
+        an error string describing the shortfall. No pool holds a volume
+        split across disks, so this catches a request the aggregate free
+        figure alone would wrongly admit."""
+        if max_volume_mib <= 0:
+            return None
+        roomiest_mib = storage_pools.roomiest_pool_free_bytes() // (1024 * 1024)
+        if max_volume_mib <= roomiest_mib:
+            return None
+        return f"Disk (largest single volume): required {max_volume_mib} MiB, roomiest pool has {roomiest_mib} MiB"
+
     @staticmethod
     def _available_disk_bytes() -> int:
-        """Disk available for new VMs, in bytes.
+        """Disk available for new VMs across every volume pool, in bytes.
 
-        Free space under PERSISTENT_VOLUMES_DIR, the same figure the pool's
-        calculate_available_disk reports: the reserved-but-unused delta it
-        added per execution is 0 for every spec-built VM (spec disks carry no
-        size). The directory is created by the supervisor's setup; if it does
-        not exist (yet), report 0 rather than failing admission outright.
+        Aggregate free space with same-filesystem pools counted once, the
+        same figure the pool's calculate_available_disk reports: the
+        reserved-but-unused delta it adds per execution is 0 for every
+        spec-built VM (spec disks carry no size). Unreachable pools (missing
+        dir, dead disk) contribute 0 rather than failing admission outright.
         """
-        try:
-            return max(shutil.disk_usage(str(settings.PERSISTENT_VOLUMES_DIR)).free, 0)
-        except OSError:
-            logger.warning("PERSISTENT_VOLUMES_DIR %s not accessible, reporting 0", settings.PERSISTENT_VOLUMES_DIR)
-            return 0
+        return max(storage_pools.pools_disk_usage()[1], 0)
 
     async def _available_gpus(self) -> list[GpuDevice]:
         """Host cards not attached to any VM, per the supervisor's HostInfo."""

--- a/src/aleph/vm/agent/cli.py
+++ b/src/aleph/vm/agent/cli.py
@@ -12,6 +12,7 @@ import sentry_sdk
 from aleph_message.models import ItemHash
 from sqlalchemy.ext.asyncio import create_async_engine
 
+from aleph.vm import storage_pools
 from aleph.vm.conf import ALLOW_DEVELOPER_SSH_KEYS, make_db_url, settings
 from aleph.vm.version import __version__, get_version_from_apt, get_version_from_git
 
@@ -247,6 +248,8 @@ def main():
         print(settings.display())
 
     settings.check()
+
+    storage_pools.setup_pools()
 
     if not args.do_not_run:
         logger.debug("Initialising the DB...")

--- a/src/aleph/vm/agent/migration/reaper.py
+++ b/src/aleph/vm/agent/migration/reaper.py
@@ -3,7 +3,7 @@
 import logging
 import shutil
 
-from aleph.vm.conf import settings
+from aleph.vm.storage_pools import iter_namespace_dirs
 
 logger = logging.getLogger(__name__)
 
@@ -19,24 +19,17 @@ async def reap_orphan_migration_files(known_vm_ids: set[str]) -> None:
     agent's own in-flight imports do not yet exist, so any ``.part`` is genuinely
     an aborted prior run.
 
-    On each <vm_hash> directory under PERSISTENT_VOLUMES_DIR:
+    On each <vm_hash> directory in every volume pool:
       - Always delete *.qcow2.export.qcow2 (orphan exports — never reused).
       - If the vm_hash is not a known live VM AND the dir contains *.part files:
           → rmtree the directory (clear evidence of an aborted import).
       - If not known AND the dir has only completed .qcow2 files:
           → keep, log warning. A subsequent import retry can detect the existing files.
     """
-    base = settings.PERSISTENT_VOLUMES_DIR
-    if not base.exists():
-        return
-
     n_exports = 0
     n_dirs = 0
 
-    for entry in base.iterdir():
-        if not entry.is_dir():
-            continue
-
+    for entry in iter_namespace_dirs():
         # Pass 1: orphan .export.qcow2 files always go.
         for export_file in entry.glob("*.qcow2.export.qcow2"):
             try:

--- a/src/aleph/vm/agent/migration/runner.py
+++ b/src/aleph/vm/agent/migration/runner.py
@@ -48,6 +48,32 @@ EXPORT_TTL_SECONDS = 1800  # 30 minutes — matches today's behaviour
 IMPORT_TTL_SECONDS = 1800
 
 
+def _collect_export_disks(vm_hash: str) -> list[Path]:
+    """The qcow2 files to export for a VM, one per basename across all pools.
+
+    A basename can legitimately appear in several pools (e.g. a complete
+    orphan preserved by the reaper after a failed import, plus a retried
+    staging in another pool). The boot-time volume lookup resolves such
+    duplicates to the lowest-index pool's copy, so export must ship exactly
+    that copy: duplicates from higher-index pools are skipped with a warning.
+    """
+    disks: list[Path] = []
+    seen_names: set[str] = set()
+    for volumes_dir in iter_namespace_dirs(vm_hash):
+        for qcow2_file in sorted(volumes_dir.glob("*.qcow2")):
+            if qcow2_file.name in seen_names:
+                logger.warning(
+                    "Volume %s for %s found in multiple pools; exporting the copy from %s",
+                    qcow2_file.name,
+                    vm_hash,
+                    next(disk.parent for disk in disks if disk.name == qcow2_file.name),
+                )
+                continue
+            seen_names.add(qcow2_file.name)
+            disks.append(qcow2_file)
+    return disks
+
+
 async def _export_ttl_cleanup(job: ExportJob, timeout: int) -> None:
     """Background task: delete export files and forget the job after TTL."""
     try:
@@ -110,26 +136,26 @@ async def run_export(
             # the import runner stages into.
             await supervisor.stop_vm(job.vm_hash)
             # A VM's volumes may span pools (each volume is placed
-            # independently); export from every namespace dir.
+            # independently); export from every namespace dir, one copy per
+            # basename (lowest-index pool wins, like the boot-time lookup).
             volume_dirs = list(iter_namespace_dirs(str(job.vm_hash)))
             job.volumes_dir = volume_dirs[0] if volume_dirs else None
 
             disk_files: list[DiskFileInfo] = []
 
-            for volumes_dir in volume_dirs:
-                for qcow2_file in sorted(volumes_dir.glob("*.qcow2")):
-                    export_path = qcow2_file.with_suffix(".qcow2.export.qcow2")
-                    await compress_disk(qcow2_file, export_path)
-                    export_paths.append(export_path)
-                    sha256 = await compute_sha256(export_path)
-                    disk_files.append(
-                        DiskFileInfo(
-                            name=qcow2_file.name,
-                            size_bytes=export_path.stat().st_size,
-                            sha256=sha256,
-                            download_path=f"/control/machine/{job.vm_hash}/migration/disk/{qcow2_file.name}",
-                        )
+            for qcow2_file in _collect_export_disks(str(job.vm_hash)):
+                export_path = qcow2_file.with_suffix(".qcow2.export.qcow2")
+                await compress_disk(qcow2_file, export_path)
+                export_paths.append(export_path)
+                sha256 = await compute_sha256(export_path)
+                disk_files.append(
+                    DiskFileInfo(
+                        name=qcow2_file.name,
+                        size_bytes=export_path.stat().st_size,
+                        sha256=sha256,
+                        download_path=f"/control/machine/{job.vm_hash}/migration/disk/{qcow2_file.name}",
                     )
+                )
 
             if not disk_files:
                 msg = "No disk files found to export"

--- a/src/aleph/vm/agent/migration/runner.py
+++ b/src/aleph/vm/agent/migration/runner.py
@@ -36,6 +36,7 @@ from aleph.vm.agent.run import finish_instance_create
 from aleph.vm.agent.translate import build_create_vm_spec
 from aleph.vm.conf import settings
 from aleph.vm.storage import get_rootfs_base_path
+from aleph.vm.storage_pools import iter_namespace_dirs, select_pool
 from aleph.vm.supervisor_interface.errors import VmNotFoundError
 
 if TYPE_CHECKING:
@@ -108,12 +109,14 @@ async def run_export(
             # step is needed. The volumes dir is the same settings-derived path
             # the import runner stages into.
             await supervisor.stop_vm(job.vm_hash)
-            volumes_dir = settings.PERSISTENT_VOLUMES_DIR / str(job.vm_hash)
-            job.volumes_dir = volumes_dir
+            # A VM's volumes may span pools (each volume is placed
+            # independently); export from every namespace dir.
+            volume_dirs = list(iter_namespace_dirs(str(job.vm_hash)))
+            job.volumes_dir = volume_dirs[0] if volume_dirs else None
 
             disk_files: list[DiskFileInfo] = []
 
-            if volumes_dir.exists():
+            for volumes_dir in volume_dirs:
                 for qcow2_file in sorted(volumes_dir.glob("*.qcow2")):
                     export_path = qcow2_file.with_suffix(".qcow2.export.qcow2")
                     await compress_disk(qcow2_file, export_path)
@@ -239,7 +242,11 @@ async def run_import(
             parent_path = await get_rootfs_base_path(parent_ref)
             parent_format = await detect_parent_format(parent_path)
 
-            dest_dir = settings.PERSISTENT_VOLUMES_DIR / str(job.vm_hash)
+            # Stage onto the pool with the most room for the whole transfer;
+            # build_create_vm_spec later adopts the staged overlay wherever it
+            # is (the downloader's volume lookup scans every pool).
+            incoming_mib = sum(df.size_bytes for df in disk_files) // (1024 * 1024)
+            dest_dir = select_pool(incoming_mib).path / str(job.vm_hash)
             dest_dir.mkdir(parents=True, exist_ok=True)
             job.dest_dir = dest_dir
             job.total_bytes_expected = sum(df.size_bytes for df in disk_files)
@@ -282,11 +289,12 @@ async def run_import(
             job.current_step = "creating_vm"
             # The standard instance-create path: build the same spec a normal
             # persistent-instance create uses (run.create_vm_execution ->
-            # build_create_vm_spec). The spec's rootfs path is
-            # PERSISTENT_VOLUMES_DIR/<vm_hash>/rootfs.qcow2, exactly where the
-            # download+rebase staged the overlay, and build_create_vm_spec adopts
-            # an already-present host-persistence overlay rather than recreating
-            # it, so create_vm reuses the staged disk (no re-download).
+            # build_create_vm_spec). The spec's rootfs path resolves through
+            # the pool-aware volume lookup, which finds the overlay exactly
+            # where the download+rebase staged it, and build_create_vm_spec
+            # adopts an already-present host-persistence overlay rather than
+            # recreating it, so create_vm reuses the staged disk (no
+            # re-download).
             spec = await build_create_vm_spec(job.vm_hash, message.content)
             # Same agent-side admission as the normal create: bucket from the
             # message type, GPU requests resolved to concrete host cards on

--- a/src/aleph/vm/agent/resources.py
+++ b/src/aleph/vm/agent/resources.py
@@ -12,6 +12,7 @@ from aleph.vm.agent.machine import get_cpu_info, get_hardware_info, get_memory_i
 from aleph.vm.conf import settings
 from aleph.vm.resources import GpuDevice
 from aleph.vm.sevclient import SevClient
+from aleph.vm.storage_pools import pools_disk_usage
 from aleph.vm.utils import (
     async_cache,
     check_amd_sev_es_supported,
@@ -213,6 +214,17 @@ async def get_machine_capability() -> MachineCapability:
     )
 
 
+def _disk_usage_from_pools(host_info) -> DiskUsage:
+    """Aggregate capacity across every volume pool (same-filesystem pools
+    counted once). Usage-aware available disk comes from the supervisor's
+    HostInfo; a gRPC supervisor that has not implemented it yet reports 0."""
+    total_bytes, free_bytes = pools_disk_usage()
+    return DiskUsage(
+        total_kB=total_bytes // 1000,
+        available_kB=(host_info.available_disk_bytes // 1000 if host_info.available_disk_bytes else free_bytes // 1000),
+    )
+
+
 @cors_allow_all
 async def about_system_usage(request: web.Request):
     """Public endpoint to expose information about the system usage."""
@@ -230,17 +242,7 @@ async def about_system_usage(request: web.Request):
             total_kB=math.ceil(psutil.virtual_memory().total / 1000),
             available_kB=math.floor(psutil.virtual_memory().available / 1000),
         ),
-        disk=DiskUsage(
-            total_kB=psutil.disk_usage(str(settings.PERSISTENT_VOLUMES_DIR)).total // 1000,
-            # Usage-aware available disk comes from the supervisor's
-            # HostInfo; the embedded engine fills it from the pool. A gRPC
-            # supervisor that has not implemented it yet reports 0.
-            available_kB=(
-                host_info.available_disk_bytes // 1000
-                if host_info.available_disk_bytes
-                else psutil.disk_usage(str(settings.PERSISTENT_VOLUMES_DIR)).free // 1000
-            ),
-        ),
+        disk=_disk_usage_from_pools(host_info),
         period=UsagePeriod(
             start_timestamp=period_start,
             duration_seconds=60,

--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -1007,6 +1007,7 @@ async def operate_reserve_resources(request: web.Request, authenticated_sender: 
             memory_mib=requirements.memory_mib,
             vcpus=requirements.vcpus,
             disk_mib=requirements.disk_mib,
+            max_volume_mib=requirements.max_volume_mib,
             is_instance=requirements.is_instance,
         )
         expiration_date = await capacity.reserve_gpus(requirements.gpu_device_ids, authenticated_sender)

--- a/src/aleph/vm/agent/views/migration.py
+++ b/src/aleph/vm/agent/views/migration.py
@@ -209,10 +209,12 @@ async def migration_disk_download(request: web.Request) -> web.StreamResponse:
     if not secrets.compare_digest(token, job.token):
         return web.HTTPUnauthorized(text="Invalid or missing export token")
 
-    if job.volumes_dir is None:
-        return web.HTTPNotFound(text=f"Disk file not found: {filename}")
-    export_path = job.volumes_dir / f"{filename}.export.qcow2"
-    if not export_path.exists():
+    # Exports may live in different pools; resolve from the recorded paths.
+    export_path = next(
+        (path for path in (job.export_paths or []) if path.name == f"{filename}.export.qcow2"),
+        None,
+    )
+    if export_path is None or not export_path.exists():
         return web.HTTPNotFound(text=f"Disk file not found: {filename}")
 
     # Increment AFTER all early-return validation paths so a 401/404 doesn't leak the counter.

--- a/src/aleph/vm/agent/vm/downloader.py
+++ b/src/aleph/vm/agent/vm/downloader.py
@@ -38,6 +38,7 @@ from aleph.vm.storage import (
     get_rootfs_base_path,
     get_runtime_path,
 )
+from aleph.vm.storage_pools import volume_path_for
 from aleph.vm.supervisor_interface.errors import ResourceDownloadError, VmSetupError
 from aleph.vm.utils import run_in_subprocess
 
@@ -66,12 +67,11 @@ async def _make_writable_volume(
         msg = f"Format {parent_format} for {volume} unhandled by QEMU hypervisor"
         raise VmSetupError(msg)
 
-    dest_path = settings.PERSISTENT_VOLUMES_DIR / namespace / f"{volume_name}.qcow2"
+    dest_path = volume_path_for(namespace, f"{volume_name}.qcow2", volume.size_mib)
     # Do not override if user asked for host persistence.
     if dest_path.exists() and volume.persistence == VolumePersistence.host:
         return dest_path
 
-    dest_path.parent.mkdir(parents=True, exist_ok=True)
     size_in_bytes = int(volume.size_mib * 1024 * 1024)
 
     await run_in_subprocess(

--- a/src/aleph/vm/agent/vm/downloader.py
+++ b/src/aleph/vm/agent/vm/downloader.py
@@ -113,7 +113,7 @@ class QemuDownloader:
         self.rootfs_path = await self.make_writable_volume(parent_image_path, volume)
 
     async def download_volumes(self) -> None:
-        self.volumes = await host_volumes_from_message(self.message_content, self.namespace)
+        self.volumes = await host_volumes_from_message(self.message_content, self.namespace, pool0_only=False)
 
     async def download_all(self) -> None:
         await asyncio.gather(
@@ -172,7 +172,10 @@ class ProgramDownloader:
         assert self.rootfs_path.is_file(), f"Runtime not found on {self.rootfs_path}"
 
     async def download_volumes(self) -> None:
-        self.volumes = await host_volumes_from_message(self.message_content, self.namespace)
+        # Programs run under Firecracker, whose jailer hardlink-copies drive
+        # files across filesystems (losing guest writes): writable volumes
+        # must stay on pool 0.
+        self.volumes = await host_volumes_from_message(self.message_content, self.namespace, pool0_only=True)
 
     async def download_data(self) -> None:
         if self.message_content.data:

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -271,6 +271,14 @@ class Settings(BaseSettings):
     )
     JAILER_BASE_DIR: Path | None = Field(None)
 
+    VOLUME_POOLS: list[str] = Field(
+        default_factory=list,
+        description="Extra VM volume pool directories, one per additional fast disk. "
+        'JSON list; entries are "path" or "path=class" (class: nvme|ssd|hdd). '
+        "PERSISTENT_VOLUMES_DIR is always the first pool. HDD pools are "
+        "rejected: rotational disks are for CACHE_ROOT/BACKUP_DIRECTORY.",
+    )
+
     MAX_PROGRAM_ARCHIVE_SIZE: int = 10_000_000  # 10 MB
     MAX_DATA_ARCHIVE_SIZE: int = 10_000_000  # 10 MB
 

--- a/src/aleph/vm/host_volumes.py
+++ b/src/aleph/vm/host_volumes.py
@@ -25,8 +25,15 @@ class HostVolume:
     size_mib: int | None
 
 
-async def host_volumes_from_message(message_content: ExecutableContent, namespace: str) -> list[HostVolume]:
-    """Resolve the extra (non-rootfs) volumes declared in a message to on-host paths."""
+async def host_volumes_from_message(
+    message_content: ExecutableContent, namespace: str, *, pool0_only: bool = False
+) -> list[HostVolume]:
+    """Resolve the extra (non-rootfs) volumes declared in a message to on-host paths.
+
+    ``pool0_only`` pins writable volumes to the first storage pool; Firecracker
+    VMs need it because the jailer hardlink-copies drive files across
+    filesystems, losing guest writes (see ``storage_pools.volume_path_for``).
+    """
     volumes = []
     # TODO: Download in parallel and prevent duplicated volume names
     volume: MachineVolume
@@ -40,7 +47,7 @@ async def host_volumes_from_message(message_content: ExecutableContent, namespac
         volumes.append(
             HostVolume(
                 mount=volume.mount,
-                path_on_host=(await get_volume_path(volume=volume, namespace=namespace)),
+                path_on_host=(await get_volume_path(volume=volume, namespace=namespace, pool0_only=pool0_only)),
                 read_only=volume.is_read_only(),
                 size_mib=getattr(volume, "size_mib", None),
             )

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import shutil
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -18,6 +17,7 @@ from aleph.vm.resources import (
     InsufficientResourcesError,
     get_gpu_devices,
 )
+from aleph.vm.storage_pools import pools_disk_usage
 from aleph.vm.supervisor.networking_db import (
     create_supervisor_tables,
     get_port_mappings,
@@ -158,7 +158,7 @@ class VmPool:
 
         This takes into account the disk request (but not used) for Volume of executions in the pool
         Result in bytes."""
-        free_space = shutil.disk_usage(str(settings.PERSISTENT_VOLUMES_DIR)).free
+        free_space = pools_disk_usage()[1]
         # Free disk space reported by the system
 
         # Calculate the reservation

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -31,6 +31,7 @@ from aleph_message.models.execution.volume import (
 )
 
 from aleph.vm.conf import settings
+from aleph.vm.storage_pools import volume_path_for
 from aleph.vm.utils import fix_message_validation, run_in_subprocess
 
 logger = logging.getLogger(__name__)
@@ -325,11 +326,9 @@ async def create_ext4(path: Path, size_mib: int) -> bool:
 async def create_volume_file(volume: PersistentVolume | RootfsVolume, namespace: str) -> Path:
     volume_name = volume.name if isinstance(volume, PersistentVolume) else "rootfs"
     # Assume that the main filesystem format is BTRFS
-    path = settings.PERSISTENT_VOLUMES_DIR / namespace / f"{volume_name}.btrfs"
+    path = volume_path_for(namespace, f"{volume_name}.btrfs", volume.size_mib)
     if not path.is_file():
         logger.debug(f"Creating {volume.size_mib}MB volume")
-        # Ensure that the parent directory exists
-        path.parent.mkdir(exist_ok=True)
         # Create an empty file the right size
         await run_in_subprocess(["fallocate", "-l", f"{volume.size_mib}M", str(path)])
         await chown_to_jailman(path)
@@ -446,11 +445,12 @@ async def get_volume_path(volume: MachineVolume, namespace: str) -> Path:
             # Sanitize volume names
             logger.debug(f"Invalid values for volume name: {volume_name!r} detected, sanitizing")
             volume_name = re.sub(r"[^\w\-_]", "_", volume_name)
-        (Path(settings.PERSISTENT_VOLUMES_DIR) / namespace).mkdir(exist_ok=True)
         if volume.parent:
+            # create_devmapper resolves its volume file through
+            # create_volume_file, which is pool-aware.
             return await create_devmapper(volume, namespace)
         else:
-            volume_path = Path(settings.PERSISTENT_VOLUMES_DIR) / namespace / f"{volume_name}.ext4"
+            volume_path = volume_path_for(namespace, f"{volume_name}.ext4", volume.size_mib)
             await create_ext4(volume_path, volume.size_mib)
             return volume_path
     else:

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -431,7 +431,7 @@ async def get_existing_file(ref: str) -> Path:
     return cache_path
 
 
-async def get_volume_path(volume: MachineVolume, namespace: str) -> Path:
+async def get_volume_path(volume: MachineVolume, namespace: str, *, pool0_only: bool = False) -> Path:
     if isinstance(volume, ImmutableVolume):
         ref = volume.ref
         return await get_existing_file(ref)
@@ -450,7 +450,7 @@ async def get_volume_path(volume: MachineVolume, namespace: str) -> Path:
             # create_volume_file, which is pool-aware.
             return await create_devmapper(volume, namespace)
         else:
-            volume_path = volume_path_for(namespace, f"{volume_name}.ext4", volume.size_mib)
+            volume_path = volume_path_for(namespace, f"{volume_name}.ext4", volume.size_mib, pool0_only=pool0_only)
             await create_ext4(volume_path, volume.size_mib)
             return volume_path
     else:

--- a/src/aleph/vm/storage_pools.py
+++ b/src/aleph/vm/storage_pools.py
@@ -133,7 +133,11 @@ def _parse_pool_entry(entry: str) -> tuple[Path, MediaClass | None]:
                 "(expected nvme, ssd or hdd)"
             )
             raise StoragePoolConfigError(msg) from error
-    return Path(path_part.strip()), override
+    path = Path(path_part.strip())
+    if not path_part.strip() or not path.is_absolute():
+        msg = f"VOLUME_POOLS entry {entry!r} needs an absolute pool path, e.g. /mnt/nvme1/aleph-volumes"
+        raise StoragePoolConfigError(msg)
+    return path, override
 
 
 def _adoption_registry_path() -> Path:
@@ -141,16 +145,36 @@ def _adoption_registry_path() -> Path:
 
 
 def _load_adopted() -> set[str]:
+    registry = _adoption_registry_path()
     try:
-        return set(json.loads(_adoption_registry_path().read_text()))
-    except (OSError, ValueError):
-        return set()
+        content = registry.read_text()
+    except FileNotFoundError:
+        return set()  # first boot: nothing adopted yet
+    try:
+        adopted = json.loads(content)
+    except ValueError as error:
+        msg = (
+            f"The pool adoption registry {registry} is not valid JSON. It guards against "
+            "writing into unmounted pool directories, so it must not be ignored: restore it "
+            "from backup or rebuild it as a JSON list of the adopted pool paths."
+        )
+        raise StoragePoolConfigError(msg) from error
+    if not isinstance(adopted, list):
+        msg = (
+            f"The pool adoption registry {registry} must contain a JSON list of pool paths, "
+            f"not {type(adopted).__name__}"
+        )
+        raise StoragePoolConfigError(msg)
+    return set(adopted)
 
 
 def _record_adopted(path: Path) -> None:
     adopted = _load_adopted()
     adopted.add(str(path))
-    _adoption_registry_path().write_text(json.dumps(sorted(adopted)) + "\n")
+    registry = _adoption_registry_path()
+    tmp_path = registry.with_name(registry.name + ".tmp")
+    tmp_path.write_text(json.dumps(sorted(adopted)) + "\n")
+    os.replace(tmp_path, registry)
 
 
 def _adopt_pool(path: Path, media_class: MediaClass) -> None:
@@ -210,6 +234,16 @@ def setup_pools(sys_root: Path = Path("/sys")) -> list[StoragePool]:
         _adopt_pool(path, media_class)
         pools.append(StoragePool(path=path, media_class=media_class, index=position))
 
+    orphaned = _load_adopted() - {str(pool.path) for pool in pools}
+    if orphaned:
+        msg = (
+            f"Pool(s) {', '.join(sorted(orphaned))} were adopted as volume pools but are no longer "
+            "configured; they hold (or held) VM volumes, so dropping them from VOLUME_POOLS would "
+            "silently orphan those volumes. To really remove a pool: migrate its volumes off, then "
+            f"remove its entry from {_adoption_registry_path()}."
+        )
+        raise StoragePoolConfigError(msg)
+
     _pools = pools
     return pools
 
@@ -236,17 +270,17 @@ def _pool_free_bytes(pool: StoragePool) -> int | None:
         return None
 
 
-def select_pool(size_mib: int) -> StoragePool:
-    """The eligible pool with the most free bytes that fits ``size_mib``.
+def _select_from(candidates: list[StoragePool], size_mib: int) -> StoragePool:
+    """The eligible candidate with the most free bytes that fits ``size_mib``.
 
-    Ties break on the lowest pool index (dict iteration is stable and pools
-    are scanned in index order, so the first max wins). Unreachable pools are
-    skipped: a dead disk stops receiving placements without failing the agent.
+    Ties break on the lowest pool index (candidates are scanned in index
+    order, so the first max wins). Unreachable pools are skipped: a dead disk
+    stops receiving placements without failing the agent.
     """
     required_bytes = size_mib * 1024 * 1024
     best: StoragePool | None = None
     best_free = -1
-    for pool in get_pools():
+    for pool in candidates:
         if not pool.vm_eligible:
             continue
         free = _pool_free_bytes(pool)
@@ -264,6 +298,11 @@ def select_pool(size_mib: int) -> StoragePool:
     return best
 
 
+def select_pool(size_mib: int) -> StoragePool:
+    """The eligible pool with the most free bytes that fits ``size_mib``."""
+    return _select_from(get_pools(), size_mib)
+
+
 def find_existing_volume(namespace: str, filename: str) -> Path | None:
     """The first ``{pool}/{namespace}/{filename}`` that exists, in pool order."""
     matches = [pool.path / namespace / filename for pool in get_pools() if (pool.path / namespace / filename).is_file()]
@@ -274,14 +313,32 @@ def find_existing_volume(namespace: str, filename: str) -> Path | None:
     return matches[0]
 
 
-def volume_path_for(namespace: str, filename: str, size_mib: int) -> Path:
+def volume_path_for(namespace: str, filename: str, size_mib: int, *, pool0_only: bool = False) -> Path:
     """The host path for a volume: its existing file when one pool already
     holds it (sticky), else a fresh placement on the best pool. The namespace
-    directory is created; the volume file itself is not."""
+    directory is created; the volume file itself is not.
+
+    ``pool0_only`` pins fresh placements to pool 0. Firecracker's jailer
+    hardlinks drive files into its chroot and silently *copies* across
+    filesystems, so a writable Firecracker volume off pool 0 would lose every
+    guest write to the chroot copy. Lookup still scans all pools (a legacy
+    volume must keep booting), but a hit off pool 0 logs an error.
+    """
+    pool0 = get_pools()[0]
     existing = find_existing_volume(namespace, filename)
     if existing is not None:
+        if pool0_only and existing.parent.parent != pool0.path:
+            logger.error(
+                "Writable Firecracker volume %s/%s lives on pool %s, not on pool 0 (%s). The jailer "
+                "hardlink turns into a copy across filesystems, so guest writes to this volume will "
+                "be LOST when the VM stops. Move the file to pool 0 to persist writes.",
+                namespace,
+                filename,
+                existing.parent.parent,
+                pool0.path,
+            )
         return existing
-    pool = select_pool(size_mib)
+    pool = _select_from([pool0], size_mib) if pool0_only else select_pool(size_mib)
     parent = pool.path / namespace
     parent.mkdir(parents=True, exist_ok=True)
     return parent / filename

--- a/src/aleph/vm/storage_pools.py
+++ b/src/aleph/vm/storage_pools.py
@@ -62,9 +62,10 @@ def _device_media_class(device_name: str, sys_root: Path) -> MediaClass | None:
     if slaves_dir.is_dir():
         slave_classes = [_device_media_class(entry.name, sys_root) for entry in slaves_dir.iterdir()]
         if slave_classes:
-            if any(slave_class is None for slave_class in slave_classes):
+            resolved_slave_classes = [slave_class for slave_class in slave_classes if slave_class is not None]
+            if len(resolved_slave_classes) != len(slave_classes):
                 return None
-            return max(slave_classes, key=lambda slave_class: slave_class.slowness)
+            return max(resolved_slave_classes, key=lambda slave_class: slave_class.slowness)
     # A partition node has no queue/; its resolved parent (the whole disk) does.
     disk_node = node.resolve()
     if not (disk_node / "queue").is_dir():

--- a/src/aleph/vm/storage_pools.py
+++ b/src/aleph/vm/storage_pools.py
@@ -1,0 +1,89 @@
+"""Agent-side storage pools: multiple fast disks for VM volumes.
+
+A pool is a directory (typically the mountpoint of one dedicated SSD/NVMe
+filesystem) holding persistent volumes and instance rootfs overlays under
+``{pool}/{namespace}/``. Pool 0 is always ``settings.PERSISTENT_VOLUMES_DIR``;
+extra pools come from ``settings.VOLUME_POOLS``. Placement picks the eligible
+pool with the most free bytes; lookup scans pools in index order. HDD pools
+are never eligible for VM volumes (rotational storage is for caches and
+backups: point CACHE_ROOT / BACKUP_DIRECTORY at it instead).
+
+The supervisor/controller side is path-agnostic (DiskConfig carries resolved
+absolute paths), so everything here is agent policy.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from enum import Enum
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class MediaClass(str, Enum):
+    NVME = "nvme"
+    SSD = "ssd"
+    HDD = "hdd"
+
+    @property
+    def slowness(self) -> int:
+        return _SLOWNESS[self]
+
+    @property
+    def vm_eligible(self) -> bool:
+        return self is not MediaClass.HDD
+
+
+_SLOWNESS = {MediaClass.NVME: 0, MediaClass.SSD: 1, MediaClass.HDD: 2}
+
+
+def _read_rotational(disk_node: Path) -> bool | None:
+    try:
+        return (disk_node / "queue" / "rotational").read_text().strip() == "1"
+    except OSError:
+        return None
+
+
+def _device_media_class(device_name: str, sys_root: Path) -> MediaClass | None:
+    """Media class of one block device, walking dm/md stacks to the slowest member."""
+    node = sys_root / "class" / "block" / device_name
+    if not node.exists():
+        return None
+    slaves_dir = node / "slaves"
+    if slaves_dir.is_dir():
+        slave_classes = [_device_media_class(entry.name, sys_root) for entry in slaves_dir.iterdir()]
+        if slave_classes:
+            if any(slave_class is None for slave_class in slave_classes):
+                return None
+            return max(slave_classes, key=lambda slave_class: slave_class.slowness)
+    # A partition node has no queue/; its resolved parent (the whole disk) does.
+    disk_node = node.resolve()
+    if not (disk_node / "queue").is_dir():
+        disk_node = disk_node.parent
+    is_rotational = _read_rotational(disk_node)
+    if is_rotational is None:
+        return None
+    if is_rotational:
+        return MediaClass.HDD
+    return MediaClass.NVME if disk_node.name.startswith("nvme") else MediaClass.SSD
+
+
+def detect_media_class(path: Path, sys_root: Path = Path("/sys")) -> MediaClass | None:
+    """Media class of the filesystem holding ``path``, None when undetectable
+    (tmpfs/overlay/network filesystems, exotic devices, missing sysfs)."""
+    try:
+        stat = os.stat(path)
+    except OSError:
+        return None
+    major, minor = os.major(stat.st_dev), os.minor(stat.st_dev)
+    if major == 0:
+        # Unnamed devices: tmpfs, overlayfs, NFS... no backing block device.
+        return None
+    dev_node = sys_root / "dev" / "block" / f"{major}:{minor}"
+    try:
+        device_name = dev_node.resolve(strict=True).name
+    except OSError:
+        return None
+    return _device_media_class(device_name, sys_root)

--- a/src/aleph/vm/storage_pools.py
+++ b/src/aleph/vm/storage_pools.py
@@ -17,11 +17,14 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
+from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
 from aleph.vm.conf import settings
+from aleph.vm.resources import InsufficientResourcesError
 
 logger = logging.getLogger(__name__)
 
@@ -222,3 +225,108 @@ def reset_pools() -> None:
     """Drop the setup_pools() result (tests)."""
     global _pools  # noqa: PLW0603
     _pools = None
+
+
+def _pool_free_bytes(pool: StoragePool) -> int | None:
+    try:
+        return shutil.disk_usage(str(pool.path)).free
+    except OSError:
+        logger.error("Volume pool %s not accessible, skipping", pool.path)
+        return None
+
+
+def select_pool(size_mib: int) -> StoragePool:
+    """The eligible pool with the most free bytes that fits ``size_mib``.
+
+    Ties break on the lowest pool index (dict iteration is stable and pools
+    are scanned in index order, so the first max wins). Unreachable pools are
+    skipped: a dead disk stops receiving placements without failing the agent.
+    """
+    required_bytes = size_mib * 1024 * 1024
+    best: StoragePool | None = None
+    best_free = -1
+    for pool in get_pools():
+        if not pool.vm_eligible:
+            continue
+        free = _pool_free_bytes(pool)
+        if free is None:
+            continue
+        if free > best_free:
+            best, best_free = pool, free
+    if best is None or best_free < required_bytes:
+        msg = f"No volume pool has {size_mib} MiB free"
+        raise InsufficientResourcesError(
+            msg,
+            required={"disk_mib": size_mib},
+            available={"disk_mib": max(best_free, 0) // (1024 * 1024)},
+        )
+    return best
+
+
+def find_existing_volume(namespace: str, filename: str) -> Path | None:
+    """The first ``{pool}/{namespace}/{filename}`` that exists, in pool order."""
+    matches = [pool.path / namespace / filename for pool in get_pools() if (pool.path / namespace / filename).is_file()]
+    if not matches:
+        return None
+    if len(matches) > 1:
+        logger.warning("Volume %s/%s found in %d pools; using %s", namespace, filename, len(matches), matches[0])
+    return matches[0]
+
+
+def volume_path_for(namespace: str, filename: str, size_mib: int) -> Path:
+    """The host path for a volume: its existing file when one pool already
+    holds it (sticky), else a fresh placement on the best pool. The namespace
+    directory is created; the volume file itself is not."""
+    existing = find_existing_volume(namespace, filename)
+    if existing is not None:
+        return existing
+    pool = select_pool(size_mib)
+    parent = pool.path / namespace
+    parent.mkdir(parents=True, exist_ok=True)
+    return parent / filename
+
+
+def iter_namespace_dirs(namespace: str | None = None) -> Iterator[Path]:
+    """Existing per-namespace dirs across pools: ``{pool}/{namespace}``, or
+    every namespace dir in every pool when ``namespace`` is None."""
+    for pool in get_pools():
+        if namespace is not None:
+            candidate = pool.path / namespace
+            if candidate.is_dir():
+                yield candidate
+            continue
+        try:
+            entries = sorted(pool.path.iterdir())
+        except OSError:
+            logger.error("Volume pool %s not accessible, skipping", pool.path)
+            continue
+        for entry in entries:
+            if entry.is_dir():
+                yield entry
+
+
+def pools_disk_usage() -> tuple[int, int]:
+    """(total, free) bytes across pools, filesystems deduplicated by st_dev
+    so two pool directories on one filesystem count once."""
+    seen_devices: set[int] = set()
+    total = free = 0
+    for pool in get_pools():
+        try:
+            st_dev = os.stat(pool.path).st_dev
+            usage = shutil.disk_usage(str(pool.path))
+        except OSError:
+            logger.warning("Volume pool %s not accessible, ignoring in accounting", pool.path)
+            continue
+        if st_dev in seen_devices:
+            continue
+        seen_devices.add(st_dev)
+        total += usage.total
+        free += usage.free
+    return total, free
+
+
+def roomiest_pool_free_bytes() -> int:
+    """Free bytes on the emptiest eligible pool (the largest single volume
+    that could still be placed); 0 when no pool is reachable."""
+    frees = [free for pool in get_pools() if pool.vm_eligible and (free := _pool_free_bytes(pool)) is not None]
+    return max(frees, default=0)

--- a/src/aleph/vm/storage_pools.py
+++ b/src/aleph/vm/storage_pools.py
@@ -14,10 +14,14 @@ absolute paths), so everything here is agent policy.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+
+from aleph.vm.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -87,3 +91,134 @@ def detect_media_class(path: Path, sys_root: Path = Path("/sys")) -> MediaClass 
     except OSError:
         return None
     return _device_media_class(device_name, sys_root)
+
+
+POOL_MARKER_NAME = ".aleph-vm-pool"
+POOL_MARKER_VERSION = 1
+
+
+@dataclass(frozen=True)
+class StoragePool:
+    path: Path
+    media_class: MediaClass
+    index: int
+
+    @property
+    def vm_eligible(self) -> bool:
+        # Pool 0 (PERSISTENT_VOLUMES_DIR) is always eligible, even on HDD:
+        # existing nodes must not break. setup_pools() warns instead.
+        return self.index == 0 or self.media_class.vm_eligible
+
+
+class StoragePoolConfigError(ValueError):
+    """A configured volume pool cannot be used; startup must abort."""
+
+
+_pools: list[StoragePool] | None = None
+
+
+def _parse_pool_entry(entry: str) -> tuple[Path, MediaClass | None]:
+    path_part, separator, class_part = entry.partition("=")
+    override: MediaClass | None = None
+    if separator:
+        try:
+            override = MediaClass(class_part.strip())
+        except ValueError as error:
+            msg = (
+                f"Unknown media class {class_part.strip()!r} in VOLUME_POOLS entry {entry!r} "
+                "(expected nvme, ssd or hdd)"
+            )
+            raise StoragePoolConfigError(msg) from error
+    return Path(path_part.strip()), override
+
+
+def _adoption_registry_path() -> Path:
+    return Path(settings.EXECUTION_ROOT) / "volume-pools.json"
+
+
+def _load_adopted() -> set[str]:
+    try:
+        return set(json.loads(_adoption_registry_path().read_text()))
+    except (OSError, ValueError):
+        return set()
+
+
+def _record_adopted(path: Path) -> None:
+    adopted = _load_adopted()
+    adopted.add(str(path))
+    _adoption_registry_path().write_text(json.dumps(sorted(adopted)) + "\n")
+
+
+def _adopt_pool(path: Path, media_class: MediaClass) -> None:
+    """Write the in-pool marker on first use; refuse a pool whose marker
+    vanished after adoption (the disk is very likely not mounted and writes
+    would silently land on the filesystem below the mountpoint)."""
+    marker = path / POOL_MARKER_NAME
+    if marker.is_file():
+        _record_adopted(path)  # heal the registry after e.g. a restore
+        return
+    if str(path) in _load_adopted():
+        msg = (
+            f"Volume pool {path} was adopted before but its {POOL_MARKER_NAME} marker is gone. "
+            "Most likely the disk is not mounted; refusing to write to whatever is at that path."
+        )
+        raise StoragePoolConfigError(msg)
+    marker.write_text(json.dumps({"version": POOL_MARKER_VERSION, "media_class": media_class.value}) + "\n")
+    _record_adopted(path)
+    logger.info("Adopted %s as a %s volume pool", path, media_class.value)
+
+
+def setup_pools(sys_root: Path = Path("/sys")) -> list[StoragePool]:
+    """Validate, classify and adopt the configured pools.
+
+    Call once at agent startup, after ``settings.setup()``. Raises
+    StoragePoolConfigError on any misconfiguration: never degrade silently.
+    """
+    global _pools  # noqa: PLW0603
+    pools: list[StoragePool] = []
+
+    default_dir = Path(settings.PERSISTENT_VOLUMES_DIR)
+    default_class = detect_media_class(default_dir, sys_root)
+    if default_class is MediaClass.HDD:
+        logger.warning(
+            "PERSISTENT_VOLUMES_DIR %s is on rotational storage; VM volumes will be slow",
+            default_dir,
+        )
+    # Record the honest media class (SSD only as the undetectable fallback);
+    # pool 0 stays VM-eligible regardless, see StoragePool.vm_eligible.
+    pools.append(StoragePool(path=default_dir, media_class=default_class or MediaClass.SSD, index=0))
+
+    for position, entry in enumerate(settings.VOLUME_POOLS, start=1):
+        path, override = _parse_pool_entry(entry)
+        if not path.is_dir():
+            msg = f"Volume pool {path} does not exist (is the disk mounted?)"
+            raise StoragePoolConfigError(msg)
+        media_class = override or detect_media_class(path, sys_root)
+        if media_class is None:
+            msg = f"Cannot detect the media class of {path}; add an explicit override, e.g. {path}=ssd"
+            raise StoragePoolConfigError(msg)
+        if media_class is MediaClass.HDD:
+            msg = (
+                f"Volume pool {path} is rotational storage (HDD); VM volumes require ssd/nvme. "
+                "Point CACHE_ROOT or BACKUP_DIRECTORY at it instead."
+            )
+            raise StoragePoolConfigError(msg)
+        _adopt_pool(path, media_class)
+        pools.append(StoragePool(path=path, media_class=media_class, index=position))
+
+    _pools = pools
+    return pools
+
+
+def get_pools() -> list[StoragePool]:
+    """The active pools. Falls back to pool 0 alone when setup_pools() has
+    not run (library/test callers); the agent CLI always runs it."""
+    if _pools is None:
+        return [StoragePool(path=Path(settings.PERSISTENT_VOLUMES_DIR), media_class=MediaClass.SSD, index=0)]
+    return _pools
+
+
+def reset_pools() -> None:
+    """Drop the setup_pools() result (tests)."""
+    global _pools  # noqa: PLW0603
+    _pools = None

--- a/src/aleph/vm/supervisor/daemon.py
+++ b/src/aleph/vm/supervisor/daemon.py
@@ -22,6 +22,7 @@ import logging
 import signal
 from pathlib import Path
 
+from aleph.vm import storage_pools
 from aleph.vm.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -100,6 +101,10 @@ def main(argv: list[str] | None = None) -> int:
 
     settings.setup()
     settings.check()
+    # The pool's capacity accounting (calculate_available_disk, GetHostInfo)
+    # must see every configured volume pool; a misconfigured pool aborts
+    # startup, consistent with the agent CLI (fail fast, never degrade).
+    storage_pools.setup_pools()
 
     socket_path = args.socket or default_socket_path()
     asyncio.run(run_daemon(socket_path))

--- a/src/aleph/vm/testing/harness.py
+++ b/src/aleph/vm/testing/harness.py
@@ -19,6 +19,7 @@ from typing import cast
 from aiohttp.web import Request, Response
 from aleph_message.models import ItemHash
 
+from aleph.vm import storage_pools
 from aleph.vm.agent.capacity import CapacityManager
 from aleph.vm.agent.expiry import ExpiryManager
 from aleph.vm.agent.pubsub import PubSub
@@ -98,6 +99,7 @@ async def benchmark(runs: int):
 
     # Finish setting up the settings
     settings.setup()
+    storage_pools.setup_pools()
     settings.check()
 
     # First test all methods

--- a/tests/migration/test_runner.py
+++ b/tests/migration/test_runner.py
@@ -718,6 +718,7 @@ async def test_import_spec_build_reuses_staged_overlay(tmp_path, monkeypatch):
     resources = QemuDownloader(message_content=None, namespace=namespace)
     rootfs_volume = MagicMock(spec=RootfsVolume)
     rootfs_volume.persistence = VolumePersistence.host
+    rootfs_volume.size_mib = 2048
 
     result = await resources.make_writable_volume(parent_path, rootfs_volume)
 

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -389,3 +389,57 @@ def test_manager_never_calls_unrelated_supervisor_methods(mocker):
     manager.check_capacity(memory_mib=1024, vcpus=1, disk_mib=0, is_instance=True)
 
     supervisor.get_host_info.assert_not_called()
+
+
+# ── pooled disk accounting ──────────────────────────────────────────────────
+
+
+def test_requirements_carry_the_largest_single_volume():
+    message = _make_qemu_instance_message()
+    requirements = requirements_from_message(message)
+    # The fixture message has a rootfs and no sized extra volumes: the largest
+    # single volume IS the rootfs.
+    assert requirements.max_volume_mib == message.rootfs.size_mib
+    assert requirements.disk_mib >= requirements.max_volume_mib
+
+
+def test_check_capacity_rejects_a_volume_no_pool_can_hold(mocker):
+    manager = _manager()
+    _patch_host(mocker, memory_bytes=64 * 1024**3, cores=16, disk_bytes=900 * 1024**3)
+    # Aggregate says 900 GiB free, but the roomiest single pool has 400 GiB.
+    mocker.patch(
+        "aleph.vm.agent.capacity.storage_pools.roomiest_pool_free_bytes",
+        return_value=400 * 1024**3,
+    )
+    with pytest.raises(InsufficientResourcesError, match="single volume"):
+        manager.check_capacity(
+            memory_mib=1024,
+            vcpus=1,
+            disk_mib=500 * 1024,
+            max_volume_mib=500 * 1024,
+            is_instance=True,
+        )
+
+
+def test_check_capacity_accepts_when_the_roomiest_pool_fits(mocker):
+    manager = _manager()
+    _patch_host(mocker, memory_bytes=64 * 1024**3, cores=16, disk_bytes=900 * 1024**3)
+    mocker.patch(
+        "aleph.vm.agent.capacity.storage_pools.roomiest_pool_free_bytes",
+        return_value=400 * 1024**3,
+    )
+    manager.check_capacity(
+        memory_mib=1024,
+        vcpus=1,
+        disk_mib=500 * 1024,
+        max_volume_mib=300 * 1024,
+        is_instance=True,
+    )
+
+
+def test_available_disk_bytes_is_the_pooled_aggregate(mocker):
+    mocker.patch(
+        "aleph.vm.agent.capacity.storage_pools.pools_disk_usage",
+        return_value=(2 * 1024**4, 3 * 1024**3),
+    )
+    assert CapacityManager._available_disk_bytes() == 3 * 1024**3

--- a/tests/supervisor/test_storage_pools.py
+++ b/tests/supervisor/test_storage_pools.py
@@ -3,12 +3,23 @@ lookup and pooled accounting (src/aleph/vm/storage_pools.py)."""
 
 from __future__ import annotations
 
+import json
+import logging
 from pathlib import Path
 
+import pytest
+
+from aleph.vm.conf import settings
 from aleph.vm.storage_pools import (
+    POOL_MARKER_NAME,
     MediaClass,
+    StoragePool,
+    StoragePoolConfigError,
     _device_media_class,
     detect_media_class,
+    get_pools,
+    reset_pools,
+    setup_pools,
 )
 
 
@@ -82,3 +93,136 @@ class TestMediaClassDetection:
         assert MediaClass.NVME.vm_eligible
         assert MediaClass.SSD.vm_eligible
         assert not MediaClass.HDD.vm_eligible
+
+
+@pytest.fixture()
+def pool_settings(tmp_path, monkeypatch):
+    """Isolated settings roots + a clean module cache; yields the tmp root."""
+    execution_root = tmp_path / "execution"
+    default_pool = execution_root / "volumes" / "persistent"
+    default_pool.mkdir(parents=True)
+    monkeypatch.setattr(settings, "EXECUTION_ROOT", execution_root)
+    monkeypatch.setattr(settings, "PERSISTENT_VOLUMES_DIR", default_pool)
+    monkeypatch.setattr(settings, "VOLUME_POOLS", [])
+    reset_pools()
+    yield tmp_path
+    reset_pools()
+
+
+def _fake_ssd_sysfs(tmp_path: Path) -> Path:
+    """A fake /sys that classifies every real filesystem as an SSD is not
+    possible (st_dev is unknowable in advance), so pool tests use explicit
+    `=class` overrides instead of detection."""
+    sys_root = tmp_path / "sys"
+    (sys_root / "dev" / "block").mkdir(parents=True)
+    (sys_root / "class" / "block").mkdir(parents=True)
+    return sys_root
+
+
+class TestSetupPools:
+    def test_no_extra_pools_is_single_default_pool(self, pool_settings):
+        sys_root = _fake_ssd_sysfs(pool_settings)
+        pools = setup_pools(sys_root=sys_root)
+        assert len(pools) == 1
+        assert isinstance(pools[0], StoragePool)
+        assert pools[0].path == Path(settings.PERSISTENT_VOLUMES_DIR)
+        assert pools[0].index == 0
+        assert pools[0].vm_eligible
+
+    def test_default_pool_on_hdd_warns_but_stays_eligible(self, pool_settings, monkeypatch, caplog):
+        """Existing nodes with PERSISTENT_VOLUMES_DIR on a spinner must keep
+        working: pool 0 warns but is always VM-eligible."""
+        sys_root = _fake_ssd_sysfs(pool_settings)
+        monkeypatch.setattr("aleph.vm.storage_pools.detect_media_class", lambda *_args: MediaClass.HDD)
+        with caplog.at_level(logging.WARNING, logger="aleph.vm.storage_pools"):
+            pools = setup_pools(sys_root=sys_root)
+        assert pools[0].media_class is MediaClass.HDD
+        assert pools[0].vm_eligible is True
+        assert any("rotational" in record.message for record in caplog.records)
+
+    def test_extra_pool_with_override_is_adopted(self, pool_settings, monkeypatch):
+        sys_root = _fake_ssd_sysfs(pool_settings)
+        extra = pool_settings / "mnt" / "nvme1"
+        extra.mkdir(parents=True)
+        monkeypatch.setattr(settings, "VOLUME_POOLS", [f"{extra}=nvme"])
+        pools = setup_pools(sys_root=sys_root)
+        assert [pool.index for pool in pools] == [0, 1]
+        assert pools[1].path == extra
+        assert pools[1].media_class.value == "nvme"
+        # Marker written into the pool, path recorded in the registry.
+        marker = json.loads((extra / POOL_MARKER_NAME).read_text())
+        assert marker["media_class"] == "nvme"
+        registry = json.loads((Path(settings.EXECUTION_ROOT) / "volume-pools.json").read_text())
+        assert str(extra) in registry
+
+    def test_missing_pool_dir_is_a_hard_error(self, pool_settings, monkeypatch):
+        sys_root = _fake_ssd_sysfs(pool_settings)
+        monkeypatch.setattr(settings, "VOLUME_POOLS", [f"{pool_settings / 'not-mounted'}=ssd"])
+        with pytest.raises(StoragePoolConfigError, match="does not exist"):
+            setup_pools(sys_root=sys_root)
+
+    def test_hdd_pool_is_a_hard_error(self, pool_settings, monkeypatch):
+        sys_root = _fake_ssd_sysfs(pool_settings)
+        extra = pool_settings / "mnt" / "spinner"
+        extra.mkdir(parents=True)
+        monkeypatch.setattr(settings, "VOLUME_POOLS", [f"{extra}=hdd"])
+        with pytest.raises(StoragePoolConfigError, match="rotational"):
+            setup_pools(sys_root=sys_root)
+
+    def test_undetectable_class_without_override_is_a_hard_error(self, pool_settings, monkeypatch):
+        # tmp dirs sit on real filesystems the empty fake /sys cannot map.
+        sys_root = _fake_ssd_sysfs(pool_settings)
+        extra = pool_settings / "mnt" / "mystery"
+        extra.mkdir(parents=True)
+        monkeypatch.setattr(settings, "VOLUME_POOLS", [str(extra)])
+        with pytest.raises(StoragePoolConfigError, match="media class"):
+            setup_pools(sys_root=sys_root)
+
+    def test_unknown_override_class_is_a_hard_error(self, pool_settings, monkeypatch):
+        sys_root = _fake_ssd_sysfs(pool_settings)
+        extra = pool_settings / "mnt" / "x"
+        extra.mkdir(parents=True)
+        monkeypatch.setattr(settings, "VOLUME_POOLS", [f"{extra}=floppy"])
+        with pytest.raises(StoragePoolConfigError, match="media class"):
+            setup_pools(sys_root=sys_root)
+
+    def test_adopted_pool_with_missing_marker_is_a_hard_error(self, pool_settings, monkeypatch):
+        """The unmounted-disk trap: the registry remembers the adoption, the
+        marker vanished with the mount, so startup must refuse."""
+        sys_root = _fake_ssd_sysfs(pool_settings)
+        extra = pool_settings / "mnt" / "nvme1"
+        extra.mkdir(parents=True)
+        monkeypatch.setattr(settings, "VOLUME_POOLS", [f"{extra}=nvme"])
+        setup_pools(sys_root=sys_root)
+        (extra / POOL_MARKER_NAME).unlink()  # simulate the empty mountpoint
+        reset_pools()
+        with pytest.raises(StoragePoolConfigError, match="not mounted"):
+            setup_pools(sys_root=sys_root)
+
+    def test_marker_without_registry_heals_the_registry(self, pool_settings, monkeypatch):
+        """EXECUTION_ROOT restored from backup: marker present, registry lost."""
+        sys_root = _fake_ssd_sysfs(pool_settings)
+        extra = pool_settings / "mnt" / "nvme1"
+        extra.mkdir(parents=True)
+        monkeypatch.setattr(settings, "VOLUME_POOLS", [f"{extra}=nvme"])
+        setup_pools(sys_root=sys_root)
+        (Path(settings.EXECUTION_ROOT) / "volume-pools.json").unlink()
+        reset_pools()
+        setup_pools(sys_root=sys_root)  # must not raise
+        registry = json.loads((Path(settings.EXECUTION_ROOT) / "volume-pools.json").read_text())
+        assert str(extra) in registry
+
+
+class TestGetPools:
+    def test_get_pools_without_setup_falls_back_to_pool_zero(self, pool_settings):  # noqa: ARG002 (pool_settings is a fixture)
+        pools = get_pools()
+        assert len(pools) == 1
+        assert pools[0].path == Path(settings.PERSISTENT_VOLUMES_DIR)
+
+    def test_get_pools_returns_the_setup_result(self, pool_settings, monkeypatch):
+        sys_root = _fake_ssd_sysfs(pool_settings)
+        extra = pool_settings / "mnt" / "ssd1"
+        extra.mkdir(parents=True)
+        monkeypatch.setattr(settings, "VOLUME_POOLS", [f"{extra}=ssd"])
+        setup_pools(sys_root=sys_root)
+        assert [pool.path for pool in get_pools()][1] == extra

--- a/tests/supervisor/test_storage_pools.py
+++ b/tests/supervisor/test_storage_pools.py
@@ -15,6 +15,7 @@ from aleph_message.models.execution.volume import PersistentVolume, VolumePersis
 import aleph.vm.storage as storage_module
 import aleph.vm.storage_pools as storage_pools_module
 from aleph.vm.agent.migration.reaper import reap_orphan_migration_files
+from aleph.vm.agent.migration.runner import _collect_export_disks
 from aleph.vm.conf import settings
 from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.storage_pools import (
@@ -429,3 +430,20 @@ class TestMigrationPools:
         assert not aborted.exists()
         assert not (exported / "rootfs.qcow2.export.qcow2").exists()
         assert exported.exists()
+
+    def test_export_collects_each_volume_from_one_pool_only(self, three_pools, caplog):
+        """A duplicated basename (e.g. a preserved orphan from a failed import
+        plus a retried staging in another pool) must export exactly one copy:
+        the lowest-index pool's, matching the boot-time volume lookup rule."""
+        for pool in (three_pools[1], three_pools[2]):
+            namespace = pool.path / "vm-x"
+            namespace.mkdir()
+            (namespace / "rootfs.qcow2").touch()
+        (three_pools[2].path / "vm-x" / "extra.qcow2").touch()
+        with caplog.at_level("WARNING"):
+            disks = _collect_export_disks("vm-x")
+        assert disks == [
+            three_pools[1].path / "vm-x" / "rootfs.qcow2",
+            three_pools[2].path / "vm-x" / "extra.qcow2",
+        ]
+        assert any("multiple pools" in record.message for record in caplog.records)

--- a/tests/supervisor/test_storage_pools.py
+++ b/tests/supervisor/test_storage_pools.py
@@ -7,9 +7,12 @@ import json
 import logging
 import shutil as shutil_module
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
+from aleph_message.models.execution.volume import PersistentVolume, VolumePersistence
 
+import aleph.vm.storage as storage_module
 import aleph.vm.storage_pools as storage_pools_module
 from aleph.vm.conf import settings
 from aleph.vm.resources import InsufficientResourcesError
@@ -377,3 +380,35 @@ class TestPooledAccounting:
             {three_pools[0].path: 10 * 1024**3, three_pools[1].path: 50 * 1024**3, three_pools[2].path: 30 * 1024**3},
         )
         assert roomiest_pool_free_bytes() == 50 * 1024**3
+
+
+def _persistent_volume(name: str = "data", size_mib: int = 1024) -> PersistentVolume:
+    return PersistentVolume(
+        mount=f"/{name}",
+        name=name,
+        persistence=VolumePersistence.host,
+        size_mib=size_mib,
+    )
+
+
+class TestStorageWiring:
+    @pytest.mark.asyncio
+    async def test_get_volume_path_places_a_new_ext4_on_the_best_pool(self, three_pools, monkeypatch, mocker):
+        _fake_disk_usage(
+            monkeypatch,
+            {three_pools[0].path: 1 * 1024**3, three_pools[1].path: 50 * 1024**3, three_pools[2].path: 2 * 1024**3},
+        )
+        create_ext4 = mocker.patch.object(storage_module, "create_ext4", new_callable=AsyncMock)
+        path = await storage_module.get_volume_path(_persistent_volume(), namespace="vmhash")
+        assert path == three_pools[1].path / "vmhash" / "data.ext4"
+        create_ext4.assert_awaited_once_with(path, 1024)
+
+    @pytest.mark.asyncio
+    async def test_get_volume_path_reuses_an_existing_volume_wherever_it_lives(self, three_pools, monkeypatch, mocker):
+        _fake_disk_usage(monkeypatch, {pool.path: 50 * 1024**3 for pool in three_pools})
+        existing = three_pools[2].path / "vmhash"
+        existing.mkdir()
+        (existing / "data.ext4").touch()
+        mocker.patch.object(storage_module, "create_ext4", new_callable=AsyncMock)
+        path = await storage_module.get_volume_path(_persistent_volume(), namespace="vmhash")
+        assert path == existing / "data.ext4"

--- a/tests/supervisor/test_storage_pools.py
+++ b/tests/supervisor/test_storage_pools.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 
 import json
 import logging
+import shutil as shutil_module
 from pathlib import Path
 
 import pytest
 
+import aleph.vm.storage_pools as storage_pools_module
 from aleph.vm.conf import settings
+from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.storage_pools import (
     POOL_MARKER_NAME,
     MediaClass,
@@ -17,9 +20,15 @@ from aleph.vm.storage_pools import (
     StoragePoolConfigError,
     _device_media_class,
     detect_media_class,
+    find_existing_volume,
     get_pools,
+    iter_namespace_dirs,
+    pools_disk_usage,
     reset_pools,
+    roomiest_pool_free_bytes,
+    select_pool,
     setup_pools,
+    volume_path_for,
 )
 
 
@@ -226,3 +235,145 @@ class TestGetPools:
         monkeypatch.setattr(settings, "VOLUME_POOLS", [f"{extra}=ssd"])
         setup_pools(sys_root=sys_root)
         assert [pool.path for pool in get_pools()][1] == extra
+
+
+@pytest.fixture()
+def three_pools(pool_settings, monkeypatch):
+    """Pool 0 (default) + one NVMe + one SSD pool, module cache primed."""
+    pool1 = pool_settings / "mnt" / "nvme1"
+    pool2 = pool_settings / "mnt" / "ssd1"
+    pool1.mkdir(parents=True)
+    pool2.mkdir(parents=True)
+    pools = [
+        StoragePool(path=Path(settings.PERSISTENT_VOLUMES_DIR), media_class=MediaClass.SSD, index=0),
+        StoragePool(path=pool1, media_class=MediaClass.NVME, index=1),
+        StoragePool(path=pool2, media_class=MediaClass.SSD, index=2),
+    ]
+    monkeypatch.setattr(storage_pools_module, "_pools", pools)
+    return pools
+
+
+def _fake_disk_usage(monkeypatch, free_by_path: dict[Path, int], total: int = 10**12):
+    """shutil.disk_usage keyed by pool path; unknown paths raise OSError."""
+
+    def fake(path):
+        for pool_path, free in free_by_path.items():
+            if str(pool_path) == str(path):
+                return shutil_module._ntuple_diskusage(total, total - free, free)
+        msg = f"no fake usage for {path}"
+        raise OSError(msg)
+
+    monkeypatch.setattr(storage_pools_module.shutil, "disk_usage", fake)
+
+
+class TestSelectPool:
+    def test_picks_the_most_free_eligible_pool(self, three_pools, monkeypatch):
+        _fake_disk_usage(
+            monkeypatch,
+            {three_pools[0].path: 10 * 1024**3, three_pools[1].path: 50 * 1024**3, three_pools[2].path: 30 * 1024**3},
+        )
+        assert select_pool(size_mib=1024) == three_pools[1]
+
+    def test_tie_break_is_lowest_index(self, three_pools, monkeypatch):
+        _fake_disk_usage(
+            monkeypatch,
+            {three_pools[0].path: 50 * 1024**3, three_pools[1].path: 50 * 1024**3, three_pools[2].path: 50 * 1024**3},
+        )
+        assert select_pool(size_mib=1024) == three_pools[0]
+
+    def test_no_pool_fits_raises(self, three_pools, monkeypatch):
+        _fake_disk_usage(
+            monkeypatch,
+            {three_pools[0].path: 1 * 1024**3, three_pools[1].path: 2 * 1024**3, three_pools[2].path: 1 * 1024**3},
+        )
+        with pytest.raises(InsufficientResourcesError):
+            select_pool(size_mib=10 * 1024)  # 10 GiB > every pool's free space
+
+    def test_unreachable_pool_is_skipped(self, three_pools, monkeypatch):
+        # Pool 1 raises OSError (dead disk): placement falls to the others.
+        _fake_disk_usage(
+            monkeypatch,
+            {three_pools[0].path: 10 * 1024**3, three_pools[2].path: 30 * 1024**3},
+        )
+        assert select_pool(size_mib=1024) == three_pools[2]
+
+
+class TestLookup:
+    def test_find_existing_scans_pools_in_order(self, three_pools):
+        (three_pools[2].path / "vmhash").mkdir()
+        (three_pools[2].path / "vmhash" / "rootfs.qcow2").touch()
+        assert find_existing_volume("vmhash", "rootfs.qcow2") == three_pools[2].path / "vmhash" / "rootfs.qcow2"
+        assert find_existing_volume("vmhash", "other.qcow2") is None
+
+    def test_duplicate_uses_lowest_index_and_warns(self, three_pools, caplog):
+        for pool in (three_pools[1], three_pools[2]):
+            (pool.path / "vmhash").mkdir()
+            (pool.path / "vmhash" / "vol.ext4").touch()
+        with caplog.at_level("WARNING"):
+            found = find_existing_volume("vmhash", "vol.ext4")
+        assert found == three_pools[1].path / "vmhash" / "vol.ext4"
+        assert any("found in 2 pools" in record.message for record in caplog.records)
+
+    def test_volume_path_for_prefers_existing_over_placement(self, three_pools, monkeypatch):
+        _fake_disk_usage(monkeypatch, {pool.path: 50 * 1024**3 for pool in three_pools})
+        (three_pools[2].path / "vmhash").mkdir()
+        (three_pools[2].path / "vmhash" / "vol.ext4").touch()
+        assert volume_path_for("vmhash", "vol.ext4", size_mib=1024) == three_pools[2].path / "vmhash" / "vol.ext4"
+
+    def test_volume_path_for_places_and_creates_the_namespace_dir(self, three_pools, monkeypatch):
+        _fake_disk_usage(
+            monkeypatch,
+            {three_pools[0].path: 1 * 1024**3, three_pools[1].path: 50 * 1024**3, three_pools[2].path: 2 * 1024**3},
+        )
+        path = volume_path_for("vmhash", "new.ext4", size_mib=1024)
+        assert path == three_pools[1].path / "vmhash" / "new.ext4"
+        assert path.parent.is_dir()
+        assert not path.exists()
+
+    def test_iter_namespace_dirs(self, three_pools):
+        (three_pools[0].path / "vm-a").mkdir()
+        (three_pools[1].path / "vm-a").mkdir()
+        (three_pools[1].path / "vm-b").mkdir()
+        (three_pools[1].path / "stray-file").touch()
+        assert list(iter_namespace_dirs("vm-a")) == [
+            three_pools[0].path / "vm-a",
+            three_pools[1].path / "vm-a",
+        ]
+        every = list(iter_namespace_dirs())
+        assert three_pools[1].path / "vm-b" in every
+        assert len(every) == 3  # dirs only, the stray file is skipped
+
+
+class TestPooledAccounting:
+    def test_sums_and_dedups_by_st_dev(self, three_pools, monkeypatch):
+        _fake_disk_usage(monkeypatch, {pool.path: 10 * 1024**3 for pool in three_pools})
+        fake_devs = {
+            str(three_pools[0].path): 1,
+            str(three_pools[1].path): 2,
+            str(three_pools[2].path): 2,  # same filesystem as pool 1
+        }
+        real_stat = storage_pools_module.os.stat
+
+        def fake_stat(path, *args, **kwargs):
+            if str(path) in fake_devs:
+                result = list(real_stat(path, *args, **kwargs))
+                result[2] = fake_devs[str(path)]  # st_dev
+                return storage_pools_module.os.stat_result(result)
+            return real_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(storage_pools_module.os, "stat", fake_stat)
+        total, free = pools_disk_usage()
+        # Pools 1 and 2 share a filesystem: counted once → 2 filesystems.
+        assert free == 2 * 10 * 1024**3
+
+    def test_unreachable_pool_contributes_zero(self, three_pools, monkeypatch):
+        _fake_disk_usage(monkeypatch, {three_pools[0].path: 10 * 1024**3})
+        total, free = pools_disk_usage()
+        assert free == 10 * 1024**3
+
+    def test_roomiest_pool_free_bytes(self, three_pools, monkeypatch):
+        _fake_disk_usage(
+            monkeypatch,
+            {three_pools[0].path: 10 * 1024**3, three_pools[1].path: 50 * 1024**3, three_pools[2].path: 30 * 1024**3},
+        )
+        assert roomiest_pool_free_bytes() == 50 * 1024**3

--- a/tests/supervisor/test_storage_pools.py
+++ b/tests/supervisor/test_storage_pools.py
@@ -14,6 +14,7 @@ from aleph_message.models.execution.volume import PersistentVolume, VolumePersis
 
 import aleph.vm.storage as storage_module
 import aleph.vm.storage_pools as storage_pools_module
+from aleph.vm.agent.migration.reaper import reap_orphan_migration_files
 from aleph.vm.conf import settings
 from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.storage_pools import (
@@ -412,3 +413,19 @@ class TestStorageWiring:
         mocker.patch.object(storage_module, "create_ext4", new_callable=AsyncMock)
         path = await storage_module.get_volume_path(_persistent_volume(), namespace="vmhash")
         assert path == existing / "data.ext4"
+
+
+class TestMigrationPools:
+    @pytest.mark.asyncio
+    async def test_reaper_sweeps_every_pool(self, three_pools):
+        # An aborted import (.part) in pool 1, an orphan export in pool 2.
+        aborted = three_pools[1].path / "dead-vm"
+        aborted.mkdir()
+        (aborted / "rootfs.qcow2.part").touch()
+        exported = three_pools[2].path / "live-vm"
+        exported.mkdir()
+        (exported / "rootfs.qcow2.export.qcow2").touch()
+        await reap_orphan_migration_files(known_vm_ids={"live-vm"})
+        assert not aborted.exists()
+        assert not (exported / "rootfs.qcow2.export.qcow2").exists()
+        assert exported.exists()

--- a/tests/supervisor/test_storage_pools.py
+++ b/tests/supervisor/test_storage_pools.py
@@ -1,0 +1,84 @@
+"""Agent-side storage pools: media-class detection, pool config, placement,
+lookup and pooled accounting (src/aleph/vm/storage_pools.py)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aleph.vm.storage_pools import (
+    MediaClass,
+    _device_media_class,
+    detect_media_class,
+)
+
+
+def _make_disk(sys_root: Path, name: str, *, rotational: bool) -> None:
+    """A whole-disk node, faithful to sysfs: the real node lives under
+    devices/ and class/block/<name> symlinks to it."""
+    disk = sys_root / "devices" / name
+    (disk / "queue").mkdir(parents=True)
+    (disk / "queue" / "rotational").write_text("1\n" if rotational else "0\n")
+    class_dir = sys_root / "class" / "block"
+    class_dir.mkdir(parents=True, exist_ok=True)
+    (class_dir / name).symlink_to(disk)
+
+
+def _make_partition(sys_root: Path, disk: str, name: str) -> None:
+    """A partition node: nested under its disk's devices/ dir (so the
+    resolved parent is the disk, which holds queue/)."""
+    part = sys_root / "devices" / disk / name
+    part.mkdir(parents=True)
+    (sys_root / "class" / "block" / name).symlink_to(part)
+
+
+def _make_stacked(sys_root: Path, name: str, slaves: list[str]) -> None:
+    """A dm/md node: has slaves/<member> entries naming its members."""
+    node = sys_root / "devices" / "virtual" / name
+    (node / "slaves").mkdir(parents=True)
+    (node / "queue").mkdir()
+    (node / "queue" / "rotational").write_text("0\n")
+    for slave in slaves:
+        (node / "slaves" / slave).mkdir()
+    class_dir = sys_root / "class" / "block"
+    class_dir.mkdir(parents=True, exist_ok=True)
+    (class_dir / name).symlink_to(node)
+
+
+class TestMediaClassDetection:
+    def test_nvme_disk_and_partition(self, tmp_path):
+        _make_disk(tmp_path, "nvme0n1", rotational=False)
+        _make_partition(tmp_path, "nvme0n1", "nvme0n1p1")
+        assert _device_media_class("nvme0n1", tmp_path) is MediaClass.NVME
+        assert _device_media_class("nvme0n1p1", tmp_path) is MediaClass.NVME
+
+    def test_sata_ssd_and_hdd(self, tmp_path):
+        _make_disk(tmp_path, "sda", rotational=False)
+        _make_disk(tmp_path, "sdb", rotational=True)
+        _make_partition(tmp_path, "sda", "sda1")
+        assert _device_media_class("sda", tmp_path) is MediaClass.SSD
+        assert _device_media_class("sda1", tmp_path) is MediaClass.SSD
+        assert _device_media_class("sdb", tmp_path) is MediaClass.HDD
+
+    def test_stacked_device_takes_slowest_member(self, tmp_path):
+        _make_disk(tmp_path, "nvme0n1", rotational=False)
+        _make_disk(tmp_path, "sdb", rotational=True)
+        _make_stacked(tmp_path, "dm-0", ["nvme0n1", "sdb"])
+        _make_stacked(tmp_path, "dm-1", ["nvme0n1"])
+        assert _device_media_class("dm-0", tmp_path) is MediaClass.HDD
+        assert _device_media_class("dm-1", tmp_path) is MediaClass.NVME
+
+    def test_unknown_device_is_none(self, tmp_path):
+        (tmp_path / "class" / "block").mkdir(parents=True)
+        assert _device_media_class("sdz", tmp_path) is None
+
+    def test_detect_media_class_unknown_mapping_is_none(self, tmp_path):
+        # An empty fake /sys has no dev/block/<maj:min> entry for tmp_path's
+        # device, so the path-level wrapper reports undetectable.
+        (tmp_path / "dev" / "block").mkdir(parents=True)
+        assert detect_media_class(tmp_path, sys_root=tmp_path) is None
+
+    def test_slowness_ordering_and_eligibility(self):
+        assert MediaClass.NVME.slowness < MediaClass.SSD.slowness < MediaClass.HDD.slowness
+        assert MediaClass.NVME.vm_eligible
+        assert MediaClass.SSD.vm_eligible
+        assert not MediaClass.HDD.vm_eligible

--- a/tests/supervisor/test_storage_pools.py
+++ b/tests/supervisor/test_storage_pools.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import shutil as shutil_module
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -16,7 +18,9 @@ import aleph.vm.storage as storage_module
 import aleph.vm.storage_pools as storage_pools_module
 from aleph.vm.agent.migration.reaper import reap_orphan_migration_files
 from aleph.vm.agent.migration.runner import _collect_export_disks
+from aleph.vm.agent.vm.downloader import ProgramDownloader, QemuDownloader
 from aleph.vm.conf import settings
+from aleph.vm.host_volumes import host_volumes_from_message
 from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.storage_pools import (
     POOL_MARKER_NAME,
@@ -226,6 +230,64 @@ class TestSetupPools:
         registry = json.loads((Path(settings.EXECUTION_ROOT) / "volume-pools.json").read_text())
         assert str(extra) in registry
 
+    def test_dropping_an_adopted_pool_from_config_is_a_hard_error(self, pool_settings, monkeypatch):
+        """A pool that holds (or held) VM volumes must not silently vanish
+        from the active set when its VOLUME_POOLS entry is removed."""
+        sys_root = _fake_ssd_sysfs(pool_settings)
+        extra = pool_settings / "mnt" / "nvme1"
+        extra.mkdir(parents=True)
+        monkeypatch.setattr(settings, "VOLUME_POOLS", [f"{extra}=nvme"])
+        setup_pools(sys_root=sys_root)
+        reset_pools()
+        monkeypatch.setattr(settings, "VOLUME_POOLS", [])
+        with pytest.raises(StoragePoolConfigError, match=re.escape(str(extra))):
+            setup_pools(sys_root=sys_root)
+
+    @pytest.mark.parametrize("entry", ["=ssd", "relative/path=ssd"])
+    def test_empty_or_relative_pool_path_is_a_hard_error(self, pool_settings, monkeypatch, entry):
+        sys_root = _fake_ssd_sysfs(pool_settings)
+        monkeypatch.setattr(settings, "VOLUME_POOLS", [entry])
+        with pytest.raises(StoragePoolConfigError, match="absolute"):
+            setup_pools(sys_root=sys_root)
+
+
+class TestAdoptionRegistry:
+    def test_corrupt_registry_json_is_a_hard_error(self, pool_settings):
+        (Path(settings.EXECUTION_ROOT) / "volume-pools.json").write_text("{not json")
+        with pytest.raises(StoragePoolConfigError, match="volume-pools.json"):
+            setup_pools(sys_root=_fake_ssd_sysfs(pool_settings))
+
+    def test_non_list_registry_json_is_a_hard_error(self, pool_settings):
+        (Path(settings.EXECUTION_ROOT) / "volume-pools.json").write_text('{"pool": "/mnt/nvme1"}')
+        with pytest.raises(StoragePoolConfigError, match="volume-pools.json"):
+            setup_pools(sys_root=_fake_ssd_sysfs(pool_settings))
+
+    def test_missing_registry_is_first_boot(self, pool_settings):
+        assert not (Path(settings.EXECUTION_ROOT) / "volume-pools.json").exists()
+        setup_pools(sys_root=_fake_ssd_sysfs(pool_settings))  # must not raise
+
+    def test_record_adopted_writes_atomically(self, pool_settings, monkeypatch):
+        """The registry is written via a temp file + os.replace so a crash
+        mid-write cannot leave a truncated (corrupt) registry behind."""
+        sys_root = _fake_ssd_sysfs(pool_settings)
+        extra = pool_settings / "mnt" / "nvme1"
+        extra.mkdir(parents=True)
+        monkeypatch.setattr(settings, "VOLUME_POOLS", [f"{extra}=nvme"])
+
+        registry = Path(settings.EXECUTION_ROOT) / "volume-pools.json"
+        replaced: list[tuple[str, str]] = []
+        real_replace = storage_pools_module.os.replace
+
+        def spying_replace(src, dst, *args, **kwargs):
+            replaced.append((str(src), str(dst)))
+            return real_replace(src, dst, *args, **kwargs)
+
+        monkeypatch.setattr(storage_pools_module.os, "replace", spying_replace)
+        setup_pools(sys_root=sys_root)
+        assert any(dst == str(registry) for _src, dst in replaced)
+        assert not Path(str(registry) + ".tmp").exists()
+        assert str(extra) in json.loads(registry.read_text())
+
 
 class TestGetPools:
     def test_get_pools_without_setup_falls_back_to_pool_zero(self, pool_settings):  # noqa: ARG002 (pool_settings is a fixture)
@@ -335,6 +397,44 @@ class TestLookup:
         assert path.parent.is_dir()
         assert not path.exists()
 
+    def test_pool0_only_placement_ignores_freer_extra_pools(self, three_pools, monkeypatch):
+        """Firecracker writable volumes: the jailer hardlink-copies across
+        filesystems, so placement must stay on pool 0 even when an extra pool
+        has more free space."""
+        _fake_disk_usage(
+            monkeypatch,
+            {three_pools[0].path: 10 * 1024**3, three_pools[1].path: 50 * 1024**3, three_pools[2].path: 30 * 1024**3},
+        )
+        path = volume_path_for("vmhash", "vol.ext4", size_mib=1024, pool0_only=True)
+        assert path == three_pools[0].path / "vmhash" / "vol.ext4"
+
+    def test_pool0_only_raises_when_pool0_cannot_fit(self, three_pools, monkeypatch):
+        # An extra pool could fit the volume, but it must not be used.
+        _fake_disk_usage(
+            monkeypatch,
+            {three_pools[0].path: 1 * 1024**3, three_pools[1].path: 50 * 1024**3, three_pools[2].path: 30 * 1024**3},
+        )
+        with pytest.raises(InsufficientResourcesError):
+            volume_path_for("vmhash", "vol.ext4", size_mib=10 * 1024, pool0_only=True)
+
+    def test_pool0_only_sticky_reuse_off_pool0_logs_an_error(self, three_pools, caplog):
+        """A legacy volume already living on an extra pool must still boot
+        (returning its path), but the lost-writes hazard is logged loudly."""
+        (three_pools[2].path / "vmhash").mkdir()
+        (three_pools[2].path / "vmhash" / "vol.ext4").touch()
+        with caplog.at_level(logging.ERROR, logger="aleph.vm.storage_pools"):
+            path = volume_path_for("vmhash", "vol.ext4", size_mib=1024, pool0_only=True)
+        assert path == three_pools[2].path / "vmhash" / "vol.ext4"
+        assert any("lost" in record.message.lower() for record in caplog.records)
+
+    def test_pool0_only_sticky_reuse_on_pool0_is_silent(self, three_pools, caplog):
+        (three_pools[0].path / "vmhash").mkdir()
+        (three_pools[0].path / "vmhash" / "vol.ext4").touch()
+        with caplog.at_level(logging.ERROR, logger="aleph.vm.storage_pools"):
+            path = volume_path_for("vmhash", "vol.ext4", size_mib=1024, pool0_only=True)
+        assert path == three_pools[0].path / "vmhash" / "vol.ext4"
+        assert not caplog.records
+
     def test_iter_namespace_dirs(self, three_pools):
         (three_pools[0].path / "vm-a").mkdir()
         (three_pools[1].path / "vm-a").mkdir()
@@ -414,6 +514,86 @@ class TestStorageWiring:
         mocker.patch.object(storage_module, "create_ext4", new_callable=AsyncMock)
         path = await storage_module.get_volume_path(_persistent_volume(), namespace="vmhash")
         assert path == existing / "data.ext4"
+
+
+class TestFirecrackerPool0Wiring:
+    """Firecracker writable volumes must stay on pool 0 (the jailer
+    hardlink-copies drive files across filesystems, losing guest writes)."""
+
+    @pytest.mark.asyncio
+    async def test_get_volume_path_pool0_only_places_ext4_on_pool0(self, three_pools, monkeypatch, mocker):
+        _fake_disk_usage(
+            monkeypatch,
+            {three_pools[0].path: 10 * 1024**3, three_pools[1].path: 50 * 1024**3, three_pools[2].path: 2 * 1024**3},
+        )
+        create_ext4 = mocker.patch.object(storage_module, "create_ext4", new_callable=AsyncMock)
+        path = await storage_module.get_volume_path(_persistent_volume(), namespace="vmhash", pool0_only=True)
+        assert path == three_pools[0].path / "vmhash" / "data.ext4"
+        create_ext4.assert_awaited_once_with(path, 1024)
+
+    @pytest.mark.asyncio
+    async def test_host_volumes_from_message_threads_pool0_only(self, mocker):
+        get_path = mocker.patch(
+            "aleph.vm.host_volumes.get_volume_path", new_callable=AsyncMock, return_value=Path("/pool0/vm/data.ext4")
+        )
+        message_content = SimpleNamespace(volumes=[_persistent_volume()])
+        await host_volumes_from_message(message_content, "vmhash", pool0_only=True)
+        assert get_path.await_args.kwargs["pool0_only"] is True
+
+    @pytest.mark.asyncio
+    async def test_program_downloader_pins_volumes_to_pool0(self, mocker):
+        resolver = mocker.patch(
+            "aleph.vm.agent.vm.downloader.host_volumes_from_message", new_callable=AsyncMock, return_value=[]
+        )
+        message_content = SimpleNamespace(
+            volumes=[], code=SimpleNamespace(encoding="zip", entrypoint="main:app", interface=None)
+        )
+        downloader = ProgramDownloader(message_content, "vmhash")
+        await downloader.download_volumes()
+        assert resolver.await_args.kwargs["pool0_only"] is True
+
+    @pytest.mark.asyncio
+    async def test_qemu_downloader_keeps_all_pools(self, mocker):
+        resolver = mocker.patch(
+            "aleph.vm.agent.vm.downloader.host_volumes_from_message", new_callable=AsyncMock, return_value=[]
+        )
+        downloader = QemuDownloader(SimpleNamespace(volumes=[]), "vmhash")
+        await downloader.download_volumes()
+        assert resolver.await_args.kwargs["pool0_only"] is False
+
+
+class TestDaemonStartup:
+    """The standalone Python supervisor daemon must run setup_pools() so its
+    capacity accounting sees every configured pool (and misconfigurations
+    abort startup instead of degrading silently)."""
+
+    @pytest.fixture()
+    def daemon_main(self, monkeypatch, tmp_path):
+        from aleph.vm.supervisor import daemon
+
+        fake_settings = SimpleNamespace(
+            setup=lambda: None,
+            check=lambda: None,
+            SUPERVISOR_GRPC_SOCKET=str(tmp_path / "supervisor.sock"),
+        )
+        monkeypatch.setattr(daemon, "settings", fake_settings)
+        monkeypatch.setattr(daemon.asyncio, "run", lambda coro: coro.close())
+        return daemon
+
+    def test_daemon_main_runs_setup_pools(self, daemon_main, monkeypatch):
+        calls: list[bool] = []
+        monkeypatch.setattr(storage_pools_module, "setup_pools", lambda: calls.append(True))
+        assert daemon_main.main([]) == 0
+        assert calls == [True]
+
+    def test_daemon_main_aborts_on_pool_config_error(self, daemon_main, monkeypatch):
+        def broken_setup_pools():
+            msg = "pool misconfigured"
+            raise StoragePoolConfigError(msg)
+
+        monkeypatch.setattr(storage_pools_module, "setup_pools", broken_setup_pools)
+        with pytest.raises(StoragePoolConfigError):
+            daemon_main.main([])
 
 
 class TestMigrationPools:


### PR DESCRIPTION
## Summary

CRNs with multiple fast disks can now spread VM volumes across them. Operators declare extra pool directories via `ALEPH_VM_VOLUME_POOLS` (JSON list, optional `path=class` override); `PERSISTENT_VOLUMES_DIR` remains the implicit first pool, so unconfigured nodes are byte-for-byte unchanged.

- **New agent-side module `storage_pools.py`**: media-class detection from sysfs (`nvme`/`ssd`/`hdd`, dm/md stacks resolve to the slowest member), most-free-pool placement, sticky cross-pool lookup, `st_dev`-deduplicated accounting.
- **HDD policy**: rotational disks are refused as extra pools (they're for `CACHE_ROOT`/`BACKUP_DIRECTORY`); pool 0 on HDD warns but stays eligible so existing nodes keep working.
- **Safety**: pools carry an adoption marker plus a registry under `EXECUTION_ROOT` — an unmounted disk, a corrupted registry, or a pool removed from config while it still holds volumes are all hard startup errors instead of silent misplacement/data loss.
- **Wired call sites**: ext4/btrfs volume creation, qcow2 instance-rootfs staging, migration (reaper sweeps all pools, export dedupes by lowest-index pool matching boot-time resolution, import stages via placement).
- **Accounting**: admission (`capacity.py`, incl. a new largest-single-volume vs roomiest-pool check), pool reservations, and `/about/usage/system` all report the deduplicated aggregate; the Rust supervisor-daemon reads the same env var and sums pools for `GetHostInfo`.
- **Firecracker**: writable program volumes pin to pool 0 — the jailer silently copies (not hardlinks) across `st_dev`, which would lose guest writes on an extra pool.
- **Untouched by design**: `proto/supervisor.proto`, `supervisor-controller`, aleph-message — `DiskConfig` already carries opaque absolute paths.

Failure domain vs LVM striping: one dead SSD loses only the VMs whose volumes live on it; everything else keeps running.

Design doc: `docs/plans/2026-07-09-multi-disk-storage-pools-design.md` (local).
Operator guide: `doc/multi-disk-storage.md`.

## Test plan

- 46 new tests in `tests/supervisor/test_storage_pools.py` (detection with fake sysfs, adoption/registry, placement/lookup, accounting dedup, migration sweep, pool0 pinning) plus capacity/migration additions; focused suites 177 passed.
- Full local Python suite: 1075 passed, 4 known environment-only failures (pyroute2-needs-root, journald stub).
- Rust: `cargo test -p supervisor-daemon` 315 passed, clippy `-D warnings` clean.
- ruff/isort/mypy at baseline (no new findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)