### PR TITLE
feat(nix): guest init mounts and execs the measured workload volume

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -7,9 +7,13 @@
   #   aleph-attest-agent static-musl binary and init.sh) + a minimal
   #   dm-verity-protected rootfs + a precomputed, reproducible sev-snp-measure
   #   launch measurement.
-  # Excluded from the donor: compose-rootfs / compose-demo, the encrypted-rootfs
-  # (LUKS) mode, and the fib-service demo app (replaced by a trivial busybox
-  # httpd placeholder workload). See rust-port-divergences.
+  # Excluded from the donor: compose-rootfs / compose-demo and the
+  # encrypted-rootfs (LUKS) mode. The fib-service demo app is NOT excluded
+  # here: it now exists as the V-PROGRAM workload (see workload.nix), baked
+  # into its own measured dm-verity volume that the guest init mounts and
+  # execs when a workload_roothash is present on the cmdline. The trivial
+  # busybox httpd remains the platform rootfs's baked /sbin/init, used as the
+  # no-workload fallback. See rust-port-divergences.
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
@@ -194,12 +198,26 @@
       '';
 
       # Parameterized SEV-SNP launch measurement builder.
-      # vcpus:    number of vCPUs (affects the launch measurement)
-      # vcpuType: QEMU CPU model ("EPYC-v4" for Genoa, "EPYC-v3" for Milan)
+      # vcpus:            number of vCPUs (affects the launch measurement)
+      # vcpuType:         QEMU CPU model ("EPYC-v4" for Genoa, "EPYC-v3" for Milan)
+      # workloadRoothash: when null (default), the cmdline is the
+      #   platform-only form `...roothash=<platform>` (workload-less parity,
+      #   what test_vm_snp and the baked `measurement` below expect). When
+      #   set to a dm-verity root hash, the cmdline is extended to the
+      #   workload form `...roothash=<platform> workload_roothash=<hex>`,
+      #   matching byte-for-byte what the daemon emits when a V-PROGRAM
+      #   workload is attached (lifecycle.rs) and the CMDLINE_TEMPLATE_EXEC_V1
+      #   manifest template (src/aleph/vm/vprogram/bundle.py). Per-workload
+      #   measurements are computed by passing this argument; they are never
+      #   baked into the platform bundle's own measurement.hex.
       # The measurement is a function of (OVMF + kernel + initrd + cmdline +
       # vCPU count + CPU type), so each configuration needs its own value.
-      measurementFor = { vcpus ? 2, vcpuType ? "EPYC-v4" }: let
-        kernelCmdline = "console=ttyS0 root=/dev/mapper/verity-root ro roothash=${builtins.readFile "${verity}/roothash"}";
+      measurementFor = { vcpus ? 2, vcpuType ? "EPYC-v4", workloadRoothash ? null }: let
+        platformRoothash = builtins.readFile "${verity}/roothash";
+        kernelCmdline =
+          if workloadRoothash == null
+          then "console=ttyS0 root=/dev/mapper/verity-root ro roothash=${platformRoothash}"
+          else "console=ttyS0 root=/dev/mapper/verity-root ro roothash=${platformRoothash} workload_roothash=${workloadRoothash}";
       in pkgs.runCommand "sev-snp-measurement-${toString vcpus}vcpus-${vcpuType}" {
         nativeBuildInputs = [ sev-snp-measure ];
       } ''
@@ -214,8 +232,22 @@
           | tr -d '\n' > $out
       '';
 
-      # Default measurement: 2 vCPUs, EPYC-v4 (Genoa).
+      # Default measurement: 2 vCPUs, EPYC-v4 (Genoa), platform-only cmdline
+      # (no workload_roothash). This is the value baked into image/measurement.hex
+      # below and MUST stay platform-only for workload-less parity (test_vm_snp).
       measurement = measurementFor { vcpus = 2; vcpuType = "EPYC-v4"; };
+
+      # Convenience: the workload-form measurement for THIS repo's fib-service
+      # demo workload (2 vCPUs, EPYC-v4), using workloadVerity's root hash.
+      # Exposed for sanity-checking the workload cmdline template end-to-end;
+      # NOT baked into the platform image's measurement.hex (see above). Real
+      # per-workload measurements at launch time are computed by the daemon's
+      # own helper from the workload's actual root hash, not by this flake.
+      workloadMeasurement = measurementFor {
+        vcpus = 2;
+        vcpuType = "EPYC-v4";
+        workloadRoothash = builtins.readFile "${workloadVerity}/roothash";
+      };
 
       # Convenience: all measured-image artifacts in one directory.
       image = pkgs.runCommand "aleph-cvm-image" {} ''
