### PR TITLE
feat(vprogram): runtime bundle tooling + typed manifest format

### DIFF
--- a/docs/plans/2026-07-09-vprogram-runtime-bundle-design.md
+++ b/docs/plans/2026-07-09-vprogram-runtime-bundle-design.md
@@ -1,0 +1,224 @@
+# V-Program Runtime Bundle Tooling — Design
+
+Date: 2026-07-09
+Status: approved
+Related: `docs/plans/2026-07-08-confidential-vm-protocol-design.md` (§11 runtime
+manifest convention), aleph-message PR #158 (`VerifiableProgramRuntime.ref`
+points at a manifest STORE).
+
+## Goal
+
+Automate the creation of V-Program runtime bundles from the Nix measured-image
+build, and give the `aleph-vprogram-runtime` manifest format a strict,
+type-safe Python model that later consumers (CRN agent launch path, pyaleph
+phase 2, CLI tooling) can reuse.
+
+Today the process is manual: CI runs
+`nix build "git+file://$REPO?dir=nix#image"`, someone hand-tars the output
+(the mainnet bundle `1db0d69c…` contains a stray `aleph-attest-cli` binary at
+top level), uploads it with `aleph file upload`, and bumps a hash in a
+workflow file. There is no manifest at all yet; `runtime.ref` in V-PROGRAM
+messages has nothing to point to.
+
+## Decisions (from brainstorming)
+
+1. **Scope: build + manifest generation only; uploads stay manual.** The
+   manifest's `bundle.ref` is the STORE item hash, which exists only after the
+   bundle is uploaded, so full automation would need account keys and network
+   in the script. Instead the tool has two steps around the manual upload, and
+   prints the exact `aleph file upload` commands.
+2. **Model home: `src/aleph/vm/vprogram/`.** Importable by the future agent
+   launch path; promoted to aleph-message once the format is proven.
+3. **Base branch: `od/controller-main-error-flow`** (the only line with
+   `nix/`). New branch off it.
+4. **Single-bundle model.** The runtime is ONE tar.gz pinned by ONE STORE
+   message (57 MB today); per-artifact STOREs are overkill. The manifest
+   spends its weight on what the tarball cannot say about itself: attestation
+   protocols and port, boot recipe, cmdline template, workload contract.
+
+## The manifest format: `aleph-vprogram-runtime/1`
+
+Reference instance (real values for the existing mainnet bundle):
+
+```json
+{
+  "format": "aleph-vprogram-runtime",
+  "format_version": 1,
+  "name": "aleph-snp-attest",
+  "version": "2026.07.08",
+  "platform": "sev_snp",
+  "bundle": {
+    "ref": "87287e4a5c8d7554a50f982cd681b64b2600c0bbb1c0b1e618465e022e01b977",
+    "sha256": "1db0d69c96dc7ed6c8a6cbb8c63f8de516ef4ed668e95c468cc216e4c44d911b",
+    "size": 57522386,
+    "members": {
+      "ovmf": "image/OVMF.fd",
+      "kernel": "image/bzImage",
+      "initrd": "image/initrd",
+      "platform_rootfs": "image/rootfs.ext4",
+      "platform_hash_tree": "image/rootfs.ext4.verity"
+    }
+  },
+  "boot": {
+    "method": "qemu-direct-kernel",
+    "kernel_hashes": true,
+    "cpu_models": ["EPYC-v4"],
+    "platform_roothash": "cb121a317be7dc7969dd633ca9b6c3718ffe9ea6715b64e0e35a871d484b56b8",
+    "cmdline_template": "console=ttyS0 root=/dev/mapper/verity-root ro roothash={platform_roothash}"
+  },
+  "attestation": [
+    { "protocol": "aleph.ra-tls", "version": "1",
+      "transport": { "type": "tcp", "port": 8443 } }
+  ],
+  "workload": { "contract": "aleph.builtin/1", "upstream_port": 8080 },
+  "source": {
+    "repo": "https://github.com/aleph-im/aleph-vm",
+    "rev": "4d90abaf",
+    "build": "nix build \"git+file://$REPO?dir=nix#image\""
+  }
+}
+```
+
+Field rationale:
+
+- `bundle.sha256` / `bundle.size` duplicate what the STORE message says, but
+  make the manifest self-sufficiently content-addressed (fetch from
+  `/api/v0/storage/raw/<sha256>`, verify, done — no message-DB round trip).
+  There is no drift authority problem: a mismatch with the STORE means the
+  manifest is invalid, full stop.
+- `boot.platform_roothash` duplicates the tarball member
+  `rootfs.ext4.roothash` so the CCN/CLI can build the measured cmdline without
+  unpacking the bundle; cross-checkable the same way.
+- `bundle.members` maps roles to tarball paths so agents never hardcode
+  layout; new bundles can reorganize without code changes.
+- `boot.cmdline_template` is the normative cmdline recipe. Only placeholders
+  defined by the format version are legal — this is the "no smuggled cmdline"
+  rule, enforced by the model.
+- `attestation` is an ordered (preference) non-empty list of protocol
+  descriptors; protocol identity lives ONLY here, never in messages
+  (denormalization rejected in the protocol design). Port 8443 matches the
+  hardcoded `aleph-attest-agent --port 8443` in `nix/init.sh`.
+- Measurements do NOT belong in the manifest: a launch digest is a joint
+  function of manifest artifacts AND message fields (vcpus, future workload
+  roothash). `measurement.hex` inside the tarball is CI convenience only.
+- `source` is informational but required: every published manifest states how
+  to rebuild and audit it.
+
+Honesty caveat: the current image's init parses only `roothash=` (the donor's
+workload-volume branch was stripped in the Phase 3 backport), so its manifest
+declares contract `aleph.builtin/1` and a template with no
+`{workload_roothash}` slot. It is a format reference and plumbing test; the
+manifest real V-Programs pin comes after the init grows workload support.
+
+## Component 1: typed model — `src/aleph/vm/vprogram/manifest.py`
+
+Pydantic v2, `model_config = ConfigDict(extra="forbid")` on every class.
+
+- `BundleMembers`: `ovmf`, `kernel`, `initrd`, `platform_rootfs`,
+  `platform_hash_tree` — each a relative path inside the tarball. Validators:
+  must be relative, must not contain `..`, must not be empty.
+- `RuntimeBundle`: `ref` (pattern `^[0-9a-f]{64}$`), `sha256` (same pattern),
+  `size` (`gt=0`), `members: BundleMembers`.
+- `BootSpec`: `method: Literal["qemu-direct-kernel"]`,
+  `kernel_hashes: Literal[True]`, `cpu_models: list[str]` (`min_length=1`),
+  `platform_roothash` (64-hex pattern), `cmdline_template: str`. Template
+  validator: parse placeholders with `string.Formatter().parse()`; every
+  placeholder must be in the closed set
+  `{"platform_roothash", "workload_roothash", "verified_volumes"}` (format
+  version 1), `{platform_roothash}` must be present, and no positional/empty
+  placeholders are allowed.
+- `AttestationTransport`: `type: Literal["tcp"]`, `port: int` (`ge=1`,
+  `le=65535`).
+- `AttestationProtocol`: `protocol` (pattern
+  `^[a-z0-9][a-z0-9_-]*(\.[a-z0-9][a-z0-9_-]*)+$`, e.g. `aleph.ra-tls`),
+  `version: str` (non-empty), `transport: AttestationTransport`.
+- `WorkloadSpec`: `contract` (pattern
+  `^[a-z0-9][a-z0-9_-]*(\.[a-z0-9][a-z0-9_-]*)+/[0-9]+$`, e.g.
+  `aleph.builtin/1`), `upstream_port: int` (`ge=1`, `le=65535`).
+- `SourceInfo`: `repo: str` (non-empty), `rev: str` (non-empty),
+  `build: str` (non-empty).
+- `RuntimeManifest`: `format: Literal["aleph-vprogram-runtime"]`,
+  `format_version: Literal[1]`, `name: str` (non-empty), `version: str`
+  (non-empty), `platform: Literal["sev_snp"]`, `bundle: RuntimeBundle`,
+  `boot: BootSpec`, `attestation: list[AttestationProtocol]`
+  (`min_length=1`), `workload: WorkloadSpec`, `source: SourceInfo`.
+  Method `to_canonical_json() -> str`: `model_dump_json` is NOT used;
+  instead `json.dumps(self.model_dump(mode="json"), separators=(",", ":"),
+  sort_keys=True)` so published bytes are reproducible.
+
+## Component 2: build script — `scripts/vprogram_bundle.py`
+
+Stdlib CLI (argparse), imports the model. Two subcommands:
+
+### `build`
+
+```
+python scripts/vprogram_bundle.py build [--repo PATH] [--image-dir PATH] --out DIR
+```
+
+1. Unless `--image-dir` is given, run
+   `nix build "git+file://$REPO?dir=nix#image" --extra-experimental-features
+   "nix-command flakes" -o <out>/image-result` (the exact invocation CI and
+   `snp-artifacts.sh` use) and use the resulting store dir.
+2. Package the image dir as `<out>/snp-image.tar.gz` with entries under
+   `image/…`. Deterministic: entries sorted by name, `uid=gid=0`,
+   `uname=gname=""`, mtime pinned to the source commit timestamp
+   (`git -C REPO log -1 --format=%ct`; falls back to `SOURCE_DATE_EPOCH`,
+   required when `--image-dir` is used outside a git repo), `gzip` stream
+   with `mtime=0`. Bundle content = the nix image output only (no
+   `aleph-attest-cli`).
+3. Write `<out>/bundle-info.json`: sha256 + size of the tarball, member
+   role→path map, `platform_roothash` (read from `rootfs.ext4.roothash`),
+   `measurement` (from `measurement.hex`, informational), source repo/rev.
+4. Print the upload command:
+   `aleph file upload <out>/snp-image.tar.gz`.
+
+### `manifest`
+
+```
+python scripts/vprogram_bundle.py manifest --bundle-info PATH --bundle-ref HASH \
+    --name NAME --runtime-version VERSION [--out PATH]
+```
+
+1. Load `bundle-info.json`; if the tarball is present next to it, re-hash and
+   cross-check sha256/size (hard error on mismatch).
+2. Construct `RuntimeManifest` through the model — validation IS the
+   constructor. Fixed v1 values: `method=qemu-direct-kernel`,
+   `kernel_hashes=true`, `cpu_models=["EPYC-v4"]`, cmdline template
+   `console=ttyS0 root=/dev/mapper/verity-root ro roothash={platform_roothash}`,
+   attestation `[aleph.ra-tls v1, tcp 8443]`, workload
+   `aleph.builtin/1` upstream 8080. These defaults describe what the current
+   image implements; overriding them is a format evolution, not a flag.
+3. Write `manifest.json` via `to_canonical_json()`.
+4. Print the upload command: `aleph file upload <out>/manifest.json`.
+
+## Tests
+
+`tests/vprogram/test_manifest.py` (model):
+- The reference manifest above (real mainnet values) validates and
+  round-trips through `to_canonical_json()` → `model_validate_json`.
+- Rejections, one test each: bad `platform_roothash` (wrong length, uppercase),
+  unknown cmdline placeholder (`{foo}`), template missing
+  `{platform_roothash}`, positional `{}` placeholder, extra field at every
+  nesting level (parametrized), `port=0` / `port=65536`, empty `attestation`,
+  member path absolute (`/etc/passwd`) or traversing (`../x`),
+  bad protocol identifier (`RA-TLS`, `aleph`), bad contract (`aleph.builtin`,
+  no `/1`), `format_version=2`, `size=0`.
+
+`tests/vprogram/test_bundle_script.py` (script, no nix, no network):
+- Fake image dir (tiny files incl. `rootfs.ext4.roothash`,
+  `measurement.hex`); `build --image-dir` twice (fixed `SOURCE_DATE_EPOCH`)
+  → byte-identical tarballs, `bundle-info.json` sha256 matches a re-hash.
+- `manifest` on that bundle-info + a dummy 64-hex ref → output parses as
+  `RuntimeManifest`, fields match bundle-info; tampered `bundle-info.json`
+  sha256 → hard error.
+
+## Out of scope
+
+- Uploads (manual; the script prints the commands).
+- A manifest-vs-remote-bundle verifier (pyaleph phase 2 territory).
+- `workload_roothash` / `verified_volumes` support in the image init
+  (separate follow-up; the model already accepts those template slots so the
+  next runtime needs no schema change).
+- Publishing the reference manifest to mainnet (done manually with this tool
+  once it lands).

