### PR TITLE
ci: drop Debian 12 from droplet integration tests

### DIFF
--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -44,6 +44,13 @@ jobs:
       - name: Initialize git submodules
         run: git submodule init
 
+      # Runner image 20260726.254 ships podman 5.8.4 but leaves a stale crun 1.14.1
+      # at /usr/bin/crun, breaking every podman run/build with "unknown version
+      # specified". Point podman at the current crun in /usr/local/bin.
+      # See https://github.com/actions/runner-images/issues/14473
+      - name: Work around actions/runner-images#14473 (podman uses stale crun)
+        run: (echo '[engine.runtimes]'; echo 'crun = [ "/usr/local/bin/crun" ]') | sudo tee /etc/containers/containers.conf
+
       - run: |
           cd packaging && make ${{ matrix.make_target }} && cd ..
           ls packaging/target

--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -49,7 +49,8 @@ jobs:
       # specified". Point podman at the current crun in /usr/local/bin.
       # See https://github.com/actions/runner-images/issues/14473
       - name: Work around actions/runner-images#14473 (podman uses stale crun)
-        run: (echo '[engine.runtimes]'; echo 'crun = [ "/usr/local/bin/crun" ]') | sudo tee /etc/containers/containers.conf
+        run: (echo '[engine.runtimes]'; echo 'crun = [ "/usr/local/bin/crun" ]') |
+          sudo tee /etc/containers/containers.conf
 
       - run: |
           cd packaging && make ${{ matrix.make_target }} && cd ..

--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -123,14 +123,9 @@ jobs:
       matrix:
 
         # Check compatibility with all supported OSes.
+        # Debian 12 is not tested anymore: DigitalOcean removed the debian-12-x64
+        # image when Debian 12 reached its end of standard support (June 2026).
         os_config:
-          - os_name: "Debian 12"
-            os_image: "debian-12-x64"
-            alias: "debian-12"
-            package_build_command: "all-podman-debian-12"
-            package_name: "aleph-vm.debian-12.deb"
-            concurrency_group: "droplet-aleph-vm-debian-12"
-
           - os_name: "Debian 13"
             os_image: "debian-13-x64"
             alias: "debian-13"
@@ -269,8 +264,8 @@ jobs:
             doctl compute droplet delete --force $DROPLET_ID
           done
 
-  run_new_runtime_debian_12:
-    name: "Test new runtime on Droplet with Debian 12"
+  run_new_runtime_debian_13:
+    name: "Test new runtime on Droplet with Debian 13"
     # Test by building a version of the runtimes and diagnostic program from the source.
     # (other tests use the version deployed in the aleph cloud)
 
@@ -306,7 +301,7 @@ jobs:
       - name: Create the Droplet
         run: |
           doctl compute droplet create \
-          --image debian-12-x64 \
+          --image debian-13-x64 \
           --size s-2vcpu-4gb-amd \
           --region ams3 \
           --vpc-uuid 5976b7bd-4417-49e8-8522-672aaa920c30 \
@@ -324,12 +319,12 @@ jobs:
       - uses: actions/download-artifact@v4
         name: "Download the debian package from artifacts."
         with:
-          name: "aleph-vm.debian-12.deb"
+          name: "aleph-vm.debian-13.deb"
           path: packaging/target/
 
       #      - name: Build Debian Package
       #        run: |
-      #          cd packaging && make all-podman-debian-12 && cd ..
+      #          cd packaging && make all-podman-debian-13 && cd ..
       #          ls packaging/target
 
       - name: Get droplet ip and export it in env
@@ -356,7 +351,7 @@ jobs:
           echo ALEPH_VM_FAKE_DATA_RUNTIME=/opt/rootfs.squashfs >> supervisor.env
           ssh  root@${DROPLET_IPV4} mkdir -p /etc/aleph-vm/
           scp supervisor.env root@${DROPLET_IPV4}:/etc/aleph-vm/supervisor.env
-          scp packaging/target/aleph-vm.debian-12.deb root@${DROPLET_IPV4}:/opt
+          scp packaging/target/aleph-vm.debian-13.deb root@${DROPLET_IPV4}:/opt
 
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 update"
           ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o Dpkg::Progress-Fancy=0 -o DPkg::Lock::Timeout=-1 upgrade -y"
@@ -365,7 +360,7 @@ jobs:
 
           # Copy our example VM on the server
           scp -pr ./examples root@${DROPLET_IPV4}:/opt/
-          ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o DPkg::Lock::Timeout=-1  -o Dpkg::Options::="--force-confold" install -y /opt/aleph-vm.debian-12.deb"
+          ssh root@${DROPLET_IPV4} DEBIAN_FRONTEND=noninteractive "apt-get -o DPkg::Lock::Timeout=-1  -o Dpkg::Options::="--force-confold" install -y /opt/aleph-vm.debian-13.deb"
 
       - name: Call the runtime and example program on the Droplet
         run: |


### PR DESCRIPTION
DigitalOcean removed the `debian-12-x64` image when Debian 12 reached its end of standard support (June 2026), per their [image deprecation policy](https://docs.digitalocean.com/products/droplets/details/image-deprecation/). Every job creating a Debian 12 droplet now fails with:

```
Error: POST https://api.digitalocean.com/v2/droplets: 422 You specified an invalid image for Droplet creation.
```

Changes:
- Remove the Debian 12 entry from the `run_on_droplet` test matrix.
- Move the `run_new_runtime_debian_12` job (which tests the locally-built runtime, not Debian 12 itself) to a Debian 13 host: renamed to `run_new_runtime_debian_13`, uses `debian-13-x64` and the `aleph-vm.debian-13.deb` artifact.

The Debian 12 `.deb` is still built and shipped (podman build, no DigitalOcean dependency, Debian 12 is in LTS until 2028); it is just no longer integration-tested on a droplet. The `aleph-debian-12-python` guest runtime is unaffected: it is the guest rootfs built with debootstrap on the GitHub runner, independent of the droplet host OS.