### PR TITLE
feat(nix): fib-service workload volume + dm-verity (reproducible roothash)

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -130,6 +130,12 @@
       };
       rootfs = pkgs.callPackage ./rootfs.nix {};
 
+      # fib-service V-PROGRAM workload volume: a content-only ext4 carrying the
+      # fib-service binary as /sbin/init, delivered to the measured guest as an
+      # extra disk (see workload.nix). Distinct from `rootfs`, which is the
+      # platform image (kernel/initrd/OS chain).
+      workloadImage = pkgs.callPackage ./workload.nix { inherit fib-service; };
+
       # dm-verity hash tree + root hash for the rootfs. The root hash is baked
       # into the kernel cmdline, binding rootfs integrity into the SEV-SNP
       # measurement.
@@ -155,6 +161,36 @@
           | grep "Root hash:" \
           | awk '{print $NF}' \
           | tr -d '\n' > $out/roothash
+      '';
+
+      # dm-verity hash tree + root hash for the fib-service workload volume.
+      # Same mechanism as `verity` above (identical fixed salt/uuid), applied to
+      # workloadImage instead of rootfs, so the workload_roothash is reproducible
+      # too and can be baked into the guest config the same way the platform
+      # rootfs roothash is.
+      workloadVerity = pkgs.runCommand "workload-verity" {
+        nativeBuildInputs = [ pkgs.cryptsetup ];
+      } ''
+        mkdir -p $out
+        veritysetup format \
+          --salt=${veritySalt} \
+          --uuid=${verityUuid} \
+          ${workloadImage} \
+          $out/hashtree \
+          | tee /dev/stderr \
+          | grep "Root hash:" \
+          | awk '{print $NF}' \
+          | tr -d '\n' > $out/roothash
+      '';
+
+      # Convenience: the workload volume + its dm-verity sidecars, staged with
+      # the .verity/.roothash suffix convention the launch path and daemon
+      # expect for extra-disk sidecars.
+      workload = pkgs.runCommand "aleph-vm-workload" {} ''
+        mkdir -p $out
+        cp ${workloadImage} $out/workload.ext4
+        cp ${workloadVerity}/hashtree $out/workload.ext4.verity
+        cp ${workloadVerity}/roothash $out/workload.ext4.roothash
       '';
 
       # Parameterized SEV-SNP launch measurement builder.
@@ -206,6 +242,9 @@
           initrd
           rootfs
           verity
+          workloadImage
+          workloadVerity
+          workload
           measurement
           image;
         default = image;

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -188,7 +188,7 @@
       # expect for extra-disk sidecars.
       workload = pkgs.runCommand "aleph-vm-workload" {} ''
         mkdir -p $out
-        cp ${workloadImage} $out/workload.ext4
+        ln -s ${workloadImage} $out/workload.ext4
         cp ${workloadVerity}/hashtree $out/workload.ext4.verity
         cp ${workloadVerity}/roothash $out/workload.ext4.roothash
       '';

--- a/nix/workload.nix
+++ b/nix/workload.nix
@@ -1,0 +1,43 @@
+{ pkgs, fib-service, ... }:
+
+# Reproducible ext4 volume for the fib-service V-PROGRAM workload (Task 6).
+#
+# Content-only volume: the platform rootfs (rootfs.nix) already supplies the
+# kernel/initrd measured-boot chain; this volume just carries the workload
+# binary that the guest init (Task 7) mounts as an extra disk and execs.
+#
+# /sbin/init IS the fib-service binary itself (copied, not a wrapper script):
+# it is the simplest form that "actually boots" per the task brief, and it
+# sidesteps needing a shell (e.g. busybox) inside this volume just to `exec`
+# the real binary via a "#!/bin/sh" entrypoint. fib-service is a static-musl,
+# statically-PIE-linked binary (see flake.nix), so the kernel can load it
+# directly with no interpreter/dynamic linker present in this volume.
+pkgs.runCommand "workload.ext4" {
+  nativeBuildInputs = [ pkgs.e2fsprogs ];
+  # Reproducible mkfs: fixed timestamps (superblock + inodes). Nix-store source
+  # files already carry a fixed mtime, so with a fixed UUID and hash seed the
+  # image bytes (and thus the dm-verity root hash) are reproducible. Mirrors
+  # rootfs.nix's determinism levers.
+  SOURCE_DATE_EPOCH = "0";
+} ''
+  mkdir -p workload/sbin
+  cp ${fib-service}/bin/fib-service workload/sbin/init
+  chmod +x workload/sbin/init
+
+  # Calculate size (add 10MB padding).
+  size=$(du -sm workload | cut -f1)
+  size=$((size + 10))
+
+  # Create a reproducible ext4 image so the dm-verity root hash is stable
+  # across builds. Determinism levers (mirrors rootfs.nix):
+  #   - fixed UUID and directory hash seed (no random per-build values),
+  #   - SOURCE_DATE_EPOCH (fixed superblock/inode timestamps),
+  #   - no journal (^has_journal): this volume is mounted read-only under
+  #     dm-verity, so a journal is useless AND a nondeterminism source,
+  #   - non-lazy inode-table/journal init so nothing is written lazily/randomly.
+  truncate -s ''${size}M $out
+  mkfs.ext4 -b 4096 -U 00000000-0000-0000-0000-000000000000 \
+    -E hash_seed=a1e5c0de-1111-2222-3333-444455556666,lazy_itable_init=0,lazy_journal_init=0 \
+    -O ^has_journal \
+    -d workload $out
+''

--- a/nix/workload.nix
+++ b/nix/workload.nix
@@ -36,6 +36,9 @@ pkgs.runCommand "workload.ext4" {
   #     dm-verity, so a journal is useless AND a nondeterminism source,
   #   - non-lazy inode-table/journal init so nothing is written lazily/randomly.
   truncate -s ''${size}M $out
+  # Note: the hash_seed must be NON-zero; mke2fs treats an all-zero hash_seed
+  # as "unset" and generates a random one, breaking reproducibility (the UUID,
+  # by contrast, may be all-zero). See rootfs.nix for the full rationale.
   mkfs.ext4 -b 4096 -U 00000000-0000-0000-0000-000000000000 \
     -E hash_seed=a1e5c0de-1111-2222-3333-444455556666,lazy_itable_init=0,lazy_journal_init=0 \
     -O ^has_journal \


### PR DESCRIPTION
Part of the V-PROGRAM workload mechanism. **Depends on #1074** (fib-service).

**This PR (Nix):** builds `workload.ext4` (fib binary as `/sbin/init`) plus its dm-verity hash tree, fully reproducible (fixed salt/UUID/hash_seed, `SOURCE_DATE_EPOCH=0`, `^has_journal`) so the roothash is stable: `1fe2475cb4901e40f891c8801e1c28233c1f563baa8640a42648191cafbac250`. That roothash is what the daemon measures (via #1072's sidecar) and what attestation binds.