### PR TITLE
refactor(migration): drop the dead ExportJob.volumes_dir field

### DIFF
--- a/src/aleph/vm/agent/migration/jobs.py
+++ b/src/aleph/vm/agent/migration/jobs.py
@@ -42,7 +42,6 @@ class ExportJob:
     token: str | None = None
     disk_files: list[DiskFileInfo] | None = None
     export_paths: list[Path] = field(default_factory=list)
-    volumes_dir: Path | None = None
     active_downloads: int = 0
     error: str | None = None
     task: asyncio.Task | None = None

--- a/src/aleph/vm/agent/migration/runner.py
+++ b/src/aleph/vm/agent/migration/runner.py
@@ -132,16 +132,15 @@ async def run_export(
             # until the controller's SIGTERM handler has ACPI-powered the guest
             # down and QMP-quit QEMU with a cache flush. The exported overlay is
             # therefore consistent once stop_vm returns; no separate graceful
-            # step is needed. The volumes dir is the same settings-derived path
-            # the import runner stages into.
+            # step is needed.
             await supervisor.stop_vm(job.vm_hash)
-            # A VM's volumes may span pools (each volume is placed
-            # independently); export from every namespace dir, one copy per
-            # basename (lowest-index pool wins, like the boot-time lookup).
-            volume_dirs = list(iter_namespace_dirs(str(job.vm_hash)))
-            job.volumes_dir = volume_dirs[0] if volume_dirs else None
 
             disk_files: list[DiskFileInfo] = []
+
+            # A VM's volumes may span pools (each volume is placed
+            # independently); _collect_export_disks scans every namespace dir,
+            # one copy per basename (lowest-index pool wins, like the
+            # boot-time lookup).
 
             for qcow2_file in _collect_export_disks(str(job.vm_hash)):
                 export_path = qcow2_file.with_suffix(".qcow2.export.qcow2")

--- a/tests/supervisor/test_local_migration_p2p.py
+++ b/tests/supervisor/test_local_migration_p2p.py
@@ -39,9 +39,10 @@ def test_supervisor_has_no_migration_method():
 
 
 @pytest.mark.asyncio
-async def test_export_drives_stop_vm_and_derives_volumes_dir(tmp_path, monkeypatch):
+async def test_export_drives_stop_vm_and_collects_disks(tmp_path, monkeypatch):
     """The export runner stops the VM through the standard stop_vm RPC and
-    computes the volumes dir from settings (no migration-specific method)."""
+    collects the disks from settings-derived pool paths (no
+    migration-specific method)."""
     vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
     monkeypatch.setattr(settings, "PERSISTENT_VOLUMES_DIR", tmp_path)
 
@@ -64,5 +65,5 @@ async def test_export_drives_stop_vm_and_derives_volumes_dir(tmp_path, monkeypat
     await run_export(job, supervisor)
 
     supervisor.stop_vm.assert_awaited_once_with(vm_hash)
-    assert job.volumes_dir == volumes_dir
+    assert job.export_paths == [volumes_dir / "rootfs.qcow2.export.qcow2"]
     assert job.state == MigrationState.EXPORTED

--- a/tests/supervisor/views/test_migration.py
+++ b/tests/supervisor/views/test_migration.py
@@ -277,7 +277,6 @@ class TestMigrationDiskDownloadEndpoint:
             state=MigrationState.EXPORTED,
             started_at=datetime.now(timezone.utc),
             token="correct-token",
-            volumes_dir=tmp_path,
         )
 
         pool = mocker.Mock(executions={})
@@ -299,7 +298,6 @@ class TestMigrationDiskDownloadEndpoint:
             state=MigrationState.EXPORTED,
             started_at=datetime.now(timezone.utc),
             token="test-token",
-            volumes_dir=tmp_path,
         )
 
         pool = mocker.Mock(executions={})
@@ -318,7 +316,7 @@ class TestMigrationDiskDownloadEndpoint:
 
         from aleph.vm.agent.migration.jobs import ExportJob, export_jobs
 
-        # The handler reads from `{volumes_dir}/{filename}.export.qcow2`
+        # The handler resolves the file through job.export_paths
         export_file = tmp_path / "rootfs.qcow2.export.qcow2"
         export_file.write_bytes(b"compressed qcow2 data")
 
@@ -327,7 +325,6 @@ class TestMigrationDiskDownloadEndpoint:
             state=MigrationState.EXPORTED,
             started_at=datetime.now(timezone.utc),
             token="test-token",
-            volumes_dir=tmp_path,
             export_paths=[export_file],
         )
 


### PR DESCRIPTION
Review follow-up 2/4 for #1049 (raised in three of the four review passes).

`job.volumes_dir` was written but never read: the download view resolves through
`job.export_paths`. Removing it also removes the `iter_namespace_dirs` scan that
existed only to feed the dead assignment, which resolves the review's separate
double-scan observation in the same stroke.

The review called it fully dead; grep verification found three test-only usages it
missed (an assertion on the dead field and two `ExportJob(volumes_dir=...)`
constructions), updated here to assert the meaningful outcome instead.

118 migration + storage-pool tests pass; ruff format clean.