--- a/scripts/vprogram_bundle.py
+++ b/scripts/vprogram_bundle.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Build V-Program runtime bundles from the Nix measured image and generate
+the aleph-vprogram-runtime manifest.
+
+Two steps around the manual upload (the manifest needs the bundle's STORE
+item hash, which only exists after uploading):
+
+  1. python scripts/vprogram_bundle.py build --out DIR [--image-dir PATH]
+     -> DIR/snp-image.tar.gz + DIR/bundle-info.json; upload the tarball with
+        the printed `aleph file upload` command and note the item hash.
+  2. python scripts/vprogram_bundle.py manifest --bundle-info DIR/bundle-info.json \
+         --bundle-ref ITEM_HASH --name NAME --runtime-version VERSION
+     -> DIR/manifest.json; upload it. Its STORE item hash is what V-PROGRAM
+        messages pin as runtime.ref.
+
+Design: docs/plans/2026-07-09-vprogram-runtime-bundle-design.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from aleph.vm.vprogram.bundle import (  # noqa: E402
+    BUNDLE_NAME,
+    MANIFEST_NAME,
+    BundleInfo,
+    build_bundle,
+    make_manifest,
+    verify_bundle_info,
+)
+from aleph.vm.vprogram.manifest import SourceInfo  # noqa: E402
+
+BUILD_COMMAND = 'nix build "git+file://$REPO?dir=nix#image"'
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],  # noqa: S603, S607
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _source_epoch(repo: Path) -> int:
+    from_env = os.environ.get("SOURCE_DATE_EPOCH")
+    if from_env is not None:
+        return int(from_env)
+    return int(_git(repo, "log", "-1", "--format=%ct"))
+
+
+def cmd_build(args: argparse.Namespace) -> int:
+    repo = args.repo.resolve()
+    out: Path = args.out
+    out.mkdir(parents=True, exist_ok=True)
+    if args.image_dir is not None:
+        image_dir = args.image_dir.resolve()
+    else:
+        subprocess.run(
+            [  # noqa: S603, S607
+                "nix",
+                "build",
+                f"git+file://{repo}?dir=nix#image",
+                "--extra-experimental-features",
+                "nix-command flakes",
+                "-o",
+                str(out / "image-result"),
+            ],
+            check=True,
+        )
+        image_dir = (out / "image-result").resolve()
+    source = SourceInfo(
+        repo="https://github.com/aleph-im/aleph-vm",
+        rev=_git(repo, "rev-parse", "--short", "HEAD"),
+        build=BUILD_COMMAND,
+    )
+    info = build_bundle(image_dir=image_dir, out_dir=out, source_epoch=_source_epoch(repo), source=source)
+    print(f"bundle:   {out / BUNDLE_NAME}")  # noqa: T201
+    print(f"sha256:   {info.sha256}")  # noqa: T201
+    print(f"size:     {info.size}")  # noqa: T201
+    print(f"roothash: {info.platform_roothash}")  # noqa: T201
+    print()  # noqa: T201
+    print("Next: upload the bundle and note the STORE item hash it prints:")  # noqa: T201
+    print(f"  aleph file upload {out / BUNDLE_NAME}")  # noqa: T201
+    return 0
+
+
+def cmd_manifest(args: argparse.Namespace) -> int:
+    info = BundleInfo.model_validate_json(args.bundle_info.read_text())
+    tar_path = args.bundle_info.parent / BUNDLE_NAME
+    if tar_path.is_file():
+        verify_bundle_info(info, tar_path)
+    manifest = make_manifest(
+        info=info, bundle_ref=args.bundle_ref, name=args.name, runtime_version=args.runtime_version
+    )
+    out: Path = args.out if args.out is not None else args.bundle_info.parent / MANIFEST_NAME
+    out.write_text(manifest.to_canonical_json())
+    print(f"manifest: {out}")  # noqa: T201
+    print()  # noqa: T201
+    print("Next: upload the manifest; its STORE item hash is what V-PROGRAM runtime.ref pins:")  # noqa: T201
+    print(f"  aleph file upload {out}")  # noqa: T201
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    p_build = subparsers.add_parser("build", help="build the nix image and package the runtime bundle")
+    p_build.add_argument("--repo", type=Path, default=REPO_ROOT, help="aleph-vm checkout (default: this one)")
+    p_build.add_argument(
+        "--image-dir",
+        type=Path,
+        default=None,
+        help="package an existing nix image output instead of building",
+    )
+    p_build.add_argument("--out", type=Path, required=True, help="output directory")
+    p_build.set_defaults(func=cmd_build)
+
+    p_manifest = subparsers.add_parser("manifest", help="generate the runtime manifest for an uploaded bundle")
+    p_manifest.add_argument("--bundle-info", type=Path, required=True, help="bundle-info.json from `build`")
+    p_manifest.add_argument("--bundle-ref", required=True, help="item hash of the bundle STORE message")
+    p_manifest.add_argument("--name", required=True, help="runtime name, e.g. aleph-snp-attest")
+    p_manifest.add_argument("--runtime-version", required=True, help="runtime version string, e.g. 2026.07.08")
+    p_manifest.add_argument("--out", type=Path, default=None, help="manifest path (default: next to bundle-info)")
+    p_manifest.set_defaults(func=cmd_manifest)
+
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vprogram_bundle.py
+++ b/scripts/vprogram_bundle.py
@@ -98,6 +98,8 @@ def cmd_manifest(args: argparse.Namespace) -> int:
     tar_path = args.bundle_info.parent / BUNDLE_NAME
     if tar_path.is_file():
         verify_bundle_info(info, tar_path)
