### PR TITLE
feat(vprogram): SEV-SNP launch path for V-PROGRAM messages

### DIFF
--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -19,11 +19,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
 import psutil
-from aleph_message.models import (
-    ExecutableContent,
-    ItemHash,
-    VerifiableProgramContent,
-)
+from aleph_message.models import ExecutableContent, ItemHash, VerifiableProgramContent
 from aleph_message.models.execution.instance import InstanceContent
 
 from aleph.vm import storage_pools

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -19,7 +19,11 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
 import psutil
-from aleph_message.models import ExecutableContent, ItemHash
+from aleph_message.models import (
+    ExecutableContent,
+    ItemHash,
+    VerifiableProgramContent,
+)
 from aleph_message.models.execution.instance import InstanceContent
 
 from aleph.vm import storage_pools
@@ -217,7 +221,12 @@ class CapacityManager:
             record_vcpus = resources.vcpus
             if not memory and not record_vcpus:
                 continue
-            if isinstance(record.message, InstanceContent):
+            # V-PROGRAMs are full SNP VMs, admitted against the instance
+            # bucket (run.py passes is_instance=True), so they must also be
+            # counted there. Bucketing them as programs would both starve the
+            # small program bucket and hide their memory from instance
+            # admission (silent over-commit).
+            if isinstance(record.message, (InstanceContent, VerifiableProgramContent)):
                 committed_instance_memory_mib += memory
             else:
                 committed_program_memory_mib += memory

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -29,6 +29,7 @@ from aleph.vm.agent.translate import build_create_vm_spec, build_program_create_
 from aleph.vm.agent.update_watcher import UpdateWatcher
 from aleph.vm.agent.vm.program_client import ProgramGuestClient
 from aleph.vm.agent.vm_registry import AgentVmRegistry, persist_record
+from aleph.vm.agent.vprogram_launch import build_vprogram_spec
 from aleph.vm.conf import settings
 from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.supervisor_interface import errors as supervisor_errors
