### PR TITLE
feat(vprogram): aleph.exec/1 workload contract + workload_roothash cmdline template

### DIFF
--- a/src/aleph/vm/vprogram/bundle.py
+++ b/src/aleph/vm/vprogram/bundle.py
@@ -122,16 +122,39 @@ def build_bundle(image_dir: Path, out_dir: Path, source_epoch: int, source: Sour
 # its init parses only roothash=). Changing these is a runtime/format
 # evolution, not a CLI flag.
 CMDLINE_TEMPLATE_V1 = "console=ttyS0 root=/dev/mapper/verity-root ro roothash={platform_roothash}"
+# Exec-runtime flavor: the daemon measures a workload rootfs alongside the
+# platform rootfs and folds its dm-verity roothash into the cmdline (Task 1's
+# daemon emits exactly this string). Client-side launch-measurement
+# computation depends on byte-identity with what the daemon emits, so this
+# constant must not be reformatted independently of that emitter.
+CMDLINE_TEMPLATE_EXEC_V1 = (
+    "console=ttyS0 root=/dev/mapper/verity-root ro roothash={platform_roothash}"
+    " workload_roothash={workload_roothash}"
+)
 DEFAULT_CPU_MODELS = ["EPYC-v4"]
 DEFAULT_ATTESTATION = [
     AttestationProtocol(protocol="aleph.ra-tls", version="1", transport=AttestationTransport(type="tcp", port=8443))
 ]
 DEFAULT_WORKLOAD = WorkloadSpec(contract="aleph.builtin/1", upstream_port=8080)
+# Exec-runtime workload contract: a plain executable/command workload rather
+# than the builtin no-workload runtime.
+EXEC_WORKLOAD = WorkloadSpec(contract="aleph.exec/1", upstream_port=8080)
 
 
-def make_manifest(info: BundleInfo, bundle_ref: str, name: str, runtime_version: str) -> RuntimeManifest:
+def make_manifest(
+    info: BundleInfo, bundle_ref: str, name: str, runtime_version: str, *, exec_runtime: bool = False
+) -> RuntimeManifest:
     """Build the manifest for an uploaded bundle. Validation is the
-    constructor: any inconsistency raises pydantic ValidationError."""
+    constructor: any inconsistency raises pydantic ValidationError.
+
+    By default builds the platform-only, no-workload manifest (builtin
+    contract, `{platform_roothash}`-only cmdline template). Pass
+    `exec_runtime=True` to select the `aleph.exec/1` workload contract and
+    the `{platform_roothash}`/`{workload_roothash}` cmdline template used by
+    runtimes that boot a separate measured workload rootfs.
+    """
+    cmdline_template = CMDLINE_TEMPLATE_EXEC_V1 if exec_runtime else CMDLINE_TEMPLATE_V1
+    workload = EXEC_WORKLOAD if exec_runtime else DEFAULT_WORKLOAD
     return RuntimeManifest(
         format="aleph-vprogram-runtime",
         format_version=1,
@@ -144,10 +167,10 @@ def make_manifest(info: BundleInfo, bundle_ref: str, name: str, runtime_version:
             kernel_hashes=True,
             cpu_models=list(DEFAULT_CPU_MODELS),
             platform_roothash=info.platform_roothash,
-            cmdline_template=CMDLINE_TEMPLATE_V1,
+            cmdline_template=cmdline_template,
         ),
         attestation=[protocol.model_copy(deep=True) for protocol in DEFAULT_ATTESTATION],
-        workload=DEFAULT_WORKLOAD.model_copy(deep=True),
+        workload=workload.model_copy(deep=True),
         source=info.source,
     )
 

--- a/tests/vprogram/test_bundle.py
+++ b/tests/vprogram/test_bundle.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from aleph.vm.vprogram.bundle import (
     BUNDLE_INFO_NAME,
     BUNDLE_NAME,
+    CMDLINE_TEMPLATE_EXEC_V1,
     BundleInfo,
     build_bundle,
     make_manifest,
@@ -146,6 +147,18 @@ def test_make_manifest_does_not_alias_module_defaults(image_dir: Path, tmp_path:
     assert first.workload is not second.workload
     assert first.attestation[0] == second.attestation[0]
     assert first.attestation[0] is not second.attestation[0]
+
+
+def test_exec_manifest_uses_workload_template(image_dir: Path, tmp_path: Path) -> None:
+    out = _out(tmp_path, "out")
+    info = build_bundle(image_dir=image_dir, out_dir=out, source_epoch=EPOCH, source=SOURCE)
+    manifest = make_manifest(
+        info=info, bundle_ref=BUNDLE_REF, name="aleph-exec", runtime_version="2026.07.08", exec_runtime=True
+    )
+    RuntimeManifest.model_validate(manifest.model_dump(mode="json"))
+    assert manifest.boot.cmdline_template == CMDLINE_TEMPLATE_EXEC_V1
+    assert manifest.workload.contract == "aleph.exec/1"
+    assert manifest.workload.upstream_port == 8080
 
 
 def test_make_manifest_rejects_bad_ref(image_dir: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
Part of the V-PROGRAM workload mechanism. **Depends on #1050** (extends its `bundle.py` / manifest tooling).

**This PR (Python):** adds the `aleph.exec/1` workload contract (direct-exec a static entrypoint, not the donor's podman/compose stack) and the `CMDLINE_TEMPLATE_EXEC_V1` that carries `workload_roothash={workload_roothash}`, plus `EXEC_WORKLOAD = WorkloadSpec(contract="aleph.exec/1", upstream_port=8080)` and `make_manifest(exec_runtime=...)`. This is what the harness/manifest declares so the daemon's measured cmdline and the guest init agree.