### PR TITLE
feat(vprogram): map the attestation port to a host IPv4 port

### DIFF
--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -180,9 +180,10 @@ def resolve_vprogram_port_forwards(vm_id: VmId, attest_port: int | None) -> list
 
 async def reconcile_vprogram_port_forwards(supervisor: Supervisor, vm_id: VmId, attest_port: int | None) -> None:
     """Drive the hypervisor's forwards to match the V-PROGRAM's single
-    attestation-port mapping. Reuses ``_reconcile_forwards``, so re-running
-    this on re-adoption (a fresh agent process picking the VM back up) is a
-    no-op once the mapping already exists.
+    attestation-port mapping. Reuses ``_reconcile_forwards``, so it is
+    idempotent by construction: a future re-adoption path (a fresh agent
+    process picking the VM back up) can call it safely, though today only
+    the create path does.
     """
     await _reconcile_forwards(supervisor, vm_id, resolve_vprogram_port_forwards(vm_id, attest_port))
 
@@ -413,6 +414,12 @@ async def create_vm_execution(
             # the guest's RA-TLS attestation endpoint; measurement-neutral
             # (no guest image/cmdline change) and idempotent via the same
             # reconcile machinery the instance path uses.
+            #
+            # A reconcile failure lands in the teardown branch below on
+            # purpose, mirroring the instance path: a V-PROGRAM whose
+            # attestation endpoint cannot be mapped is unreachable for its
+            # sole consumer, so failing the create loudly (and letting the
+            # scheduler retry) beats keeping an unusable VM alive.
             await reconcile_vprogram_port_forwards(supervisor, info.vm_id, attest_port)
         except Exception:
             registry.forget(vm_hash)

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -132,14 +132,14 @@ async def resolve_port_forwards(vm_id: VmId, content) -> list[PortForwardSpec]:
     return forwards
 
 
-async def reconcile_port_forwards(supervisor: Supervisor, vm_id: VmId, content) -> None:
-    """Drive the hypervisor's forwards to match the aggregate settings.
-
-    Agent policy half of the old fetch_port_redirect_config_and_setup: compute
-    the desired set, diff against what the hypervisor reports, and issue
-    add/remove calls. The hypervisor owns application and persistence.
+async def _reconcile_forwards(supervisor: Supervisor, vm_id: VmId, desired_specs: list[PortForwardSpec]) -> None:
+    """Diff `desired_specs` against what the hypervisor currently reports for
+    `vm_id` and issue add/remove calls so the two converge. The hypervisor
+    owns application and persistence; this is pure agent policy, and it is
+    idempotent: calling it again with the same desired set (e.g. on
+    re-adoption) issues no calls at all.
     """
-    desired = {(int(spec.vm_port), spec.protocol): spec for spec in await resolve_port_forwards(vm_id, content)}
+    desired = {(int(spec.vm_port), spec.protocol): spec for spec in desired_specs}
     current = {(int(info.vm_port), info.protocol): info for info in await supervisor.list_port_forwards(vm_id)}
     for key, info in current.items():
         if key not in desired:
@@ -147,6 +147,44 @@ async def reconcile_port_forwards(supervisor: Supervisor, vm_id: VmId, content) 
     for key, spec in desired.items():
         if key not in current:
             await supervisor.add_port_forward(spec)
+
+
+async def reconcile_port_forwards(supervisor: Supervisor, vm_id: VmId, content) -> None:
+    """Drive the hypervisor's forwards to match the aggregate settings.
+
+    Agent policy half of the old fetch_port_redirect_config_and_setup: compute
+    the desired set, then converge through ``_reconcile_forwards``.
+    """
+    await _reconcile_forwards(supervisor, vm_id, await resolve_port_forwards(vm_id, content))
+
+
+def resolve_vprogram_port_forwards(vm_id: VmId, attest_port: int | None) -> list[PortForwardSpec]:
+    """The only forward a V-PROGRAM gets: the manifest's RA-TLS attestation
+    port (tcp), mapped to a host IPv4 port so an external client (the aleph
+    CLI) can reach the guest's RA-TLS endpoint. Host-only DNAT,
+    measurement-neutral: unlike instances, no user aggregate is consulted and
+    SSH is never force-added. `attest_port` is None when the manifest
+    declared no aleph.ra-tls tcp transport; that V-PROGRAM gets no mapping.
+    """
+    if attest_port is None:
+        return []
+    return [
+        PortForwardSpec(
+            vm_id=vm_id,
+            host_port=HostPort(0),
+            vm_port=GuestPort(int(attest_port)),
+            protocol=Protocol.TCP,
+        )
+    ]
+
+
+async def reconcile_vprogram_port_forwards(supervisor: Supervisor, vm_id: VmId, attest_port: int | None) -> None:
+    """Drive the hypervisor's forwards to match the V-PROGRAM's single
+    attestation-port mapping. Reuses ``_reconcile_forwards``, so re-running
+    this on re-adoption (a fresh agent process picking the VM back up) is a
+    no-op once the mapping already exists.
+    """
+    await _reconcile_forwards(supervisor, vm_id, resolve_vprogram_port_forwards(vm_id, attest_port))
 
 
 async def _wait_until_running(
@@ -355,7 +393,7 @@ async def create_vm_execution(
         # set), so the plain readiness wait applies.
         record = registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
         try:
-            spec = await build_vprogram_spec(vm_hash, content)
+            spec, attest_port = await build_vprogram_spec(vm_hash, content)
             # Agent-side admission after the download, like the instance path:
             # a failed bundle fetch never consumes capacity.
             capacity.check_capacity(
@@ -371,6 +409,11 @@ async def create_vm_execution(
             raise
         try:
             await _wait_until_running(supervisor, info.vm_id)
+            # Host-only DNAT so an external client (the aleph CLI) can reach
+            # the guest's RA-TLS attestation endpoint; measurement-neutral
+            # (no guest image/cmdline change) and idempotent via the same
+            # reconcile machinery the instance path uses.
+            await reconcile_vprogram_port_forwards(supervisor, info.vm_id, attest_port)
         except Exception:
             registry.forget(vm_hash)
             try:

--- a/src/aleph/vm/agent/vprogram_launch.py
+++ b/src/aleph/vm/agent/vprogram_launch.py
@@ -180,13 +180,31 @@ def _ensure_verity_sidecars(rootfs_path: Path, hash_tree_path: Path, platform_ro
             shutil.copyfile(hash_tree_path, verity_path)
 
 
-async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramContent) -> CreateVmSpec:
+def _select_attestation_port(manifest: RuntimeManifest) -> int | None:
+    """The RA-TLS attestation port a CRN maps to a host IPv4 port, so an
+    external client (the aleph CLI) can reach the guest's attestation
+    endpoint. Selects the ``aleph.ra-tls`` protocol's tcp transport port;
+    None when the manifest declares none (the caller skips port-forward
+    setup rather than failing closed on it, since attestation reachability
+    is not required for the VM itself to boot and run)."""
+    for protocol in manifest.attestation:
+        if protocol.protocol == "aleph.ra-tls" and protocol.transport.type == "tcp":
+            return protocol.transport.port
+    return None
+
+
+async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramContent) -> tuple[CreateVmSpec, int | None]:
     """Fetch, verify and stage the runtime bundle, then build the SNP spec.
 
     Mirrors the on-host launch template (aleph-testnets test_vm_snp.py): QEMU
     backend, direct-kernel boot from the measured bundle members, and a disk
     order that IS the contract: the guest init reads the platform rootfs from
     /dev/vda and the dm-verity hash tree from /dev/vdb.
+
+    Also returns the manifest's RA-TLS attestation port (or None), so the
+    caller can map it to a host port after the VM reaches RUNNING. Nothing
+    here touches spec construction to surface it: the attestation port is a
+    host-only DNAT concern, entirely orthogonal to the measured launch.
     """
     manifest = await fetch_runtime_manifest(str(content.runtime.ref))
 
@@ -238,7 +256,7 @@ async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramConte
 
     session_base = settings.CONFIDENTIAL_SESSION_DIRECTORY or (Path(settings.EXECUTION_ROOT) / "sessions")
 
-    return CreateVmSpec(
+    spec = CreateVmSpec(
         vm_id=VmId(str(vm_hash)),
         backend=Backend.QEMU,
         kernel_path=kernel_path,
@@ -266,3 +284,4 @@ async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramConte
         persistent=True,
         hostname=get_hostname_from_hash(vm_hash),
     )
+    return spec, _select_attestation_port(manifest)

--- a/src/aleph/vm/agent/vprogram_launch.py
+++ b/src/aleph/vm/agent/vprogram_launch.py
@@ -186,7 +186,9 @@ def _select_attestation_port(manifest: RuntimeManifest) -> int | None:
     endpoint. Selects the ``aleph.ra-tls`` protocol's tcp transport port;
     None when the manifest declares none (the caller skips port-forward
     setup rather than failing closed on it, since attestation reachability
-    is not required for the VM itself to boot and run)."""
+    is not required for the VM itself to boot and run). First match wins:
+    the schema allows several ``aleph.ra-tls`` entries but a single RA-TLS
+    transport is the expected case, so extra entries are not mapped."""
     for protocol in manifest.attestation:
         if protocol.protocol == "aleph.ra-tls" and protocol.transport.type == "tcp":
             return protocol.transport.port

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -202,7 +202,9 @@ async def test_create_vm_execution_vprogram_launches_snp(mocker):
     mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
 
     fake_spec = MagicMock()
-    mock_build = mocker.patch("aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=fake_spec)
+    mock_build = mocker.patch(
+        "aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=(fake_spec, 8443)
+    )
     mock_persist = mocker.patch("aleph.vm.agent.run.persist_record", new_callable=AsyncMock)
 
     info = _running_vm_info(str(vm_hash))
@@ -211,6 +213,8 @@ async def test_create_vm_execution_vprogram_launches_snp(mocker):
         create_vm=AsyncMock(return_value=info),
         get_vm=AsyncMock(return_value=info),
         delete_vm=AsyncMock(),
+        list_port_forwards=AsyncMock(return_value=[]),
+        add_port_forward=AsyncMock(),
     )
     registry = AgentVmRegistry()
 
@@ -225,6 +229,10 @@ async def test_create_vm_execution_vprogram_launches_snp(mocker):
     mock_build.assert_awaited_once_with(vm_hash, message.content)
     supervisor.create_vm.assert_awaited_once_with(fake_spec)
     supervisor.delete_vm.assert_not_awaited()
+    supervisor.add_port_forward.assert_awaited_once()
+    added_spec = supervisor.add_port_forward.await_args.args[0]
+    assert added_spec.vm_port == 8443
+    assert added_spec.protocol.value == "tcp"
     assert vm_hash in registry
     record = registry.get(vm_hash)
     assert record is not None and record.persistent

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -264,7 +264,7 @@ async def test_create_vm_execution_vprogram_wait_failure_tears_down(mocker):
     mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
 
     fake_spec = MagicMock()
-    mocker.patch("aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=fake_spec)
+    mocker.patch("aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=(fake_spec, 8443))
     mock_persist = mocker.patch("aleph.vm.agent.run.persist_record", new_callable=AsyncMock)
 
     info = _failed_vm_info(str(vm_hash))
@@ -326,7 +326,7 @@ async def test_create_vm_execution_vprogram_capacity_failure_forgets_record(mock
     create_vm (a distinct failure path from a build failure)."""
     message = load_vprogram_message()
     mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
