### PR TITLE
feat(vprogram): attach the measured workload volume + roothash sidecar

### DIFF
--- a/src/aleph/vm/agent/vprogram_launch.py
+++ b/src/aleph/vm/agent/vprogram_launch.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import logging
+import re
 import shutil
 import tarfile
 from pathlib import Path
@@ -57,6 +58,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _SHA256_CHUNK_SIZE = 1024 * 1024
+
+# The workload roothash sidecar content is trusted verbatim by the daemon
+# (snp_config_slice appends it to the measured cmdline unquoted): bare hex
+# only, no length pinned here since the daemon does not pin one either.
+HEX64 = re.compile(r"\A[0-9a-fA-F]+\Z")
 
 
 def vprogram_staging_dir(vm_hash: ItemHash) -> Path:
@@ -204,6 +210,33 @@ async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramConte
 
     _ensure_verity_sidecars(rootfs_path, hash_tree_path, manifest.boot.platform_roothash)
 
+    # Disk ORDER is load-bearing: the guest init reads the rootfs from the
+    # first virtio disk (/dev/vda), the platform dm-verity hash tree from
+    # /dev/vdb, and (when a workload is present) the workload data from
+    # /dev/vdc and its hash tree from /dev/vdd.
+    #
+    # The platform hash tree is NOT attached here: the daemon force-inserts
+    # `{rootfs}.verity` (written by _ensure_verity_sidecars above) as the
+    # first SNP host volume (-> /dev/vdb). Attaching it here too would
+    # duplicate it and shift the workload disks to vdd/vde, breaking the
+    # guest's vdc/vdd workload-verity assumption.
+    disks = [
+        DiskSpec(path=rootfs_path, readonly=True, format=DiskFormat.RAW, role=DiskRole.ROOTFS),
+    ]
+
+    if content.workload is not None:
+        wl_roothash = content.workload.roothash
+        if not HEX64.match(wl_roothash):
+            msg = f"V-PROGRAM {vm_hash} workload roothash is not bare hex"
+            raise VmSetupError(msg)
+        workload_data = await get_existing_file(str(content.workload.ref))
+        workload_hashtree = await get_existing_file(str(content.workload.hash_tree))
+        # The daemon derives ' workload_roothash=' from this sidecar next to the
+        # rootfs (proto has no cmdline field). Fail closed on a bad roothash.
+        (rootfs_path.parent / f"{rootfs_path.name}.workload_roothash").write_text(wl_roothash)
+        disks.append(DiskSpec(path=workload_data, readonly=True, format=DiskFormat.RAW, role=DiskRole.EXTRA))
+        disks.append(DiskSpec(path=workload_hashtree, readonly=True, format=DiskFormat.RAW, role=DiskRole.EXTRA))
+
     session_base = settings.CONFIDENTIAL_SESSION_DIRECTORY or (Path(settings.EXECUTION_ROOT) / "sessions")
 
     return CreateVmSpec(
@@ -211,12 +244,7 @@ async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramConte
         backend=Backend.QEMU,
         kernel_path=kernel_path,
         initrd_path=initrd_path,
-        # Disk ORDER is load-bearing: the guest init reads the rootfs from the
-        # first virtio disk (/dev/vda) and the dm-verity hash tree from /dev/vdb.
-        disks=[
-            DiskSpec(path=rootfs_path, readonly=True, format=DiskFormat.RAW, role=DiskRole.ROOTFS),
-            DiskSpec(path=hash_tree_path, readonly=True, format=DiskFormat.RAW, role=DiskRole.EXTRA),
-        ],
+        disks=disks,
         vcpus=content.resources.vcpus,
         memory_mib=content.resources.memory,
         tee=TeeConfig(

--- a/src/aleph/vm/agent/vprogram_launch.py
+++ b/src/aleph/vm/agent/vprogram_launch.py
@@ -31,6 +31,7 @@ import tarfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from aleph_message.models.execution.vprogram import VERITY_ROOTHASH_PATTERN
 from pydantic import ValidationError
 
 from aleph.vm.conf import settings
@@ -58,11 +59,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _SHA256_CHUNK_SIZE = 1024 * 1024
-
-# The workload roothash sidecar content is trusted verbatim by the daemon
-# (snp_config_slice appends it to the measured cmdline unquoted): bare hex
-# only, no length pinned here since the daemon does not pin one either.
-HEX64 = re.compile(r"\A[0-9a-fA-F]+\Z")
 
 
 def vprogram_staging_dir(vm_hash: ItemHash) -> Path:
@@ -212,8 +208,8 @@ async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramConte
 
     # Disk ORDER is load-bearing: the guest init reads the rootfs from the
     # first virtio disk (/dev/vda), the platform dm-verity hash tree from
-    # /dev/vdb, and (when a workload is present) the workload data from
-    # /dev/vdc and its hash tree from /dev/vdd.
+    # /dev/vdb, the workload data from /dev/vdc and its hash tree from
+    # /dev/vdd.
     #
     # The platform hash tree is NOT attached here: the daemon force-inserts
     # `{rootfs}.verity` (written by _ensure_verity_sidecars above) as the
@@ -224,18 +220,21 @@ async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramConte
         DiskSpec(path=rootfs_path, readonly=True, format=DiskFormat.RAW, role=DiskRole.ROOTFS),
     ]
 
-    if content.workload is not None:
-        wl_roothash = content.workload.roothash
-        if not HEX64.match(wl_roothash):
-            msg = f"V-PROGRAM {vm_hash} workload roothash is not bare hex"
-            raise VmSetupError(msg)
-        workload_data = await get_existing_file(str(content.workload.ref))
-        workload_hashtree = await get_existing_file(str(content.workload.hash_tree))
-        # The daemon derives ' workload_roothash=' from this sidecar next to the
-        # rootfs (proto has no cmdline field). Fail closed on a bad roothash.
-        (rootfs_path.parent / f"{rootfs_path.name}.workload_roothash").write_text(wl_roothash)
-        disks.append(DiskSpec(path=workload_data, readonly=True, format=DiskFormat.RAW, role=DiskRole.EXTRA))
-        disks.append(DiskSpec(path=workload_hashtree, readonly=True, format=DiskFormat.RAW, role=DiskRole.EXTRA))
+    # The daemon trusts the sidecar content verbatim (snp_config_slice appends
+    # it to the measured cmdline unquoted). The schema already pins the field
+    # to this pattern on message validation; re-checking it here fails closed
+    # on the unvalidated construction routes (model_copy/model_construct).
+    wl_roothash = content.workload.roothash
+    if not re.fullmatch(VERITY_ROOTHASH_PATTERN, wl_roothash):
+        msg = f"V-PROGRAM {vm_hash} workload roothash is not a bare sha256 hex string"
+        raise VmSetupError(msg)
+    workload_data = await get_existing_file(str(content.workload.ref))
+    workload_hashtree = await get_existing_file(str(content.workload.hash_tree))
+    # The daemon derives ' workload_roothash=' from this sidecar next to the
+    # rootfs (proto has no cmdline field).
+    (rootfs_path.parent / f"{rootfs_path.name}.workload_roothash").write_text(wl_roothash + "\n")
+    disks.append(DiskSpec(path=workload_data, readonly=True, format=DiskFormat.RAW, role=DiskRole.EXTRA))
+    disks.append(DiskSpec(path=workload_hashtree, readonly=True, format=DiskFormat.RAW, role=DiskRole.EXTRA))
 
     session_base = settings.CONFIDENTIAL_SESSION_DIRECTORY or (Path(settings.EXECUTION_ROOT) / "sessions")
 

--- a/tests/supervisor/test_vprogram_launch.py
+++ b/tests/supervisor/test_vprogram_launch.py
@@ -39,6 +39,14 @@ MANIFEST_REF = "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe
 BUNDLE_REF = "87287e4a5c8d7554a50f982cd681b64b2600c0bbb1c0b1e618465e022e01b977"
 PLATFORM_ROOTHASH = "cb121a317be7dc7969dd633ca9b6c3718ffe9ea6715b64e0e35a871d484b56b8"
 
+# Matches content.workload in tests/supervisor/fixtures/vprogram_message.json:
+# the fixture message always carries a workload block (the field is required
+# on VerifiableProgramContent), so every test that runs build_vprogram_spec
+# to completion needs get_existing_file to resolve these two refs too.
+WORKLOAD_REF = "beefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef"
+WORKLOAD_HASH_TREE_REF = "feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed"
+WORKLOAD_ROOTHASH = "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
+
 # The reference manifest shape (tests/vprogram/test_manifest.py), with the
 # bundle digest/size patched per-test to match the locally built tarball.
 MANIFEST_TEMPLATE: dict[str, Any] = {
@@ -139,13 +147,26 @@ def storage_files(tmp_path, monkeypatch) -> dict[str, Path]:
     return files
 
 
+def stage_workload(storage_files: dict[str, Path], tmp_path: Path) -> dict[str, Path]:
+    """Register the fixture message's workload ref + hash_tree with
+    get_existing_file, mirroring how the runtime bundle members are staged."""
+    data_path = tmp_path / "workload_data.img"
+    data_path.write_bytes(b"workload data volume")
+    hashtree_path = tmp_path / "workload_hashtree.img"
+    hashtree_path.write_bytes(b"workload hash tree")
+    storage_files[WORKLOAD_REF] = data_path
+    storage_files[WORKLOAD_HASH_TREE_REF] = hashtree_path
+    return {"data": data_path, "hashtree": hashtree_path}
+
+
 @pytest.fixture
 def staged_bundle(tmp_path, storage_files) -> dict[str, Path]:
     tar_path = make_bundle(tmp_path)
     manifest_path = make_manifest(tar_path, tmp_path)
     storage_files[MANIFEST_REF] = manifest_path
     storage_files[BUNDLE_REF] = tar_path
-    return {"tar": tar_path, "manifest": manifest_path}
+    workload = stage_workload(storage_files, tmp_path)
+    return {"tar": tar_path, "manifest": manifest_path, **workload}
 
 
 @pytest.mark.asyncio
@@ -206,8 +227,10 @@ async def test_bundle_size_mismatch_fails_closed(tmp_path, storage_files):
 @pytest.mark.asyncio
 async def test_build_vprogram_spec(staged_bundle):
     """The spec mirrors the on-host SNP launch template: QEMU + SEV_SNP tee,
-    direct-kernel boot from the extracted members, rootfs then hash tree (the
-    order IS the guest contract: /dev/vda and /dev/vdb), persistent."""
+    direct-kernel boot from the extracted members, and a disk order that IS
+    the guest contract: platform rootfs (/dev/vda), platform hash tree
+    (/dev/vdb), workload data (/dev/vdc), workload hash tree (/dev/vdd);
+    persistent."""
     message = load_vprogram_message()
     content = message.content
     spec = await build_vprogram_spec(message.item_hash, content)
@@ -219,10 +242,23 @@ async def test_build_vprogram_spec(staged_bundle):
     assert spec.initrd_path == staging / "image/initrd"
     assert spec.kernel_path.read_bytes() == b"kernel image"
 
-    assert [d.path for d in spec.disks] == [staging / "image/rootfs.ext4", staging / "image/rootfs.ext4.verity"]
-    assert [d.role for d in spec.disks] == [DiskRole.ROOTFS, DiskRole.EXTRA]
+    # The platform hash tree is NOT a spec disk: the daemon force-inserts
+    # {rootfs}.verity as the first SNP host volume (/dev/vdb). The spec carries
+    # only the rootfs + the workload data/hash tree (/dev/vdc, /dev/vdd).
+    assert [d.path for d in spec.disks] == [
+        staging / "image/rootfs.ext4",
+        staged_bundle["data"],
+        staged_bundle["hashtree"],
+    ]
+    assert [d.role for d in spec.disks] == [
+        DiskRole.ROOTFS,
+        DiskRole.EXTRA,
+        DiskRole.EXTRA,
+    ]
     assert all(d.readonly for d in spec.disks)
     assert all(d.format is DiskFormat.RAW for d in spec.disks)
+    # The platform verity sidecar still exists on disk for the daemon.
+    assert (staging / "image/rootfs.ext4.verity").is_file()
 
     assert spec.vcpus == content.resources.vcpus == 2
     assert spec.memory_mib == content.resources.memory == 2048
@@ -264,6 +300,7 @@ async def test_roothash_sidecar_written_when_bundle_lacks_it(tmp_path, storage_f
     tar_path = make_bundle(tmp_path, files)
     storage_files[MANIFEST_REF] = make_manifest(tar_path, tmp_path)
     storage_files[BUNDLE_REF] = tar_path
+    stage_workload(storage_files, tmp_path)
 
     message = load_vprogram_message()
     spec = await build_vprogram_spec(message.item_hash, message.content)
@@ -320,3 +357,50 @@ async def test_corrupt_tarball_fails_closed_on_extract(tmp_path, storage_files):
         await build_vprogram_spec(message.item_hash, message.content)
     # Fail closed leaves no partial staging behind: the except branch removes it.
     assert not staging.exists()
+
+
+@pytest.mark.asyncio
+async def test_workload_attached_and_sidecar_written(staged_bundle):
+    """content.workload is attached as two EXTRA disks (data, then hash tree)
+    after the rootfs, and its roothash is staged in a sidecar next to the
+    rootfs: the daemon has no cmdline field on the proto, so this sidecar is
+    the only way it learns 'workload_roothash=<hex>'. The platform hash tree
+    is NOT a spec disk (the daemon force-inserts it as /dev/vdb), so the
+    workload data/hash tree land at /dev/vdc, /dev/vdd."""
+    message = load_vprogram_message()
+    content = message.content
+    assert content.workload.roothash == WORKLOAD_ROOTHASH
+    spec = await build_vprogram_spec(message.item_hash, content)
+
+    assert len(spec.disks) == 3
+    assert [d.role for d in spec.disks] == [
+        DiskRole.ROOTFS,
+        DiskRole.EXTRA,
+        DiskRole.EXTRA,
+    ]
+    assert spec.disks[1].path == staged_bundle["data"]
+    assert spec.disks[2].path == staged_bundle["hashtree"]
+    assert all(d.readonly for d in spec.disks[1:])
+    assert all(d.format is DiskFormat.RAW for d in spec.disks[2:])
+
+    rootfs = spec.rootfs.path
+    sidecar = rootfs.with_name(rootfs.name + ".workload_roothash")
+    assert sidecar.is_file()
+    assert sidecar.read_text() == content.workload.roothash
+
+
+@pytest.mark.asyncio
+async def test_workload_roothash_non_hex_fails_closed(staged_bundle):
+    """A workload roothash that is not bare hex must never be staged or
+    attached: the daemon trusts the sidecar content verbatim, appending it to
+    the measured cmdline unquoted."""
+    message = load_vprogram_message()
+    bad_workload = message.content.workload.model_copy(update={"roothash": "not-bare-hex!!"})
+    content = message.content.model_copy(update={"workload": bad_workload})
+
+    with pytest.raises(VmSetupError, match="not bare hex"):
+        await build_vprogram_spec(message.item_hash, content)
+
+    staging = vprogram_staging_dir(message.item_hash)
+    rootfs = staging / "image" / "rootfs.ext4"
+    assert not rootfs.with_name(rootfs.name + ".workload_roothash").is_file()

--- a/tests/supervisor/test_vprogram_launch.py
+++ b/tests/supervisor/test_vprogram_launch.py
@@ -381,24 +381,34 @@ async def test_workload_attached_and_sidecar_written(staged_bundle):
     assert spec.disks[1].path == staged_bundle["data"]
     assert spec.disks[2].path == staged_bundle["hashtree"]
     assert all(d.readonly for d in spec.disks[1:])
-    assert all(d.format is DiskFormat.RAW for d in spec.disks[2:])
+    assert all(d.format is DiskFormat.RAW for d in spec.disks[1:])
 
     rootfs = spec.rootfs.path
     sidecar = rootfs.with_name(rootfs.name + ".workload_roothash")
     assert sidecar.is_file()
-    assert sidecar.read_text() == content.workload.roothash
+    assert sidecar.read_text().strip() == content.workload.roothash
 
 
 @pytest.mark.asyncio
-async def test_workload_roothash_non_hex_fails_closed(staged_bundle):
-    """A workload roothash that is not bare hex must never be staged or
-    attached: the daemon trusts the sidecar content verbatim, appending it to
-    the measured cmdline unquoted."""
+@pytest.mark.parametrize(
+    "bad_roothash",
+    [
+        "not-bare-hex!!",
+        "cafef00d",  # valid hex but not a full sha256
+        "CD" * 32,  # right length, but the schema pins lowercase
+    ],
+)
+async def test_workload_roothash_non_hex_fails_closed(staged_bundle, bad_roothash):
+    """A workload roothash that does not match the schema's
+    VERITY_ROOTHASH_PATTERN must never be staged or attached: the daemon
+    trusts the sidecar content verbatim, appending it to the measured
+    cmdline unquoted. model_copy bypasses field validation, so this exercises
+    the launch-path re-check."""
     message = load_vprogram_message()
-    bad_workload = message.content.workload.model_copy(update={"roothash": "not-bare-hex!!"})
+    bad_workload = message.content.workload.model_copy(update={"roothash": bad_roothash})
     content = message.content.model_copy(update={"workload": bad_workload})
 
-    with pytest.raises(VmSetupError, match="not bare hex"):
+    with pytest.raises(VmSetupError, match="not a bare sha256 hex"):
         await build_vprogram_spec(message.item_hash, content)
 
     staging = vprogram_staging_dir(message.item_hash)


### PR DESCRIPTION
Part of the V-PROGRAM workload mechanism. **Depends on #1071** (launch path) and #1050 (manifest import); CI is red until #1050/#1052 land on dev.

**This PR (Python, agent launch):** when `content.workload` is present, download `content.workload.ref` (data) + `.hash_tree` and attach them as EXTRA disks (→ `/dev/vdc`, `/dev/vdd`), and write a `{rootfs}.workload_roothash` sidecar from `content.workload.roothash` so the daemon can bind it into the measured cmdline.

The platform hash tree is **not** attached here: the daemon force-inserts `{rootfs}.verity` as the first SNP host volume (`/dev/vdb`), so attaching it again would shift the workload disks to vdd/vde and break the guest's vdc/vdd workload-verity assumption. (This was the disk-shift bug caught on hardware.) Fail closed on a non-bare-hex roothash. Multi-volume `content.volumes` deferred.