@@ -344,13 +345,41 @@ async def create_vm_execution(
         return None
 
     if isinstance(content, VerifiableProgramContent):
-        # Scheduler wiring for V-Programs lands before the launch path: the
-        # allocation is accepted, but building a CreateVmSpec for an SNP guest
-        # (runtime manifest fetch, measured cmdline, verified volumes) is not
-        # implemented yet. Fail with the create-path vocabulary so
-        # update_allocations reports it per-VM and the scheduler can react.
-        msg = f"V-PROGRAM {vm_hash} accepted, but this CRN does not implement the SEV-SNP launch path yet"
-        raise VmSetupError(msg)
+        # V-PROGRAM: an auto-booting SEV-SNP VM. build_vprogram_spec fetches
+        # the runtime manifest, integrity-checks and stages the measured
+        # bundle, and returns a spec whose TeeConfig takes the SNP launch
+        # path. Mirrors the instance path above: record early, build spec,
+        # create, wait, persist; forget (and tear down) on failure. Unlike
+        # SEV instances there is no owner session to wait for: the daemon
+        # boots an SNP VM immediately (awaiting_confidential_init is never
+        # set), so the plain readiness wait applies.
+        record = registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
+        try:
+            spec = await build_vprogram_spec(vm_hash, content)
+            # Agent-side admission after the download, like the instance path:
+            # a failed bundle fetch never consumes capacity.
+            capacity.check_capacity(
+                memory_mib=content.resources.memory,
+                vcpus=content.resources.vcpus,
+                disk_mib=0,
+                is_instance=True,
+                exclude_vm_hash=vm_hash,
+            )
+            info = await supervisor.create_vm(spec)
+        except Exception:
+            registry.forget(vm_hash)
+            raise
+        try:
+            await _wait_until_running(supervisor, info.vm_id)
+        except Exception:
+            registry.forget(vm_hash)
+            try:
+                await supervisor.delete_vm(info.vm_id)
+            except Exception:
+                logger.exception("Teardown of half-started V-PROGRAM %s failed", vm_hash)
+            raise
+        await persist_record(vm_hash, record)
+        return None
 
     # Every supported content type is handled above: programs through the spec
     # program path, instances (plain, GPU, confidential) through the spec path.

--- a/src/aleph/vm/agent/vprogram_launch.py
+++ b/src/aleph/vm/agent/vprogram_launch.py
@@ -1,0 +1,231 @@
+"""SEV-SNP launch path for V-PROGRAM messages: runtime bundle staging and
+CreateVmSpec construction.
+
+A V-PROGRAM pins its measured platform through a runtime manifest (a STORE
+message holding JSON parsed by ``aleph.vm.vprogram.manifest.RuntimeManifest``).
+The manifest pins the runtime bundle: ONE tar.gz holding the measured OVMF,
+kernel, initrd and the dm-verity platform rootfs plus its hash tree.
+
+This module is the agent half of the launch: fetch the manifest, fetch and
+integrity-check the bundle (sha256 pinned by the manifest), extract it into a
+per-VM staging directory, make sure the dm-verity sidecars sit where the
+supervisor daemon looks for them, and build the SNP CreateVmSpec. The daemon
+derives the measured kernel cmdline itself from the ``<rootfs>.roothash``
+sidecar next to the rootfs disk and reads the hash tree at ``<rootfs>.verity``
+(see rust/crates/supervisor-daemon/src/lifecycle.rs, snp_config_slice, and
+docs/plans/rust-port-divergences.md entry 68c): the proto deliberately has no
+cmdline field, so nothing here passes one.
+
+Every check fails closed with VmSetupError: a mismeasured or tampered bundle
+must never reach create_vm.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import shutil
+import tarfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import ValidationError
+
+from aleph.vm.conf import settings
+from aleph.vm.storage import get_existing_file
+from aleph.vm.supervisor_interface.errors import VmSetupError
+from aleph.vm.supervisor_interface.types import (
+    Backend,
+    CreateVmSpec,
+    DirectoryPath,
+    DiskFormat,
+    DiskRole,
+    DiskSpec,
+    NetworkConfig,
+    TeeBackend,
+    TeeConfig,
+    VmId,
+)
+from aleph.vm.utils import get_hostname_from_hash
+from aleph.vm.vprogram.manifest import RuntimeManifest
+
+if TYPE_CHECKING:
+    from aleph_message.models import ItemHash
+    from aleph_message.models.execution.vprogram import VerifiableProgramContent
+
+logger = logging.getLogger(__name__)
+
+_SHA256_CHUNK_SIZE = 1024 * 1024
+
+
+def vprogram_staging_dir(vm_hash: ItemHash) -> Path:
+    """The per-VM directory the runtime bundle is extracted into."""
+    return Path(settings.EXECUTION_ROOT) / "vprogram" / str(vm_hash)
+
+
+async def fetch_runtime_manifest(runtime_ref: str) -> RuntimeManifest:
+    """Download and parse the runtime manifest pinned by ``runtime.ref``.
+
+    The ref is the item hash of a STORE message whose file is the manifest
+    JSON. Parsing is strict (extra keys, malformed templates and traversing
+    member paths are all rejected by the model); any failure is a
+    VmSetupError so update_allocations reports it per-VM.
+    """
+    manifest_path = await get_existing_file(runtime_ref)
+    try:
+        return RuntimeManifest.model_validate_json(manifest_path.read_bytes())
+    except (ValidationError, ValueError, OSError) as error:
+        msg = f"runtime manifest {runtime_ref} is invalid: {error}"
+        raise VmSetupError(msg) from error
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fileobj:
+        while chunk := fileobj.read(_SHA256_CHUNK_SIZE):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _verify_bundle(tar_path: Path, manifest: RuntimeManifest) -> None:
+    """The integrity gate: the downloaded tarball must be byte-identical to
+    the one the manifest measured (sha256 + size), or nothing gets extracted."""
+    actual_size = tar_path.stat().st_size
+    if actual_size != manifest.bundle.size:
+        msg = f"runtime bundle {manifest.bundle.ref} size mismatch: expected {manifest.bundle.size}, got {actual_size}"
+        raise VmSetupError(msg)
+    actual_sha256 = _sha256_file(tar_path)
+    if actual_sha256 != manifest.bundle.sha256:
+        msg = (
+            f"runtime bundle {manifest.bundle.ref} sha256 mismatch: "
+            f"expected {manifest.bundle.sha256}, got {actual_sha256}"
+        )
+        raise VmSetupError(msg)
+
+
+def _extract_bundle(tar_path: Path, dest: Path) -> None:
+    """Extract the verified tarball into a clean staging directory.
+
+    ``filter="data"`` is the tarfile safety filter: it rejects absolute
+    member names, upward traversal, links pointing outside the destination,
+    and strips setuid/devices, so a hostile tarball cannot escape ``dest``.
+    """
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.mkdir(parents=True)
+    try:
+        with tarfile.open(tar_path, mode="r:gz") as tar:
+            tar.extractall(dest, filter="data")
+    except (tarfile.TarError, OSError) as error:
+        msg = f"cannot extract runtime bundle {tar_path} into {dest}: {error}"
+        raise VmSetupError(msg) from error
+
+
+def _member_path(bundle_dir: Path, relative: str, role: str) -> Path:
+    """Resolve a manifest member (already validated relative + no-upward by
+    the model) inside the extracted bundle, failing closed if it is missing
+    or somehow escapes the staging directory."""
+    path = bundle_dir / relative
+    if not path.resolve().is_relative_to(bundle_dir.resolve()):
+        msg = f"bundle member {role} escapes the staging directory: {relative}"
+        raise VmSetupError(msg)
+    if not path.is_file():
+        msg = f"bundle member {role} missing after extraction: {path}"
+        raise VmSetupError(msg)
+    return path
+
+
+def _ensure_verity_sidecars(rootfs_path: Path, hash_tree_path: Path, platform_roothash: str) -> None:
+    """Place the dm-verity sidecars where the daemon looks for them.
+
+    snp_config_slice reads ``<rootfs>.roothash`` (measured cmdline input) and
+    ``<rootfs>.verity`` (the hash tree it wires as /dev/vdb) NEXT TO the
+    rootfs disk path in the spec. The #1050 bundle already ships both
+    adjacent to rootfs.ext4; this guards against a layout where they are not.
+
+    A roothash sidecar that disagrees with the manifest's platform_roothash
+    is a tampered or mispackaged bundle: fail closed rather than boot a VM
+    whose measured cmdline does not match what the manifest declared.
+    """
+    roothash_path = rootfs_path.with_name(rootfs_path.name + ".roothash")
+    if roothash_path.is_file():
+        found = roothash_path.read_text().strip()
+        if found != platform_roothash:
+            msg = (
+                f"bundle roothash sidecar {roothash_path} disagrees with the manifest: "
+                f"expected {platform_roothash}, got {found}"
+            )
+            raise VmSetupError(msg)
+    else:
+        roothash_path.write_text(platform_roothash + "\n")
+
+    verity_path = rootfs_path.with_name(rootfs_path.name + ".verity")
+    if not verity_path.is_file():
+        # The manifest may name the hash tree member differently; the daemon
+        # only ever reads <rootfs>.verity, so link the member there.
+        try:
+            verity_path.hardlink_to(hash_tree_path)
+        except OSError:
+            shutil.copyfile(hash_tree_path, verity_path)
+
+
+async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramContent) -> CreateVmSpec:
+    """Fetch, verify and stage the runtime bundle, then build the SNP spec.
+
+    Mirrors the on-host launch template (aleph-testnets test_vm_snp.py): QEMU
+    backend, direct-kernel boot from the measured bundle members, and a disk
+    order that IS the contract: the guest init reads the platform rootfs from
+    /dev/vda and the dm-verity hash tree from /dev/vdb.
+    """
+    manifest = await fetch_runtime_manifest(str(content.runtime.ref))
+
+    tar_path = await get_existing_file(manifest.bundle.ref)
+    _verify_bundle(tar_path, manifest)
+
+    bundle_dir = vprogram_staging_dir(vm_hash)
+    _extract_bundle(tar_path, bundle_dir)
+
+    members = manifest.bundle.members
+    ovmf_path = _member_path(bundle_dir, members.ovmf, "ovmf")
+    kernel_path = _member_path(bundle_dir, members.kernel, "kernel")
+    initrd_path = _member_path(bundle_dir, members.initrd, "initrd")
+    rootfs_path = _member_path(bundle_dir, members.platform_rootfs, "platform_rootfs")
+    hash_tree_path = _member_path(bundle_dir, members.platform_hash_tree, "platform_hash_tree")
+
+    _ensure_verity_sidecars(rootfs_path, hash_tree_path, manifest.boot.platform_roothash)
+
+    session_base = settings.CONFIDENTIAL_SESSION_DIRECTORY or (Path(settings.EXECUTION_ROOT) / "sessions")
+
+    return CreateVmSpec(
+        vm_id=VmId(str(vm_hash)),
+        backend=Backend.QEMU,
+        kernel_path=kernel_path,
+        initrd_path=initrd_path,
+        # Disk ORDER is load-bearing: the guest init reads the rootfs from the
+        # first virtio disk (/dev/vda) and the dm-verity hash tree from /dev/vdb.
+        disks=[
+            DiskSpec(path=rootfs_path, readonly=True, format=DiskFormat.RAW, role=DiskRole.ROOTFS),
+            DiskSpec(path=hash_tree_path, readonly=True, format=DiskFormat.RAW, role=DiskRole.EXTRA),
+        ],
+        vcpus=content.resources.vcpus,
+        memory_mib=content.resources.memory,
+        tee=TeeConfig(
+            backend=TeeBackend.SEV_SNP,
+            policy=str(content.verification.policy),
+            # The daemon derives its own CONFIDENTIAL_SESSION_DIRECTORY/<vm_id>
+            # for SNP (lifecycle.rs): required-but-ignored placeholder.
+            session_dir=DirectoryPath(Path(session_base) / str(vm_hash)),
+            firmware_path=ovmf_path,
+        ),
+        network=NetworkConfig(
+            internet_access=bool(content.environment.internet),
+            requested_ipv6="",
+            ipv6_prefix_len=0,
+        ),
+        gpus=[],
+        numa_node=None,
+        # QEMU instances start under systemd only; the daemon rejects a
+        # non-persistent QEMU VM.
+        persistent=True,
+        hostname=get_hostname_from_hash(vm_hash),
+    )

--- a/src/aleph/vm/agent/vprogram_launch.py
+++ b/src/aleph/vm/agent/vprogram_launch.py
@@ -121,6 +121,8 @@ def _extract_bundle(tar_path: Path, dest: Path) -> None:
             # rather than an opaque error (never extract without the filter).
             tar.extractall(dest, filter="data")
     except (tarfile.TarError, OSError, TypeError) as error:
+        # Never leave a partially-populated staging dir behind on failure.
+        shutil.rmtree(dest, ignore_errors=True)
         msg = f"cannot extract runtime bundle {tar_path} into {dest}: {error}"
         raise VmSetupError(msg) from error
 
@@ -188,6 +190,7 @@ async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramConte
 
     bundle_dir = vprogram_staging_dir(vm_hash)
     _extract_bundle(tar_path, bundle_dir)
+    logger.debug("Staged V-PROGRAM %s runtime bundle at %s", vm_hash, bundle_dir)
 
     members = manifest.bundle.members
     ovmf_path = _member_path(bundle_dir, members.ovmf, "ovmf")

--- a/src/aleph/vm/agent/vprogram_launch.py
+++ b/src/aleph/vm/agent/vprogram_launch.py
@@ -115,8 +115,12 @@ def _extract_bundle(tar_path: Path, dest: Path) -> None:
     dest.mkdir(parents=True)
     try:
         with tarfile.open(tar_path, mode="r:gz") as tar:
+            # filter="data" (PEP 706) needs CPython >= 3.12 / 3.11.4 / 3.10.12.
+            # On an older patch release the keyword is absent and extractall
+            # raises TypeError; catch it so we fail closed as VmSetupError
+            # rather than an opaque error (never extract without the filter).
             tar.extractall(dest, filter="data")
-    except (tarfile.TarError, OSError) as error:
+    except (tarfile.TarError, OSError, TypeError) as error:
         msg = f"cannot extract runtime bundle {tar_path} into {dest}: {error}"
         raise VmSetupError(msg) from error
 

--- a/src/aleph/vm/agent/vprogram_launch.py
+++ b/src/aleph/vm/agent/vprogram_launch.py
@@ -23,6 +23,7 @@ must never reach create_vm.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import logging
 import shutil
 import tarfile
@@ -95,7 +96,9 @@ def _verify_bundle(tar_path: Path, manifest: RuntimeManifest) -> None:
         msg = f"runtime bundle {manifest.bundle.ref} size mismatch: expected {manifest.bundle.size}, got {actual_size}"
         raise VmSetupError(msg)
     actual_sha256 = _sha256_file(tar_path)
-    if actual_sha256 != manifest.bundle.sha256:
+    # Constant-time compare: defense-in-depth for the hash gate, even though the
+    # manifest is content-addressed and the timing surface here is negligible.
+    if not hmac.compare_digest(actual_sha256, manifest.bundle.sha256):
         msg = (
             f"runtime bundle {manifest.bundle.ref} sha256 mismatch: "
             f"expected {manifest.bundle.sha256}, got {actual_sha256}"

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -128,6 +128,35 @@ def test_committed_memory_from_registry_is_bucketed(mocker):
         manager.check_capacity(memory_mib=2048, vcpus=1, disk_mib=0, is_instance=False)
 
 
+def test_committed_vprogram_memory_uses_instance_bucket(mocker):
+    # Regression: a V-PROGRAM is admitted against the instance bucket
+    # (run.py passes is_instance=True), so a *running* V-PROGRAM's memory must
+    # also be counted there. Bucketing it as a program would starve the small
+    # program bucket and hide its memory from instance admission (over-commit).
+    from test_vprogram import load_vprogram_message
+
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 4096)
+
+    content = load_vprogram_message().content
+    committed = content.resources.memory  # MiB the running V-PROGRAM holds
+    instance_cap = 64 * 1024 - 2048 - 4096
+
+    registry = AgentVmRegistry()
+    registry.record("v" * 64, message=content, original=content, persistent=True)
+    manager = _manager(registry=registry)
+
+    # Instance bucket sees the V-PROGRAM's memory committed: a request that
+    # exactly fills the remainder passes, one MiB more does not.
+    assert manager.check_capacity(memory_mib=instance_cap - committed, vcpus=1, disk_mib=0, is_instance=True) is None
+    with pytest.raises(InsufficientResourcesError):
+        manager.check_capacity(memory_mib=instance_cap - committed + 1, vcpus=1, disk_mib=0, is_instance=True)
+
+    # Program bucket sees nothing committed by the V-PROGRAM: its full cap is free.
+    assert manager.check_capacity(memory_mib=4096, vcpus=1, disk_mib=0, is_instance=False) is None
+
+
 def test_exclude_vm_hash_skips_the_vms_own_record(mocker):
     # The create paths record the VM before admission (owner record, or a
     # leftover record on a recreate): its own record must not count against

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -227,7 +227,58 @@ async def test_create_vm_execution_vprogram_launches_snp(mocker):
     assert vm_hash in registry
     record = registry.get(vm_hash)
     assert record is not None and record.persistent
-    mock_persist.assert_awaited_once()
+    mock_persist.assert_awaited_once_with(vm_hash, record)
+
+
+def _failed_vm_info(vm_hash: str) -> VmInfo:
+    return VmInfo(
+        vm_id=VmId(vm_hash),
+        status=VmStatus.FAILED,
+        ipv4=IpAssignment(),
+        ipv6=IpAssignment(),
+        uptime_secs=0,
+        backend=Backend.QEMU,
+        numa_node=None,
+        status_message="boot failed",
+        confidential_mode=ConfidentialMode.SEV_SNP,
+        gpus=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_vm_execution_vprogram_wait_failure_tears_down(mocker):
+    """create_vm succeeds but the VM never reaches RUNNING: the launch path
+    must tear the half-started VM down (supervisor.delete_vm) and forget its
+    registry record, without persisting."""
+    message = load_vprogram_message()
+    vm_hash = message.item_hash
+    mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
+
+    fake_spec = MagicMock()
+    mocker.patch("aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=fake_spec)
+    mock_persist = mocker.patch("aleph.vm.agent.run.persist_record", new_callable=AsyncMock)
+
+    info = _failed_vm_info(str(vm_hash))
+    supervisor = MagicMock(
+        create_vm=AsyncMock(return_value=info),
+        # get_vm reports FAILED, so _wait_until_running raises.
+        get_vm=AsyncMock(return_value=info),
+        delete_vm=AsyncMock(),
+    )
+    registry = AgentVmRegistry()
+
+    with pytest.raises(RuntimeError):
+        await create_vm_execution(
+            vm_hash,
+            supervisor=supervisor,
+            registry=registry,
+            capacity=MagicMock(),
+            persistent=True,
+        )
+
+    supervisor.delete_vm.assert_awaited_once_with(info.vm_id)
+    assert vm_hash not in registry
+    mock_persist.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -192,21 +192,71 @@ async def test_update_allocations_spares_scheduled_vprogram(aiohttp_client, mock
 
 
 @pytest.mark.asyncio
-async def test_create_vm_execution_vprogram_fails_cleanly(mocker):
-    """The allocation is accepted but the SNP launch path is not wired yet:
-    create must raise the create-path vocabulary (VmSetupError), which
-    update_allocations reports per-VM."""
+async def test_create_vm_execution_vprogram_launches_snp(mocker):
+    """A V-PROGRAM allocation goes through the SNP launch path: build the
+    spec from the runtime bundle, create_vm, wait for RUNNING, persist the
+    registry record. No confidential-init wait: SNP VMs auto-boot."""
     message = load_vprogram_message()
+    vm_hash = message.item_hash
     mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
 
-    with pytest.raises(VmSetupError, match="SEV-SNP"):
+    fake_spec = MagicMock()
+    mock_build = mocker.patch("aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=fake_spec)
+    mock_persist = mocker.patch("aleph.vm.agent.run.persist_record", new_callable=AsyncMock)
+
+    info = _running_vm_info(str(vm_hash))
+    assert not info.awaiting_confidential_init
+    supervisor = MagicMock(
+        create_vm=AsyncMock(return_value=info),
+        get_vm=AsyncMock(return_value=info),
+        delete_vm=AsyncMock(),
+    )
+    registry = AgentVmRegistry()
+
+    await create_vm_execution(
+        vm_hash,
+        supervisor=supervisor,
+        registry=registry,
+        capacity=MagicMock(),
+        persistent=True,
+    )
+
+    mock_build.assert_awaited_once_with(vm_hash, message.content)
+    supervisor.create_vm.assert_awaited_once_with(fake_spec)
+    supervisor.delete_vm.assert_not_awaited()
+    assert vm_hash in registry
+    record = registry.get(vm_hash)
+    assert record is not None and record.persistent
+    mock_persist.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_vm_execution_vprogram_build_failure_forgets_record(mocker):
+    """A failed bundle fetch/verify must surface the create-path vocabulary
+    (VmSetupError, reported per-VM by update_allocations) and leave no
+    dangling registry record behind."""
+    message = load_vprogram_message()
+    mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
+    mocker.patch(
+        "aleph.vm.agent.run.build_vprogram_spec",
+        new_callable=AsyncMock,
+        side_effect=VmSetupError("runtime bundle sha256 mismatch"),
+    )
+
+    supervisor = MagicMock(create_vm=AsyncMock())
+    registry = AgentVmRegistry()
+
+    with pytest.raises(VmSetupError, match="sha256 mismatch"):
         await create_vm_execution(
             message.item_hash,
-            supervisor=MagicMock(),
-            registry=AgentVmRegistry(),
+            supervisor=supervisor,
+            registry=registry,
             capacity=MagicMock(),
             persistent=True,
         )
+
+    supervisor.create_vm.assert_not_awaited()
+    assert message.item_hash not in registry
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -26,6 +26,7 @@ from aleph.vm.agent.supervisor import setup_webapp
 from aleph.vm.agent.tasks import _group_executions_by_payment
 from aleph.vm.agent.vm_registry import AgentVmRecord, AgentVmRegistry
 from aleph.vm.conf import settings
+from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.supervisor.local import LocalSupervisor
 from aleph.vm.supervisor_interface.errors import VmSetupError
 from aleph.vm.supervisor_interface.types import (
@@ -303,6 +304,33 @@ async def test_create_vm_execution_vprogram_build_failure_forgets_record(mocker)
             supervisor=supervisor,
             registry=registry,
             capacity=MagicMock(),
+            persistent=True,
+        )
+
+    supervisor.create_vm.assert_not_awaited()
+    assert message.item_hash not in registry
+
+
+@pytest.mark.asyncio
+async def test_create_vm_execution_vprogram_capacity_failure_forgets_record(mocker):
+    """Capacity admission runs after the bundle is staged and before create_vm:
+    an InsufficientResourcesError there must forget the record and never reach
+    create_vm (a distinct failure path from a build failure)."""
+    message = load_vprogram_message()
+    mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
+    mocker.patch("aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=MagicMock())
+
+    capacity = MagicMock()
+    capacity.check_capacity.side_effect = InsufficientResourcesError("no room", required={}, available={})
+    supervisor = MagicMock(create_vm=AsyncMock())
+    registry = AgentVmRegistry()
+
+    with pytest.raises(InsufficientResourcesError):
+        await create_vm_execution(
+            message.item_hash,
+            supervisor=supervisor,
+            registry=registry,
+            capacity=capacity,
             persistent=True,
         )
 

--- a/tests/supervisor/test_vprogram_launch.py
+++ b/tests/supervisor/test_vprogram_launch.py
@@ -312,6 +312,5 @@ async def test_corrupt_tarball_fails_closed_on_extract(tmp_path, storage_files):
         shutil.rmtree(staging)
     with pytest.raises(VmSetupError, match="cannot extract runtime bundle"):
         await build_vprogram_spec(message.item_hash, message.content)
-    # Nothing was extracted: the staging dir is absent or empty (open fails
-    # before any member is written), so no partial members are left behind.
-    assert not staging.exists() or not any(staging.iterdir())
+    # Fail closed leaves no partial staging behind: the except branch removes it.
+    assert not staging.exists()

--- a/tests/supervisor/test_vprogram_launch.py
+++ b/tests/supervisor/test_vprogram_launch.py
@@ -1,0 +1,294 @@
+"""Tests for the V-PROGRAM SEV-SNP launch path (agent side).
+
+Everything runs offline: get_existing_file is monkeypatched to serve a
+manifest JSON and a locally built bundle tarball from tmp_path, mirroring
+the real layout (#1050: members under an ``image/`` prefix, dm-verity
+sidecars adjacent to rootfs.ext4).
+"""
+
+import copy
+import gzip
+import hashlib
+import io
+import json
+import shutil
+import tarfile
+from pathlib import Path
+from typing import IO, Any, cast
+
+import pytest
+from aleph_message.models import VerifiableProgramMessage, parse_message
+
+from aleph.vm.agent.vprogram_launch import (
+    build_vprogram_spec,
+    fetch_runtime_manifest,
+    vprogram_staging_dir,
+)
+from aleph.vm.supervisor_interface.errors import VmSetupError
+from aleph.vm.supervisor_interface.types import (
+    Backend,
+    DiskFormat,
+    DiskRole,
+    TeeBackend,
+)
+from aleph.vm.vprogram.manifest import RuntimeManifest
+
+FIXTURE = Path(__file__).parent / "fixtures" / "vprogram_message.json"
+
+MANIFEST_REF = "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe"
+BUNDLE_REF = "87287e4a5c8d7554a50f982cd681b64b2600c0bbb1c0b1e618465e022e01b977"
+PLATFORM_ROOTHASH = "cb121a317be7dc7969dd633ca9b6c3718ffe9ea6715b64e0e35a871d484b56b8"
+
+# The reference manifest shape (tests/vprogram/test_manifest.py), with the
+# bundle digest/size patched per-test to match the locally built tarball.
+MANIFEST_TEMPLATE: dict[str, Any] = {
+    "format": "aleph-vprogram-runtime",
+    "format_version": 1,
+    "name": "aleph-snp-attest",
+    "version": "2026.07.08",
+    "platform": "sev_snp",
+    "bundle": {
+        "ref": BUNDLE_REF,
+        "sha256": "0" * 64,
+        "size": 1,
+        "members": {
+            "ovmf": "image/OVMF.fd",
+            "kernel": "image/bzImage",
+            "initrd": "image/initrd",
+            "platform_rootfs": "image/rootfs.ext4",
+            "platform_hash_tree": "image/rootfs.ext4.verity",
+        },
+    },
+    "boot": {
+        "method": "qemu-direct-kernel",
+        "kernel_hashes": True,
+        "cpu_models": ["EPYC-v4"],
+        "platform_roothash": PLATFORM_ROOTHASH,
+        "cmdline_template": "console=ttyS0 root=/dev/mapper/verity-root ro roothash={platform_roothash}",
+    },
+    "attestation": [{"protocol": "aleph.ra-tls", "version": "1", "transport": {"type": "tcp", "port": 8443}}],
+    "workload": {"contract": "aleph.builtin/1", "upstream_port": 8080},
+    "source": {
+        "repo": "https://github.com/aleph-im/aleph-vm",
+        "rev": "4d90abaf",
+        "build": 'nix build "git+file://$REPO?dir=nix#image"',
+    },
+}
+
+BUNDLE_FILES: dict[str, bytes] = {
+    "OVMF.fd": b"ovmf firmware blob",
+    "bzImage": b"kernel image",
+    "initrd": b"initial ramdisk",
+    "rootfs.ext4": b"platform rootfs",
+    "rootfs.ext4.verity": b"dm-verity hash tree",
+    "rootfs.ext4.roothash": PLATFORM_ROOTHASH.encode() + b"\n",
+}
+
+
+def load_vprogram_message() -> VerifiableProgramMessage:
+    message = parse_message(json.loads(FIXTURE.read_text()))
+    assert isinstance(message, VerifiableProgramMessage)
+    return message
+
+
+def make_bundle(out_dir: Path, files: dict[str, bytes] | None = None) -> Path:
+    """Build a tar.gz shaped like the #1050 bundle: members under image/."""
+    files = BUNDLE_FILES if files is None else files
+    tar_path = out_dir / "snp-image.tar.gz"
+    with tar_path.open("wb") as raw:
+        with gzip.GzipFile(filename="", fileobj=raw, mode="wb", mtime=0) as gz:
+            with tarfile.open(fileobj=cast(IO[bytes], gz), mode="w") as tar:
+                directory = tarfile.TarInfo("image")
+                directory.type = tarfile.DIRTYPE
+                directory.mode = 0o755
+                tar.addfile(directory)
+                for name, data in sorted(files.items()):
+                    member = tarfile.TarInfo(f"image/{name}")
+                    member.size = len(data)
+                    member.mode = 0o644
+                    tar.addfile(member, io.BytesIO(data))
+    return tar_path
+
+
+def make_manifest(tar_path: Path, out_dir: Path, **overrides: Any) -> Path:
+    """Write a manifest JSON whose bundle digest/size match tar_path."""
+    data = copy.deepcopy(MANIFEST_TEMPLATE)
+    raw = tar_path.read_bytes()
+    data["bundle"]["sha256"] = hashlib.sha256(raw).hexdigest()
+    data["bundle"]["size"] = len(raw)
+    for dotted, value in overrides.items():
+        target = data
+        *parents, leaf = dotted.split(".")
+        for key in parents:
+            target = target[key]
+        target[leaf] = value
+    manifest_path = out_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(data))
+    return manifest_path
+
+
+@pytest.fixture
+def storage_files(tmp_path, monkeypatch) -> dict[str, Path]:
+    """Serve get_existing_file from a local ref -> path map: no network."""
+    files: dict[str, Path] = {}
+
+    async def fake_get_existing_file(ref: str) -> Path:
+        return files[str(ref)]
+
+    monkeypatch.setattr("aleph.vm.agent.vprogram_launch.get_existing_file", fake_get_existing_file)
+    return files
+
+
+@pytest.fixture
+def staged_bundle(tmp_path, storage_files) -> dict[str, Path]:
+    tar_path = make_bundle(tmp_path)
+    manifest_path = make_manifest(tar_path, tmp_path)
+    storage_files[MANIFEST_REF] = manifest_path
+    storage_files[BUNDLE_REF] = tar_path
+    return {"tar": tar_path, "manifest": manifest_path}
+
+
+@pytest.mark.asyncio
+async def test_fetch_runtime_manifest_parses(staged_bundle):
+    manifest = await fetch_runtime_manifest(MANIFEST_REF)
+    assert isinstance(manifest, RuntimeManifest)
+    assert manifest.platform == "sev_snp"
+    assert manifest.bundle.members.platform_rootfs == "image/rootfs.ext4"
+    assert manifest.boot.platform_roothash == PLATFORM_ROOTHASH
+
+
+@pytest.mark.asyncio
+async def test_fetch_runtime_manifest_rejects_garbage(tmp_path, storage_files):
+    bad = tmp_path / "manifest.json"
+    bad.write_text('{"format": "not-a-runtime"}')
+    storage_files[MANIFEST_REF] = bad
+    with pytest.raises(VmSetupError, match="invalid"):
+        await fetch_runtime_manifest(MANIFEST_REF)
+
+
+@pytest.mark.asyncio
+async def test_bundle_sha256_mismatch_fails_closed(tmp_path, storage_files):
+    """The manifest's sha256 is the integrity gate: a tarball with different
+    bytes must never be extracted or launched."""
+    tar_path = make_bundle(tmp_path)
+    manifest_path = make_manifest(tar_path, tmp_path, **{"bundle.sha256": "f" * 64})
+    storage_files[MANIFEST_REF] = manifest_path
+    storage_files[BUNDLE_REF] = tar_path
+
+    message = load_vprogram_message()
+    staging = vprogram_staging_dir(message.item_hash)
+    if staging.exists():  # leftover from a previous pytest run: EXECUTION_ROOT persists
+        shutil.rmtree(staging)
+    with pytest.raises(VmSetupError, match="sha256 mismatch"):
+        await build_vprogram_spec(message.item_hash, message.content)
+    # Fail closed means nothing was staged.
+    assert not staging.exists()
+
+
+@pytest.mark.asyncio
+async def test_bundle_size_mismatch_fails_closed(tmp_path, storage_files):
+    tar_path = make_bundle(tmp_path)
+    manifest_path = make_manifest(tar_path, tmp_path, **{"bundle.size": 7})
+    storage_files[MANIFEST_REF] = manifest_path
+    storage_files[BUNDLE_REF] = tar_path
+
+    message = load_vprogram_message()
+    with pytest.raises(VmSetupError, match="size mismatch"):
+        await build_vprogram_spec(message.item_hash, message.content)
+
+
+@pytest.mark.asyncio
+async def test_build_vprogram_spec(staged_bundle):
+    """The spec mirrors the on-host SNP launch template: QEMU + SEV_SNP tee,
+    direct-kernel boot from the extracted members, rootfs then hash tree (the
+    order IS the guest contract: /dev/vda and /dev/vdb), persistent."""
+    message = load_vprogram_message()
+    content = message.content
+    spec = await build_vprogram_spec(message.item_hash, content)
+
+    staging = vprogram_staging_dir(message.item_hash)
+    assert spec.vm_id == str(message.item_hash)
+    assert spec.backend is Backend.QEMU
+    assert spec.kernel_path == staging / "image/bzImage"
+    assert spec.initrd_path == staging / "image/initrd"
+    assert spec.kernel_path.read_bytes() == b"kernel image"
+
+    assert [d.path for d in spec.disks] == [staging / "image/rootfs.ext4", staging / "image/rootfs.ext4.verity"]
+    assert [d.role for d in spec.disks] == [DiskRole.ROOTFS, DiskRole.EXTRA]
+    assert all(d.readonly for d in spec.disks)
+    assert all(d.format is DiskFormat.RAW for d in spec.disks)
+
+    assert spec.vcpus == content.resources.vcpus == 2
+    assert spec.memory_mib == content.resources.memory == 2048
+
+    assert spec.tee is not None
+    assert spec.tee.backend is TeeBackend.SEV_SNP
+    assert spec.tee.policy == str(content.verification.policy) == "196608"
+    assert spec.tee.firmware_path == staging / "image/OVMF.fd"
+
+    assert spec.network.internet_access is True
+    assert spec.network.requested_ipv6 == ""
+    assert spec.network.ipv6_prefix_len == 0
+    assert spec.persistent is True
+    assert spec.gpus == []
+    assert spec.ssh_authorized_keys == []
+
+
+@pytest.mark.asyncio
+async def test_roothash_sidecar_present_after_staging(staged_bundle):
+    """The daemon derives the measured cmdline from <rootfs>.roothash and the
+    hash tree from <rootfs>.verity next to the rootfs disk: both must be in
+    place after staging, with the manifest's platform roothash."""
+    message = load_vprogram_message()
+    spec = await build_vprogram_spec(message.item_hash, message.content)
+
+    rootfs = spec.rootfs.path
+    roothash_sidecar = rootfs.with_name(rootfs.name + ".roothash")
+    verity_sidecar = rootfs.with_name(rootfs.name + ".verity")
+    assert roothash_sidecar.is_file()
+    assert roothash_sidecar.read_text().strip() == PLATFORM_ROOTHASH
+    assert verity_sidecar.is_file()
+
+
+@pytest.mark.asyncio
+async def test_roothash_sidecar_written_when_bundle_lacks_it(tmp_path, storage_files):
+    """A bundle without the roothash sidecar (only the 5 declared members)
+    still stages one, sourced from manifest.boot.platform_roothash."""
+    files = {name: data for name, data in BUNDLE_FILES.items() if name != "rootfs.ext4.roothash"}
+    tar_path = make_bundle(tmp_path, files)
+    storage_files[MANIFEST_REF] = make_manifest(tar_path, tmp_path)
+    storage_files[BUNDLE_REF] = tar_path
+
+    message = load_vprogram_message()
+    spec = await build_vprogram_spec(message.item_hash, message.content)
+    rootfs = spec.rootfs.path
+    assert rootfs.with_name(rootfs.name + ".roothash").read_text().strip() == PLATFORM_ROOTHASH
+
+
+@pytest.mark.asyncio
+async def test_roothash_sidecar_disagreeing_with_manifest_fails_closed(tmp_path, storage_files):
+    """A tarball sidecar that contradicts the manifest's platform_roothash is
+    a mispackaged or tampered bundle: never boot a mismeasured VM."""
+    files = dict(BUNDLE_FILES)
+    files["rootfs.ext4.roothash"] = b"a" * 64 + b"\n"
+    tar_path = make_bundle(tmp_path, files)
+    storage_files[MANIFEST_REF] = make_manifest(tar_path, tmp_path)
+    storage_files[BUNDLE_REF] = tar_path
+
+    message = load_vprogram_message()
+    with pytest.raises(VmSetupError, match="disagrees with the manifest"):
+        await build_vprogram_spec(message.item_hash, message.content)
+
+
+@pytest.mark.asyncio
+async def test_missing_member_fails_closed(tmp_path, storage_files):
+    """A verified tarball that still lacks a declared member must fail before
+    any spec is produced."""
+    files = {name: data for name, data in BUNDLE_FILES.items() if name != "bzImage"}
+    tar_path = make_bundle(tmp_path, files)
+    storage_files[MANIFEST_REF] = make_manifest(tar_path, tmp_path)
+    storage_files[BUNDLE_REF] = tar_path
+
+    message = load_vprogram_message()
+    with pytest.raises(VmSetupError, match="kernel missing"):
+        await build_vprogram_spec(message.item_hash, message.content)