-    mocker.patch("aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=MagicMock())
+    mocker.patch("aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=(MagicMock(), 8443))
 
     capacity = MagicMock()
     capacity.check_capacity.side_effect = InsufficientResourcesError("no room", required={}, available={})

--- a/tests/supervisor/test_vprogram_launch.py
+++ b/tests/supervisor/test_vprogram_launch.py
@@ -233,7 +233,8 @@ async def test_build_vprogram_spec(staged_bundle):
     persistent."""
     message = load_vprogram_message()
     content = message.content
-    spec = await build_vprogram_spec(message.item_hash, content)
+    spec, attest_port = await build_vprogram_spec(message.item_hash, content)
+    assert attest_port == 8443
 
     staging = vprogram_staging_dir(message.item_hash)
     assert spec.vm_id == str(message.item_hash)
@@ -277,12 +278,36 @@ async def test_build_vprogram_spec(staged_bundle):
 
 
 @pytest.mark.asyncio
+async def test_build_vprogram_spec_no_ra_tls_attestation_port(tmp_path, storage_files):
+    """A manifest whose attestation list has no aleph.ra-tls tcp entry
+    surfaces attest_port=None: the caller (run.py) skips port-forward setup
+    rather than failing the create path on it."""
+    tar_path = make_bundle(tmp_path)
+    manifest_path = make_manifest(
+        tar_path,
+        tmp_path,
+        **{
+            "attestation": [
+                {"protocol": "aleph.other-attest", "version": "1", "transport": {"type": "tcp", "port": 9000}}
+            ]
+        },
+    )
+    storage_files[MANIFEST_REF] = manifest_path
+    storage_files[BUNDLE_REF] = tar_path
+    stage_workload(storage_files, tmp_path)
+
+    message = load_vprogram_message()
+    _spec, attest_port = await build_vprogram_spec(message.item_hash, message.content)
+    assert attest_port is None
+
+
+@pytest.mark.asyncio
 async def test_roothash_sidecar_present_after_staging(staged_bundle):
     """The daemon derives the measured cmdline from <rootfs>.roothash and the
     hash tree from <rootfs>.verity next to the rootfs disk: both must be in
     place after staging, with the manifest's platform roothash."""
     message = load_vprogram_message()
-    spec = await build_vprogram_spec(message.item_hash, message.content)
+    spec, _attest_port = await build_vprogram_spec(message.item_hash, message.content)
 
     rootfs = spec.rootfs.path
     roothash_sidecar = rootfs.with_name(rootfs.name + ".roothash")
@@ -303,7 +328,7 @@ async def test_roothash_sidecar_written_when_bundle_lacks_it(tmp_path, storage_f
     stage_workload(storage_files, tmp_path)
 
     message = load_vprogram_message()
-    spec = await build_vprogram_spec(message.item_hash, message.content)
+    spec, _attest_port = await build_vprogram_spec(message.item_hash, message.content)
     rootfs = spec.rootfs.path
     assert rootfs.with_name(rootfs.name + ".roothash").read_text().strip() == PLATFORM_ROOTHASH
 
@@ -370,7 +395,7 @@ async def test_workload_attached_and_sidecar_written(staged_bundle):
     message = load_vprogram_message()
     content = message.content
     assert content.workload.roothash == WORKLOAD_ROOTHASH
-    spec = await build_vprogram_spec(message.item_hash, content)
+    spec, _attest_port = await build_vprogram_spec(message.item_hash, content)
 
     assert len(spec.disks) == 3
     assert [d.role for d in spec.disks] == [

--- a/tests/supervisor/test_vprogram_port_map.py
+++ b/tests/supervisor/test_vprogram_port_map.py
@@ -1,0 +1,149 @@
+"""Task 1: the CRN auto-maps a running V-PROGRAM's attestation port (from
+the runtime manifest's ``aleph.ra-tls`` entry) to a host IPv4 port, so an
+external client (the ``aleph`` CLI) can reach the guest's RA-TLS endpoint.
+Host-only DNAT, measurement-neutral (no guest image/cmdline change),
+idempotent on re-adoption.
+
+Uses the canonical cross-SDK fixture message shared with test_vprogram.py.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aleph_message.models import VerifiableProgramMessage, parse_message
+
+from aleph.vm.agent.run import create_vm_execution, reconcile_vprogram_port_forwards
+from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor_interface.types import (
+    Backend,
+    ConfidentialMode,
+    IpAssignment,
+    PortForwardInfo,
+    Protocol,
+    VmId,
+    VmInfo,
+    VmStatus,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "vprogram_message.json"
+ATTEST_PORT = 8443
+
+
+def load_vprogram_message() -> VerifiableProgramMessage:
+    message = parse_message(json.loads(FIXTURE.read_text()))
+    assert isinstance(message, VerifiableProgramMessage)
+    return message
+
+
+def _running_vm_info(vm_hash: str) -> VmInfo:
+    return VmInfo(
+        vm_id=VmId(vm_hash),
+        status=VmStatus.RUNNING,
+        ipv4=IpAssignment(),
+        ipv6=IpAssignment(),
+        uptime_secs=0,
+        backend=Backend.QEMU,
+        numa_node=None,
+        status_message="",
+        confidential_mode=ConfidentialMode.SEV_SNP,
+        gpus=[],
+    )
+
+
+class FakeSupervisor:
+    """Enough of the Supervisor surface to drive the V-PROGRAM create path
+    and its port-forward reconcile. Keeps a real in-memory mapping store (not
+    just a call recorder) so a second reconcile against the same desired set
+    genuinely no-ops, the way the real hypervisor's diff would.
+    """
+
+    def __init__(self, info: VmInfo):
+        self._info = info
+        self._forwards: dict[tuple[str, int, Protocol], int] = {}
+        self._next_host_port = 40000
+        self.add_port_forward_calls: list = []
+
+    async def create_vm(self, spec):
+        return self._info
+
+    async def get_vm(self, vm_id):
+        return self._info
+
+    async def delete_vm(self, vm_id, **kwargs):
+        pass
+
+    async def add_port_forward(self, spec):
+        self.add_port_forward_calls.append(spec)
+        key = (str(spec.vm_id), int(spec.vm_port), spec.protocol)
+        host_port = self._next_host_port
+        self._next_host_port += 1
+        self._forwards[key] = host_port
+        return PortForwardInfo(vm_id=spec.vm_id, host_port=host_port, vm_port=spec.vm_port, protocol=spec.protocol)
+
+    async def remove_port_forward(self, vm_id, host_port, protocol):
+        self._forwards = {
+            key: value
+            for key, value in self._forwards.items()
+            if not (key[0] == str(vm_id) and value == host_port and key[2] == protocol)
+        }
+
+    async def list_port_forwards(self, vm_id=None):
+        return [
+            PortForwardInfo(vm_id=VmId(key[0]), host_port=value, vm_port=key[1], protocol=key[2])
+            for key, value in self._forwards.items()
+            if vm_id is None or key[0] == str(vm_id)
+        ]
+
+
+@pytest.mark.asyncio
+async def test_vprogram_create_maps_attestation_port(mocker):
+    """After a V-PROGRAM reaches RUNNING, the create path calls
+    add_port_forward exactly once, for the manifest's RA-TLS attestation
+    port (tcp); a second reconcile (e.g. re-adoption) adds no duplicate."""
+    message = load_vprogram_message()
+    vm_hash = message.item_hash
+    mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
+
+    fake_spec = MagicMock()
+    mocker.patch(
+        "aleph.vm.agent.run.build_vprogram_spec",
+        new_callable=AsyncMock,
+        return_value=(fake_spec, ATTEST_PORT),
+    )
+    mocker.patch("aleph.vm.agent.run.persist_record", new_callable=AsyncMock)
+
+    info = _running_vm_info(str(vm_hash))
+    supervisor = FakeSupervisor(info)
+    registry = AgentVmRegistry()
+
+    await create_vm_execution(
+        vm_hash,
+        supervisor=supervisor,
+        registry=registry,
+        capacity=MagicMock(),
+        persistent=True,
+    )
+
+    assert len(supervisor.add_port_forward_calls) == 1
+    pf = supervisor.add_port_forward_calls[0]
+    assert pf.vm_port == ATTEST_PORT
+    assert pf.protocol is Protocol.TCP
+
+    # Idempotency: re-running the reconcile (e.g. daemon re-adopts the VM on
+    # restart) must not create a duplicate mapping.
+    await reconcile_vprogram_port_forwards(supervisor, VmId(str(vm_hash)), ATTEST_PORT)
+    assert len(supervisor.add_port_forward_calls) == 1
+    active = await supervisor.list_port_forwards(VmId(str(vm_hash)))
+    assert len(active) == 1
+
+
+@pytest.mark.asyncio
+async def test_reconcile_vprogram_no_attestation_port_is_noop():
+    """A manifest with no aleph.ra-tls tcp transport (attest_port=None, the
+    guard build_vprogram_spec applies) yields no forwards and no calls."""
+    supervisor = FakeSupervisor(_running_vm_info("deadbeef"))
+    await reconcile_vprogram_port_forwards(supervisor, VmId("deadbeef"), None)
+    assert supervisor.add_port_forward_calls == []
+    assert await supervisor.list_port_forwards(VmId("deadbeef")) == []


### PR DESCRIPTION
Task 1 of the V-PROGRAM CLI E2E design (docs/plans/2026-08-05-vprogram-cli-e2e-*). Reviewable 1-commit diff; already fast-forwarded into `od/vprogram-integration` (de9ed350) so the deb-builder CI picks it up.

The CRN auto-maps a running V-PROGRAM's manifest-declared `aleph.ra-tls` attestation port (:8443) to a host IPv4 port via the existing DNAT machinery, so an external client (`aleph vprogram call`) can reach the guest's attested endpoint. Manifest-driven (`build_vprogram_spec` -> `(spec, attest_port)`), idempotent on re-adopt (`reconcile_vprogram_port_forwards`), host-only DNAT so **measurement-neutral**. Surfaces in `/v2/about/executions/list` `mapped_ports`. Daemon `add_port_forward` confirmed not vm-type-gated. 26 targeted + 188 regression tests pass; mypy/ruff/isort clean.

(Base is a stable anchor at the pre-Task-1 integration tip; retarget to dev once the V-PROGRAM stack lands there.)