+    else:
+        print(f"note: {tar_path} not found, skipping bundle cross-check")  # noqa: T201
     manifest = make_manifest(
         info=info, bundle_ref=args.bundle_ref, name=args.name, runtime_version=args.runtime_version
     )

--- a/src/aleph/vm/vprogram/__init__.py
+++ b/src/aleph/vm/vprogram/__init__.py
@@ -1,0 +1,2 @@
+"""V-Program (verifiable program) runtime support: the aleph-vprogram-runtime
+manifest format and runtime-bundle packaging."""

--- a/src/aleph/vm/vprogram/bundle.py
+++ b/src/aleph/vm/vprogram/bundle.py
@@ -4,7 +4,9 @@ bundle, plus manifest construction from the recorded build facts.
 The bundle is ONE tar.gz pinned by ONE STORE message. Determinism matters:
 independently rebuilding the same image must yield the same tarball bytes,
 so entries are sorted, ownership is zeroed, mtimes are pinned to the source
-commit timestamp and the gzip header carries no name or timestamp.
+commit timestamp and the gzip header carries no name or timestamp. The tar
+layer is fully deterministic; the compressed bytes are deterministic for a
+given Python/zlib build (zlib-ng emits different bytes at the same level).
 """
 
 from __future__ import annotations

--- a/src/aleph/vm/vprogram/bundle.py
+++ b/src/aleph/vm/vprogram/bundle.py
@@ -144,8 +144,8 @@ def make_manifest(info: BundleInfo, bundle_ref: str, name: str, runtime_version:
             platform_roothash=info.platform_roothash,
             cmdline_template=CMDLINE_TEMPLATE_V1,
         ),
-        attestation=list(DEFAULT_ATTESTATION),
-        workload=DEFAULT_WORKLOAD,
+        attestation=[protocol.model_copy(deep=True) for protocol in DEFAULT_ATTESTATION],
+        workload=DEFAULT_WORKLOAD.model_copy(deep=True),
         source=info.source,
     )
 

--- a/src/aleph/vm/vprogram/bundle.py
+++ b/src/aleph/vm/vprogram/bundle.py
@@ -20,9 +20,15 @@ from pydantic import Field
 
 from aleph.vm.vprogram.manifest import (
     SHA256_HEX_PATTERN,
+    AttestationProtocol,
+    AttestationTransport,
+    BootSpec,
     BundleMembers,
+    RuntimeBundle,
+    RuntimeManifest,
     SourceInfo,
     StrictModel,
+    WorkloadSpec,
 )
 
 BUNDLE_NAME = "snp-image.tar.gz"
@@ -107,3 +113,50 @@ def build_bundle(image_dir: Path, out_dir: Path, source_epoch: int, source: Sour
     info_path = out_dir / BUNDLE_INFO_NAME
     info_path.write_text(json.dumps(info.model_dump(mode="json"), indent=2, sort_keys=True) + "\n")
     return info
+
+
+# Fixed format-version-1 values describing what the current image implements
+# (nix/init.sh hardcodes the agent on tcp/8443 proxying 127.0.0.1:8080, and
+# its init parses only roothash=). Changing these is a runtime/format
+# evolution, not a CLI flag.
+CMDLINE_TEMPLATE_V1 = "console=ttyS0 root=/dev/mapper/verity-root ro roothash={platform_roothash}"
+DEFAULT_CPU_MODELS = ["EPYC-v4"]
+DEFAULT_ATTESTATION = [
+    AttestationProtocol(protocol="aleph.ra-tls", version="1", transport=AttestationTransport(type="tcp", port=8443))
+]
+DEFAULT_WORKLOAD = WorkloadSpec(contract="aleph.builtin/1", upstream_port=8080)
+
+
+def make_manifest(info: BundleInfo, bundle_ref: str, name: str, runtime_version: str) -> RuntimeManifest:
+    """Build the manifest for an uploaded bundle. Validation is the
+    constructor: any inconsistency raises pydantic ValidationError."""
+    return RuntimeManifest(
+        format="aleph-vprogram-runtime",
+        format_version=1,
+        name=name,
+        version=runtime_version,
+        platform="sev_snp",
+        bundle=RuntimeBundle(ref=bundle_ref, sha256=info.sha256, size=info.size, members=info.members),
+        boot=BootSpec(
+            method="qemu-direct-kernel",
+            kernel_hashes=True,
+            cpu_models=list(DEFAULT_CPU_MODELS),
+            platform_roothash=info.platform_roothash,
+            cmdline_template=CMDLINE_TEMPLATE_V1,
+        ),
+        attestation=list(DEFAULT_ATTESTATION),
+        workload=DEFAULT_WORKLOAD,
+        source=info.source,
+    )
+
+
+def verify_bundle_info(info: BundleInfo, tar_path: Path) -> None:
+    """Cross-check a bundle-info sidecar against the tarball on disk."""
+    data = tar_path.read_bytes()
+    digest = hashlib.sha256(data).hexdigest()
+    if digest != info.sha256 or len(data) != info.size:
+        msg = (
+            f"bundle {tar_path} does not match bundle-info: "
+            f"sha256 {digest} != {info.sha256} or size {len(data)} != {info.size}"
+        )
+        raise ValueError(msg)

--- a/src/aleph/vm/vprogram/bundle.py
+++ b/src/aleph/vm/vprogram/bundle.py
@@ -1,0 +1,109 @@
+"""Deterministic packaging of the Nix measured-image output into a runtime
+bundle, plus manifest construction from the recorded build facts.
+
+The bundle is ONE tar.gz pinned by ONE STORE message. Determinism matters:
+independently rebuilding the same image must yield the same tarball bytes,
+so entries are sorted, ownership is zeroed, mtimes are pinned to the source
+commit timestamp and the gzip header carries no name or timestamp.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import re
+import tarfile
+from pathlib import Path
+
+from pydantic import Field
+
+from aleph.vm.vprogram.manifest import (
+    SHA256_HEX_PATTERN,
+    BundleMembers,
+    SourceInfo,
+    StrictModel,
+)
+
+BUNDLE_NAME = "snp-image.tar.gz"
+BUNDLE_INFO_NAME = "bundle-info.json"
+MANIFEST_NAME = "manifest.json"
+TAR_PREFIX = "image"
+
+# Role -> file name inside the nix `image` output directory.
+MEMBER_FILES = {
+    "ovmf": "OVMF.fd",
+    "kernel": "bzImage",
+    "initrd": "initrd",
+    "platform_rootfs": "rootfs.ext4",
+    "platform_hash_tree": "rootfs.ext4.verity",
+}
+ROOTHASH_FILE = "rootfs.ext4.roothash"
+MEASUREMENT_FILE = "measurement.hex"
+
+
+class BundleInfo(StrictModel):
+    """Sidecar record of a `build` run: everything `manifest` needs except
+    the STORE item hash, which only exists after the manual upload."""
+
+    sha256: str = Field(pattern=SHA256_HEX_PATTERN)
+    size: int = Field(gt=0)
+    members: BundleMembers
+    platform_roothash: str = Field(pattern=SHA256_HEX_PATTERN)
+    # The measurement baked by the nix build (fixed CI shape); informational.
+    measurement: str = Field(min_length=1)
+    source: SourceInfo
+
+
+def _read_sidecar(image_dir: Path, name: str, pattern: str | None) -> str:
+    value = (image_dir / name).read_text().strip()
+    if pattern is not None and not re.fullmatch(pattern, value):
+        msg = f"{name} does not look like a dm-verity roothash: {value!r}"
+        raise ValueError(msg)
+    return value
+
+
+def build_bundle(image_dir: Path, out_dir: Path, source_epoch: int, source: SourceInfo) -> BundleInfo:
+    """Package a nix image output directory as a deterministic tar.gz and
+    write the bundle-info sidecar. Returns the recorded facts."""
+    file_names = sorted({*MEMBER_FILES.values(), ROOTHASH_FILE, MEASUREMENT_FILE})
+    for name in file_names:
+        if not (image_dir / name).is_file():
+            msg = f"expected image file missing: {image_dir / name}"
+            raise FileNotFoundError(msg)
+
+    platform_roothash = _read_sidecar(image_dir, ROOTHASH_FILE, SHA256_HEX_PATTERN)
+    measurement = _read_sidecar(image_dir, MEASUREMENT_FILE, None)
+
+    tar_path = out_dir / BUNDLE_NAME
+    with tar_path.open("wb") as raw:
+        # filename="" keeps the output path out of the gzip header (FNAME);
+        # mtime=0 pins the gzip timestamp. Both are required for determinism.
+        with gzip.GzipFile(filename="", fileobj=raw, mode="wb", mtime=0) as gz:
+            with tarfile.open(fileobj=gz, mode="w", format=tarfile.USTAR_FORMAT) as tar:  # type: ignore[arg-type]
+                directory = tarfile.TarInfo(TAR_PREFIX)
+                directory.type = tarfile.DIRTYPE
+                directory.mode = 0o755
+                directory.mtime = source_epoch
+                tar.addfile(directory)
+                for name in file_names:
+                    path = image_dir / name
+                    member = tarfile.TarInfo(f"{TAR_PREFIX}/{name}")
+                    member.size = path.stat().st_size
+                    member.mode = 0o644
+                    member.mtime = source_epoch
+                    with path.open("rb") as fileobj:
+                        tar.addfile(member, fileobj)
+
+    data = tar_path.read_bytes()
+    info = BundleInfo(
+        sha256=hashlib.sha256(data).hexdigest(),
+        size=len(data),
+        members=BundleMembers(**{role: f"{TAR_PREFIX}/{name}" for role, name in MEMBER_FILES.items()}),
+        platform_roothash=platform_roothash,
+        measurement=measurement,
+        source=source,
+    )
+    info_path = out_dir / BUNDLE_INFO_NAME
+    info_path.write_text(json.dumps(info.model_dump(mode="json"), indent=2, sort_keys=True) + "\n")
+    return info