@@ -246,6 +278,7 @@
           workloadVerity
           workload
           measurement
+          workloadMeasurement
           image;
         default = image;
       };

--- a/nix/init.sh
+++ b/nix/init.sh
@@ -53,6 +53,13 @@ fi
 
 # Parse boot mode from kernel command line.
 roothash=$(/bin/busybox sed -n 's/.*\broothash=\([0-9a-fA-F]*\).*/\1/p' /proc/cmdline)
+# Parse the V-PROGRAM workload root hash, if present. `\b` requires a
+# non-word character immediately before the match: since "_" and letters are
+# both word characters, `\broothash=` above never matches inside
+# "workload_roothash=" (no boundary between the "d" of "workload" and the "_"
+# that follows, nor between that "_" and "r"), and this `\bworkload_roothash=`
+# match is unambiguous on its own. The two tokens never cross-match.
+workload_roothash=$(/bin/busybox sed -n 's/.*\bworkload_roothash=\([0-9a-fA-F]*\).*/\1/p' /proc/cmdline)
 
 # Wait for the rootfs block device to appear.
 blkdev=""
@@ -72,6 +79,24 @@ if [ -z "$blkdev" ]; then
     echo "init: FATAL: no block device found"
     exec /bin/busybox poweroff -f
 fi
+
+# Wait (up to 3s) for a block device to appear, e.g. a dm-verity hash tree
+# disk attached by QEMU as an extra virtio-blk device. Used for both the
+# platform hash tree (/dev/vdb) and the workload data + hash tree devices
+# (/dev/vdc, /dev/vdd) below, so each disk is waited for explicitly instead
+# of assuming a single fixed device name.
+wait_for_dev() {
+    dev="$1"
+    n=0
+    while [ "$n" -lt 30 ]; do
+        if [ -b "$dev" ]; then
+            return 0
+        fi
+        /bin/busybox sleep 0.1
+        n=$((n + 1))
+    done
+    return 1
+}
 
 /bin/busybox mkdir -p /mnt/root
 
@@ -147,8 +172,9 @@ NFT
     fi
 }
 
-# Load dm-verity kernel modules if verity is requested.
-if [ -n "$roothash" ]; then
+# Load dm-verity kernel modules if verity is requested (platform rootfs
+# and/or workload volume: either token alone is enough to need dm-verity).
+if [ -n "$roothash" ] || [ -n "$workload_roothash" ]; then
     echo "init: loading dm-verity kernel modules"
     /bin/busybox insmod /lib/modules/dax.ko 2>&1 || echo "init: warning: insmod dax.ko failed"
     /bin/busybox insmod /lib/modules/dm-mod.ko 2>&1 || echo "init: warning: insmod dm-mod.ko failed"
@@ -160,34 +186,25 @@ if [ -n "$roothash" ]; then
 fi
 
 if [ -n "$roothash" ]; then
-    # dm-verity: wait for hash tree device (/dev/vdb)
-    hashdev=""
-    n=0
-    while [ "$n" -lt 30 ]; do
-        if [ -b /dev/vdb ]; then
-            hashdev="/dev/vdb"
-            break
-        fi
-        /bin/busybox sleep 0.1
-        n=$((n + 1))
-    done
-
-    if [ -z "$hashdev" ]; then
+    # dm-verity: wait for the platform hash tree device (/dev/vdb).
+    if wait_for_dev /dev/vdb; then
+        hashdev="/dev/vdb"
+    else
         echo "init: FATAL: roothash set but /dev/vdb (hash tree) not found"
         exec /bin/busybox poweroff -f
-    else
-        echo "init: setting up dm-verity on ${blkdev} with hash tree ${hashdev}"
-        echo "init: roothash=${roothash}"
-        if /bin/veritysetup open "$blkdev" verity-root "$hashdev" "$roothash" 2>&1; then
-            echo "init: mounting /dev/mapper/verity-root"
-            if ! /bin/busybox mount -t ext4 -o ro /dev/mapper/verity-root /mnt/root; then
-                echo "init: FATAL: verity mount failed"
-                exec /bin/busybox poweroff -f
-            fi
-        else
-            echo "init: FATAL: dm-verity verification failed - rootfs may be tampered"
+    fi
+
+    echo "init: setting up dm-verity on ${blkdev} with hash tree ${hashdev}"
+    echo "init: roothash=${roothash}"
+    if /bin/veritysetup open "$blkdev" verity-root "$hashdev" "$roothash" 2>&1; then
+        echo "init: mounting /dev/mapper/verity-root"
+        if ! /bin/busybox mount -t ext4 -o ro /dev/mapper/verity-root /mnt/root; then
+            echo "init: FATAL: verity mount failed"
             exec /bin/busybox poweroff -f
         fi
