### PR TITLE
fix(systemd): retry on stale proxy after daemon-reexec

### DIFF
--- a/src/aleph/vm/systemd.py
+++ b/src/aleph/vm/systemd.py
@@ -23,6 +23,12 @@ _NO_SUCH_UNIT = "org.freedesktop.systemd1.NoSuchUnit"
 # name" (typically after systemctl daemon-reexec or a systemd package
 # upgrade rotates its unique bus name). Reconnecting and retrying the
 # call resolves the well-known name to the current owner.
+#
+# NoReply is included so we survive systemd being briefly unresponsive
+# during a restart, at the cost of retrying legitimate slow calls once
+# — worst case doubles that call's wall time. Acceptable tradeoff:
+# genuine NoReply is rare on a healthy host and we still fail fast if
+# the retry itself times out.
 _STALE_CONNECTION_ERRORS = frozenset(
     {
         "org.freedesktop.DBus.Error.ServiceUnknown",
@@ -92,26 +98,25 @@ class SystemDManager:
         msg = "Failed to establish D-Bus connection after multiple attempts"
         raise DBusException(msg)
 
-    def _call_with_reconnect(self, fn, *args, **kwargs):
-        """Run a manager call; on stale-connection errors, reconnect and retry once.
+    def _call_with_reconnect(self, work):
+        """Run ``work()``; on stale-connection errors, reconnect and re-run once.
 
-        ``follow_name_owner_changes=True`` on the proxy makes routine
-        systemd restarts transparent, but a call issued while systemd
-        is *mid*-restart can still hit an error before the new owner
-        registers. On the errors in ``_STALE_CONNECTION_ERRORS``, tear
-        down and rebuild the bus, then retry the same D-Bus method
-        against the freshly-built ``_manager``.
+        ``work`` is a zero-argument callable that performs the D-Bus
+        operation from scratch (typically a lambda that calls
+        ``self._get_manager().SomeMethod(...)``). Passing a callable
+        rather than a pre-resolved method matters: a pre-resolved
+        ``_ProxyMethod`` is bound to the ``_connection`` we just closed
+        via ``self._bus.close()``, so retrying it would go through the
+        dead connection. Re-invoking ``work()`` after ``_connect()``
+        reads the new ``self._manager`` and routes through the fresh
+        proxy — no need to peek at ``_method_name`` or rebind.
 
-        The retry MUST be issued through the new manager: ``fn`` here is
-        a ``dbus.proxies._ProxyMethod`` bound to a specific ``_connection``
-        that ``_connect()`` just closed via ``self._bus.close()``. Calling
-        the original ``fn`` again would go through the dead connection.
-        We rebind by looking up the same method name on the new manager
-        via ``_method_name`` (the documented ``_ProxyMethod`` attribute)
-        and ``Interface.get_dbus_method``.
+        Also handles multi-call chains (e.g. ``manager.GetUnit`` then
+        ``bus.get_object`` then ``properties.Get``): the whole sequence
+        is redone against the fresh bus and manager.
         """
         try:
-            return fn(*args, **kwargs)
+            return work()
         except DBusException as error:
             if error.get_dbus_name() not in _STALE_CONNECTION_ERRORS:
                 raise
@@ -119,14 +124,8 @@ class SystemDManager:
                 "Stale systemd D-Bus proxy (%s), reconnecting and retrying",
                 error.get_dbus_name(),
             )
-            method_name = getattr(fn, "_method_name", None)
             self._connect()
-            if method_name is None or self._manager is None:
-                # No safe way to rebind; retrying fn would call through
-                # the connection we just closed. Better to surface the
-                # original failure than to fail obscurely.
-                raise
-            return self._manager.get_dbus_method(method_name)(*args, **kwargs)
+            return work()
 
     def _ensure_connection(self) -> None:
         """Ensure D-Bus connection is active, reconnect if necessary.
@@ -190,37 +189,51 @@ class SystemDManager:
             logger.warning("Failed to disable %s: %s", service, error)
 
     def enable(self, service: str) -> None:
-        manager = self._get_manager()
-        self._call_with_reconnect(manager.EnableUnitFiles, [service], False, True)  # noqa: FBT003
+        self._call_with_reconnect(
+            lambda: self._get_manager().EnableUnitFiles([service], False, True)  # noqa: FBT003
+        )
         logger.debug(f"Enabled {service} service")
 
     def start(self, service: str) -> None:
-        manager = self._get_manager()
-        self._call_with_reconnect(manager.StartUnit, service, "replace")
+        self._call_with_reconnect(lambda: self._get_manager().StartUnit(service, "replace"))
         logger.debug(f"Started {service} service")
 
     def stop(self, service: str) -> None:
-        manager = self._get_manager()
-        self._call_with_reconnect(manager.StopUnit, service, "replace")
+        self._call_with_reconnect(lambda: self._get_manager().StopUnit(service, "replace"))
         logger.debug(f"Stopped {service} service")
 
     def restart(self, service: str) -> None:
-        manager = self._get_manager()
-        self._call_with_reconnect(manager.RestartUnit, service, "replace")
+        self._call_with_reconnect(lambda: self._get_manager().RestartUnit(service, "replace"))
         logger.debug(f"Restarted {service} service")
 
     def disable(self, service: str) -> None:
-        manager = self._get_manager()
-        self._call_with_reconnect(manager.DisableUnitFiles, [service], False)  # noqa: FBT003
+        self._call_with_reconnect(
+            lambda: self._get_manager().DisableUnitFiles([service], False)  # noqa: FBT003
+        )
         logger.debug(f"Disabled {service} service")
 
     def is_service_enabled(self, service: str) -> bool:
         try:
-            manager = self._get_manager()
-            return manager.GetUnitFileState(service) == "enabled"
+            return self._call_with_reconnect(lambda: self._get_manager().GetUnitFileState(service)) == "enabled"
         except DBusException as error:
-            logger.error(error)
+            _log_dbus_lookup_error(service, error)
             return False
+
+    def _read_active_state(self, service: str) -> str:
+        """Fetch ActiveState for ``service`` via manager + property lookup.
+
+        Extracted so the whole multi-call chain can be re-run atomically
+        under ``_call_with_reconnect``: on a stale proxy, ``GetUnit``
+        fails first, we reconnect, and the whole sequence re-runs against
+        the fresh bus and manager (so ``bus.get_object`` and the properties
+        interface are also fresh).
+        """
+        manager = self._get_manager()
+        bus = self._get_bus()
+        unit_path = manager.GetUnit(service)
+        unit_proxy = bus.get_object("org.freedesktop.systemd1", object_path=unit_path)
+        properties = dbus.Interface(unit_proxy, "org.freedesktop.DBus.Properties")
+        return str(properties.Get("org.freedesktop.systemd1.Unit", "ActiveState"))
 
     def get_service_active_state(self, service: str) -> str:
         """Return the ActiveState string for a systemd service.
@@ -233,41 +246,16 @@ class SystemDManager:
         rather than treating it as terminal.
         """
         try:
-            manager = self._get_manager()
-            bus = self._get_bus()
-            unit_path = manager.GetUnit(service)
-            unit_proxy = bus.get_object(
-                "org.freedesktop.systemd1",
-                object_path=unit_path,
-            )
-            properties = dbus.Interface(
-                unit_proxy,
-                "org.freedesktop.DBus.Properties",
-            )
-            return str(
-                properties.Get(
-                    "org.freedesktop.systemd1.Unit",
-                    "ActiveState",
-                )
-            )
+            return self._call_with_reconnect(lambda: self._read_active_state(service))
         except DBusException as error:
             _log_dbus_lookup_error(service, error)
             return "unknown"
 
     def is_service_active(self, service: str) -> bool:
+        if not self.is_service_enabled(service):
+            return False
         try:
-            if not self.is_service_enabled(service):
-                return False
-
-            manager = self._get_manager()
-            bus = self._get_bus()
-
-            unit_path = manager.GetUnit(service)
-            systemd_service = bus.get_object("org.freedesktop.systemd1", object_path=unit_path)
-            unit = dbus.Interface(systemd_service, "org.freedesktop.systemd1.Unit")
-            unit_properties = dbus.Interface(unit, "org.freedesktop.DBus.Properties")
-            active_state = unit_properties.Get("org.freedesktop.systemd1.Unit", "ActiveState")
-            return active_state == "active"
+            return self._call_with_reconnect(lambda: self._read_active_state(service)) == "active"
         except DBusException as error:
             _log_dbus_lookup_error(service, error)
             return False
@@ -288,8 +276,7 @@ class SystemDManager:
             return {}
 
         try:
-            manager = self._get_manager()
-            units = manager.ListUnits()
+            units = self._call_with_reconnect(lambda: self._get_manager().ListUnits())
 
             # Build lookup from ListUnits() result
             # ListUnits returns: (name, description, load_state, active_state, sub_state,

--- a/src/aleph/vm/systemd.py
+++ b/src/aleph/vm/systemd.py
@@ -59,13 +59,22 @@ class SystemDManager:
     def _connect(self, max_retries: int = 3) -> None:
         """Establish connection to D-Bus with a retry mechanism.
 
-        Uses ``follow_name_owner_changes=True`` so the proxy tracks the
-        well-known ``org.freedesktop.systemd1`` name across owner
-        changes. Without it, dbus-python latches onto systemd's unique
-        name (e.g. ``:1.3``) at proxy creation time, and any subsequent
-        ``systemctl daemon-reexec`` or systemd package upgrade would
-        cause every method call to fail with
-        ``org.freedesktop.DBus.Error.ServiceUnknown``.
+        Each call resolves ``org.freedesktop.systemd1`` to systemd's
+        current unique bus name at proxy creation time. A subsequent
+        ``systemctl daemon-reexec`` or systemd package upgrade rotates
+        that unique name, and the cached proxy then fails with
+        ``org.freedesktop.DBus.Error.ServiceUnknown``. That failure is
+        caught by ``_call_with_reconnect`` on every state-changing
+        method, which calls ``_connect()`` again to rebuild the proxy
+        against the new owner and retries the call.
+
+        (The alternative — ``follow_name_owner_changes=True`` — would
+        keep the proxy bound to the well-known name and avoid the
+        first-call failure after a restart, but it internally subscribes
+        to ``NameOwnerChanged`` signals, which requires a D-Bus main
+        loop. Aleph-vm's asyncio supervisor has no such main loop, and
+        constructing the proxy without one raises RuntimeError at
+        import time in every context that instantiates SystemDManager.)
         """
         for attempt in range(max_retries):
             if self._bus:
@@ -75,7 +84,6 @@ class SystemDManager:
                 systemd = self._bus.get_object(
                     "org.freedesktop.systemd1",
                     "/org/freedesktop/systemd1",
-                    follow_name_owner_changes=True,
                 )
                 self._manager = dbus.Interface(systemd, "org.freedesktop.systemd1.Manager")
                 return

--- a/src/aleph/vm/systemd.py
+++ b/src/aleph/vm/systemd.py
@@ -90,8 +90,17 @@ class SystemDManager:
         ``follow_name_owner_changes=True`` on the proxy makes routine
         systemd restarts transparent, but a call issued while systemd
         is *mid*-restart can still hit an error before the new owner
-        registers. Catch that narrow class of errors and retry against
-        the freshly-resolved manager.
+        registers. On the errors in ``_STALE_CONNECTION_ERRORS``, tear
+        down and rebuild the bus, then retry the same D-Bus method
+        against the freshly-built ``_manager``.
+
+        The retry MUST be issued through the new manager: ``fn`` here is
+        a ``dbus.proxies._ProxyMethod`` bound to a specific ``_connection``
+        that ``_connect()`` just closed via ``self._bus.close()``. Calling
+        the original ``fn`` again would go through the dead connection.
+        We rebind by looking up the same method name on the new manager
+        via ``_method_name`` (the documented ``_ProxyMethod`` attribute)
+        and ``Interface.get_dbus_method``.
         """
         try:
             return fn(*args, **kwargs)
@@ -102,14 +111,14 @@ class SystemDManager:
                 "Stale systemd D-Bus proxy (%s), reconnecting and retrying",
                 error.get_dbus_name(),
             )
+            method_name = getattr(fn, "_method_name", None)
             self._connect()
-            # Re-resolve fn against the fresh manager. Callers pass a
-            # bound method on the previous ``_manager``; rebinding to
-            # the same attribute on the new one is what makes the retry
-            # actually target the reconnected proxy.
-            if getattr(fn, "__self__", None) is not None and self._manager is not None:
-                fn = getattr(self._manager, fn.__name__)
-            return fn(*args, **kwargs)
+            if method_name is None or self._manager is None:
+                # No safe way to rebind; retrying fn would call through
+                # the connection we just closed. Better to surface the
+                # original failure than to fail obscurely.
+                raise
+            return self._manager.get_dbus_method(method_name)(*args, **kwargs)
 
     def _ensure_connection(self) -> None:
         """Ensure D-Bus connection is active, reconnect if necessary.

--- a/src/aleph/vm/systemd.py
+++ b/src/aleph/vm/systemd.py
@@ -19,6 +19,18 @@ class SystemDManagerError(Exception):
 
 _NO_SUCH_UNIT = "org.freedesktop.systemd1.NoSuchUnit"
 
+# DBus errors that mean "your cached proxy points at a dead unique
+# name" (typically after systemctl daemon-reexec or a systemd package
+# upgrade rotates its unique bus name). Reconnecting and retrying the
+# call resolves the well-known name to the current owner.
+_STALE_CONNECTION_ERRORS = frozenset(
+    {
+        "org.freedesktop.DBus.Error.ServiceUnknown",
+        "org.freedesktop.DBus.Error.NoReply",
+        "org.freedesktop.DBus.Error.Disconnected",
+    }
+)
+
 
 def _log_dbus_lookup_error(service: str, error: DBusException) -> None:
     """Log a unit lookup error at the right severity.
@@ -45,19 +57,59 @@ class SystemDManager:
         self._connect()
 
     def _connect(self, max_retries: int = 3) -> None:
-        """Establish connection to D-Bus with a retry mechanism."""
+        """Establish connection to D-Bus with a retry mechanism.
+
+        Uses ``follow_name_owner_changes=True`` so the proxy tracks the
+        well-known ``org.freedesktop.systemd1`` name across owner
+        changes. Without it, dbus-python latches onto systemd's unique
+        name (e.g. ``:1.3``) at proxy creation time, and any subsequent
+        ``systemctl daemon-reexec`` or systemd package upgrade would
+        cause every method call to fail with
+        ``org.freedesktop.DBus.Error.ServiceUnknown``.
+        """
         for attempt in range(max_retries):
             if self._bus:
                 self._bus.close()
             try:
                 self._bus = dbus.SystemBus()
-                systemd = self._bus.get_object("org.freedesktop.systemd1", "/org/freedesktop/systemd1")
+                systemd = self._bus.get_object(
+                    "org.freedesktop.systemd1",
+                    "/org/freedesktop/systemd1",
+                    follow_name_owner_changes=True,
+                )
                 self._manager = dbus.Interface(systemd, "org.freedesktop.systemd1.Manager")
                 return
             except DBusException as e:
                 logger.warning(f"D-Bus connection attempt {attempt + 1} failed: {e}")
         msg = "Failed to establish D-Bus connection after multiple attempts"
         raise DBusException(msg)
+
+    def _call_with_reconnect(self, fn, *args, **kwargs):
+        """Run a manager call; on stale-connection errors, reconnect and retry once.
+
+        ``follow_name_owner_changes=True`` on the proxy makes routine
+        systemd restarts transparent, but a call issued while systemd
+        is *mid*-restart can still hit an error before the new owner
+        registers. Catch that narrow class of errors and retry against
+        the freshly-resolved manager.
+        """
+        try:
+            return fn(*args, **kwargs)
+        except DBusException as error:
+            if error.get_dbus_name() not in _STALE_CONNECTION_ERRORS:
+                raise
+            logger.info(
+                "Stale systemd D-Bus proxy (%s), reconnecting and retrying",
+                error.get_dbus_name(),
+            )
+            self._connect()
+            # Re-resolve fn against the fresh manager. Callers pass a
+            # bound method on the previous ``_manager``; rebinding to
+            # the same attribute on the new one is what makes the retry
+            # actually target the reconnected proxy.
+            if getattr(fn, "__self__", None) is not None and self._manager is not None:
+                fn = getattr(self._manager, fn.__name__)
+            return fn(*args, **kwargs)
 
     def _ensure_connection(self) -> None:
         """Ensure D-Bus connection is active, reconnect if necessary.
@@ -122,27 +174,27 @@ class SystemDManager:
 
     def enable(self, service: str) -> None:
         manager = self._get_manager()
-        manager.EnableUnitFiles([service], False, True)  # noqa: FBT003
+        self._call_with_reconnect(manager.EnableUnitFiles, [service], False, True)  # noqa: FBT003
         logger.debug(f"Enabled {service} service")
 
     def start(self, service: str) -> None:
         manager = self._get_manager()
-        manager.StartUnit(service, "replace")
+        self._call_with_reconnect(manager.StartUnit, service, "replace")
         logger.debug(f"Started {service} service")
 
     def stop(self, service: str) -> None:
         manager = self._get_manager()
-        manager.StopUnit(service, "replace")
+        self._call_with_reconnect(manager.StopUnit, service, "replace")
         logger.debug(f"Stopped {service} service")
 
     def restart(self, service: str) -> None:
         manager = self._get_manager()
-        manager.RestartUnit(service, "replace")
+        self._call_with_reconnect(manager.RestartUnit, service, "replace")
         logger.debug(f"Restarted {service} service")
 
     def disable(self, service: str) -> None:
         manager = self._get_manager()
-        manager.DisableUnitFiles([service], False)  # noqa: FBT003
+        self._call_with_reconnect(manager.DisableUnitFiles, [service], False)  # noqa: FBT003
         logger.debug(f"Disabled {service} service")
 
     def is_service_enabled(self, service: str) -> bool:

--- a/tests/supervisor/test_systemd.py
+++ b/tests/supervisor/test_systemd.py
@@ -1,0 +1,154 @@
+"""Unit tests for aleph.vm.systemd.SystemDManager.
+
+Focus on the stale-proxy retry path: when a call raises one of
+``_STALE_CONNECTION_ERRORS`` (e.g. after ``systemctl daemon-reexec``
+rotates systemd's unique bus name), the manager must reconnect and
+retry the same D-Bus method against the NEW manager, not re-invoke the
+stale ``_ProxyMethod`` against a closed connection.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from dbus.exceptions import DBusException
+
+from aleph.vm.systemd import SystemDManager
+
+
+def _make_dbus_error(name: str, msg: str = "boom") -> DBusException:
+    """Build a DBusException whose ``get_dbus_name()`` returns ``name``.
+
+    Mirrors what dbus-python raises when the daemon replies with an
+    error name, without touching a real bus.
+    """
+    err = DBusException(msg, name=name)
+    return err
+
+
+@pytest.fixture
+def fake_manager(monkeypatch):
+    """Instantiate a SystemDManager backed by a MagicMock manager.
+
+    Yields ``(manager_instance, initial_dbus_manager, install_new_manager_fn)``.
+    Calling ``install_new_manager_fn(new_mgr)`` patches ``_connect`` so the
+    NEXT reconnect installs ``new_mgr`` (simulating systemd daemon-reexec).
+    """
+    initial = MagicMock(name="initial_manager")
+
+    def install(mgr):
+        def fake_connect(self, max_retries: int = 3) -> None:
+            self._bus = MagicMock()
+            self._bus.get_is_connected.return_value = True
+            self._manager = mgr
+
+        monkeypatch.setattr(SystemDManager, "_connect", fake_connect)
+
+    install(initial)
+    sm = SystemDManager()
+    return sm, initial, install
+
+
+def test_happy_path_no_reconnect(fake_manager):
+    sm, initial, _ = fake_manager
+    method = MagicMock(return_value="ok")
+    method._method_name = "StartUnit"
+
+    assert sm._call_with_reconnect(method, "svc", "replace") == "ok"
+
+    method.assert_called_once_with("svc", "replace")
+    # No rebind against the manager happened
+    initial.get_dbus_method.assert_not_called()
+
+
+def test_non_stale_error_reraises_without_reconnect(fake_manager):
+    sm, initial, _ = fake_manager
+    real_error = _make_dbus_error("org.freedesktop.systemd1.NoSuchUnit")
+    method = MagicMock(side_effect=real_error)
+    method._method_name = "GetUnit"
+
+    with pytest.raises(DBusException) as excinfo:
+        sm._call_with_reconnect(method, "svc")
+
+    assert excinfo.value is real_error
+    initial.get_dbus_method.assert_not_called()
+    # Manager was not swapped
+    assert sm._manager is initial
+
+
+def test_stale_error_reconnects_and_retries_via_new_manager(fake_manager):
+    """The core regression test.
+
+    Simulates systemd daemon-reexec:
+      1. First call on the stale _ProxyMethod raises ServiceUnknown.
+      2. _connect() runs and installs a fresh manager.
+      3. Retry MUST go through new_manager.get_dbus_method(...), not
+         through the stale method whose _connection was just closed.
+    """
+    sm, initial, install = fake_manager
+
+    new_mgr = MagicMock(name="new_manager")
+    fresh_method = MagicMock(return_value="ok-from-new")
+    new_mgr.get_dbus_method.return_value = fresh_method
+    install(new_mgr)
+
+    stale_method = MagicMock(side_effect=_make_dbus_error("org.freedesktop.DBus.Error.ServiceUnknown"))
+    stale_method._method_name = "EnableUnitFiles"
+
+    result = sm._call_with_reconnect(stale_method, ["svc"], False, True)
+
+    assert result == "ok-from-new"
+    # Reconnect swapped the manager
+    assert sm._manager is new_mgr
+    # Method was looked up on the NEW manager by name
+    new_mgr.get_dbus_method.assert_called_once_with("EnableUnitFiles")
+    fresh_method.assert_called_once_with(["svc"], False, True)
+    # Stale method was NOT retried (that would go through the closed connection)
+    assert stale_method.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "error_name",
+    [
+        "org.freedesktop.DBus.Error.ServiceUnknown",
+        "org.freedesktop.DBus.Error.NoReply",
+        "org.freedesktop.DBus.Error.Disconnected",
+    ],
+)
+def test_all_stale_error_names_trigger_retry(fake_manager, error_name):
+    sm, _initial, install = fake_manager
+    new_mgr = MagicMock()
+    new_mgr.get_dbus_method.return_value = MagicMock(return_value="ok")
+    install(new_mgr)
+
+    stale = MagicMock(side_effect=_make_dbus_error(error_name))
+    stale._method_name = "StartUnit"
+
+    assert sm._call_with_reconnect(stale, "svc", "replace") == "ok"
+    new_mgr.get_dbus_method.assert_called_once_with("StartUnit")
+
+
+def test_reraises_when_method_name_missing(fake_manager):
+    """A callable without ``_method_name`` can't be safely rebound.
+
+    Retrying it directly would call through the connection ``_connect()``
+    just closed. Better to surface the original failure than to fail
+    obscurely.
+    """
+    sm, _initial, install = fake_manager
+    new_mgr = MagicMock()
+    install(new_mgr)
+
+    original_error = _make_dbus_error("org.freedesktop.DBus.Error.Disconnected")
+    plain_callable = MagicMock(side_effect=original_error)
+    # No _method_name attribute
+    del plain_callable._method_name
+
+    with pytest.raises(DBusException) as excinfo:
+        sm._call_with_reconnect(plain_callable, "arg")
+
+    assert excinfo.value is original_error
+    # Reconnect DID run (we discover the un-rebindable fn only after)
+    assert sm._manager is new_mgr
+    # But we didn't retry against the stale callable
+    assert plain_callable.call_count == 1
+    new_mgr.get_dbus_method.assert_not_called()

--- a/tests/supervisor/test_systemd.py
+++ b/tests/supervisor/test_systemd.py
@@ -1,10 +1,10 @@
 """Unit tests for aleph.vm.systemd.SystemDManager.
 
-Focus on the stale-proxy retry path: when a call raises one of
+Focus on the stale-proxy retry path: when a D-Bus call raises one of
 ``_STALE_CONNECTION_ERRORS`` (e.g. after ``systemctl daemon-reexec``
-rotates systemd's unique bus name), the manager must reconnect and
-retry the same D-Bus method against the NEW manager, not re-invoke the
-stale ``_ProxyMethod`` against a closed connection.
+rotates systemd's unique bus name), ``_call_with_reconnect`` must
+reconnect and re-run the callable so the second attempt routes through
+the freshly-built manager, not the closed connection.
 """
 
 from unittest.mock import MagicMock
@@ -21,15 +21,14 @@ def _make_dbus_error(name: str, msg: str = "boom") -> DBusException:
     Mirrors what dbus-python raises when the daemon replies with an
     error name, without touching a real bus.
     """
-    err = DBusException(msg, name=name)
-    return err
+    return DBusException(msg, name=name)
 
 
 @pytest.fixture
 def fake_manager(monkeypatch):
-    """Instantiate a SystemDManager backed by a MagicMock manager.
+    """Instantiate a SystemDManager backed by MagicMock buses/managers.
 
-    Yields ``(manager_instance, initial_dbus_manager, install_new_manager_fn)``.
+    Returns ``(manager_instance, initial_dbus_manager, install_new_manager_fn)``.
     Calling ``install_new_manager_fn(new_mgr)`` patches ``_connect`` so the
     NEXT reconnect installs ``new_mgr`` (simulating systemd daemon-reexec).
     """
@@ -50,60 +49,63 @@ def fake_manager(monkeypatch):
 
 def test_happy_path_no_reconnect(fake_manager):
     sm, initial, _ = fake_manager
-    method = MagicMock(return_value="ok")
-    method._method_name = "StartUnit"
+    work = MagicMock(return_value="ok")
 
-    assert sm._call_with_reconnect(method, "svc", "replace") == "ok"
+    assert sm._call_with_reconnect(work) == "ok"
 
-    method.assert_called_once_with("svc", "replace")
-    # No rebind against the manager happened
-    initial.get_dbus_method.assert_not_called()
+    work.assert_called_once_with()
+    # No reconnect happened: manager unchanged.
+    assert sm._manager is initial
 
 
 def test_non_stale_error_reraises_without_reconnect(fake_manager):
     sm, initial, _ = fake_manager
     real_error = _make_dbus_error("org.freedesktop.systemd1.NoSuchUnit")
-    method = MagicMock(side_effect=real_error)
-    method._method_name = "GetUnit"
+    work = MagicMock(side_effect=real_error)
 
     with pytest.raises(DBusException) as excinfo:
-        sm._call_with_reconnect(method, "svc")
+        sm._call_with_reconnect(work)
 
     assert excinfo.value is real_error
-    initial.get_dbus_method.assert_not_called()
-    # Manager was not swapped
+    work.assert_called_once_with()
     assert sm._manager is initial
 
 
-def test_stale_error_reconnects_and_retries_via_new_manager(fake_manager):
+def test_stale_error_reconnects_and_work_sees_new_manager(fake_manager):
     """The core regression test.
 
     Simulates systemd daemon-reexec:
-      1. First call on the stale _ProxyMethod raises ServiceUnknown.
+      1. work() reads self._manager and calls it. First call raises
+         ServiceUnknown from the stale manager.
       2. _connect() runs and installs a fresh manager.
-      3. Retry MUST go through new_manager.get_dbus_method(...), not
-         through the stale method whose _connection was just closed.
+      3. work() is re-invoked. It reads self._manager again — this time
+         it sees the NEW manager, and the second call succeeds.
+
+    The test asserts work observed the manager swap, which is exactly
+    what the retry mechanism must guarantee.
     """
     sm, initial, install = fake_manager
 
+    stale_error = _make_dbus_error("org.freedesktop.DBus.Error.ServiceUnknown")
+    initial.SomeCall.side_effect = stale_error
+
     new_mgr = MagicMock(name="new_manager")
-    fresh_method = MagicMock(return_value="ok-from-new")
-    new_mgr.get_dbus_method.return_value = fresh_method
+    new_mgr.SomeCall.return_value = "ok-from-new"
     install(new_mgr)
 
-    stale_method = MagicMock(side_effect=_make_dbus_error("org.freedesktop.DBus.Error.ServiceUnknown"))
-    stale_method._method_name = "EnableUnitFiles"
+    managers_seen = []
 
-    result = sm._call_with_reconnect(stale_method, ["svc"], False, True)
+    def work():
+        mgr = sm._manager
+        managers_seen.append(mgr)
+        return mgr.SomeCall("arg")
+
+    result = sm._call_with_reconnect(work)
 
     assert result == "ok-from-new"
-    # Reconnect swapped the manager
-    assert sm._manager is new_mgr
-    # Method was looked up on the NEW manager by name
-    new_mgr.get_dbus_method.assert_called_once_with("EnableUnitFiles")
-    fresh_method.assert_called_once_with(["svc"], False, True)
-    # Stale method was NOT retried (that would go through the closed connection)
-    assert stale_method.call_count == 1
+    assert managers_seen == [initial, new_mgr]
+    initial.SomeCall.assert_called_once_with("arg")
+    new_mgr.SomeCall.assert_called_once_with("arg")
 
 
 @pytest.mark.parametrize(
@@ -116,39 +118,45 @@ def test_stale_error_reconnects_and_retries_via_new_manager(fake_manager):
 )
 def test_all_stale_error_names_trigger_retry(fake_manager, error_name):
     sm, _initial, install = fake_manager
+
     new_mgr = MagicMock()
-    new_mgr.get_dbus_method.return_value = MagicMock(return_value="ok")
+    new_mgr.SomeCall.return_value = "ok"
     install(new_mgr)
 
-    stale = MagicMock(side_effect=_make_dbus_error(error_name))
-    stale._method_name = "StartUnit"
+    calls = [0]
 
-    assert sm._call_with_reconnect(stale, "svc", "replace") == "ok"
-    new_mgr.get_dbus_method.assert_called_once_with("StartUnit")
+    def work():
+        calls[0] += 1
+        if calls[0] == 1:
+            raise _make_dbus_error(error_name)
+        return sm._manager.SomeCall()
+
+    assert sm._call_with_reconnect(work) == "ok"
+    assert calls[0] == 2
+    new_mgr.SomeCall.assert_called_once_with()
 
 
-def test_reraises_when_method_name_missing(fake_manager):
-    """A callable without ``_method_name`` can't be safely rebound.
+def test_retry_failure_propagates(fake_manager):
+    """If the retry itself fails with the same stale error, don't loop.
 
-    Retrying it directly would call through the connection ``_connect()``
-    just closed. Better to surface the original failure than to fail
-    obscurely.
+    The whole point of a single retry is to avoid infinite loops when
+    something is fundamentally broken (bus daemon down, systemd not
+    coming back). The second failure should propagate to the caller.
     """
     sm, _initial, install = fake_manager
-    new_mgr = MagicMock()
-    install(new_mgr)
 
-    original_error = _make_dbus_error("org.freedesktop.DBus.Error.Disconnected")
-    plain_callable = MagicMock(side_effect=original_error)
-    # No _method_name attribute
-    del plain_callable._method_name
+    def broken_connect(self, max_retries: int = 3) -> None:
+        self._bus = MagicMock()
+        self._manager = MagicMock()
+
+    # Both first call and post-reconnect retry raise the same stale error.
+    stale = _make_dbus_error("org.freedesktop.DBus.Error.Disconnected")
+    work = MagicMock(side_effect=stale)
+    install(MagicMock())  # so reconnect doesn't blow up
 
     with pytest.raises(DBusException) as excinfo:
-        sm._call_with_reconnect(plain_callable, "arg")
+        sm._call_with_reconnect(work)
 
-    assert excinfo.value is original_error
-    # Reconnect DID run (we discover the un-rebindable fn only after)
-    assert sm._manager is new_mgr
-    # But we didn't retry against the stale callable
-    assert plain_callable.call_count == 1
-    new_mgr.get_dbus_method.assert_not_called()
+    assert excinfo.value is stale
+    # First call + one retry = two attempts, no more.
+    assert work.call_count == 2


### PR DESCRIPTION
## Summary

Fixes the ``org.freedesktop.DBus.Error.ServiceUnknown: The name :1.N was not provided by any .service files`` 500 that appears on ``notify_allocation`` after ``systemctl daemon-reexec`` (or a systemd package upgrade) rotates systemd's unique bus name. Observed on aleph-server-5:

```
POST /control/allocation/notify
500 {\"error\": \"org.freedesktop.DBus.Error.ServiceUnknown: The name :1.3 was not provided by any .service files\"}
```

The cached ``SystemDManager`` proxy was bound to systemd's old unique name; every call after the rotation went to a dead peer until the supervisor was manually restarted.

## Fix

Add ``_call_with_reconnect(work)``: on ``ServiceUnknown`` / ``NoReply`` / ``Disconnected``, call ``_connect()`` (fresh bus and manager) and re-run the callable so the retry routes through the new manager. Wrap every D-Bus-touching method — writes (enable, start, stop, restart, disable) and reads (is_service_enabled, get_service_active_state, is_service_active, get_services_active_states) — with lambdas that read ``self._get_manager()`` at call time.

Not using ``follow_name_owner_changes=True``: it internally subscribes the proxy to ``NameOwnerChanged`` signals, which requires a D-Bus main loop the asyncio supervisor does not have (RuntimeError at ``SystemDManager.__init__`` in every test and at supervisor startup). Retry-on-stale-error achieves the same self-healing at the cost of one extra round-trip on the first call after a rotation.

## Test plan
- [x] Unit tests cover happy path, non-stale reraise, all three stale error names triggering retry, work observes manager swap between attempts, retry-that-also-fails does not loop.
- [ ] Deploy to a staging CRN, verify a normal instance start works.
- [ ] Run ``sudo systemctl daemon-reexec`` on the CRN and confirm the next ``aleph instance start …`` succeeds without restarting the supervisor.
- [ ] Verify ``is_service_active`` also self-heals after the same reexec (payment monitor / status endpoints).