--- a/src/aleph/vm/vprogram/manifest.py
+++ b/src/aleph/vm/vprogram/manifest.py
@@ -1,0 +1,150 @@
+"""Typed model of the aleph-vprogram-runtime manifest format (version 1).
+
+A runtime manifest is a small JSON document, published as a STORE message,
+that a V-PROGRAM message pins via runtime.ref. It points at the runtime
+bundle (ONE tar.gz holding OVMF, kernel, initrd and the dm-verity platform
+rootfs plus its hash tree) and declares everything the tarball cannot say
+about itself: the boot recipe, the normative kernel cmdline template, the
+attestation protocols the runtime implements, and the workload contract.
+
+Design: docs/plans/2026-07-09-vprogram-runtime-bundle-design.md
+"""
+
+from __future__ import annotations
+
+import json
+import string
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+SHA256_HEX_PATTERN = r"^[0-9a-f]{64}$"
+# Namespaced identifier such as "aleph.ra-tls": at least two dot-separated
+# labels, so bare names cannot collide with future namespaces.
+PROTOCOL_PATTERN = r"^[a-z0-9][a-z0-9_-]*(\.[a-z0-9][a-z0-9_-]*)+$"
+# Namespaced contract with a required version suffix, e.g. "aleph.builtin/1".
+CONTRACT_PATTERN = r"^[a-z0-9][a-z0-9_-]*(\.[a-z0-9][a-z0-9_-]*)+/[0-9]+$"
+
+# The closed set of placeholders a format-version-1 cmdline template may use.
+# The template is the normative cmdline recipe: restricting its slots is what
+# prevents a malicious manifest from smuggling arbitrary kernel parameters.
+CMDLINE_PLACEHOLDERS_V1 = frozenset({"platform_roothash", "workload_roothash", "verified_volumes"})
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class BundleMembers(StrictModel):
+    """Role -> path map inside the bundle tarball, so consumers never
+    hardcode the layout."""
+
+    ovmf: str
+    kernel: str
+    initrd: str
+    platform_rootfs: str
+    platform_hash_tree: str
+
+    @field_validator("ovmf", "kernel", "initrd", "platform_rootfs", "platform_hash_tree")
+    @classmethod
+    def check_member_path(cls, value: str) -> str:
+        if not value:
+            msg = "member path must not be empty"
+            raise ValueError(msg)
+        if value.startswith("/"):
+            msg = f"member path must be relative: {value}"
+            raise ValueError(msg)
+        if ".." in value.split("/"):
+            msg = f"member path must not traverse upward: {value}"
+            raise ValueError(msg)
+        return value
+
+
+class RuntimeBundle(StrictModel):
+    ref: str = Field(pattern=SHA256_HEX_PATTERN, description="Item hash of the bundle STORE message")
+    sha256: str = Field(pattern=SHA256_HEX_PATTERN, description="sha256 of the bundle tarball file")
+    size: int = Field(gt=0, description="Size of the bundle tarball in bytes")
+    members: BundleMembers
+
+
+class BootSpec(StrictModel):
+    method: Literal["qemu-direct-kernel"]
+    kernel_hashes: Literal[True]
+    cpu_models: list[str] = Field(min_length=1)
+    platform_roothash: str = Field(
+        pattern=SHA256_HEX_PATTERN,
+        description="dm-verity root hash of the platform rootfs; measured via the cmdline",
+    )
+    cmdline_template: str
+
+    @field_validator("cmdline_template")
+    @classmethod
+    def check_cmdline_template(cls, value: str) -> str:
+        placeholders: set[str] = set()
+        try:
+            parsed = list(string.Formatter().parse(value))
+        except ValueError as exc:
+            msg = f"malformed cmdline template: {exc}"
+            raise ValueError(msg) from exc
+        for _literal, field_name, format_spec, conversion in parsed:
+            if field_name is None:
+                continue
+            if field_name == "":
+                msg = "cmdline template must not use positional placeholders"
+                raise ValueError(msg)
+            if format_spec or conversion:
+                msg = f"cmdline placeholder must be plain (no format spec / conversion): {field_name}"
+                raise ValueError(msg)
+            placeholders.add(field_name)
+        unknown = placeholders - CMDLINE_PLACEHOLDERS_V1
+        if unknown:
+            msg = f"unknown cmdline placeholders for format version 1: {sorted(unknown)}"
+            raise ValueError(msg)
+        if "platform_roothash" not in placeholders:
+            msg = "cmdline template must contain {platform_roothash}"
+            raise ValueError(msg)
+        return value
+
+
+class AttestationTransport(StrictModel):
+    type: Literal["tcp"]
+    port: int = Field(ge=1, le=65535)
+
+
+class AttestationProtocol(StrictModel):
+    protocol: str = Field(pattern=PROTOCOL_PATTERN, description='Protocol identifier, e.g. "aleph.ra-tls"')
+    version: str = Field(min_length=1)
+    transport: AttestationTransport
+
+
+class WorkloadSpec(StrictModel):
+    contract: str = Field(pattern=CONTRACT_PATTERN, description='Workload contract, e.g. "aleph.builtin/1"')
+    upstream_port: int = Field(ge=1, le=65535)
+
+
+class SourceInfo(StrictModel):
+    """How to rebuild and audit the bundle. Informational but required."""
+
+    repo: str = Field(min_length=1)
+    rev: str = Field(min_length=1)
+    build: str = Field(min_length=1)
+
+
+class RuntimeManifest(StrictModel):
+    format: Literal["aleph-vprogram-runtime"]
+    format_version: Literal[1]
+    name: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+    platform: Literal["sev_snp"]
+    bundle: RuntimeBundle
+    boot: BootSpec
+    # Ordered by preference; protocol identity lives ONLY here, never in
+    # V-PROGRAM messages (rejected as denormalization in the protocol design).
+    attestation: list[AttestationProtocol] = Field(min_length=1)
+    workload: WorkloadSpec
+    source: SourceInfo
+
+    def to_canonical_json(self) -> str:
+        """The exact bytes to publish: compact separators, sorted keys, so
+        independently regenerated manifests hash identically."""
+        return json.dumps(self.model_dump(mode="json"), separators=(",", ":"), sort_keys=True)

