### PR TITLE
ci: extend crun workaround to all podman-using workflows

### DIFF
--- a/.github/workflows/deploy-main-on-staging.yml
+++ b/.github/workflows/deploy-main-on-staging.yml
@@ -30,6 +30,14 @@ jobs:
           # Fetch the whole history for all tags and branches (required for aleph.__version__)
           fetch-depth: 0
 
+      # Runner image 20260726.254 ships podman 5.8.4 but leaves a stale crun 1.14.1
+      # at /usr/bin/crun, breaking every podman run/build with "unknown version
+      # specified". Point podman at the current crun in /usr/local/bin.
+      # See https://github.com/actions/runner-images/issues/14473
+      - name: Work around actions/runner-images#14473 (podman uses stale crun)
+        run: (echo '[engine.runtimes]'; echo 'crun = [ "/usr/local/bin/crun" ]') |
+          sudo tee /etc/containers/containers.conf
+
       - run: |
           cd packaging && make ${{ matrix.staging_servers.make_target }} && cd ..
           ls packaging/target

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Initialize git submodules
         run: git submodule init
 
+      # Runner image 20260726.254 ships podman 5.8.4 but leaves a stale crun 1.14.1
+      # at /usr/bin/crun, breaking every podman run/build with "unknown version
+      # specified". Point podman at the current crun in /usr/local/bin.
+      # See https://github.com/actions/runner-images/issues/14473
+      - name: Work around actions/runner-images#14473 (podman uses stale crun)
+        run: (echo '[engine.runtimes]'; echo 'crun = [ "/usr/local/bin/crun" ]') |
+          sudo tee /etc/containers/containers.conf
+
       - name: Build package
         run: |
           cd packaging && make ${{ matrix.make_target }} && cd ..

--- a/.github/workflows/test-using-pytest.yml
+++ b/.github/workflows/test-using-pytest.yml
@@ -27,6 +27,14 @@ jobs:
       - name: Workaround github issue https://github.com/actions/runner-images/issues/7192
         run: sudo echo RESET grub-efi/install_devices | sudo debconf-communicate grub-pc
 
+      # Runner image 20260726.254 ships podman 5.8.4 but leaves a stale crun 1.14.1
+      # at /usr/bin/crun, breaking every podman run/build with "unknown version
+      # specified". The example volume build script prefers podman when installed.
+      # See https://github.com/actions/runner-images/issues/14473
+      - name: Work around actions/runner-images#14473 (podman uses stale crun)
+        run: (echo '[engine.runtimes]'; echo 'crun = [ "/usr/local/bin/crun" ]') |
+          sudo tee /etc/containers/containers.conf
+
       - name: Install required system packages for installing and running tests
         run: |
           sudo apt-get update


### PR DESCRIPTION
Follow-up to #1056. The `containers.conf` workaround for the broken `ubuntu-24.04` runner image ([actions/runner-images#14473](https://github.com/actions/runner-images/issues/14473)) only covered the `build_deb` job of the droplet workflow. Three other workflows still run podman unprotected and fail with `crun: unknown version specified` whenever a job lands on image `20260726.254`:

- `test-using-pytest.yml`: the "Build example volume" step runs `examples/volumes/build_squashfs.sh`, which prefers podman over docker when installed (bit PR #1038 today)
- `release-on-tag.yml`: all four package builds — a release tagged while the broken image is in rotation would coin-flip
- `deploy-main-on-staging.yml`: the staging package build

Same one-step fix in each: point podman at the current crun in `/usr/local/bin`. Harmless on healthy images; remove all four instances once GitHub fixes the runner image.