+    else
+        echo "init: FATAL: dm-verity verification failed - rootfs may be tampered"
+        exec /bin/busybox poweroff -f
     fi
 else
     # No dm-verity: direct mount (backwards compatible)
@@ -199,13 +216,54 @@ else
     fi
 fi
 
+# V-PROGRAM workload volume: verity-verify and mount the workload data disk
+# (/dev/vdc) against its hash tree (/dev/vdd), distinct devices from the
+# platform rootfs (/dev/vda) and its hash tree (/dev/vdb) above. Only present
+# when the daemon attached a workload; when workload_roothash is empty this
+# whole block is skipped and behavior is unchanged (platform /sbin/init runs
+# below, as today).
+if [ -n "$workload_roothash" ]; then
+    if ! wait_for_dev /dev/vdc; then
+        echo "init: FATAL: workload_roothash set but /dev/vdc (workload data) not found"
+        exec /bin/busybox poweroff -f
+    fi
+    if ! wait_for_dev /dev/vdd; then
+        echo "init: FATAL: workload_roothash set but /dev/vdd (workload hash tree) not found"
+        exec /bin/busybox poweroff -f
+    fi
+
+    echo "init: setting up dm-verity on /dev/vdc with hash tree /dev/vdd (workload)"
+    echo "init: workload_roothash=${workload_roothash}"
+    if /bin/veritysetup open /dev/vdc verity-workload /dev/vdd "$workload_roothash" 2>&1; then
+        /bin/busybox mkdir -p /mnt/workload
+        echo "init: mounting /dev/mapper/verity-workload"
+        if ! /bin/busybox mount -t ext4 -o ro /dev/mapper/verity-workload /mnt/workload; then
+            echo "init: FATAL: workload verity mount failed"
+            exec /bin/busybox poweroff -f
+        fi
+    else
+        echo "init: FATAL: dm-verity verification failed for the workload volume - it may be tampered"
+        exec /bin/busybox poweroff -f
+    fi
+fi
+
 prepare_chroot
 
 # Install the guest firewall BEFORE starting the workload, so the app can never
 # be reached directly even during the window before the agent is up.
 setup_firewall
 
-if [ -x /mnt/root/sbin/init ]; then
+# When a V-PROGRAM workload is mounted, its /sbin/init (the workload
+# entrypoint, e.g. fib-service) runs INSTEAD OF the baked platform
+# /sbin/init (the busybox httpd fallback used when no workload is present).
+if [ -n "$workload_roothash" ]; then
+    if [ -x /mnt/workload/sbin/init ]; then
+        echo "init: starting /sbin/init from workload volume"
+        /bin/busybox chroot /mnt/workload /sbin/init &
+    else
+        echo "init: WARNING: no /sbin/init found in workload volume"
+    fi
+elif [ -x /mnt/root/sbin/init ]; then
     echo "init: starting /sbin/init from rootfs"
     /bin/busybox chroot /mnt/root /sbin/init &
 else