--- a/tests/vprogram/test_bundle.py
+++ b/tests/vprogram/test_bundle.py
@@ -5,9 +5,17 @@ import tarfile
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
-from aleph.vm.vprogram.bundle import BUNDLE_INFO_NAME, BUNDLE_NAME, BundleInfo, build_bundle
-from aleph.vm.vprogram.manifest import SourceInfo
+from aleph.vm.vprogram.bundle import (
+    BUNDLE_INFO_NAME,
+    BUNDLE_NAME,
+    BundleInfo,
+    build_bundle,
+    make_manifest,
+    verify_bundle_info,
+)
+from aleph.vm.vprogram.manifest import RuntimeManifest, SourceInfo
 
 ROOTHASH = "cb121a317be7dc7969dd633ca9b6c3718ffe9ea6715b64e0e35a871d484b56b8"
 MEASUREMENT = "de" * 48
@@ -97,3 +105,49 @@ def test_malformed_roothash_is_an_error(image_dir: Path, tmp_path: Path) -> None
     (image_dir / "rootfs.ext4.roothash").write_text("not a hash\n")
     with pytest.raises(ValueError, match="roothash"):
         build_bundle(image_dir=image_dir, out_dir=_out(tmp_path, "out"), source_epoch=EPOCH, source=SOURCE)
