### PR TITLE
fix(storage): normalize pool paths for adoption-registry comparison

### DIFF
--- a/src/aleph/vm/storage_pools.py
+++ b/src/aleph/vm/storage_pools.py
@@ -133,11 +133,23 @@ def _parse_pool_entry(entry: str) -> tuple[Path, MediaClass | None]:
                 "(expected nvme, ssd or hdd)"
             )
             raise StoragePoolConfigError(msg) from error
-    path = Path(path_part.strip())
-    if not path_part.strip() or not path.is_absolute():
+    stripped = path_part.strip()
+    path = Path(_canonical(stripped)) if stripped else Path("")
+    if not stripped or not path.is_absolute():
         msg = f"VOLUME_POOLS entry {entry!r} needs an absolute pool path, e.g. /mnt/nvme1/aleph-volumes"
         raise StoragePoolConfigError(msg)
     return path, override
+
+
+def _canonical(path: Path | str) -> str:
+    """The canonical string form of a pool path, for registry storage and
+    comparison: lexically normalized (redundant separators and ``..``
+    segments collapsed) but deliberately NOT symlink-resolved. Resolving
+    would change pool identity across a symlink rewrite, silently merging or
+    splitting pools; a lexical form only forgives cosmetic rewrites of the
+    same configured path. A false mismatch here is a startup failure (the
+    orphaned-pool guard), so the forgiveness matters."""
+    return os.path.normpath(str(path))
 
 
 def _adoption_registry_path() -> Path:
@@ -165,12 +177,14 @@ def _load_adopted() -> set[str]:
             f"not {type(adopted).__name__}"
         )
         raise StoragePoolConfigError(msg)
-    return set(adopted)
+    # Normalize on read so registries written before canonicalization (or
+    # edited by hand) still match their configured pools.
+    return {_canonical(entry) for entry in adopted}
 
 
 def _record_adopted(path: Path) -> None:
     adopted = _load_adopted()
-    adopted.add(str(path))
+    adopted.add(_canonical(path))
     registry = _adoption_registry_path()
     tmp_path = registry.with_name(registry.name + ".tmp")
     tmp_path.write_text(json.dumps(sorted(adopted)) + "\n")
@@ -185,7 +199,7 @@ def _adopt_pool(path: Path, media_class: MediaClass) -> None:
     if marker.is_file():
         _record_adopted(path)  # heal the registry after e.g. a restore
         return
-    if str(path) in _load_adopted():
+    if _canonical(path) in _load_adopted():
         msg = (
             f"Volume pool {path} was adopted before but its {POOL_MARKER_NAME} marker is gone. "
             "Most likely the disk is not mounted; refusing to write to whatever is at that path."
@@ -234,7 +248,7 @@ def setup_pools(sys_root: Path = Path("/sys")) -> list[StoragePool]:
         _adopt_pool(path, media_class)
         pools.append(StoragePool(path=path, media_class=media_class, index=position))
 
-    orphaned = _load_adopted() - {str(pool.path) for pool in pools}
+    orphaned = _load_adopted() - {_canonical(pool.path) for pool in pools}
     if orphaned:
         msg = (
             f"Pool(s) {', '.join(sorted(orphaned))} were adopted as volume pools but are no longer "

--- a/tests/supervisor/test_storage_pools.py
+++ b/tests/supervisor/test_storage_pools.py
@@ -243,6 +243,35 @@ class TestSetupPools:
         with pytest.raises(StoragePoolConfigError, match=re.escape(str(extra))):
             setup_pools(sys_root=sys_root)
 
+    def test_cosmetic_path_rewrite_is_not_an_orphan(self, pool_settings, monkeypatch):
+        """A lexical rewrite of a configured pool path (.. segments, doubled
+        separators) must not trip the orphaned-pool guard: that guard is a
+        hard startup failure, and the pool is still the same directory. The
+        comparison normalizes lexically but never resolves symlinks."""
+        sys_root = _fake_ssd_sysfs(pool_settings)
+        extra = pool_settings / "mnt" / "nvme1"
+        extra.mkdir(parents=True)
+        monkeypatch.setattr(settings, "VOLUME_POOLS", [f"{extra}=nvme"])
+        setup_pools(sys_root=sys_root)
+        reset_pools()
+        rewritten = f"{extra.parent}//elsewhere/../{extra.name}"
+        monkeypatch.setattr(settings, "VOLUME_POOLS", [f"{rewritten}=nvme"])
+        pools = setup_pools(sys_root=sys_root)  # must not raise a false orphan
+        assert pools[1].path == extra
+
+    def test_unnormalized_registry_entry_still_guards_missing_marker(self, pool_settings, monkeypatch):
+        """A hand-edited (or pre-normalization) registry entry must still be
+        recognized as this pool: with the marker gone, startup must refuse
+        (the unmounted-disk trap), not silently re-adopt."""
+        sys_root = _fake_ssd_sysfs(pool_settings)
+        extra = pool_settings / "mnt" / "nvme1"
+        extra.mkdir(parents=True)
+        registry = Path(settings.EXECUTION_ROOT) / "volume-pools.json"
+        registry.write_text(json.dumps([f"{extra.parent}//elsewhere/../{extra.name}"]) + "\n")
+        monkeypatch.setattr(settings, "VOLUME_POOLS", [f"{extra}=nvme"])
+        with pytest.raises(StoragePoolConfigError, match="not mounted"):
+            setup_pools(sys_root=sys_root)
+
     @pytest.mark.parametrize("entry", ["=ssd", "relative/path=ssd"])
     def test_empty_or_relative_pool_path_is_a_hard_error(self, pool_settings, monkeypatch, entry):
         sys_root = _fake_ssd_sysfs(pool_settings)


### PR DESCRIPTION
Review follow-up 4/4 for #1049.

The orphaned-pool guard and missing-marker refusal compared raw `str(path)` against
the registry. A cosmetic rewrite of a VOLUME_POOLS entry (`..` segments, doubled
separators) produced a different string for the same directory, and a mismatch is a
**hard startup failure** (false orphan), not the minor robustness issue the review
rated it as.

Two deliberate deviations from the review's suggestion:
- `os.path.normpath` instead of `Path.resolve()`: resolving follows symlinks, which
  would change pool identity across a symlink rewrite (silently merging or splitting
  pools). Lexical normalization only forgives rewrites of the same configured text.
- Normalization applies on registry **read** too, so registries written before this
  change (or edited by hand) keep matching.

Tests: a `..`-rewritten entry of an adopted pool boots cleanly; an unnormalized
registry entry still triggers the unmounted-disk refusal when the marker is gone.
52 tests pass; ruff + mypy clean.