--- a/nix/init.sh
+++ b/nix/init.sh
@@ -86,6 +86,7 @@ fi
 # (/dev/vdc, /dev/vdd) below, so each disk is waited for explicitly instead
 # of assuming a single fixed device name.
 wait_for_dev() {
+    local dev n
     dev="$1"
     n=0
     while [ "$n" -lt 30 ]; do
@@ -100,46 +101,55 @@ wait_for_dev() {
 
 /bin/busybox mkdir -p /mnt/root
 
-# Prepare the chroot environment: bind-mount /proc, /sys, /dev, the secret dir,
-# and set up DNS. Called after mounting rootfs, before starting /sbin/init.
+# Prepare a chroot environment: bind-mount /proc, /sys, /dev, the secret dir,
+# and set up DNS in the given target. Called with the chroot that will
+# actually run its /sbin/init (/mnt/workload when a V-PROGRAM workload volume
+# is mounted, /mnt/root otherwise), after mounting it.
+#
+# The target is mounted read-only under dm-verity, so the mkdirs below cannot
+# create anything there: the mount-point directories (and the resolv.conf
+# placeholder file) are shipped in the image (rootfs.nix / workload.nix) and
+# the mkdirs no-op. They only do real work on the legacy writable-mount path.
 prepare_chroot() {
-    /bin/busybox mkdir -p /mnt/root/proc /mnt/root/sys /mnt/root/dev /mnt/root/etc
-    /bin/busybox mount --bind /proc /mnt/root/proc
-    /bin/busybox mount --bind /sys /mnt/root/sys
-    /bin/busybox mount --bind /dev /mnt/root/dev
+    local target
+    target="$1"
+    /bin/busybox mkdir -p "$target/proc" "$target/sys" "$target/dev" "$target/etc"
+    /bin/busybox mount --bind /proc "$target/proc"
+    /bin/busybox mount --bind /sys "$target/sys"
+    /bin/busybox mount --bind /dev "$target/dev"
     # Secret delivery: the attest-agent writes injected secrets under /tmp/secrets
     # in THIS (initramfs) mount namespace, but the workload runs chrooted into
-    # /mnt/root, where /tmp/secrets is a different filesystem. Bind-mount the
+    # the target, where /tmp/secrets is a different filesystem. Bind-mount the
     # agent's secret dir into the chroot so the app reads exactly what the agent
     # writes. The source path matches the agent's DEFAULT_SECRETS_DIR
     # (/tmp/secrets in secrets.rs); pre-create it 0700 so the agent's hardened
     # directory check accepts it (real dir, agent-owned, owner-only).
     /bin/busybox mkdir -m 0700 -p /tmp/secrets
-    /bin/busybox mkdir -m 0700 -p /mnt/root/tmp/secrets
-    /bin/busybox mount --bind /tmp/secrets /mnt/root/tmp/secrets
-    # DNS for the chrooted workload. The rootfs is mounted read-only under
-    # dm-verity, so writing /mnt/root/etc/resolv.conf directly cannot work
+    /bin/busybox mkdir -m 0700 -p "$target/tmp/secrets"
+    /bin/busybox mount --bind /tmp/secrets "$target/tmp/secrets"
+    # DNS for the chrooted workload. The target is mounted read-only under
+    # dm-verity, so writing its /etc/resolv.conf directly cannot work
     # there (the old `echo >` only ever worked on legacy writable mounts).
     # Instead, expose the initramfs /etc/resolv.conf (written by udhcpc.script
     # from the DHCP option-6 nameservers) via a file bind-mount over the
-    # rootfs placeholder. On the static ip= path there is no DHCP lease, so
+    # image's placeholder. On the static ip= path there is no DHCP lease, so
     # seed the initramfs copy from the gateway first (common for VM bridges).
     if [ ! -f /etc/resolv.conf ] && [ -n "$gateway" ]; then
         /bin/busybox mkdir -p /etc
         echo "nameserver ${gateway}" > /etc/resolv.conf
     fi
     if [ -f /etc/resolv.conf ]; then
-        if [ -f /mnt/root/etc/resolv.conf ]; then
-            /bin/busybox mount --bind /etc/resolv.conf /mnt/root/etc/resolv.conf \
+        if [ -f "$target/etc/resolv.conf" ]; then
+            /bin/busybox mount --bind /etc/resolv.conf "$target/etc/resolv.conf" \
                 || echo "init: WARNING: resolv.conf bind-mount failed; workload DNS unavailable"
         else
-            # Legacy rootfs without the placeholder: best-effort copy (works
-            # only if the rootfs is mounted writable).
-            /bin/busybox cp /etc/resolv.conf /mnt/root/etc/resolv.conf 2>/dev/null \
-                || echo "init: WARNING: rootfs has no /etc/resolv.conf placeholder; workload DNS unavailable"
+            # Legacy image without the placeholder: best-effort copy (works
+            # only if the target is mounted writable).
+            /bin/busybox cp /etc/resolv.conf "$target/etc/resolv.conf" 2>/dev/null \
+                || echo "init: WARNING: ${target} has no /etc/resolv.conf placeholder; workload DNS unavailable"
         fi
     fi
-    echo "init: chroot environment prepared (proc, sys, dev, secrets, DNS)"
+    echo "init: chroot environment prepared at ${target} (proc, sys, dev, secrets, DNS)"
 }
 
 # Install a minimal guest firewall so only the attested TLS port is reachable
@@ -247,7 +257,15 @@ if [ -n "$workload_roothash" ]; then
     fi
 fi
 
-prepare_chroot
+# Prepare only the chroot that will actually run its /sbin/init: when a
+# workload volume is mounted, the workload runs INSTEAD OF the platform
+# /sbin/init, so the bind mounts (proc, sys, dev, secrets, DNS) belong in
+# /mnt/workload and preparing /mnt/root would be wasted work (and vice versa).
+if [ -n "$workload_roothash" ]; then
+    prepare_chroot /mnt/workload
+else
+    prepare_chroot /mnt/root
+fi
 
 # Install the guest firewall BEFORE starting the workload, so the app can never
 # be reached directly even during the window before the agent is up.
@@ -261,7 +279,12 @@ if [ -n "$workload_roothash" ]; then
         echo "init: starting /sbin/init from workload volume"
         /bin/busybox chroot /mnt/workload /sbin/init &
     else
-        echo "init: WARNING: no /sbin/init found in workload volume"
+        # dm-verity already proved the volume authentic, so a missing
+        # /sbin/init means a malformed workload image: fail closed like every
+        # other error path instead of leaving the attest-agent proxying to a
+        # dead upstream.
+        echo "init: FATAL: no /sbin/init found in workload volume"
+        exec /bin/busybox poweroff -f
     fi
 elif [ -x /mnt/root/sbin/init ]; then
     echo "init: starting /sbin/init from rootfs"

--- a/nix/rootfs.nix
+++ b/nix/rootfs.nix
@@ -22,6 +22,10 @@ pkgs.runCommand "rootfs.ext4" {
 } ''
   # Create a minimal ext4 image with /sbin/init entrypoint.
   mkdir -p rootfs/sbin rootfs/bin rootfs/srv rootfs/etc
+  # Mount-point targets for init.sh's prepare_chroot proc/sys/dev bind mounts:
+  # like the resolv.conf and secrets targets below, these cannot be created at
+  # boot on the read-only verity mount, so they must ship in the image.
+  mkdir -p rootfs/proc rootfs/sys rootfs/dev
   cp ${staticBusybox}/bin/busybox rootfs/bin/
 
   # Empty resolv.conf placeholder: the rootfs is mounted read-only under

--- a/nix/workload.nix
+++ b/nix/workload.nix
@@ -24,6 +24,16 @@ pkgs.runCommand "workload.ext4" {
   cp ${fib-service}/bin/fib-service workload/sbin/init
   chmod +x workload/sbin/init
 
+  # Mount-point targets for init.sh's prepare_chroot: the volume is mounted
+  # read-only under dm-verity, so init.sh cannot create these at boot; they
+  # must ship in the image for the proc/sys/dev bind mounts, the /tmp/secrets
+  # secret-delivery bind mount, and the /etc/resolv.conf file bind mount
+  # (a file bind-mount needs an existing target). Mirrors rootfs.nix.
+  mkdir -p workload/proc workload/sys workload/dev workload/etc workload/tmp/secrets
+  touch workload/etc/resolv.conf
+  chmod 1777 workload/tmp
+  chmod 0700 workload/tmp/secrets
+
   # Calculate size (add 10MB padding).
   size=$(du -sm workload | cut -f1)
   size=$((size + 10))

--- a/src/aleph/vm/vprogram/bundle.py
+++ b/src/aleph/vm/vprogram/bundle.py
@@ -119,8 +119,8 @@ def build_bundle(image_dir: Path, out_dir: Path, source_epoch: int, source: Sour
 
 # Fixed format-version-1 values describing what the current image implements
 # (nix/init.sh hardcodes the agent on tcp/8443 proxying 127.0.0.1:8080, and
-# its init parses only roothash=). Changing these is a runtime/format
-# evolution, not a CLI flag.
+# its init parses roothash= plus the optional workload_roothash=). Changing
+# these is a runtime/format evolution, not a CLI flag.
 CMDLINE_TEMPLATE_V1 = "console=ttyS0 root=/dev/mapper/verity-root ro roothash={platform_roothash}"
 # Exec-runtime flavor: the daemon measures a workload rootfs alongside the
 # platform rootfs and folds its dm-verity roothash into the cmdline (Task 1's


### PR DESCRIPTION
Part of the V-PROGRAM workload mechanism. **Depends on #1075** (workload volume).

**This PR (Nix):** the guest `init.sh` parses `workload_roothash=` from the measured cmdline; when present it `veritysetup open`s the workload (vdc data / vdd hash tree) against the measured roothash, mounts it, and execs `/sbin/init` from it. The workload-less boot path is unchanged. New platform measurement reflects the init change: `d86657015ea1edd9346c76faa636c03d1ebe6341928a3ac9ee82286b9815741698278551edea97f1baa661648725b197`.