+
+
+BUNDLE_REF = "87287e4a5c8d7554a50f982cd681b64b2600c0bbb1c0b1e618465e022e01b977"
+
+
+def test_make_manifest_from_bundle_info(image_dir: Path, tmp_path: Path) -> None:
+    out = _out(tmp_path, "out")
+    info = build_bundle(image_dir=image_dir, out_dir=out, source_epoch=EPOCH, source=SOURCE)
+    manifest = make_manifest(info=info, bundle_ref=BUNDLE_REF, name="aleph-snp-attest", runtime_version="2026.07.08")
+    # The result re-validates from its own canonical JSON.
+    reparsed = RuntimeManifest.model_validate_json(manifest.to_canonical_json())
+    assert reparsed == manifest
+    assert manifest.bundle.ref == BUNDLE_REF
+    assert manifest.bundle.sha256 == info.sha256
+    assert manifest.bundle.size == info.size
+    assert manifest.bundle.members == info.members
+    assert manifest.boot.platform_roothash == info.platform_roothash
+    expected_cmdline = "console=ttyS0 root=/dev/mapper/verity-root ro roothash={platform_roothash}"
+    assert manifest.boot.cmdline_template == expected_cmdline
+    assert manifest.boot.cpu_models == ["EPYC-v4"]
+    assert manifest.attestation[0].protocol == "aleph.ra-tls"
+    assert manifest.attestation[0].transport.port == 8443
+    assert manifest.workload.contract == "aleph.builtin/1"
+    assert manifest.workload.upstream_port == 8080
+    assert manifest.source == SOURCE
+
+
+def test_make_manifest_rejects_bad_ref(image_dir: Path, tmp_path: Path) -> None:
+    info = build_bundle(image_dir=image_dir, out_dir=_out(tmp_path, "out"), source_epoch=EPOCH, source=SOURCE)
+    with pytest.raises(ValidationError):
+        make_manifest(info=info, bundle_ref="not-a-hash", name="x", runtime_version="1")
+
+
+def test_verify_bundle_info_accepts_untampered(image_dir: Path, tmp_path: Path) -> None:
+    out = _out(tmp_path, "out")
+    info = build_bundle(image_dir=image_dir, out_dir=out, source_epoch=EPOCH, source=SOURCE)
+    verify_bundle_info(info, out / BUNDLE_NAME)  # must not raise
+
+
+def test_verify_bundle_info_rejects_tampered(image_dir: Path, tmp_path: Path) -> None:
+    out = _out(tmp_path, "out")
+    info = build_bundle(image_dir=image_dir, out_dir=out, source_epoch=EPOCH, source=SOURCE)
+    tar_path = out / BUNDLE_NAME
+    tar_path.write_bytes(tar_path.read_bytes() + b"x")
+    with pytest.raises(ValueError, match="does not match"):
+        verify_bundle_info(info, tar_path)

--- a/tests/vprogram/test_bundle.py
+++ b/tests/vprogram/test_bundle.py
@@ -132,6 +132,16 @@ def test_make_manifest_from_bundle_info(image_dir: Path, tmp_path: Path) -> None
     assert manifest.source == SOURCE
 
 
+def test_make_manifest_does_not_alias_module_defaults(image_dir: Path, tmp_path: Path) -> None:
+    info = build_bundle(image_dir=image_dir, out_dir=_out(tmp_path, "out"), source_epoch=EPOCH, source=SOURCE)
+    first = make_manifest(info=info, bundle_ref=BUNDLE_REF, name="x", runtime_version="1")
+    second = make_manifest(info=info, bundle_ref=BUNDLE_REF, name="x", runtime_version="1")
+    assert first.workload == second.workload
+    assert first.workload is not second.workload
+    assert first.attestation[0] == second.attestation[0]
+    assert first.attestation[0] is not second.attestation[0]
+
+
 def test_make_manifest_rejects_bad_ref(image_dir: Path, tmp_path: Path) -> None:
     info = build_bundle(image_dir=image_dir, out_dir=_out(tmp_path, "out"), source_epoch=EPOCH, source=SOURCE)
     with pytest.raises(ValidationError):

--- a/tests/vprogram/test_bundle.py
+++ b/tests/vprogram/test_bundle.py
@@ -1,0 +1,99 @@
+"""Tests for deterministic bundle packaging and manifest construction."""
+
+import hashlib
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from aleph.vm.vprogram.bundle import BUNDLE_INFO_NAME, BUNDLE_NAME, BundleInfo, build_bundle
+from aleph.vm.vprogram.manifest import SourceInfo
+
+ROOTHASH = "cb121a317be7dc7969dd633ca9b6c3718ffe9ea6715b64e0e35a871d484b56b8"
+MEASUREMENT = "de" * 48
+EPOCH = 1700000000
+
+SOURCE = SourceInfo(
+    repo="https://github.com/aleph-im/aleph-vm",
+    rev="abc1234",
+    build='nix build "git+file://$REPO?dir=nix#image"',
+)
+
+
+@pytest.fixture()
+def image_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "image"
+    d.mkdir()
+    (d / "OVMF.fd").write_bytes(b"ovmf firmware")
+    (d / "bzImage").write_bytes(b"kernel")
+    (d / "initrd").write_bytes(b"initrd contents")
+    (d / "rootfs.ext4").write_bytes(b"rootfs")
+    (d / "rootfs.ext4.verity").write_bytes(b"hash tree")
+    (d / "rootfs.ext4.roothash").write_text(ROOTHASH + "\n")
+    (d / "measurement.hex").write_text(MEASUREMENT + "\n")
+    return d
+
+
+def _out(tmp_path: Path, name: str) -> Path:
+    out = tmp_path / name
+    out.mkdir()
+    return out
+
+
+def test_build_bundle_is_deterministic(image_dir: Path, tmp_path: Path) -> None:
+    out1, out2 = _out(tmp_path, "out1"), _out(tmp_path, "out2")
+    info1 = build_bundle(image_dir=image_dir, out_dir=out1, source_epoch=EPOCH, source=SOURCE)
+    info2 = build_bundle(image_dir=image_dir, out_dir=out2, source_epoch=EPOCH, source=SOURCE)
+    assert (out1 / BUNDLE_NAME).read_bytes() == (out2 / BUNDLE_NAME).read_bytes()
+    assert info1 == info2
+
+
+def test_bundle_info_matches_tarball(image_dir: Path, tmp_path: Path) -> None:
+    out = _out(tmp_path, "out")
+    info = build_bundle(image_dir=image_dir, out_dir=out, source_epoch=EPOCH, source=SOURCE)
+    data = (out / BUNDLE_NAME).read_bytes()
+    assert info.sha256 == hashlib.sha256(data).hexdigest()
+    assert info.size == len(data)
+    assert info.platform_roothash == ROOTHASH
+    assert info.measurement == MEASUREMENT
+    assert info.members.ovmf == "image/OVMF.fd"
+    assert info.members.platform_hash_tree == "image/rootfs.ext4.verity"
+    # The sidecar file round-trips to the same model.
+    on_disk = BundleInfo.model_validate_json((out / BUNDLE_INFO_NAME).read_text())
+    assert on_disk == info
+
+
+def test_tarball_layout_and_metadata(image_dir: Path, tmp_path: Path) -> None:
+    out = _out(tmp_path, "out")
+    build_bundle(image_dir=image_dir, out_dir=out, source_epoch=EPOCH, source=SOURCE)
+    with tarfile.open(out / BUNDLE_NAME, "r:gz") as tar:
+        names = tar.getnames()
+        members = tar.getmembers()
+    assert names == [
+        "image",
+        "image/OVMF.fd",
+        "image/bzImage",
+        "image/initrd",
+        "image/measurement.hex",
+        "image/rootfs.ext4",
+        "image/rootfs.ext4.roothash",
+        "image/rootfs.ext4.verity",
+    ]
+    for member in members:
+        assert member.uid == 0
+        assert member.gid == 0
+        assert member.uname == ""
+        assert member.gname == ""
+        assert member.mtime == EPOCH
+
+
+def test_missing_image_file_is_an_error(image_dir: Path, tmp_path: Path) -> None:
+    (image_dir / "initrd").unlink()
+    with pytest.raises(FileNotFoundError):
+        build_bundle(image_dir=image_dir, out_dir=_out(tmp_path, "out"), source_epoch=EPOCH, source=SOURCE)
+
+
+def test_malformed_roothash_is_an_error(image_dir: Path, tmp_path: Path) -> None:
+    (image_dir / "rootfs.ext4.roothash").write_text("not a hash\n")
+    with pytest.raises(ValueError, match="roothash"):
+        build_bundle(image_dir=image_dir, out_dir=_out(tmp_path, "out"), source_epoch=EPOCH, source=SOURCE)