--- a/tests/supervisor/test_vprogram_launch.py
+++ b/tests/supervisor/test_vprogram_launch.py
@@ -193,8 +193,14 @@ async def test_bundle_size_mismatch_fails_closed(tmp_path, storage_files):
     storage_files[BUNDLE_REF] = tar_path
 
     message = load_vprogram_message()
+    staging = vprogram_staging_dir(message.item_hash)
+    if staging.exists():  # leftover from a previous pytest run: EXECUTION_ROOT persists
+        shutil.rmtree(staging)
     with pytest.raises(VmSetupError, match="size mismatch"):
         await build_vprogram_spec(message.item_hash, message.content)
+    # The size gate runs before extraction, so nothing is staged (symmetric
+    # with the sha256 mismatch test).
+    assert not staging.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_vprogram_launch.py
+++ b/tests/supervisor/test_vprogram_launch.py
@@ -292,3 +292,26 @@ async def test_missing_member_fails_closed(tmp_path, storage_files):
     message = load_vprogram_message()
     with pytest.raises(VmSetupError, match="kernel missing"):
         await build_vprogram_spec(message.item_hash, message.content)
+
+
+@pytest.mark.asyncio
+async def test_corrupt_tarball_fails_closed_on_extract(tmp_path, storage_files):
+    """A blob that passes the sha256+size gate but is not a valid gzip/tar
+    stream must surface as VmSetupError from the extract step (fail closed),
+    not an opaque tarfile/OS error, and stage no members."""
+    blob = tmp_path / "snp-image.tar.gz"
+    blob.write_bytes(b"not a gzip stream, but of the right length" * 4)
+    # Digest and size are computed from the blob, so integrity passes and the
+    # failure is forced into _extract_bundle rather than the sha256/size gate.
+    storage_files[MANIFEST_REF] = make_manifest(blob, tmp_path)
+    storage_files[BUNDLE_REF] = blob
+
+    message = load_vprogram_message()
+    staging = vprogram_staging_dir(message.item_hash)
+    if staging.exists():  # leftover from a previous pytest run: EXECUTION_ROOT persists
+        shutil.rmtree(staging)
+    with pytest.raises(VmSetupError, match="cannot extract runtime bundle"):
+        await build_vprogram_spec(message.item_hash, message.content)
+    # Nothing was extracted: the staging dir is absent or empty (open fails
+    # before any member is written), so no partial members are left behind.
+    assert not staging.exists() or not any(staging.iterdir())


