### PR TITLE
feat: V-PROGRAM scheduler support (allocations, type threading, SNP vCPU advertising)

### DIFF
--- a/docs/plans/2026-07-11-vprogram-scheduler-support-design.md
+++ b/docs/plans/2026-07-11-vprogram-scheduler-support-design.md
@@ -1,0 +1,236 @@
+# V-PROGRAM scheduler support: design
+
+**Date:** 2026-07-11
+**Status:** Approved design, implementation plan pending
+**Repos:** aleph-vm (node side), aleph-vm-scheduler (follow-up stacked on PR #193)
+
+## Goal
+
+Let the Aleph Cloud scheduler command compatible aleph-vm nodes to run V-PROGRAM
+messages (verifiable SEV-SNP programs), and replace the too-broad
+"AuthenticAMD + sev_snp flag" node matching with advertising that reflects what
+the node can actually launch.
+
+Related documents:
+
+- `docs/plans/2026-07-08-confidential-vm-protocol-design.md` (protocol design,
+  message schema, runtime bundle)
+- aleph-vm-scheduler PR #193 (`od/vprogram-scheduling`): scheduler-side
+  V-PROGRAM scheduling, defines the wire contract this design implements
+- aleph-message PR #158 (`od/vprogram-schema`): `VerifiableProgramContent`
+
+## Scope
+
+In scope:
+
+1. Accept v-programs on the scheduler-controlled allocation endpoint and thread
+   the new message type through the supervisor (parse, dispatch, lifecycle).
+2. Structured TEE capability advertising (supported SNP guest vCPU models) plus
+   the scheduler follow-up that consumes it.
+3. Explicit rejection of v-programs on on-demand execution endpoints.
+4. No payment checks for v-programs, including exclusion from the background
+   payment sweep.
+
+Out of scope:
+
+- SEV-SNP guest launch. That is the Phase 3 backport (SNP-capable QEMU
+  controller). On this stack, a v-program that reaches `start()` fails with a
+  clear "SEV-SNP launch backend not available" error; the scheduler observes
+  the failure through the executions list it already polls and reschedules.
+- Measurement validation (CCN responsibility, pyaleph phase 2).
+- Replication / redundancy (deferred in the protocol design).
+
+## Dependencies and base
+
+- `aleph-message` pinned to the git ref of PR #158 (branch `od/vprogram-schema`)
+  for development, same pattern as pyaleph PR #1220. **Merge gate: swap the pin
+  for a released aleph-message version first.** The pin provides the V-PROGRAM
+  message type, `VerifiableProgramContent`, and the message class.
+- Scheduler follow-up stacks on aleph-vm-scheduler PR #193, which is not merged
+  yet, so wire-model renames there are still free.
+
+## 1. Allocation endpoint (aleph-vm)
+
+### Wire model
+
+`Allocation` (`src/aleph/vm/orchestrator/resources.py`) gains:
+
+```python
+v_programs: set[ItemHash] = set()
+```
+
+Naming note: PR #193 currently calls this bucket `persistent_programs`, which
+collides with the legacy notion of persistent (Firecracker) programs that ride
+in `persistent_vms`. The scheduler follow-up renames the field to `v_programs`
+everywhere it appears (CRN-bound `Allocation`, public `NodePlan`, dispatcher),
+matching the `"v_program"` vm-type string. aleph-vm implements `v_programs`
+only; it never accepts the transitional `persistent_programs` name.
+
+### Reconciliation semantics
+
+`update_allocations` merges `v_programs` into the scheduled set and starts each
+hash through the existing `start_persistent_vm` path.
+
+Stop semantics diverge deliberately from confidential instances: the current
+stop-guard refuses to stop confidential VMs missing from an allocation because
+user-paid confidential instances are not scheduler-owned. V-programs are the
+opposite: the scheduler is the single source of truth, so **a v-program absent
+from the allocation is stopped**, even though it is confidential. The guard
+therefore keys on "is a v-program" before the confidential exemption.
+
+`notify_allocation` keeps rejecting non-instance messages. V-programs are
+scheduler-designated only and never arrive through notification.
+
+## 2. Message-type threading (aleph-vm)
+
+The gates that must learn the new type:
+
+- `storage.get_message`: accept the v-program message class in the isinstance
+  assert.
+- `messages.update_message`: v-programs are immutable by schema (`allow_amend`
+  is false, enforced at parse time), so no amend resolution: return the message
+  unchanged.
+- `VmType` (`src/aleph/vm/vm_type.py`): new member for v-programs. The node
+  side IPv6 computation uses **type value 4**, mirroring
+  `scheduler-events::VmType::ipv6_value()`. A test vector copied from the
+  scheduler test suite locks the two implementations together.
+- `VmExecution` (`src/aleph/vm/models.py`): new `is_vprogram` property.
+  `is_confidential` currently keys on `environment.trusted_execution`, which
+  v-programs do not have (they carry a `verification` block instead), so every
+  confidential-related branch gets an explicit v-program check. The hypervisor
+  for v-programs is unconditionally the QEMU confidential SNP controller; on
+  this stack, reaching it raises the clean launch-unavailable error described
+  in Scope.
+
+## 3. On-demand rejection (aleph-vm)
+
+`run_code_on_request` / `create_vm_execution` gain an explicit guard: HTTP 400
+"V-PROGRAM executions are scheduler-controlled" on `/vm/{item_hash}` and the
+hostname-based path. Today v-programs are rejected only by accident (the
+storage assert), which section 2 removes, so the explicit gate is required.
+
+## 4. Payment: none, by design
+
+- `POST /control/allocations` performs no payment checks today; that stays
+  true for v-programs.
+- V-program executions are excluded from the `check_payment` background sweep
+  (`src/aleph/vm/orchestrator/tasks.py`).
+- The `notify_allocation` payment branches never see v-programs (type gate),
+  no change needed there.
+
+Rationale: credit-only enforcement already happens at the CCN (pyaleph
+`check_balance`) and at the scheduler. Node-side duplication adds code and
+complexity for no security benefit, and node-side payment checks are planned
+for removal across all VM types anyway.
+
+## 5. Capability advertising (aleph-vm)
+
+### Wire shape
+
+New platform-keyed block in `/about/usage/system`, mirrored in
+`/about/capability`:
+
+```json
+"properties": {
+  "cpu": { "...": "unchanged" },
+  "tee": {
+    "sev_snp": {
+      "supported_vcpu_types": ["EPYC", "EPYC-v4"]
+    }
+  }
+}
+```
+
+- Sibling of `properties.cpu`, not nested inside it: host-CPU facts and
+  TEE-launch facts are different things, and this avoids touching the
+  aleph-message `CpuProperties` schema (no release dependency).
+- Platform-keyed (`sev_snp` today) so `tdx` or GPU-CC slot in later.
+- Old schedulers ignore the unknown field; presence of the block doubles as
+  the "this node speaks v-program" signal (see section 6).
+
+### Detection: QEMU QMP probe
+
+`supported_vcpu_types` comes from QEMU itself, not from a hardcoded CPUID
+table, because only QEMU knows what this exact QEMU build + host kernel +
+silicon combination can launch:
+
+- At supervisor startup, spawn a short-lived
+  `qemu-system-x86_64 -machine none -accel kvm` with a QMP socket, run
+  `query-cpu-definitions`, keep EPYC-family models whose
+  `unavailable-features` list is empty, cache for the process lifetime.
+- The `tee` block is only emitted when SNP is actually supported. This also
+  fixes `check_amd_sev_snp_supported`, which currently lacks the `/dev/sev`
+  existence check that the SEV and SEV-ES probes have.
+- Probe failure on an SNP host: no `tee` block, log a warning. We never
+  advertise what we cannot prove. No static fallback table.
+
+## 6. Scheduler follow-up (aleph-vm-scheduler, stacked on #193)
+
+- Rename `persistent_programs` to `v_programs` (see section 1).
+- `NodeSnapshot` gains `snp_vcpu_types: Vec<String>` parsed from
+  `properties.tee.sev_snp.supported_vcpu_types` in the node watcher.
+- `can_vm_run_on_node`, for v-programs:
+  - A node without the `tee` block never receives v-programs (strict gate).
+    This naturally excludes older aleph-vm versions that advertise the
+    `sev_snp` feature flag but do not understand the `v_programs` allocation
+    bucket.
+  - At least one of the message's `LaunchMeasurement.vcpu_type` values must be
+    in the node's `snp_vcpu_types` set (case-insensitive, consistent with the
+    existing feature matching).
+  - A measurement without `vcpu_type` matches against a documented default of
+    `EPYC` (QEMU's baseline model). Documented in the schema so publishers
+    know that omitting `vcpu_type` narrows compatibility rather than widening
+    it.
+- The existing gates (confidential enabled, `sev_snp` feature, IPv6, vendor,
+  architecture) stay as base filters.
+
+## 7. Error handling
+
+- Launch failure (no SNP backend, manifest fetch error, malformed workload)
+  surfaces in the execution record and in the executions list the scheduler
+  already polls (`GET v2/about/executions/list`), so the scheduler reschedules.
+  No new endpoint.
+- Message fetch/parse failure at allocation time: reported per-VM in the
+  `update_allocations` response, same as instances today.
+- QMP probe failure: warning log, no `tee` block advertised (node simply does
+  not receive v-programs).
+
+## 8. Testing
+
+aleph-vm:
+
+- Allocation parsing: `v_programs` accepted, old payloads without the key
+  still parse.
+- Each type-threading gate (storage, update_message, VmType, VmExecution) with
+  a canonical v-program fixture (reuse the cross-SDK fixture, item_hash
+  `4c319b6bdf98f1e90f2bf8c69da175679fa21ca27d4547bbfa32f77dd3b49fe6`).
+- On-demand rejection paths return 400.
+- Payment sweep excludes v-program executions.
+- `tee` block emission with a mocked QMP probe; absence when SNP unsupported
+  or probe fails.
+- IPv6 type value 4 against the vector from the scheduler test suite.
+
+aleph-vm-scheduler:
+
+- Extend PR #193's suite: vcpu_type matching, strict tee-block gating, the
+  `EPYC` default for untagged measurements, `v_programs` rename round-trip.
+
+Integration:
+
+- Testnet loop with the real scheduler driving `POST /control/allocations`
+  against a node running this branch (scheduler-in-the-loop is a stated goal
+  for the v-program testnet work).
+
+## Decisions log
+
+| Decision | Choice |
+|---|---|
+| Launch scope | Wiring only; SNP launch comes from Phase 3. Clean failure at start until then. |
+| Compatibility model | Node advertises supported SNP guest vCPU models; scheduler matches measurement `vcpu_type`. |
+| Repo scope | Both repos: aleph-vm implementation + scheduler follow-up stacked on #193. |
+| Wire shape | `properties.tee.sev_snp.supported_vcpu_types` in `/about/usage/system`. |
+| Detection | QMP `query-cpu-definitions` probe, no static fallback. |
+| Allocation bucket name | `v_programs` (renamed from #193's `persistent_programs`, which collided with legacy persistent programs). |
+| Stop semantics | Scheduler is authoritative for v-programs: absent from allocation means stop, despite being confidential. |
+| Payment | No node-side checks anywhere for v-programs; excluded from the payment sweep. |
+| Untagged measurements | Scheduler matches them as `EPYC` (documented default). |

--- a/docs/plans/2026-07-11-vprogram-scheduler-support-implementation.md
+++ b/docs/plans/2026-07-11-vprogram-scheduler-support-implementation.md
@@ -1,0 +1,508 @@
+# V-PROGRAM Scheduler Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the scheduler command aleph-vm nodes to run V-PROGRAM messages (accept `v_programs` in `POST /control/allocations`, thread the type through the agent, no payment checks, clean launch failure) and advertise supported SNP guest vCPU models so the scheduler matches truly compatible nodes.
+
+**Architecture:** Python agent (src/aleph/vm/agent/) drives VMs through the `Supervisor` boundary; V-PROGRAM launch stays out of scope (fails cleanly at create with `VmSetupError`). Capability advertising adds a `properties.tee` block to `/about/usage/system` populated by a QEMU QMP probe. Scheduler follow-up (aleph-vm-scheduler, PR #193 branch) renames the allocation bucket to `v_programs` and matches measurement `vcpu_type` against the advertised models.
+
+**Tech Stack:** Python 3.12+ (aiohttp, pydantic), aleph-message (git pin, PR #158), pytest; Rust (scheduler repo).
+
+**Design doc:** `docs/plans/2026-07-11-vprogram-scheduler-support-design.md`
+
+## Global Constraints
+
+- Branch `od/vprogram-scheduler-support` off `origin/dev`, worktree `/home/olivier/git/aleph/aleph-vm/.worktrees/vprogram-scheduler` (referred to as `$WT`).
+- aleph-message pinned to git ref `bc9c0f86958a746faeecbd6c6f96cc6f5b4538de` (PR #158 head). **MERGE GATE: swap for a released aleph-message before merging.**
+- Local test invocation (venv is py3.14 with C-module stubs; aleph-message checkout provides the pinned version):
+  `PYTHONPATH="$WT/src:/home/olivier/git/aleph/aleph-message:/home/olivier/git/aleph/aleph-vm/.dev-stubs" ALEPH_VM_CACHE_ROOT=$HOME/.cache/aleph-vm-tests ALEPH_VM_EXECUTION_ROOT=$HOME/.cache/aleph-vm-exec /home/olivier/git/aleph/aleph-vm/venv/bin/python -m pytest -p no:cacheprovider`
+- Local gates before push: pytest (baseline = ~9 environment-only failures), `mypy` (1.8.0, project config), ruff/black/isort, `lint-imports` (agent must not import supervisor side).
+- No em-dashes in prose/comments/commit messages. No Co-Authored-By trailer.
+- Message type enum member is `MessageType.v_program` (wire value `"V-PROGRAM"`); content class `VerifiableProgramContent`; message class `VerifiableProgramMessage`.
+- Node-side `VmType` member is named `v_program` so `.name` matches the scheduler's `"v_program"` string.
+- IPv6 type value for v-programs: **4** (mirrors scheduler-events `VmType::ipv6_value()`).
+
+---
+
+## Part A: aleph-vm
+
+### Task A0: Commit design doc + plan
+
+**Files:**
+- Add: `docs/plans/2026-07-11-vprogram-scheduler-support-design.md` (copy from main checkout)
+- Add: `docs/plans/2026-07-11-vprogram-scheduler-support-implementation.md` (this file)
+
+**Steps:**
+- [ ] Copy the design doc from the main checkout into `$WT/docs/plans/`, remove it from the main checkout (it was untracked there).
+- [ ] `git add docs/plans/2026-07-11-vprogram-scheduler-support-*.md && git commit -m "docs: v-program scheduler support design + implementation plan"`
+
+### Task A1: Pin aleph-message and add the canonical fixture
+
+**Files:**
+- Modify: `pyproject.toml:38`
+- Create: `tests/supervisor/fixtures/vprogram_message.json` (copy of aleph-message `aleph_message/tests/messages/vprogram_machine.json`)
+
+**Interfaces:**
+- Produces: importable `aleph_message.models.VerifiableProgramContent`, `VerifiableProgramMessage`, `MessageType.v_program`; fixture path used by all later tests.
+
+**Steps:**
+- [ ] **Edit pyproject.toml line 38:**
+```toml
+  # MERGE GATE: replace the git pin with a released aleph-message version.
+  "aleph-message @ git+https://github.com/aleph-im/aleph-message@bc9c0f86958a746faeecbd6c6f96cc6f5b4538de",
+```
+- [ ] **Copy fixture:** `cp /home/olivier/git/aleph/aleph-message/aleph_message/tests/messages/vprogram_machine.json tests/supervisor/fixtures/vprogram_message.json` (create the fixtures dir if tests/supervisor has none; if one already exists under another name, use it).
+- [ ] **Sanity check the pinned types import:** run a python one-liner with the test PYTHONPATH asserting `MessageType.v_program.value == "V-PROGRAM"` and `parse_message` on the fixture returns a `VerifiableProgramMessage`.
+- [ ] Commit: `build: pin aleph-message to the V-PROGRAM schema ref (merge-gated)`
+
+### Task A2: Accept V-PROGRAM messages in storage + type map + IPv6 prefix
+
+**Files:**
+- Modify: `src/aleph/vm/storage.py:205,231`
+- Modify: `src/aleph/vm/vm_type.py`
+- Modify: `src/aleph/vm/network/hostnetwork.py:50-54`
+- Test: `tests/supervisor/test_vprogram.py` (new), `tests/supervisor/test_ipv6_allocator.py`
+
+**Interfaces:**
+- Produces: `VmType.v_program` (value 4); `get_message` returning `VerifiableProgramMessage`; IPv6 prefix "4".
+
+**Steps:**
+- [ ] **Failing tests** in `tests/supervisor/test_vprogram.py`:
+```python
+import json
+from pathlib import Path
+
+import pytest
+from aleph_message.models import VerifiableProgramContent, VerifiableProgramMessage, parse_message
+
+from aleph.vm.vm_type import VmType
+
+FIXTURE = Path(__file__).parent / "fixtures" / "vprogram_message.json"
+
+
+def load_vprogram_message() -> VerifiableProgramMessage:
+    message = parse_message(json.loads(FIXTURE.read_text()))
+    assert isinstance(message, VerifiableProgramMessage)
+    return message
+
+
+def test_vm_type_v_program():
+    message = load_vprogram_message()
+    assert isinstance(message.content, VerifiableProgramContent)
+    assert VmType.from_message_content(message.content) == VmType.v_program
+    assert VmType.v_program.name == "v_program"
+```
+   and in `tests/supervisor/test_ipv6_allocator.py` (mirror the existing static-allocator test style):
+```python
+def test_static_allocator_v_program_prefix():
+    allocator = StaticIPv6Allocator(ipv6_range=IPv6Network("2a01:240:ad00:2500::/64"), subnet_prefix=124)
+    subnet = allocator.allocate_vm_ipv6_subnet(
+        vm_id=3,
+        vm_hash=ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe"),
+        vm_type=VmType.v_program,
+    )
+    # 16-bit VM-type field = 4: must mirror scheduler-events VmType::ipv6_value()
+    assert subnet == IPv6Network("2a01:240:ad00:2500:4:cafe:cafe:caf0/124")
+```
+- [ ] Run both, expect FAIL (no `v_program` member / KeyError in prefix map).
+- [ ] **Implement** `src/aleph/vm/vm_type.py`:
+```python
+from enum import Enum
+
+from aleph_message.models import (
+    ExecutableContent,
+    InstanceContent,
+    ProgramContent,
+    VerifiableProgramContent,
+)
+
+
+class VmType(Enum):
+    microvm = 1
+    persistent_program = 2
+    instance = 3
+    v_program = 4
+
+    @staticmethod
+    def from_message_content(content: ExecutableContent) -> "VmType":
+        if isinstance(content, InstanceContent):
+            return VmType.instance
+        elif isinstance(content, VerifiableProgramContent):
+            return VmType.v_program
+        elif isinstance(content, ProgramContent):
+            if content.on.persistent:
+                return VmType.persistent_program
+            return VmType.microvm
+
+        msg = f"Unexpected message content type: {type(content)}"
+        raise TypeError(msg)
+```
+   `src/aleph/vm/network/hostnetwork.py` VM_TYPE_PREFIX:
+```python
+    VM_TYPE_PREFIX = {
+        VmType.microvm: "1",
+        VmType.persistent_program: "2",
+        VmType.instance: "3",
+        # Must match the scheduler's VmType::ipv6_value() (scheduler-events)
+        VmType.v_program: "4",
+    }
+```
+   `src/aleph/vm/storage.py`: import `VerifiableProgramMessage`, signature `-> ProgramMessage | InstanceMessage | VerifiableProgramMessage`, assert `isinstance(result, InstanceMessage | ProgramMessage | VerifiableProgramMessage)`.
+   Add a storage-level test (same test file, monkeypatching the message cache dir or using `parse_message` directly if `get_message` needs network; minimal: assert the widened assert accepts the fixture message object type).
+- [ ] Run tests, expect PASS.
+- [ ] Commit: `feat(agent): parse V-PROGRAM messages, map VmType.v_program, IPv6 type 4`
+
+### Task A3: update_message immutability branch
+
+**Files:**
+- Modify: `src/aleph/vm/agent/messages.py:54-68`
+- Test: `tests/supervisor/test_vprogram.py`
+
+**Steps:**
+- [ ] **Failing test:**
+```python
+@pytest.mark.asyncio
+async def test_update_message_vprogram_is_noop():
+    message = load_vprogram_message()
+    # Must not attempt any amend resolution (no network): v-programs are immutable
+    await update_message(message)
+```
+- [ ] **Implement** in `update_message`:
+```python
+    if message.type == MessageType.program:
+        ...existing...
+    elif message.type == MessageType.v_program:
+        # V-Programs are immutable (allow_amend is schema-rejected) and every
+        # reference is pinned by exact hash, so there are no amends to resolve.
+        return
+    else:
+        assert message.type == MessageType.instance
+        ...existing...
+```
+- [ ] Run test, expect PASS. Commit: `feat(agent): no amend resolution for immutable V-PROGRAM messages`
+
+### Task A4: AgentVmRecord.is_vprogram
+
+**Files:**
+- Modify: `src/aleph/vm/agent/vm_registry.py`
+- Test: `tests/supervisor/test_agent_vm_registry.py`
+
+**Interfaces:**
+- Produces: `AgentVmRecord.is_vprogram: bool` (consumed by A5 stop-guard and A7 payment sweep).
+
+**Steps:**
+- [ ] **Failing test** (in test_agent_vm_registry.py, using the fixture loader from test_vprogram.py or a local copy):
+```python
+def test_record_is_vprogram():
+    message = load_vprogram_message()
+    record = AgentVmRecord(message=message.content, original=message.content, persistent=True)
+    assert record.is_vprogram
+    assert record.uses_payment_credit  # schema enforces credit; sweep exclusion is explicit
+```
+- [ ] **Implement:**
+```python
+    @property
+    def is_vprogram(self) -> bool:
+        return isinstance(self.message, VerifiableProgramContent)
+```
+- [ ] Run, PASS. Commit: `feat(agent): AgentVmRecord.is_vprogram`
+
+### Task A5: Allocation.v_programs + update_allocations wiring
+
+**Files:**
+- Modify: `src/aleph/vm/agent/resources.py:274-291` (Allocation model)
+- Modify: `src/aleph/vm/agent/views/__init__.py:575,585-603,647-666`
+- Test: `tests/supervisor/test_views.py` (mirror `test_update_allocations_stop_loop_uses_supervisor` at :1278 and `test_update_allocations_spares_payg_via_registry` at :1466)
+
+**Steps:**
+- [ ] **Failing tests:** (a) POST /control/allocations with `{"v_programs": ["<fixture hash>"]}` parses and reaches the start loop (assert `start_persistent_vm` called via mock, or scheduling error surfaces in `errors`); (b) a running v-program execution (registry record from fixture content, persistent, RUNNING, confidential) absent from the allocation IS stopped despite `uses_payment_credit`; (c) old payloads without the key still validate.
+- [ ] **Implement** Allocation:
+```python
+    v_programs: set[ItemHash] = Field(default_factory=set)
+```
+   `update_allocations`: line 575 `allocations = allocation.persistent_vms | allocation.instances | allocation.v_programs`; stop-guard becomes:
+```python
+            if (
+                record is not None
+                and record.persistent
+                and vm_hash not in allocations
+                and info.status is VmStatus.RUNNING
+                and (
+                    # The scheduler is the single source of truth for
+                    # v-programs: absence from the allocation stops them,
+                    # even though they are credit-paid and confidential.
+                    record.is_vprogram
+                    or (
+                        not record.uses_payment_stream
+                        and not record.uses_payment_credit
+                        and not info.gpus
+                        and info.confidential_mode is ConfidentialMode.NONE
+                    )
+                )
+            ):
+```
+   and a start loop after the instances loop, identical in shape to the instances loop but iterating `allocation.v_programs`.
+- [ ] Run tests, PASS. Commit: `feat(agent): accept v_programs bucket in /control/allocations`
+
+### Task A6: create dispatch failure + on-demand rejection
+
+**Files:**
+- Modify: `src/aleph/vm/agent/run.py` (`create_vm_execution` before the final raise at :344; `run_code_on_request` :578; `run_code_on_event` :658)
+- Test: `tests/supervisor/test_vprogram.py`, `tests/supervisor/views/test_run_code.py`
+
+**Steps:**
+- [ ] **Failing tests:** (a) `create_vm_execution` with a v-program message raises `VmSetupError` mentioning SEV-SNP; (b) on-demand run path returns 400 with a scheduler-controlled message for a v-program hash.
+- [ ] **Implement** in `create_vm_execution` (before the final `raise HTTPBadRequest`):
+```python
+    if isinstance(content, VerifiableProgramContent):
+        # Scheduler wiring for V-Programs lands before the launch path: the
+        # allocation is accepted, but building a CreateVmSpec for an SNP
+        # guest (runtime manifest fetch, measured cmdline, verified volumes)
+        # is not implemented yet. Fail with the create-path vocabulary so
+        # update_allocations reports it per-VM and the scheduler can react.
+        msg = f"V-PROGRAM {vm_hash} accepted, but this CRN does not implement the SEV-SNP launch path yet"
+        raise VmSetupError(msg)
+```
+   In `run_code_on_request` (and `run_code_on_event`), before the existing non-program rejection:
+```python
+    if isinstance(content, VerifiableProgramContent):
+        raise HTTPBadRequest(reason=f"VM {vm_hash} is a V-PROGRAM: executions are scheduler-controlled")
+```
+- [ ] Run tests, PASS. Commit: `feat(agent): v-program create fails cleanly, on-demand endpoints reject`
+
+### Task A7: Exclude v-programs from the payment sweep
+
+**Files:**
+- Modify: `src/aleph/vm/agent/tasks.py:329-351` (`_group_executions_by_payment`)
+- Test: `tests/supervisor/test_checkpayment.py`
+
+**Steps:**
+- [ ] **Failing test:** a RUNNING v-program execution with zero credit balance is NOT stopped by `check_payment` (mirror the existing credit-sweep test setup).
+- [ ] **Implement** in `_group_executions_by_payment`, right after the `record is None` skip:
+```python
+        if record.is_vprogram:
+            # V-Programs are not payment-checked on the node: the CCN and
+            # the scheduler already enforce their credit budget, node-side
+            # duplication adds nothing.
+            continue
+```
+- [ ] Run test, PASS (also confirm the terminal-status stop loop is untouched: forgotten/rejected v-program messages still stop). Commit: `feat(agent): no node-side payment checks for v-programs`
+
+### Task A8: SNP detection fix, QMP vCPU probe, tee advertising
+
+**Files:**
+- Modify: `src/aleph/vm/utils/__init__.py:175-182` (`check_amd_sev_snp_supported`)
+- Create: `src/aleph/vm/agent/vcpu_probe.py`
+- Modify: `src/aleph/vm/agent/resources.py` (models + `get_machine_properties` + `get_machine_capability`)
+- Test: `tests/supervisor/test_vprogram_probe.py` (new), `tests/supervisor/test_resources.py`, `tests/supervisor/test_utils.py`
+
+**Interfaces:**
+- Produces: `get_supported_snp_vcpu_types() -> list[str]` (async, cached); `/about/usage/system` JSON gains `properties.tee.sev_snp.supported_vcpu_types` when non-empty, absent otherwise.
+
+**Steps:**
+- [ ] **Failing tests:**
+```python
+def test_filter_snp_vcpu_types():
+    definitions = [
+        {"name": "EPYC-v4", "unavailable-features": []},
+        {"name": "EPYC-Genoa", "unavailable-features": ["some-feature"]},
+        {"name": "EPYC", "unavailable-features": []},
+        {"name": "Skylake-Server", "unavailable-features": []},
+    ]
+    assert filter_snp_vcpu_types(definitions) == ["EPYC", "EPYC-v4"]
+
+@pytest.mark.asyncio
+async def test_get_supported_snp_vcpu_types_no_snp(mocker):
+    mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=False)
+    probe = mocker.patch("aleph.vm.agent.vcpu_probe.query_cpu_definitions")
+    assert await get_supported_snp_vcpu_types.__wrapped__() == []
+    probe.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_get_supported_snp_vcpu_types_probe_failure(mocker):
+    mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=True)
+    mocker.patch("aleph.vm.agent.vcpu_probe.query_cpu_definitions", side_effect=OSError("no qemu"))
+    assert await get_supported_snp_vcpu_types.__wrapped__() == []
+```
+   plus a `/about/usage/system` test asserting the tee block appears with a mocked probe and is absent when it returns [] (mirror existing test_resources.py style, resetting the async_cache), and a `check_amd_sev_snp_supported` test asserting it requires `/dev/sev`.
+- [ ] **Implement** `src/aleph/vm/agent/vcpu_probe.py`:
+```python
+"""Probe QEMU for the SNP guest CPU models this host can actually launch.
+
+The scheduler matches a v-program's launch-measurement vcpu_type against the
+models advertised here, so the source of truth must be QEMU itself (this
+exact QEMU build + host kernel + silicon), not a static CPUID table.
+"""
+
+import asyncio
+import json
+import logging
+
+from aleph.vm.utils import async_cache, check_amd_sev_snp_supported
+
+logger = logging.getLogger(__name__)
+
+PROBE_TIMEOUT_SECONDS = 15.0
+
+
+async def _read_qmp_response(stdout: asyncio.StreamReader) -> dict:
+    """Read the next QMP response, skipping asynchronous events."""
+    while True:
+        line = await stdout.readline()
+        if not line:
+            msg = "QMP stream closed before a response arrived"
+            raise RuntimeError(msg)
+        message = json.loads(line)
+        if "event" in message:
+            continue
+        return message
+
+
+async def query_cpu_definitions() -> list[dict]:
+    """Ask a KVM-accelerated QEMU which CPU models it can launch on this host."""
+    process = await asyncio.create_subprocess_exec(
+        "qemu-system-x86_64",
+        "-machine", "none",
+        "-accel", "kvm",
+        "-display", "none",
+        "-nodefaults",
+        "-qmp", "stdio",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    assert process.stdin is not None and process.stdout is not None
+    try:
+        async with asyncio.timeout(PROBE_TIMEOUT_SECONDS):
+            greeting = await _read_qmp_response(process.stdout)
+            if "QMP" not in greeting:
+                msg = f"Unexpected QMP greeting: {greeting}"
+                raise RuntimeError(msg)
+            definitions: list[dict] | None = None
+            for command in ("qmp_capabilities", "query-cpu-definitions", "quit"):
+                process.stdin.write(json.dumps({"execute": command}).encode() + b"\n")
+                await process.stdin.drain()
+                response = await _read_qmp_response(process.stdout)
+                if command == "query-cpu-definitions":
+                    definitions = response["return"]
+            await process.wait()
+    finally:
+        if process.returncode is None:
+            process.kill()
+    assert definitions is not None
+    return definitions
+
+
+def filter_snp_vcpu_types(definitions: list[dict]) -> list[str]:
+    """Keep the EPYC-family models QEMU reports as runnable on this host."""
+    return sorted(
+        definition["name"]
+        for definition in definitions
+        if definition["name"].startswith("EPYC") and not definition.get("unavailable-features")
+    )
+
+
+@async_cache
+async def get_supported_snp_vcpu_types() -> list[str]:
+    """SNP guest CPU models this node can launch; [] when SNP is unsupported
+    or the probe fails (we never advertise what we cannot prove)."""
+    if not check_amd_sev_snp_supported():
+        return []
+    try:
+        definitions = await query_cpu_definitions()
+    except Exception:
+        logger.warning("QEMU vCPU probe failed, not advertising SNP guest models", exc_info=True)
+        return []
+    return filter_snp_vcpu_types(definitions)
+```
+   (If `async_cache` does not expose `__wrapped__`, test the uncached internals instead; adapt at implementation time.)
+   `src/aleph/vm/utils/__init__.py`:
+```python
+def check_amd_sev_snp_supported() -> bool:
+    """..."""
+    return (check_system_module("kvm_amd/parameters/sev_snp") == "Y") and Path("/dev/sev").exists()
+```
+   `src/aleph/vm/agent/resources.py`:
+```python
+class SevSnpProperties(BaseModel):
+    supported_vcpu_types: list[str] = Field(
+        description="QEMU SNP guest CPU models this host can launch (e.g. EPYC-v4)"
+    )
+
+
+class TeeProperties(BaseModel):
+    sev_snp: SevSnpProperties | None = None
+
+
+class MachineProperties(BaseModel):
+    cpu: CpuProperties
+    tee: TeeProperties | None = None
+```
+   In `get_machine_properties` (and `get_machine_capability` for `/about/capability`, adding `tee` to `MachineCapability` too):
+```python
+    snp_vcpu_types = await get_supported_snp_vcpu_types()
+    tee = (
+        TeeProperties(sev_snp=SevSnpProperties(supported_vcpu_types=snp_vcpu_types)) if snp_vcpu_types else None
+    )
+```
+- [ ] Run tests, PASS. Commit: `feat(agent): advertise SNP guest vCPU models via QEMU QMP probe`
+
+### Task A9: Full local gates
+
+- [ ] Full pytest run with the invocation from Global Constraints; compare against the dev baseline (run baseline on a clean `origin/dev` checkout of the same worktree BEFORE the first code task if not already done; only environment-only failures allowed).
+- [ ] `mypy` from `$WT` root on the project config; `ruff check src tests`, `black --check`, `isort --check` (match `hatch run linting:style` set); `lint-imports`.
+- [ ] Fix anything found; amend or add fixup commits per logical change.
+
+### Task A10: Push, PR, CI loop
+
+- [ ] `git push -u origin od/vprogram-scheduler-support`
+- [ ] `gh pr create --draft --base dev` with a body summarizing the design (link the design doc, note the aleph-message merge gate).
+- [ ] Watch CI (`gh pr checks --watch` or poll via ScheduleWakeup ~270s); fix failures and push until green. Expect the pinned git dependency to be exercised by both the pytest workflow and the deb/droplet workflow.
+
+## Part B: aleph-vm-scheduler (repo /home/olivier/git/aleph/aleph-vm-scheduler)
+
+### Task B1: Rename persistent_programs to v_programs (on `od/vprogram-scheduling`, PR #193)
+
+**Files:**
+- Modify: `scheduler-rs/src/models.rs` (Allocation field + all uses: is_empty/item_hashes/contains/find_vm_type/add_vm/all_vms + tests)
+- Modify: `scheduler-api/src/routes/v0.rs` (NodePlan field + bucketing + tests)
+- Modify: `scheduler-rs/src/actors/dispatcher.rs` (per-node Allocation rebuild)
+
+**Steps:**
+- [ ] `git -C /home/olivier/git/aleph/aleph-vm-scheduler switch od/vprogram-scheduling && git pull`
+- [ ] Rename the field and serde key `persistent_programs` -> `v_programs` everywhere it was added by PR #193 (`grep -rn persistent_programs`); keep `#[serde(default)]`. Update test JSON assertions.
+- [ ] `cargo fmt && cargo clippy --locked --all-targets -- -D warnings && cargo test`
+- [ ] Commit: `refactor: rename allocation bucket persistent_programs to v_programs` and push (updates PR #193).
+
+### Task B2: Parse the node tee block
+
+**Files:**
+- Modify: `scheduler-rs/src/crn_client.rs` (MachineUsage properties struct: add optional `tee` with `sev_snp.supported_vcpu_types`)
+- Modify: `scheduler-rs/src/nodes.rs` (NodeSnapshot: `snp_vcpu_types: Vec<String>`)
+- Modify: `scheduler-rs/src/actors/node_watcher.rs:104-189` (populate from usage properties)
+
+**Steps:**
+- [ ] Failing test: deserialize a MachineUsage JSON with and without the tee block; snapshot carries the list (empty when absent).
+- [ ] Implement structs (`#[serde(default)]` throughout so old nodes parse), thread into NodeSnapshot.
+- [ ] `cargo test`, PASS. Commit: `feat: read SNP guest vCPU models from CRN usage properties`
+
+### Task B3: Match measurement vcpu_type in can_vm_run_on_node
+
+**Files:**
+- Modify: `scheduler-rs/src/actors/message_watcher.rs` (extract per-VM required vcpu_types from `content.verification.measurements[].vcpu_type`, default `"EPYC"` for untagged measurements)
+- Modify: `scheduler-rs/src/scheduling.rs:57-113` (`can_vm_run_on_node`)
+
+**Steps:**
+- [ ] Failing tests: (a) v-program with `vcpu_type: "EPYC-v4"` lands only on a node advertising `EPYC-v4` (case-insensitive); (b) node without the tee block (empty `snp_vcpu_types`) never receives v-programs even with the `sev_snp` feature flag; (c) an untagged measurement matches a node advertising `EPYC`; (d) non-v-program VMs are unaffected by empty `snp_vcpu_types`.
+- [ ] Implement: for v-programs require `!node.snapshot.snp_vcpu_types.is_empty()` AND any required vcpu_type (measurement vcpu_type or `"EPYC"` default) present in the node set, case-insensitive.
+- [ ] `cargo fmt && cargo clippy --locked --all-targets -- -D warnings && cargo test`, PASS. Commit: `feat: match v-program launch-measurement vcpu_type against node SNP models`
+
+### Task B4: Push + CI
+
+- [ ] Push `od/vprogram-scheduling`; watch PR #193 CI until green.
+
+## Self-Review Notes
+
+- Spec coverage: allocation bucket (A5), type threading (A2/A3/A4), on-demand rejection (A6), payment (A7), advertising + probe + /dev/sev fix (A8), IPv6 type 4 (A2), scheduler rename (B1), snapshot + matching + strict gate + EPYC default (B2/B3), clean launch failure (A6), testing (each task + A9/A10/B4).
+- Deliberately deferred (recorded in design): the spec-create IPv6 path (`pool.py:239` hardcodes `VmType.instance`) only matters once v-program launch is wired; the launch increment must pass the vm type through `CreateVmSpec`.
+- `notify_allocation` needs no change: its `message.type != MessageType.instance` gate already rejects v-programs.

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -39,9 +39,10 @@ debian-package-code:
 	python3 -m venv build_venv
 	build_venv/bin/pip install   --progress-bar off --upgrade pip setuptools wheel
 	# Versions below MUST mirror pyproject.toml so the .deb ships what the code is tested against.
+	# MERGE GATE: aleph-message is git-pinned to the V-PROGRAM schema ref, swap for a release with pyproject.toml.
 	# protobuf is pinned to 5.29.6: 5.29.0 has a compilation issue; 6.x needs grpcio/tools 1.71+.
 	# legacy-cgi is packaging-only: it backfills the `cgi` module removed from the Python 3.13+ stdlib.
-	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message~=1.1' 'eth-account~=0.10' 'sentry-sdk==2.8' 'qmp==1.1' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2' 'aiosqlite==0.19' 'alembic==1.13.1' 'aiohttp-cors~=0.7.0' 'pydantic-settings~=2.6.1' 'pyroute2==0.7.12' 'python-cpuid==0.1.1' 'solathon==1.0.7' 'protobuf==5.29.6' 'grpcio>=1.70,<1.71' 'redis>=4.2' 'legacy-cgi>=1.0'
+	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message @ git+https://github.com/aleph-im/aleph-message@bc9c0f86958a746faeecbd6c6f96cc6f5b4538de' 'eth-account~=0.10' 'sentry-sdk==2.8' 'qmp==1.1' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2' 'aiosqlite==0.19' 'alembic==1.13.1' 'aiohttp-cors~=0.7.0' 'pydantic-settings~=2.6.1' 'pyroute2==0.7.12' 'python-cpuid==0.1.1' 'solathon==1.0.7' 'protobuf==5.29.6' 'grpcio>=1.70,<1.71' 'redis>=4.2' 'legacy-cgi>=1.0'
 	build_venv/bin/python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux target/bin/sevctl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "aleph-superfluid~=0.2.1",
   "dbus-python==1.3.2",
   "eth-account~=0.10",
-  "grpcio>=1.70,<1.71",                                                                                   # generated _pb2_grpc.py embeds GRPC_GENERATED_VERSION=1.70.0; older installs RuntimeError on import
+  "grpcio>=1.70,<1.71",                                                                                     # generated _pb2_grpc.py embeds GRPC_GENERATED_VERSION=1.70.0; older installs RuntimeError on import
   "jsonschema==4.19.1",
   "jwcrypto==1.5.6",
   "msgpack==1.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
   "aiohttp-cors~=0.7.0",
   "aiosqlite==0.19",
   "alembic==1.13.1",
-  "aleph-message~=1.1",
+  # MERGE GATE: replace the git pin with a released aleph-message version (V-PROGRAM schema, PR #158)
+  "aleph-message @ git+https://github.com/aleph-im/aleph-message@bc9c0f86958a746faeecbd6c6f96cc6f5b4538de",
   "aleph-superfluid~=0.2.1",
   "dbus-python==1.3.2",
   "eth-account~=0.10",

--- a/src/aleph/vm/agent/messages.py
+++ b/src/aleph/vm/agent/messages.py
@@ -60,6 +60,10 @@ async def update_message(message: ExecutableMessage):
             update_with_latest_ref(message.content.data),
             *(update_with_latest_ref(volume) for volume in (message.content.volumes or [])),
         )
+    elif message.type == MessageType.v_program:
+        # V-Programs are immutable (allow_amend is schema-rejected) and every
+        # reference is pinned by exact hash, so there are no amends to resolve.
+        return
     else:
         assert message.type == MessageType.instance
         await asyncio.gather(

--- a/src/aleph/vm/agent/resources.py
+++ b/src/aleph/vm/agent/resources.py
@@ -9,10 +9,10 @@ from pydantic import BaseModel, Field
 
 from aleph.vm.agent.aggregate import get_compatible_gpus, update_aggregate_settings
 from aleph.vm.agent.machine import get_cpu_info, get_hardware_info, get_memory_info
+from aleph.vm.agent.vcpu_probe import get_supported_snp_vcpu_types
 from aleph.vm.conf import settings
 from aleph.vm.resources import GpuDevice
 from aleph.vm.sevclient import SevClient
-from aleph.vm.agent.vcpu_probe import get_supported_snp_vcpu_types
 from aleph.vm.storage_pools import pools_disk_usage
 from aleph.vm.utils import (
     async_cache,

--- a/src/aleph/vm/agent/resources.py
+++ b/src/aleph/vm/agent/resources.py
@@ -282,6 +282,8 @@ class Allocation(BaseModel):
     instances: set[ItemHash] = Field(default_factory=set)
     on_demand_vms: set[ItemHash] | None = None
     jobs: set[ItemHash] | None = None
+    # V-PROGRAM messages (verifiable SEV-SNP programs), scheduler-designated
+    v_programs: set[ItemHash] = Field(default_factory=set)
 
 
 class VMNotification(BaseModel):

--- a/src/aleph/vm/agent/resources.py
+++ b/src/aleph/vm/agent/resources.py
@@ -12,6 +12,7 @@ from aleph.vm.agent.machine import get_cpu_info, get_hardware_info, get_memory_i
 from aleph.vm.conf import settings
 from aleph.vm.resources import GpuDevice
 from aleph.vm.sevclient import SevClient
+from aleph.vm.agent.vcpu_probe import get_supported_snp_vcpu_types
 from aleph.vm.storage_pools import pools_disk_usage
 from aleph.vm.utils import (
     async_cache,
@@ -72,8 +73,22 @@ class UsagePeriod(BaseModel):
     duration_seconds: float
 
 
+class SevSnpProperties(BaseModel):
+    supported_vcpu_types: list[str] = Field(
+        description="QEMU SNP guest CPU models this host can launch (e.g. EPYC-v4). "
+        "The scheduler matches v-program launch-measurement vcpu_type against this list."
+    )
+
+
+class TeeProperties(BaseModel):
+    """TEE launch capability, keyed by platform so TDX and friends slot in later."""
+
+    sev_snp: SevSnpProperties | None = None
+
+
 class MachineProperties(BaseModel):
     cpu: CpuProperties
+    tee: TeeProperties | None = None
 
 
 class AnnotatedGpuDevice(GpuDevice):
@@ -123,6 +138,7 @@ class MemoryProperties(BaseModel):
 class MachineCapability(BaseModel):
     cpu: ExtendedCpuProperties
     memory: MemoryProperties
+    tee: TeeProperties | None = None
 
 
 async def _gpus_from_host_info(host_info) -> GpuProperties:
@@ -154,6 +170,14 @@ async def _gpus_from_host_info(host_info) -> GpuProperties:
 machine_properties_cached = None
 
 
+async def _get_tee_properties() -> TeeProperties | None:
+    """TEE launch capability, absent when there is nothing provable to advertise."""
+    snp_vcpu_types = await get_supported_snp_vcpu_types()
+    if not snp_vcpu_types:
+        return None
+    return TeeProperties(sev_snp=SevSnpProperties(supported_vcpu_types=snp_vcpu_types))
+
+
 @async_cache
 async def get_machine_properties() -> MachineProperties:
     """Fetch machine properties such as architecture, CPU vendor, ...
@@ -178,6 +202,7 @@ async def get_machine_properties() -> MachineProperties:
                 )
             ),
         ),
+        tee=await _get_tee_properties(),
     )
 
 
@@ -211,6 +236,7 @@ async def get_machine_capability() -> MachineCapability:
             type=mem_info["type"],
             clock=mem_info["clock"],
         ),
+        tee=await _get_tee_properties(),
     )
 
 

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -13,7 +13,12 @@ from aiohttp.web_exceptions import (
     HTTPInternalServerError,
     HTTPServiceUnavailable,
 )
-from aleph_message.models import InstanceContent, ItemHash, ProgramContent
+from aleph_message.models import (
+    InstanceContent,
+    ItemHash,
+    ProgramContent,
+    VerifiableProgramContent,
+)
 from msgpack import UnpackValueError
 from multidict import CIMultiDict
 
@@ -338,6 +343,15 @@ async def create_vm_execution(
         await persist_record(vm_hash, record)
         return None
 
+    if isinstance(content, VerifiableProgramContent):
+        # Scheduler wiring for V-Programs lands before the launch path: the
+        # allocation is accepted, but building a CreateVmSpec for an SNP guest
+        # (runtime manifest fetch, measured cmdline, verified volumes) is not
+        # implemented yet. Fail with the create-path vocabulary so
+        # update_allocations reports it per-VM and the scheduler can react.
+        msg = f"V-PROGRAM {vm_hash} accepted, but this CRN does not implement the SEV-SNP launch path yet"
+        raise VmSetupError(msg)
+
     # Every supported content type is handled above: programs through the spec
     # program path, instances (plain, GPU, confidential) through the spec path.
     # There is no pool fallback anymore. Anything else is genuinely unsupported.
@@ -575,6 +589,8 @@ async def run_code_on_request(vm_hash: ItemHash, path: str, request: web.Request
     expiry.cancel(vm_id)  # do not reap a VM we are about to serve
 
     content, original = await _resolve_program_content(vm_hash, registry)
+    if isinstance(content, VerifiableProgramContent):
+        raise HTTPBadRequest(reason=f"VM {vm_hash} is a V-PROGRAM: executions are scheduler-controlled")
     if not isinstance(content, ProgramContent):
         raise HTTPBadRequest(reason=f"VM {vm_hash} is an instance, not a program")
 
@@ -655,6 +671,8 @@ async def run_code_on_event(
     expiry.cancel(vm_id)  # do not reap a VM we are about to serve
 
     content, original = await _resolve_program_content(vm_hash, registry)
+    if isinstance(content, VerifiableProgramContent):
+        raise HTTPBadRequest(reason=f"VM {vm_hash} is a V-PROGRAM: executions are scheduler-controlled")
     if not isinstance(content, ProgramContent):
         raise HTTPBadRequest(reason=f"VM {vm_hash} is an instance, not a program")
 

--- a/src/aleph/vm/agent/tasks.py
+++ b/src/aleph/vm/agent/tasks.py
@@ -341,6 +341,11 @@ def _group_executions_by_payment(
         record = registry.get(vm_hash)
         if record is None:
             continue
+        if record.is_vprogram:
+            # V-Programs are not payment-checked on the node: the CCN and the
+            # scheduler already enforce their credit budget, node-side
+            # duplication adds nothing.
+            continue
         if vm_hash in (settings.CHECK_FASTAPI_VM_ID, settings.LEGACY_CHECK_FASTAPI_VM_ID):
             continue
         if info.status is not VmStatus.RUNNING:

--- a/src/aleph/vm/agent/vcpu_probe.py
+++ b/src/aleph/vm/agent/vcpu_probe.py
@@ -47,25 +47,29 @@ async def query_cpu_definitions() -> list[dict]:
         stderr=asyncio.subprocess.DEVNULL,
     )
     assert process.stdin is not None and process.stdout is not None
+
+    async def _converse() -> list[dict]:
+        assert process.stdin is not None and process.stdout is not None
+        greeting = await _read_qmp_response(process.stdout)
+        if "QMP" not in greeting:
+            msg = f"Unexpected QMP greeting: {greeting}"
+            raise RuntimeError(msg)
+        definitions: list[dict] | None = None
+        for command in ("qmp_capabilities", "query-cpu-definitions", "quit"):
+            process.stdin.write(json.dumps({"execute": command}).encode() + b"\n")
+            await process.stdin.drain()
+            response = await _read_qmp_response(process.stdout)
+            if command == "query-cpu-definitions":
+                definitions = response["return"]
+        await process.wait()
+        assert definitions is not None
+        return definitions
+
     try:
-        async with asyncio.timeout(PROBE_TIMEOUT_SECONDS):
-            greeting = await _read_qmp_response(process.stdout)
-            if "QMP" not in greeting:
-                msg = f"Unexpected QMP greeting: {greeting}"
-                raise RuntimeError(msg)
-            definitions: list[dict] | None = None
-            for command in ("qmp_capabilities", "query-cpu-definitions", "quit"):
-                process.stdin.write(json.dumps({"execute": command}).encode() + b"\n")
-                await process.stdin.drain()
-                response = await _read_qmp_response(process.stdout)
-                if command == "query-cpu-definitions":
-                    definitions = response["return"]
-            await process.wait()
+        return await asyncio.wait_for(_converse(), timeout=PROBE_TIMEOUT_SECONDS)
     finally:
         if process.returncode is None:
             process.kill()
-    assert definitions is not None
-    return definitions
 
 
 def filter_snp_vcpu_types(definitions: list[dict]) -> list[str]:

--- a/src/aleph/vm/agent/vcpu_probe.py
+++ b/src/aleph/vm/agent/vcpu_probe.py
@@ -1,0 +1,92 @@
+"""Probe QEMU for the SNP guest CPU models this host can actually launch.
+
+The scheduler matches a v-program's launch-measurement vcpu_type against the
+models advertised here, so the source of truth must be QEMU itself (this
+exact QEMU build + host kernel + silicon), not a static CPUID table.
+"""
+
+import asyncio
+import json
+import logging
+
+from aleph.vm.utils import async_cache, check_amd_sev_snp_supported
+
+logger = logging.getLogger(__name__)
+
+PROBE_TIMEOUT_SECONDS = 15.0
+
+
+async def _read_qmp_response(stdout: asyncio.StreamReader) -> dict:
+    """Read the next QMP response, skipping asynchronous events."""
+    while True:
+        line = await stdout.readline()
+        if not line:
+            msg = "QMP stream closed before a response arrived"
+            raise RuntimeError(msg)
+        message = json.loads(line)
+        if "event" in message:
+            continue
+        return message
+
+
+async def query_cpu_definitions() -> list[dict]:
+    """Ask a KVM-accelerated QEMU which CPU models it can launch on this host."""
+    process = await asyncio.create_subprocess_exec(
+        "qemu-system-x86_64",
+        "-machine",
+        "none",
+        "-accel",
+        "kvm",
+        "-display",
+        "none",
+        "-nodefaults",
+        "-qmp",
+        "stdio",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    assert process.stdin is not None and process.stdout is not None
+    try:
+        async with asyncio.timeout(PROBE_TIMEOUT_SECONDS):
+            greeting = await _read_qmp_response(process.stdout)
+            if "QMP" not in greeting:
+                msg = f"Unexpected QMP greeting: {greeting}"
+                raise RuntimeError(msg)
+            definitions: list[dict] | None = None
+            for command in ("qmp_capabilities", "query-cpu-definitions", "quit"):
+                process.stdin.write(json.dumps({"execute": command}).encode() + b"\n")
+                await process.stdin.drain()
+                response = await _read_qmp_response(process.stdout)
+                if command == "query-cpu-definitions":
+                    definitions = response["return"]
+            await process.wait()
+    finally:
+        if process.returncode is None:
+            process.kill()
+    assert definitions is not None
+    return definitions
+
+
+def filter_snp_vcpu_types(definitions: list[dict]) -> list[str]:
+    """Keep the EPYC-family models QEMU reports as runnable on this host
+    (empty unavailable-features means every feature the model needs exists)."""
+    return sorted(
+        definition["name"]
+        for definition in definitions
+        if definition["name"].startswith("EPYC") and not definition.get("unavailable-features")
+    )
+
+
+@async_cache
+async def get_supported_snp_vcpu_types() -> list[str]:
+    """SNP guest CPU models this node can launch; [] when SNP is unsupported
+    or the probe fails. We never advertise what we cannot prove."""
+    if not check_amd_sev_snp_supported():
+        return []
+    try:
+        definitions = await query_cpu_definitions()
+    except Exception:
+        logger.warning("QEMU vCPU probe failed, not advertising SNP guest models", exc_info=True)
+        return []
+    return filter_snp_vcpu_types(definitions)

--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -572,7 +572,7 @@ async def update_allocations(request: web.Request):
     async with allocation_lock:
         logger.debug("Got allocation_lock, updating allocations")
         # First, free resources from persistent programs and instances that are not scheduled anymore.
-        allocations = allocation.persistent_vms | allocation.instances
+        allocations = allocation.persistent_vms | allocation.instances | allocation.v_programs
         stopped_vms = []
         # Status comes from the supervisor (VmInfo); persistence, payment tier
         # and owner come from the agent registry. A VM with no registry record is
@@ -587,10 +587,18 @@ async def update_allocations(request: web.Request):
                 and record.persistent
                 and vm_hash not in allocations
                 and info.status is VmStatus.RUNNING
-                and not record.uses_payment_stream
-                and not record.uses_payment_credit
-                and not info.gpus
-                and info.confidential_mode is ConfidentialMode.NONE
+                and (
+                    # The scheduler is the single source of truth for
+                    # v-programs: absence from the allocation stops them,
+                    # even though they are credit-paid and confidential.
+                    record.is_vprogram
+                    or (
+                        not record.uses_payment_stream
+                        and not record.uses_payment_credit
+                        and not info.gpus
+                        and info.confidential_mode is ConfidentialMode.NONE
+                    )
+                )
             ):
                 vm_type = VmType.from_message_content(record.message).name
                 logger.info("Stopping %s %s", vm_type, vm_hash)
@@ -664,6 +672,27 @@ async def update_allocations(request: web.Request):
                 # Handle unknown exception separately, to avoid leaking data
                 logger.exception("Unhandled Error while starting VM '%s': %s", instance_hash, error)
                 scheduling_errors[instance_hash] = Exception("Unhandled Error")
+
+        # Schedule the start of v-programs (verifiable SEV-SNP programs):
+        for vprogram_hash in allocation.v_programs:
+            vprogram_item_hash = ItemHash(vprogram_hash)
+            try:
+                await start_persistent_vm(
+                    vprogram_item_hash,
+                    pubsub,
+                    supervisor=supervisor,
+                    registry=registry,
+                    capacity=capacity,
+                    expiry=expiry,
+                    update_watcher=update_watcher,
+                )
+            except vm_creation_exceptions as error:
+                logger.exception("Error while starting VM '%s': %s", vprogram_hash, error)
+                scheduling_errors[vprogram_item_hash] = error
+            except Exception as error:
+                # Handle unknown exception separately, to avoid leaking data
+                logger.exception("Unhandled Error while starting VM '%s': %s", vprogram_hash, error)
+                scheduling_errors[vprogram_item_hash] = Exception("Unhandled Error")
 
         # Log unsupported features
         if allocation.on_demand_vms:

--- a/src/aleph/vm/agent/vm_registry.py
+++ b/src/aleph/vm/agent/vm_registry.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from uuid import uuid4
 
-from aleph_message.models import ExecutableContent, ItemHash
+from aleph_message.models import ExecutableContent, ItemHash, VerifiableProgramContent
 
 from aleph.vm.agent.metrics import ExecutionRecord, get_execution_records, save_record
 from aleph.vm.utils import get_message_executable_content
@@ -42,6 +42,10 @@ class AgentVmRecord:
     @property
     def uses_payment_credit(self) -> bool:
         return bool(self.message.payment and self.message.payment.is_credit)
+
+    @property
+    def is_vprogram(self) -> bool:
+        return isinstance(self.message, VerifiableProgramContent)
 
 
 class AgentVmRegistry:

--- a/src/aleph/vm/network/hostnetwork.py
+++ b/src/aleph/vm/network/hostnetwork.py
@@ -51,6 +51,8 @@ class StaticIPv6Allocator(IPv6Allocator):
         VmType.microvm: "1",
         VmType.persistent_program: "2",
         VmType.instance: "3",
+        # Must match the scheduler's VmType::ipv6_value() (scheduler-events)
+        VmType.v_program: "4",
     }
 
     def __init__(self, ipv6_range: IPv6Network, subnet_prefix: int):

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -240,7 +240,9 @@ async def get_code_path(ref: str) -> Path:
     if settings.FAKE_DATA_PROGRAM:
         archive_path = Path(settings.FAKE_DATA_PROGRAM)
 
-        encoding: Encoding = (await get_message(ref="fake-message")).content.code.encoding
+        fake_message = await get_message(ref="fake-message")
+        assert isinstance(fake_message, ProgramMessage), "The fake data message must be a program"
+        encoding: Encoding = fake_message.content.code.encoding
         if encoding == Encoding.squashfs:
             squashfs_path = Path(archive_path.name + ".squashfs")
             squashfs_path.unlink(missing_ok=True)

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -19,6 +19,7 @@ from aleph_message.models import (
     InstanceMessage,
     ItemHash,
     ProgramMessage,
+    VerifiableProgramMessage,
     parse_message,
 )
 from aleph_message.models.execution.instance import RootfsVolume
@@ -203,7 +204,7 @@ async def get_latest_amend(item_hash: str) -> str:
     return item_hash
 
 
-async def get_message(ref: str) -> ProgramMessage | InstanceMessage:
+async def get_message(ref: str) -> ProgramMessage | InstanceMessage | VerifiableProgramMessage:
     if ref == settings.FAKE_INSTANCE_ID:
         logger.debug("Using the fake instance message since the ref matches")
         cache_path = settings.FAKE_INSTANCE_MESSAGE
@@ -229,7 +230,9 @@ async def get_message(ref: str) -> ProgramMessage | InstanceMessage:
             msg = fix_message_validation(msg)
 
         result = parse_message(message_dict=msg)
-        assert isinstance(result, InstanceMessage | ProgramMessage), "Parsed message is not executable"
+        assert isinstance(
+            result, InstanceMessage | ProgramMessage | VerifiableProgramMessage
+        ), "Parsed message is not executable"
         return result
 
 

--- a/src/aleph/vm/utils/__init__.py
+++ b/src/aleph/vm/utils/__init__.py
@@ -179,7 +179,7 @@ def check_amd_sev_snp_supported() -> bool:
     Adds strong memory integrity protection to help prevent malicious hypervisor-based attacks like data replay,
     memory re-mapping, and more in order to create an isolated execution environment.
     """
-    return check_system_module("kvm_amd/parameters/sev_snp") == "Y"
+    return (check_system_module("kvm_amd/parameters/sev_snp") == "Y") and Path("/dev/sev").exists()
 
 
 def fix_message_validation(message: dict) -> dict:

--- a/src/aleph/vm/vm_type.py
+++ b/src/aleph/vm/vm_type.py
@@ -1,17 +1,26 @@
 from enum import Enum
 
-from aleph_message.models import ExecutableContent, InstanceContent, ProgramContent
+from aleph_message.models import (
+    ExecutableContent,
+    InstanceContent,
+    ProgramContent,
+    VerifiableProgramContent,
+)
 
 
 class VmType(Enum):
     microvm = 1
     persistent_program = 2
     instance = 3
+    v_program = 4
 
     @staticmethod
     def from_message_content(content: ExecutableContent) -> "VmType":
         if isinstance(content, InstanceContent):
             return VmType.instance
+
+        elif isinstance(content, VerifiableProgramContent):
+            return VmType.v_program
 
         elif isinstance(content, ProgramContent):
             if content.on.persistent:

--- a/tests/supervisor/fixtures/vprogram_message.json
+++ b/tests/supervisor/fixtures/vprogram_message.json
@@ -1,0 +1,55 @@
+{
+    "chain": "ETH",
+    "sender": "0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba",
+    "type": "V-PROGRAM",
+    "channel": "TEST",
+    "signature": "0x372da8230552b8c3e65c05b31a0ff3a24666d66c575f8e11019f62579bf48c2b7fe2f0bbe907a2a5bf8050989cdaf8a59ff8a1cbcafcdef0656c54279b4aa0c71b",
+    "time": 1719502000.0,
+    "item_type": "inline",
+    "content": {
+        "address": "0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba",
+        "time": 1719502000.0,
+        "allow_amend": false,
+        "payment": {
+            "type": "credit"
+        },
+        "environment": {
+            "internet": true
+        },
+        "resources": {
+            "vcpus": 2,
+            "memory": 2048,
+            "seconds": 30
+        },
+        "runtime": {
+            "ref": "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
+            "comment": "compose-runner snp bundle"
+        },
+        "workload": {
+            "ref": "beefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            "hash_tree": "feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed",
+            "roothash": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
+        },
+        "verification": {
+            "backend": "sev_snp",
+            "policy": 196608,
+            "measurements": [
+                {
+                    "platform": "sev_snp",
+                    "digest": "abababababababababababababababababababababababababababababababababababababababababababababababab",
+                    "vcpu_type": "EPYC-v4"
+                }
+            ]
+        },
+        "volumes": [
+            {
+                "ref": "dadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadada",
+                "hash_tree": "d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5",
+                "roothash": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefef",
+                "comment": "model weights"
+            }
+        ]
+    },
+    "item_content": "{\"address\":\"0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba\",\"time\":1719502000.0,\"allow_amend\":false,\"payment\":{\"type\":\"credit\"},\"environment\":{\"internet\":true},\"resources\":{\"vcpus\":2,\"memory\":2048,\"seconds\":30},\"runtime\":{\"ref\":\"cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe\",\"comment\":\"compose-runner snp bundle\"},\"workload\":{\"ref\":\"beefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef\",\"hash_tree\":\"feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed\",\"roothash\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd\"},\"verification\":{\"backend\":\"sev_snp\",\"policy\":196608,\"measurements\":[{\"platform\":\"sev_snp\",\"digest\":\"abababababababababababababababababababababababababababababababababababababababababababababababab\",\"vcpu_type\":\"EPYC-v4\"}]},\"volumes\":[{\"ref\":\"dadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadada\",\"hash_tree\":\"d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5\",\"roothash\":\"efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefef\",\"comment\":\"model weights\"}]}",
+    "item_hash": "4c319b6bdf98f1e90f2bf8c69da175679fa21ca27d4547bbfa32f77dd3b49fe6"
+}

--- a/tests/supervisor/test_ipv6_allocator.py
+++ b/tests/supervisor/test_ipv6_allocator.py
@@ -19,3 +19,14 @@ def test_static_ipv6_allocator():
         vm_type=VmType.microvm,
     )
     assert ip_subnet == IPv6Network("1111:2222:3333:4444:0001:8920:215b:2e90/124")
+
+
+def test_static_ipv6_allocator_v_program_prefix():
+    allocator = StaticIPv6Allocator(ipv6_range=IPv6Network("1111:2222:3333:4444::/64"), subnet_prefix=124)
+    ip_subnet = allocator.allocate_vm_ipv6_subnet(
+        vm_index=3,
+        vm_hash=ItemHash("8920215b2e961a4d4c59a8ceb2803af53f91530ff53d6704273ab4d380bc6446"),
+        vm_type=VmType.v_program,
+    )
+    # 16-bit VM-type field = 4: must mirror scheduler-events VmType::ipv6_value()
+    assert ip_subnet == IPv6Network("1111:2222:3333:4444:0004:8920:215b:2e90/124")

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -290,6 +290,7 @@ async def test_system_capability_mock(aiohttp_client, mocker):
     mocker.patch("aleph.vm.agent.resources.check_amd_sev_supported", return_value=True)
     mocker.patch("aleph.vm.agent.resources.check_amd_sev_es_supported", return_value=True)
     mocker.patch("aleph.vm.agent.resources.check_amd_sev_snp_supported", return_value=False)
+    mocker.patch("aleph.vm.agent.resources.get_supported_snp_vcpu_types", new_callable=AsyncMock, return_value=[])
     mocker.patch(
         "psutil.getloadavg",
         lambda: [1, 2, 3],
@@ -314,6 +315,7 @@ async def test_system_capability_mock(aiohttp_client, mocker):
             "count": 200,
         },
         "memory": {"size": 17179869184, "units": "bytes", "type": "", "clock": None, "clock_units": None},
+        "tee": None,
     }
 
 

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -1,0 +1,61 @@
+"""V-PROGRAM (verifiable SEV-SNP program) support in the agent.
+
+Uses the canonical cross-SDK fixture message (item_hash 4c319b6b...); see
+docs/plans/2026-07-11-vprogram-scheduler-support-design.md.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from aleph_message.models import (
+    InstanceMessage,
+    ProgramMessage,
+    VerifiableProgramContent,
+    VerifiableProgramMessage,
+    parse_message,
+)
+
+from aleph.vm.agent.messages import update_message
+from aleph.vm.agent.vm_registry import AgentVmRecord
+from aleph.vm.vm_type import VmType
+
+FIXTURE = Path(__file__).parent / "fixtures" / "vprogram_message.json"
+
+
+def load_vprogram_message() -> VerifiableProgramMessage:
+    message = parse_message(json.loads(FIXTURE.read_text()))
+    assert isinstance(message, VerifiableProgramMessage)
+    return message
+
+
+def test_vm_type_v_program():
+    message = load_vprogram_message()
+    assert isinstance(message.content, VerifiableProgramContent)
+    assert VmType.from_message_content(message.content) == VmType.v_program
+    # .name is exposed in the executions list and must match the scheduler's
+    # "v_program" vm-type string
+    assert VmType.v_program.name == "v_program"
+
+
+def test_storage_executable_assert_accepts_vprogram():
+    # get_message asserts the parsed message is executable; the union must
+    # include VerifiableProgramMessage
+    message = load_vprogram_message()
+    assert isinstance(message, InstanceMessage | ProgramMessage | VerifiableProgramMessage)
+
+
+def test_agent_record_is_vprogram():
+    message = load_vprogram_message()
+    record = AgentVmRecord(message=message.content, original=message.content, persistent=True)
+    assert record.is_vprogram
+    # The schema enforces credit payment; node-side sweep exclusion is explicit
+    assert record.uses_payment_credit
+
+
+@pytest.mark.asyncio
+async def test_update_message_vprogram_is_noop():
+    message = load_vprogram_message()
+    # Must not attempt any amend resolution (would hit the network):
+    # v-programs are immutable and every reference is pinned by exact hash
+    await update_message(message)

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -6,10 +6,13 @@ docs/plans/2026-07-11-vprogram-scheduler-support-design.md.
 
 import json
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aleph_message.models import (
     InstanceMessage,
+    ItemHash,
+    PaymentType,
     ProgramMessage,
     VerifiableProgramContent,
     VerifiableProgramMessage,
@@ -17,10 +20,27 @@ from aleph_message.models import (
 )
 
 from aleph.vm.agent.messages import update_message
-from aleph.vm.agent.vm_registry import AgentVmRecord
+from aleph.vm.agent.resources import Allocation
+from aleph.vm.agent.run import create_vm_execution, run_code_on_request
+from aleph.vm.agent.supervisor import setup_webapp
+from aleph.vm.agent.tasks import _group_executions_by_payment
+from aleph.vm.agent.vm_registry import AgentVmRecord, AgentVmRegistry
+from aleph.vm.conf import settings
+from aleph.vm.supervisor.local import LocalSupervisor
+from aleph.vm.supervisor_interface.errors import VmSetupError
+from aleph.vm.supervisor_interface.types import (
+    Backend,
+    ConfidentialMode,
+    IpAssignment,
+    VmId,
+    VmInfo,
+    VmStatus,
+)
 from aleph.vm.vm_type import VmType
 
 FIXTURE = Path(__file__).parent / "fixtures" / "vprogram_message.json"
+# SHA-256 of "test", used by the existing views tests as the allocation token
+TEST_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
 
 
 def load_vprogram_message() -> VerifiableProgramMessage:
@@ -59,3 +79,172 @@ async def test_update_message_vprogram_is_noop():
     # Must not attempt any amend resolution (would hit the network):
     # v-programs are immutable and every reference is pinned by exact hash
     await update_message(message)
+
+
+def _running_vm_info(vm_hash: str) -> VmInfo:
+    return VmInfo(
+        vm_id=VmId(vm_hash),
+        status=VmStatus.RUNNING,
+        ipv4=IpAssignment(),
+        ipv6=IpAssignment(),
+        uptime_secs=0,
+        backend=Backend.QEMU,
+        numa_node=None,
+        status_message="",
+        confidential_mode=ConfidentialMode.SEV_SNP,
+        gpus=[],
+    )
+
+
+def test_allocation_model_v_programs():
+    # New bucket parses; old payloads without the key still validate
+    allocation = Allocation.model_validate({"persistent_vms": []})
+    assert allocation.v_programs == set()
+    vm_hash = load_vprogram_message().item_hash
+    allocation = Allocation.model_validate({"v_programs": [str(vm_hash)]})
+    assert allocation.v_programs == {vm_hash}
+
+
+@pytest.mark.asyncio
+async def test_update_allocations_starts_v_programs(aiohttp_client, mocker):
+    """v_programs hashes go through the same start path as instances."""
+    message = load_vprogram_message()
+    vm_hash = str(message.item_hash)
+
+    app = setup_webapp(supervisor=LocalSupervisor(None))
+    app["pubsub"] = None
+    app["supervisor"] = MagicMock(delete_vm=AsyncMock(), list_vms=AsyncMock(return_value=[]))
+
+    mock_start = mocker.patch("aleph.vm.agent.views.start_persistent_vm", new_callable=AsyncMock)
+    settings.ALLOCATION_TOKEN_HASH = TEST_TOKEN_HASH
+    client = await aiohttp_client(app)
+
+    response = await client.post(
+        "/control/allocations",
+        json={"v_programs": [vm_hash]},
+        headers={"X-Auth-Signature": "test"},
+    )
+    assert response.status == 200
+    resp_json = await response.json()
+    assert vm_hash in resp_json["successful"]
+    assert mock_start.await_count == 1
+    assert mock_start.await_args.args[0] == ItemHash(vm_hash)
+
+
+@pytest.mark.asyncio
+async def test_update_allocations_stops_descheduled_vprogram(aiohttp_client, mocker):
+    """The scheduler is the single source of truth for v-programs: absence from
+    the allocation stops them, despite being credit-paid and confidential
+    (both of which spare other VM types)."""
+    message = load_vprogram_message()
+    vm_hash = str(message.item_hash)
+
+    app = setup_webapp(supervisor=LocalSupervisor(None))
+    app["pubsub"] = None
+    app["vm_registry"].record(ItemHash(vm_hash), message=message.content, original=message.content, persistent=True)
+
+    fake_supervisor = MagicMock(
+        delete_vm=AsyncMock(), list_vms=AsyncMock(return_value=[_running_vm_info(vm_hash)])
+    )
+    app["supervisor"] = fake_supervisor
+
+    mock_delete_records = mocker.patch("aleph.vm.agent.views.delete_records_for_vm", new_callable=AsyncMock)
+    settings.ALLOCATION_TOKEN_HASH = TEST_TOKEN_HASH
+    client = await aiohttp_client(app)
+
+    response = await client.post(
+        "/control/allocations",
+        json={"persistent_vms": []},
+        headers={"X-Auth-Signature": "test"},
+    )
+    assert response.status == 200
+    resp_json = await response.json()
+    assert vm_hash in resp_json["stopped"]
+    fake_supervisor.delete_vm.assert_awaited_once_with(VmId(vm_hash))
+    mock_delete_records.assert_awaited_once_with(vm_hash)
+    assert ItemHash(vm_hash) not in app["vm_registry"]
+
+
+@pytest.mark.asyncio
+async def test_update_allocations_spares_scheduled_vprogram(aiohttp_client, mocker):
+    """A running v-program still listed in v_programs must not be stopped."""
+    message = load_vprogram_message()
+    vm_hash = str(message.item_hash)
+
+    mocker.patch("aleph.vm.agent.views.start_persistent_vm", new_callable=AsyncMock)
+    app = setup_webapp(supervisor=LocalSupervisor(None))
+    app["pubsub"] = None
+    app["vm_registry"].record(ItemHash(vm_hash), message=message.content, original=message.content, persistent=True)
+
+    fake_supervisor = MagicMock(
+        delete_vm=AsyncMock(), list_vms=AsyncMock(return_value=[_running_vm_info(vm_hash)])
+    )
+    app["supervisor"] = fake_supervisor
+
+    settings.ALLOCATION_TOKEN_HASH = TEST_TOKEN_HASH
+    client = await aiohttp_client(app)
+
+    response = await client.post(
+        "/control/allocations",
+        json={"v_programs": [vm_hash]},
+        headers={"X-Auth-Signature": "test"},
+    )
+    assert response.status == 200
+    resp_json = await response.json()
+    assert vm_hash not in resp_json["stopped"]
+    fake_supervisor.delete_vm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_vm_execution_vprogram_fails_cleanly(mocker):
+    """The allocation is accepted but the SNP launch path is not wired yet:
+    create must raise the create-path vocabulary (VmSetupError), which
+    update_allocations reports per-VM."""
+    message = load_vprogram_message()
+    mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
+
+    with pytest.raises(VmSetupError, match="SEV-SNP"):
+        await create_vm_execution(
+            message.item_hash,
+            supervisor=MagicMock(),
+            registry=AgentVmRegistry(),
+            capacity=MagicMock(),
+            persistent=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_code_rejects_vprogram(mocker):
+    """On-demand execution endpoints must reject v-programs: they are
+    scheduler-controlled."""
+    from aiohttp.web_exceptions import HTTPBadRequest
+
+    message = load_vprogram_message()
+    registry = AgentVmRegistry()
+    registry.record(message.item_hash, message=message.content, original=message.content, persistent=True)
+
+    request = MagicMock()
+    request.app = {
+        "supervisor": MagicMock(),
+        "expiry": MagicMock(),
+        "update_watcher": MagicMock(),
+        "vm_registry": registry,
+        "capacity": MagicMock(),
+        "program_client": MagicMock(),
+    }
+
+    with pytest.raises(HTTPBadRequest, match="scheduler-controlled"):
+        await run_code_on_request(message.item_hash, "/", request)
+
+
+def test_payment_sweep_excludes_vprograms():
+    """V-Programs are credit-paid by schema but must never be grouped into the
+    node-side payment sweep: the CCN and the scheduler enforce their budget."""
+    message = load_vprogram_message()
+    vm_hash = str(message.item_hash)
+
+    registry = AgentVmRegistry()
+    registry.record(ItemHash(vm_hash), message=message.content, original=message.content, persistent=True)
+
+    grouped = _group_executions_by_payment([_running_vm_info(vm_hash)], registry, PaymentType.credit)
+    assert grouped == {}

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -143,9 +143,7 @@ async def test_update_allocations_stops_descheduled_vprogram(aiohttp_client, moc
     app["pubsub"] = None
     app["vm_registry"].record(ItemHash(vm_hash), message=message.content, original=message.content, persistent=True)
 
-    fake_supervisor = MagicMock(
-        delete_vm=AsyncMock(), list_vms=AsyncMock(return_value=[_running_vm_info(vm_hash)])
-    )
+    fake_supervisor = MagicMock(delete_vm=AsyncMock(), list_vms=AsyncMock(return_value=[_running_vm_info(vm_hash)]))
     app["supervisor"] = fake_supervisor
 
     mock_delete_records = mocker.patch("aleph.vm.agent.views.delete_records_for_vm", new_callable=AsyncMock)
@@ -176,9 +174,7 @@ async def test_update_allocations_spares_scheduled_vprogram(aiohttp_client, mock
     app["pubsub"] = None
     app["vm_registry"].record(ItemHash(vm_hash), message=message.content, original=message.content, persistent=True)
 
-    fake_supervisor = MagicMock(
-        delete_vm=AsyncMock(), list_vms=AsyncMock(return_value=[_running_vm_info(vm_hash)])
-    )
+    fake_supervisor = MagicMock(delete_vm=AsyncMock(), list_vms=AsyncMock(return_value=[_running_vm_info(vm_hash)]))
     app["supervisor"] = fake_supervisor
 
     settings.ALLOCATION_TOKEN_HASH = TEST_TOKEN_HASH
@@ -214,7 +210,7 @@ async def test_create_vm_execution_vprogram_fails_cleanly(mocker):
 
 
 @pytest.mark.asyncio
-async def test_run_code_rejects_vprogram(mocker):
+async def test_run_code_rejects_vprogram():
     """On-demand execution endpoints must reject v-programs: they are
     scheduler-controlled."""
     from aiohttp.web_exceptions import HTTPBadRequest

--- a/tests/supervisor/test_vprogram_probe.py
+++ b/tests/supervisor/test_vprogram_probe.py
@@ -1,0 +1,117 @@
+"""SNP guest vCPU model probing and TEE capability advertising.
+
+The scheduler matches a v-program's launch-measurement vcpu_type against the
+models advertised in /about/usage/system properties.tee, so the advertised
+list must reflect what this exact QEMU + kernel + silicon can launch.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aleph.vm.agent.resources import get_machine_properties
+from aleph.vm.agent.vcpu_probe import (
+    filter_snp_vcpu_types,
+    get_supported_snp_vcpu_types,
+)
+
+
+def test_filter_snp_vcpu_types():
+    definitions = [
+        {"name": "EPYC-v4", "unavailable-features": []},
+        {"name": "EPYC-Genoa", "unavailable-features": ["some-feature"]},
+        {"name": "EPYC", "unavailable-features": []},
+        {"name": "Skylake-Server", "unavailable-features": []},
+    ]
+    assert filter_snp_vcpu_types(definitions) == ["EPYC", "EPYC-v4"]
+
+
+@pytest.mark.asyncio
+async def test_get_supported_snp_vcpu_types_no_snp(mocker):
+    mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=False)
+    probe = mocker.patch("aleph.vm.agent.vcpu_probe.query_cpu_definitions", new_callable=AsyncMock)
+    assert await get_supported_snp_vcpu_types.__wrapped__() == []
+    probe.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_supported_snp_vcpu_types_probe_failure(mocker):
+    # We never advertise what we cannot prove: a failed probe advertises nothing
+    mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=True)
+    mocker.patch(
+        "aleph.vm.agent.vcpu_probe.query_cpu_definitions",
+        new_callable=AsyncMock,
+        side_effect=OSError("qemu-system-x86_64 not found"),
+    )
+    assert await get_supported_snp_vcpu_types.__wrapped__() == []
+
+
+@pytest.mark.asyncio
+async def test_get_supported_snp_vcpu_types_success(mocker):
+    mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=True)
+    mocker.patch(
+        "aleph.vm.agent.vcpu_probe.query_cpu_definitions",
+        new_callable=AsyncMock,
+        return_value=[
+            {"name": "EPYC-Milan", "unavailable-features": []},
+            {"name": "EPYC-Genoa", "unavailable-features": ["flag"]},
+        ],
+    )
+    assert await get_supported_snp_vcpu_types.__wrapped__() == ["EPYC-Milan"]
+
+
+def _mock_cpu_info() -> dict:
+    return {"architecture": "x86_64", "vendor": "AuthenticAMD", "model": "EPYC", "frequency": 2000, "count": 8}
+
+
+@pytest.mark.asyncio
+async def test_machine_properties_tee_block(mocker):
+    mocker.patch("aleph.vm.agent.resources.get_hardware_info", new_callable=AsyncMock, return_value={})
+    mocker.patch("aleph.vm.agent.resources.get_cpu_info", return_value=_mock_cpu_info())
+    mocker.patch("aleph.vm.agent.resources.check_amd_sev_supported", return_value=True)
+    mocker.patch("aleph.vm.agent.resources.check_amd_sev_es_supported", return_value=True)
+    mocker.patch("aleph.vm.agent.resources.check_amd_sev_snp_supported", return_value=True)
+    mocker.patch(
+        "aleph.vm.agent.resources.get_supported_snp_vcpu_types",
+        new_callable=AsyncMock,
+        return_value=["EPYC", "EPYC-v4"],
+    )
+
+    properties = await get_machine_properties.__wrapped__()
+    assert properties.tee is not None
+    assert properties.tee.sev_snp is not None
+    assert properties.tee.sev_snp.supported_vcpu_types == ["EPYC", "EPYC-v4"]
+    dumped = properties.model_dump(exclude_none=True)
+    assert dumped["tee"] == {"sev_snp": {"supported_vcpu_types": ["EPYC", "EPYC-v4"]}}
+
+
+@pytest.mark.asyncio
+async def test_machine_properties_no_tee_block_without_models(mocker):
+    mocker.patch("aleph.vm.agent.resources.get_hardware_info", new_callable=AsyncMock, return_value={})
+    mocker.patch("aleph.vm.agent.resources.get_cpu_info", return_value=_mock_cpu_info())
+    mocker.patch("aleph.vm.agent.resources.check_amd_sev_supported", return_value=False)
+    mocker.patch("aleph.vm.agent.resources.check_amd_sev_es_supported", return_value=False)
+    mocker.patch("aleph.vm.agent.resources.check_amd_sev_snp_supported", return_value=False)
+    mocker.patch(
+        "aleph.vm.agent.resources.get_supported_snp_vcpu_types",
+        new_callable=AsyncMock,
+        return_value=[],
+    )
+
+    properties = await get_machine_properties.__wrapped__()
+    assert properties.tee is None
+    # exclude_none keeps the usage-endpoint JSON free of a null tee key
+    assert "tee" not in properties.model_dump(exclude_none=True)
+
+
+def test_check_amd_sev_snp_requires_dev_sev(mocker):
+    # SNP launches go through /dev/sev like SEV/SEV-ES; a host without the
+    # device node cannot launch, whatever the kernel module parameter says
+    from aleph.vm import utils
+
+    mocker.patch("aleph.vm.utils.check_system_module", return_value="Y")
+    path_cls = mocker.patch("aleph.vm.utils.Path")
+    path_cls.return_value.exists.return_value = False
+    assert utils.check_amd_sev_snp_supported() is False
+    path_cls.return_value.exists.return_value = True
+    assert utils.check_amd_sev_snp_supported() is True

--- a/tests/supervisor/test_vprogram_probe.py
+++ b/tests/supervisor/test_vprogram_probe.py
@@ -5,7 +5,7 @@ models advertised in /about/usage/system properties.tee, so the advertised
 list must reflect what this exact QEMU + kernel + silicon can launch.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 


### PR DESCRIPTION
Adds scheduler-facing support for the V-PROGRAM message type (verifiable SEV-SNP programs), per the design in docs/plans/2026-07-11-vprogram-scheduler-support-design.md. Pairs with aleph-vm-scheduler PR #193 (od/vprogram-scheduling).

## What this does

- POST /control/allocations accepts a new v_programs bucket (matching the scheduler wire model after the persistent_programs -> v_programs rename in #193). Absence from the allocation stops a running v-program: the scheduler is the single source of truth for this type, unlike credit-paid or confidential instances which the stop loop spares.
- V-PROGRAM messages parse through storage/get_message, resolve no amends (immutable by schema), and map to VmType.v_program with IPv6 type value 4 (mirrors scheduler-events VmType::ipv6_value()).
- No node-side payment checks: v-programs are excluded from the check_payment sweep. The CCN and the scheduler already enforce their credit budget.
- On-demand /vm/{item_hash} paths reject v-programs (scheduler-controlled only).
- Launch is deliberately out of scope: create fails cleanly with VmSetupError until the SNP launch increment (runtime manifest fetch, measured cmdline, verified volumes) lands on top of the Phase 3 backport.
- Capability advertising: /about/usage/system and /about/capability gain a platform-keyed properties.tee block with tee.sev_snp.supported_vcpu_types, populated by a QEMU QMP probe (query-cpu-definitions under KVM, EPYC-family models with empty unavailable-features). This lets the scheduler match a v-program's launch-measurement vcpu_type against what the node can actually launch, instead of the too-broad AuthenticAMD + sev_snp flag. A failed probe advertises nothing. check_amd_sev_snp_supported now also requires /dev/sev, like the SEV/SEV-ES probes.

## Merge gate

- [ ] aleph-message is git-pinned to the PR #158 head (bc9c0f8); swap for a released version before merging.
- [ ] aleph-vm-scheduler #193 renames its allocation bucket to v_programs.

## Testing

Canonical cross-SDK fixture (item_hash 4c319b6b...) drives new suites tests/supervisor/test_vprogram.py and test_vprogram_probe.py; full supervisor suite at the origin/dev baseline locally (only the known pyroute2/journald environment failures). The QMP probe was exercised live against this host's QEMU (reports 13 runnable EPYC models).