### PR TITLE
perf(systemd): run enable_and_start off the event loop

### DIFF
--- a/src/aleph/vm/systemd.py
+++ b/src/aleph/vm/systemd.py
@@ -2,7 +2,9 @@
 async SystemD Manager implementation.
 """
 
+import asyncio
 import logging
+import threading
 
 import dbus
 from dbus import DBusException, SystemBus
@@ -60,6 +62,10 @@ class SystemDManager:
     def __init__(self):
         self._bus: SystemBus | None = None
         self._manager: Interface | None = None
+        # Guards _connect(): concurrent callers (event loop + payment
+        # monitor worker + enable_and_start worker) must not race on
+        # close+reopen of self._bus.
+        self._connect_lock = threading.Lock()
         self._connect()
 
     def _connect(self, max_retries: int = 3) -> None:
@@ -82,21 +88,30 @@ class SystemDManager:
         constructing the proxy without one raises RuntimeError at
         import time in every context that instantiates SystemDManager.)
         """
-        for attempt in range(max_retries):
-            if self._bus:
-                self._bus.close()
-            try:
-                self._bus = dbus.SystemBus()
-                systemd = self._bus.get_object(
-                    "org.freedesktop.systemd1",
-                    "/org/freedesktop/systemd1",
-                )
-                self._manager = dbus.Interface(systemd, "org.freedesktop.systemd1.Manager")
-                return
-            except DBusException as e:
-                logger.warning(f"D-Bus connection attempt {attempt + 1} failed: {e}")
-        msg = "Failed to establish D-Bus connection after multiple attempts"
-        raise DBusException(msg)
+        # Lock serializes concurrent reconnects across threads (event
+        # loop + payment monitor worker + enable_and_start worker).
+        # Two threads hitting the same stale error at the same moment
+        # will each reconnect once inside the lock; the redundant work
+        # is bounded and doesn't corrupt state. We do NOT fast-path on
+        # get_is_connected(): callers reach _connect() precisely when
+        # they know the proxy is stale, and get_is_connected() is a
+        # local flag that stays True across bus-name rotations.
+        with self._connect_lock:
+            for attempt in range(max_retries):
+                if self._bus:
+                    self._bus.close()
+                try:
+                    self._bus = dbus.SystemBus()
+                    systemd = self._bus.get_object(
+                        "org.freedesktop.systemd1",
+                        "/org/freedesktop/systemd1",
+                    )
+                    self._manager = dbus.Interface(systemd, "org.freedesktop.systemd1.Manager")
+                    return
+                except DBusException as e:
+                    logger.warning(f"D-Bus connection attempt {attempt + 1} failed: {e}")
+            msg = "Failed to establish D-Bus connection after multiple attempts"
+            raise DBusException(msg)
 
     def _call_with_reconnect(self, work):
         """Run ``work()``; on stale-connection errors, reconnect and re-run once.
@@ -326,8 +341,22 @@ class SystemDManager:
             return {service: False for service in services}
         return result
 
-    async def enable_and_start(self, service: str) -> None:
+    def _enable_and_start_sync(self, service: str) -> None:
+        """Sync body of enable_and_start; runs in a worker thread."""
         if not self.is_service_enabled(service):
             self.enable(service)
         if not self.is_service_active(service):
             self.start(service)
+
+    async def enable_and_start(self, service: str) -> None:
+        """Enable and start a systemd unit without blocking the event loop.
+
+        Each of the four underlying D-Bus round-trips is synchronous and
+        would block the asyncio event loop if run inline (visible as
+        multi-second TTFB spikes when many VMs start together). Push the
+        whole sequence to a worker thread. Thread safety of the shared
+        SystemDManager is provided by ``_connect_lock`` around the only
+        state-mutating operation (reconnect); individual D-Bus calls go
+        through dbus-python's own connection-level locking.
+        """
+        await asyncio.to_thread(self._enable_and_start_sync, service)

--- a/tests/supervisor/test_systemd.py
+++ b/tests/supervisor/test_systemd.py
@@ -160,3 +160,42 @@ def test_retry_failure_propagates(fake_manager):
     assert excinfo.value is stale
     # First call + one retry = two attempts, no more.
     assert work.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_enable_and_start_runs_off_event_loop(fake_manager, monkeypatch):
+    """enable_and_start must not block the event loop.
+
+    Records the thread on which the sync body runs and asserts it is
+    NOT the main thread (asyncio.to_thread hands work to the default
+    executor). Prevents accidental regression to inline sync D-Bus.
+    """
+    import threading
+
+    sm, _initial, _install = fake_manager
+
+    main_thread = threading.get_ident()
+    thread_seen = {}
+
+    def fake_sync(service):
+        thread_seen["ident"] = threading.get_ident()
+
+    monkeypatch.setattr(sm, "_enable_and_start_sync", fake_sync)
+
+    await sm.enable_and_start("aleph-vm-controller@svc.service")
+
+    assert thread_seen["ident"] != main_thread
+
+
+@pytest.mark.asyncio
+async def test_enable_and_start_propagates_errors(fake_manager, monkeypatch):
+    """Exceptions raised by the sync body must surface to the async caller."""
+    sm, _initial, _install = fake_manager
+
+    def raising(_):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(sm, "_enable_and_start_sync", raising)
+
+    with pytest.raises(RuntimeError, match="kaboom"):
+        await sm.enable_and_start("aleph-vm-controller@svc.service")


### PR DESCRIPTION
## Summary

`SystemDManager.enable_and_start` is declared `async` but its body is entirely **synchronous D-Bus round-trips** — `is_service_enabled` → `enable` → `is_service_active` → `start`. Every VM start blocked the asyncio event loop for ~4 round-trips inline; on a busy CRN this stacks and shows up as multi-second TTFB on unrelated HTTP requests during allocation bursts. Same shape as the `monitor_payments` sweep fix in #963.

## Changes

- Extract `_enable_and_start_sync` with the existing sync body.
- Make `enable_and_start` `await asyncio.to_thread(_enable_and_start_sync)`. Callers already `await`, so no API break.
- Add `threading.Lock` around `_connect()` so the payment monitor worker (already off-thread via #963) and the `enable_and_start` worker cannot race on close+reopen of the shared `SystemBus`. Individual D-Bus calls go through dbus-python's own per-connection locking; only the reconnect path needs external serialization.
- Fast-path check in `_connect` intentionally omitted: callers reach `_connect()` precisely when they know the proxy is stale, and `get_is_connected()` is a local flag that stays True across bus-name rotations. The bounded redundant work (two threads both reconnecting once) is preferable to silently retrying against a stale proxy.

## Test plan
- [x] `test_enable_and_start_runs_off_event_loop` asserts the sync body runs on a non-main thread.
- [x] `test_enable_and_start_propagates_errors` asserts exceptions surface to the async caller.
- [ ] Deploy to staging; verify TTFB stability during a batch of `notify_allocation` calls.

## Depends on
#1053 — this branch is based on `aliel-fix-systemd-stale-proxy` and inherits its wrapped read/write methods. Rebase onto `main` after #1053 merges.