### PR DESCRIPTION
Boots a V-PROGRAM as an SEV-SNP confidential guest. Replaces the "not implemented" seam left by #1052 (`run.py`) with the real launch path.

## ⚠️ Dependency (diamond)
This stacks on **#1052** (base) but also requires **#1050**'s `aleph.vm.vprogram.manifest` module (`vprogram_launch.py` imports `RuntimeManifest`). #1050 and #1052 are independent branches off dev, so the intended merge order is: **#1050 → dev, #1052 → dev, then rebase this onto dev** (both deps present, CI green). Until #1050 lands, CI here is red on the missing import — the diff is deliberately kept to the launch code only rather than vendoring #1050's module.

## What it does
On a V-PROGRAM allocation, the agent now (new `src/aleph/vm/agent/vprogram_launch.py`):
1. Fetches + strict-parses the runtime manifest (`content.runtime.ref` STORE → `RuntimeManifest`).
2. Fetches the bundle (`manifest.bundle.ref`), **verifies sha256 + size** against the manifest (fail closed), extracts the measured image into `EXECUTION_ROOT/vprogram/<vm_hash>` with `tarfile` `filter="data"` (traversal-safe).
3. Builds an SNP `CreateVmSpec` (QEMU, `tee.backend=SEV_SNP`, kernel/initrd/OVMF from the extracted members, disks `[rootfs RAW ROOTFS ro, hash_tree RAW EXTRA ro]` in that order, `persistent=True`). The daemon derives the measured cmdline from the `{rootfs}.roothash` sidecar (proto has no cmdline field); staging fails closed if a shipped sidecar disagrees with `manifest.boot.platform_roothash`, and synthesizes it from the manifest when absent.
4. `create_vm` → `_wait_until_running` → persist, mirroring the confidential-instance path (early record, capacity check after download, teardown on failure). SNP VMs never `awaiting_confidential_init`.

The `run.py` seam is small (build spec via the helper, create/wait/persist). `content.workload`/`content.volumes` are **not** attached yet — the current measured image runs the built-in `aleph.builtin/1` httpd; user-workload volumes (`workload_roothash`/`verified_volumes`) need guest-init support first (a follow-up, per #1050's design).

## Tests
`tests/supervisor/test_vprogram_launch.py` (9): manifest parse/reject, sha256+size mismatch fail-closed with nothing staged, full spec construction, roothash+verity sidecar present/synthesized/disagreement, missing member. `tests/supervisor/test_vprogram.py` updated: the obsolete "fails cleanly" test replaced with launch + build-failure-forgets-record. 21 pass on the integration branch; `ruff format`/`isort`/`mypy` clean.

## Validated end-to-end on real hardware
On aleph-testnets, a V-PROGRAM published to the CCN was scheduled to the SNP CRN, which fetched the manifest + bundle, extracted the measured image, and **booted the SEV-SNP guest** (journal: `started per-tap DHCP server for SNP VM … guest_ip=172.16.4.2`; the item hash reached RUNNING in the execution list). Aggregated deb-builder: PR #1070.