--- a/tests/vprogram/test_bundle.py
+++ b/tests/vprogram/test_bundle.py
@@ -77,6 +77,12 @@ def test_tarball_layout_and_metadata(image_dir: Path, tmp_path: Path) -> None:
     with tarfile.open(out / BUNDLE_NAME, "r:gz") as tar:
         names = tar.getnames()
         members = tar.getmembers()
+        extracted_kernel = tar.extractfile("image/bzImage")
+        assert extracted_kernel is not None
+        assert extracted_kernel.read() == b"kernel"
+        extracted_roothash = tar.extractfile("image/rootfs.ext4.roothash")
+        assert extracted_roothash is not None
+        assert extracted_roothash.read() == (ROOTHASH + "\n").encode()
     assert names == [
         "image",
         "image/OVMF.fd",

--- a/tests/vprogram/test_cli.py
+++ b/tests/vprogram/test_cli.py
@@ -1,0 +1,94 @@
+"""End-to-end CLI tests (subprocess; no nix, no network — --image-dir is the seam)."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from aleph.vm.vprogram.manifest import RuntimeManifest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "vprogram_bundle.py"
+ROOTHASH = "cb121a317be7dc7969dd633ca9b6c3718ffe9ea6715b64e0e35a871d484b56b8"
+BUNDLE_REF = "87287e4a5c8d7554a50f982cd681b64b2600c0bbb1c0b1e618465e022e01b977"
+
+
+@pytest.fixture()
+def image_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "image"
+    d.mkdir()
+    (d / "OVMF.fd").write_bytes(b"ovmf firmware")
+    (d / "bzImage").write_bytes(b"kernel")
+    (d / "initrd").write_bytes(b"initrd contents")
+    (d / "rootfs.ext4").write_bytes(b"rootfs")
+    (d / "rootfs.ext4.verity").write_bytes(b"hash tree")
+    (d / "rootfs.ext4.roothash").write_text(ROOTHASH + "\n")
+    (d / "measurement.hex").write_text("de" * 48 + "\n")
+    return d
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "SOURCE_DATE_EPOCH": "1700000000"}
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],  # noqa: S603
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_build_then_manifest(image_dir: Path, tmp_path: Path) -> None:
+    out = tmp_path / "out"
+    result = _run("build", "--image-dir", str(image_dir), "--out", str(out))
+    assert result.returncode == 0, result.stderr
+    assert "aleph file upload" in result.stdout
+    assert (out / "snp-image.tar.gz").is_file()
+    info = json.loads((out / "bundle-info.json").read_text())
+    assert info["platform_roothash"] == ROOTHASH
+
+    result = _run(
+        "manifest",
+        "--bundle-info",
+        str(out / "bundle-info.json"),
+        "--bundle-ref",
+        BUNDLE_REF,
+        "--name",
+        "aleph-snp-attest",
+        "--runtime-version",
+        "2026.07.08",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "aleph file upload" in result.stdout
+    manifest = RuntimeManifest.model_validate_json((out / "manifest.json").read_text())
+    assert manifest.bundle.ref == BUNDLE_REF
+    assert manifest.boot.platform_roothash == ROOTHASH
+
+
+def test_manifest_rejects_tampered_bundle(image_dir: Path, tmp_path: Path) -> None:
+    out = tmp_path / "out"
+    assert _run("build", "--image-dir", str(image_dir), "--out", str(out)).returncode == 0
+    tar_path = out / "snp-image.tar.gz"
+    tar_path.write_bytes(tar_path.read_bytes() + b"x")
+    result = _run(
+        "manifest",
+        "--bundle-info",
+        str(out / "bundle-info.json"),
+        "--bundle-ref",
+        BUNDLE_REF,
+        "--name",
+        "x",
+        "--runtime-version",
+        "1",
+    )
+    assert result.returncode != 0
+    assert "does not match" in result.stderr
+
+
+def test_build_missing_image_file_fails(image_dir: Path, tmp_path: Path) -> None:
+    (image_dir / "bzImage").unlink()
+    result = _run("build", "--image-dir", str(image_dir), "--out", str(tmp_path / "out"))
+    assert result.returncode != 0

--- a/tests/vprogram/test_manifest.py
+++ b/tests/vprogram/test_manifest.py
@@ -1,0 +1,112 @@
+"""Tests for the aleph-vprogram-runtime manifest model."""
+
+import copy
+import json
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from aleph.vm.vprogram.manifest import RuntimeManifest
+
+# The reference manifest from the design doc, with the real mainnet bundle values.
+REFERENCE_MANIFEST: dict[str, Any] = {
+    "format": "aleph-vprogram-runtime",
+    "format_version": 1,
+    "name": "aleph-snp-attest",
+    "version": "2026.07.08",
+    "platform": "sev_snp",
+    "bundle": {
+        "ref": "87287e4a5c8d7554a50f982cd681b64b2600c0bbb1c0b1e618465e022e01b977",
+        "sha256": "1db0d69c96dc7ed6c8a6cbb8c63f8de516ef4ed668e95c468cc216e4c44d911b",
+        "size": 57522386,
+        "members": {
+            "ovmf": "image/OVMF.fd",
+            "kernel": "image/bzImage",
+            "initrd": "image/initrd",
+            "platform_rootfs": "image/rootfs.ext4",
+            "platform_hash_tree": "image/rootfs.ext4.verity",
+        },
+    },
+    "boot": {
+        "method": "qemu-direct-kernel",
+        "kernel_hashes": True,
+        "cpu_models": ["EPYC-v4"],
+        "platform_roothash": "cb121a317be7dc7969dd633ca9b6c3718ffe9ea6715b64e0e35a871d484b56b8",
+        "cmdline_template": "console=ttyS0 root=/dev/mapper/verity-root ro roothash={platform_roothash}",
+    },
+    "attestation": [{"protocol": "aleph.ra-tls", "version": "1", "transport": {"type": "tcp", "port": 8443}}],
+    "workload": {"contract": "aleph.builtin/1", "upstream_port": 8080},
+    "source": {
+        "repo": "https://github.com/aleph-im/aleph-vm",
+        "rev": "4d90abaf",
+        "build": 'nix build "git+file://$REPO?dir=nix#image"',
+    },
+}
+
+
+def test_reference_manifest_validates_and_roundtrips() -> None:
+    manifest = RuntimeManifest.model_validate(REFERENCE_MANIFEST)
+    canonical = manifest.to_canonical_json()
+    assert RuntimeManifest.model_validate_json(canonical) == manifest
+    # Canonical form is compact, key-sorted, and loses no data.
+    assert json.loads(canonical) == REFERENCE_MANIFEST
+    assert ": " not in canonical
+    assert canonical == json.dumps(json.loads(canonical), separators=(",", ":"), sort_keys=True)
+
+
+def test_workload_roothash_and_verified_volumes_slots_are_legal() -> None:
+    data = copy.deepcopy(REFERENCE_MANIFEST)
+    data["boot"]["cmdline_template"] = (
+        "console=ttyS0 root=/dev/mapper/verity-root ro roothash={platform_roothash}"
+        " workload_roothash={workload_roothash} verified_volumes={verified_volumes}"
+    )
+    RuntimeManifest.model_validate(data)  # must not raise
+
+
+REJECTION_CASES: list[tuple[str, Callable[[dict[str, Any]], None]]] = [
+    ("roothash too short", lambda d: d["boot"].update(platform_roothash="cb12")),
+    ("roothash uppercase", lambda d: d["boot"].update(platform_roothash="CB" * 32)),
+    ("bundle ref not hex", lambda d: d["bundle"].update(ref="z" * 64)),
+    (
+        "unknown cmdline placeholder",
+        lambda d: d["boot"].update(cmdline_template="roothash={platform_roothash} x={foo}"),
+    ),
+    ("template missing platform_roothash", lambda d: d["boot"].update(cmdline_template="console=ttyS0 ro")),
+    ("positional placeholder", lambda d: d["boot"].update(cmdline_template="roothash={platform_roothash} {}")),
+    ("format spec in placeholder", lambda d: d["boot"].update(cmdline_template="roothash={platform_roothash:>10}")),
+    ("conversion in placeholder", lambda d: d["boot"].update(cmdline_template="roothash={platform_roothash!r}")),
+    ("unbalanced brace", lambda d: d["boot"].update(cmdline_template="roothash={platform_roothash} {oops")),
+    ("port zero", lambda d: d["attestation"][0]["transport"].update(port=0)),
+    ("port too large", lambda d: d["attestation"][0]["transport"].update(port=65536)),
+    ("empty attestation list", lambda d: d.update(attestation=[])),
+    ("bad protocol identifier", lambda d: d["attestation"][0].update(protocol="RA-TLS")),
+    ("unnamespaced protocol", lambda d: d["attestation"][0].update(protocol="aleph")),
+    ("empty protocol version", lambda d: d["attestation"][0].update(version="")),
+    ("absolute member path", lambda d: d["bundle"]["members"].update(ovmf="/etc/passwd")),
+    ("traversing member path", lambda d: d["bundle"]["members"].update(kernel="image/../../x")),
+    ("empty member path", lambda d: d["bundle"]["members"].update(initrd="")),
+    ("contract without version", lambda d: d["workload"].update(contract="aleph.builtin")),
+    ("unnamespaced contract", lambda d: d["workload"].update(contract="builtin/1")),
+    ("unknown format", lambda d: d.update(format="aleph-runtime")),
+    ("unknown format_version", lambda d: d.update(format_version=2)),
+    ("unknown platform", lambda d: d.update(platform="tdx")),
+    ("kernel_hashes false", lambda d: d["boot"].update(kernel_hashes=False)),
+    ("empty cpu_models", lambda d: d["boot"].update(cpu_models=[])),
+    ("bundle size zero", lambda d: d["bundle"].update(size=0)),
+    ("empty name", lambda d: d.update(name="")),
+    ("empty source rev", lambda d: d["source"].update(rev="")),
+    ("extra top-level field", lambda d: d.update(comment="hi")),
+    ("extra bundle field", lambda d: d["bundle"].update(mirror="x")),
+    ("extra boot field", lambda d: d["boot"].update(ip="dhcp")),
+    ("extra transport field", lambda d: d["attestation"][0]["transport"].update(host="x")),
+]
+
+
+@pytest.mark.parametrize(("description", "mutate"), REJECTION_CASES, ids=[c[0] for c in REJECTION_CASES])
+def test_rejections(description: str, mutate: Callable[[dict[str, Any]], None]) -> None:  # noqa: ARG001
+    data = copy.deepcopy(REFERENCE_MANIFEST)
+    mutate(data)
+    with pytest.raises(ValidationError):
+        RuntimeManifest.model_validate(data)


### PR DESCRIPTION
## What

Tooling to stop hand-rolling V-Program runtime bundles:

- **`aleph.vm.vprogram.manifest`** — strict pydantic-v2 model of the `aleph-vprogram-runtime/1` manifest format: one bundle (single STORE-pinned tar.gz) + boot recipe + normative cmdline template with a **closed placeholder set** (no smuggled kernel params) + attestation protocol descriptors (protocol/version/transport port) + workload contract. `extra="forbid"` everywhere, anchored hex patterns, member-path traversal guards, canonical (compact, key-sorted) JSON serialization.
- **`aleph.vm.vprogram.bundle`** — deterministic packaging of the nix `image` output (sorted entries, zeroed ownership, mtimes pinned to the source commit, gzip `filename=""`/`mtime=0`, USTAR) + `bundle-info.json` sidecar + `make_manifest` with the fixed v1 values matching what `nix/init.sh` actually implements (tcp/8443 attest-agent, upstream 8080, `roothash=`-only cmdline, contract `aleph.builtin/1`).
- **`scripts/vprogram_bundle.py`** — operator CLI: `build` (runs the nix build or packages an existing output via `--image-dir`) and `manifest` (takes the STORE item hash after the manual upload, cross-checks the tarball, emits canonical `manifest.json`). Uploads stay manual; the script prints the exact `aleph file upload` commands.

## Why

`VerifiableProgramRuntime.ref` in V-PROGRAM messages (aleph-message #158) points at a runtime manifest STORE. Nothing could produce one: the current mainnet bundle is a hand-made tarball with a stray `aleph-attest-cli` inside, pinned by raw file hash in a CI workflow. This makes bundle creation reproducible and gives the manifest format a typed home that the CRN agent launch path and (later) aleph-message/pyaleph can reuse.

Design doc: `docs/plans/2026-07-09-vprogram-runtime-bundle-design.md` (committed on this branch).

## Notes

- `aleph.vm.vprogram` is a leaf module (pydantic + stdlib only); import-linter clean.
- 47 new tests (34 model, 10 packaging, 3 CLI subprocess); no nix, no network in tests.
- Stacked on `od/controller-main-error-flow` (needs the phase-3 chain only for `nix/`; the Python code itself is independent).
