### PR TITLE
fix(migration): never collect stale export artifacts as source disks

### DIFF
--- a/src/aleph/vm/agent/migration/runner.py
+++ b/src/aleph/vm/agent/migration/runner.py
@@ -61,6 +61,12 @@ def _collect_export_disks(vm_hash: str) -> list[Path]:
     seen_names: set[str] = set()
     for volumes_dir in iter_namespace_dirs(vm_hash):
         for qcow2_file in sorted(volumes_dir.glob("*.qcow2")):
+            if qcow2_file.name.endswith(".export.qcow2"):
+                # A stale export artifact from an earlier failed run: the
+                # reaper only sweeps at startup, so a retry without an agent
+                # restart would otherwise collect it as a source disk and
+                # re-export an export.
+                continue
             if qcow2_file.name in seen_names:
                 logger.warning(
                     "Volume %s for %s found in multiple pools; exporting the copy from %s",

--- a/tests/supervisor/test_storage_pools.py
+++ b/tests/supervisor/test_storage_pools.py
@@ -627,3 +627,14 @@ class TestMigrationPools:
             three_pools[2].path / "vm-x" / "extra.qcow2",
         ]
         assert any("multiple pools" in record.message for record in caplog.records)
+
+    def test_export_skips_stale_export_artifacts(self, three_pools):
+        """A leftover .export.qcow2 from an earlier failed export (the reaper
+        only sweeps at startup) must not be collected as a source disk: the
+        *.qcow2 glob matches it, so it needs explicit filtering."""
+        namespace = three_pools[1].path / "vm-x"
+        namespace.mkdir()
+        (namespace / "rootfs.qcow2").touch()
+        (namespace / "rootfs.qcow2.export.qcow2").touch()
+        disks = _collect_export_disks("vm-x")
+        assert disks == [namespace / "rootfs.qcow2"]


### PR DESCRIPTION
Review follow-up 3/4 for #1049.

`_collect_export_disks` globs `*.qcow2`, which also matches
`rootfs.qcow2.export.qcow2` (a previous attempt's artifact). The reaper only sweeps
at startup, so an export retried after a failure without an agent restart would
collect the stale artifact as a source disk and re-export an export. Pre-existing
behavior, but the multi-pool scan widens exposure.

One-line filter plus the regression test the review suggested (stale artifact next to
its source volume is skipped). 72 tests pass; ruff format clean.