### PR TITLE
fix(storage): thread pool0_only through the devmapper volume chain

### DIFF
--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -323,10 +323,12 @@ async def create_ext4(path: Path, size_mib: int) -> bool:
     return True
 
 
-async def create_volume_file(volume: PersistentVolume | RootfsVolume, namespace: str) -> Path:
+async def create_volume_file(
+    volume: PersistentVolume | RootfsVolume, namespace: str, *, pool0_only: bool = False
+) -> Path:
     volume_name = volume.name if isinstance(volume, PersistentVolume) else "rootfs"
     # Assume that the main filesystem format is BTRFS
-    path = volume_path_for(namespace, f"{volume_name}.btrfs", volume.size_mib)
+    path = volume_path_for(namespace, f"{volume_name}.btrfs", volume.size_mib, pool0_only=pool0_only)
     if not path.is_file():
         logger.debug(f"Creating {volume.size_mib}MB volume")
         # Create an empty file the right size
@@ -365,9 +367,17 @@ async def resize_and_tune_file_system(device_path: Path, mount_path: Path) -> No
     await run_in_subprocess(["umount", str(mount_path)])
 
 
-async def create_devmapper(volume: PersistentVolume | RootfsVolume, namespace: str) -> Path:
+async def create_devmapper(
+    volume: PersistentVolume | RootfsVolume, namespace: str, *, pool0_only: bool = False
+) -> Path:
     """It creates a /dev/mapper/DEVICE inside the VM, that is an extended mapped device of the volume specified.
     We follow the steps described here: https://community.aleph.im/t/deploying-mutable-vm-instances-on-aleph/56/2
+
+    ``pool0_only`` pins the backing volume file's placement to pool 0 (see
+    volume_path_for): the Firecracker jailer hardlink-copies drive files
+    across filesystems, silently losing guest writes. Devmapper volumes are
+    only used by QEMU instances today, but the flag is threaded through so
+    that assumption never has to hold silently.
     """
     volume_name = volume.name if isinstance(volume, PersistentVolume) else "rootfs"
     mapped_volume_name = f"{namespace}_{volume_name}"
@@ -390,7 +400,7 @@ async def create_devmapper(volume: PersistentVolume | RootfsVolume, namespace: s
         base_table_command = f"0 {image_block_size} linear {image_loop_device} 0"
         await create_mapped_device(image_volume_name, base_table_command)
 
-    volume_path = await create_volume_file(volume, namespace)
+    volume_path = await create_volume_file(volume, namespace, pool0_only=pool0_only)
     extended_block_size: int = await get_block_size(volume_path)
 
     mapped_volume_name_base = f"{namespace}_base"
@@ -447,8 +457,10 @@ async def get_volume_path(volume: MachineVolume, namespace: str, *, pool0_only: 
             volume_name = re.sub(r"[^\w\-_]", "_", volume_name)
         if volume.parent:
             # create_devmapper resolves its volume file through
-            # create_volume_file, which is pool-aware.
-            return await create_devmapper(volume, namespace)
+            # create_volume_file, which is pool-aware; pool0_only rides along
+            # so a hypothetical Firecracker parent volume could never land off
+            # pool 0 (jailer hardlink-copy would lose guest writes).
+            return await create_devmapper(volume, namespace, pool0_only=pool0_only)
         else:
             volume_path = volume_path_for(namespace, f"{volume_name}.ext4", volume.size_mib, pool0_only=pool0_only)
             await create_ext4(volume_path, volume.size_mib)

--- a/tests/supervisor/test_storage_pools.py
+++ b/tests/supervisor/test_storage_pools.py
@@ -12,7 +12,11 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from aleph_message.models.execution.volume import PersistentVolume, VolumePersistence
+from aleph_message.models.execution.volume import (
+    ParentVolume,
+    PersistentVolume,
+    VolumePersistence,
+)
 
 import aleph.vm.storage as storage_module
 import aleph.vm.storage_pools as storage_pools_module
@@ -530,6 +534,32 @@ class TestFirecrackerPool0Wiring:
         path = await storage_module.get_volume_path(_persistent_volume(), namespace="vmhash", pool0_only=True)
         assert path == three_pools[0].path / "vmhash" / "data.ext4"
         create_ext4.assert_awaited_once_with(path, 1024)
+
+    @pytest.mark.asyncio
+    async def test_get_volume_path_devmapper_threads_pool0_only(self, three_pools, mocker):  # noqa: ARG002
+        """The devmapper branch must forward pool0_only into the
+        create_devmapper -> create_volume_file -> volume_path_for chain, so a
+        hypothetical Firecracker parent volume could never place its backing
+        file off pool 0 (the jailer hardlink-copy would lose guest writes)."""
+        devmapper = mocker.patch.object(
+            storage_module, "create_devmapper", new_callable=AsyncMock, return_value=Path("/dev/mapper/vmhash_data")
+        )
+        volume = _persistent_volume().model_copy(update={"parent": ParentVolume(ref="cafe" * 16, use_latest=False)})
+        await storage_module.get_volume_path(volume, namespace="vmhash", pool0_only=True)
+        assert devmapper.await_args.kwargs["pool0_only"] is True
+
+    @pytest.mark.asyncio
+    async def test_create_volume_file_pool0_only_places_on_pool0(self, three_pools, monkeypatch, mocker):
+        """create_volume_file (the devmapper backing file) must honor
+        pool0_only even when an extra pool has more free space."""
+        _fake_disk_usage(
+            monkeypatch,
+            {three_pools[0].path: 10 * 1024**3, three_pools[1].path: 50 * 1024**3, three_pools[2].path: 2 * 1024**3},
+        )
+        mocker.patch.object(storage_module, "run_in_subprocess", new_callable=AsyncMock)
+        mocker.patch.object(storage_module, "chown_to_jailman", new_callable=AsyncMock)
+        path = await storage_module.create_volume_file(_persistent_volume(), "vmhash", pool0_only=True)
+        assert path == three_pools[0].path / "vmhash" / "data.btrfs"
 
     @pytest.mark.asyncio
     async def test_host_volumes_from_message_threads_pool0_only(self, mocker):


### PR DESCRIPTION
Review follow-up 1/4 for #1049 (raised in three of the four review passes).

`get_volume_path` forwarded `pool0_only` on the ext4 branch but dropped it on the
devmapper branch: `create_devmapper` -> `create_volume_file` resolved the backing file
with default all-pools placement. Unreachable today (devmapper is QEMU-only), but a
hypothetical Firecracker parent volume would land off pool 0 and hit the jailer
hardlink-copy data loss the pin exists to prevent. The flag now rides the whole chain,
so the invariant is enforced rather than assumed.

Tests: devmapper branch forwards the flag; `create_volume_file` honors `pool0_only`
over a freer extra pool. 52/52 storage-pool tests pass; ruff format clean; mypy
unchanged vs base.