### PR TITLE
feat(vprogram): IPv6 reachability for confidential guests (guest-ready; host RA sender pending)

### DIFF
--- a/nix/init.sh
+++ b/nix/init.sh
@@ -49,6 +49,32 @@ else
         # per-tap dnsmasq but never configure its IP. See udhcpc.script.
         /bin/busybox udhcpc -i "$iface" -q -t 5 -A 2 -s /bin/udhcpc.script 2>&1 || echo "init: DHCP failed on ${iface}"
     fi
+
+    # IPv6: SLAAC via Router Advertisements ONLY, never a kernel-cmdline
+    # address. The assigned /124 is per-VM (CRN /64 + vm-hash), so baking it
+    # into cmdline would make the measured SNP kernel cmdline depend on the
+    # address, breaking the publisher's precompute -- the exact reason the
+    # IPv4 path above uses DHCP/static-from-gateway instead of a hardcoded
+    # guest IP. `accept_ra=2` accepts RAs even though this host never
+    # forwards (belt and suspenders: forwarding stays off here regardless).
+    # The wait below is bounded and non-fatal: with no RA source reachable
+    # on this tap the guest simply stays IPv4-only, matching Python's
+    # ipv6_forwarding_enabled=False fallback.
+    echo 0 > "/proc/sys/net/ipv6/conf/${iface}/disable_ipv6" 2>/dev/null || true
+    echo 2 > "/proc/sys/net/ipv6/conf/${iface}/accept_ra" 2>/dev/null || true
+    n=0
+    while [ "$n" -lt 20 ]; do
+        if /bin/busybox ip addr show dev "$iface" 2>/dev/null | /bin/busybox grep -q "inet6.*scope global"; then
+            break
+        fi
+        /bin/busybox sleep 0.1
+        n=$((n + 1))
+    done
+    if /bin/busybox ip addr show dev "$iface" 2>/dev/null | /bin/busybox grep -q "inet6.*scope global"; then
+        echo "init: IPv6 SLAAC address configured on ${iface}"
+    else
+        echo "init: no global IPv6 address on ${iface} after RA wait; continuing IPv4-only"
+    fi
 fi
 
 # Parse boot mode from kernel command line.
@@ -161,6 +187,21 @@ prepare_chroot() {
 # The ruleset is STATELESS on purpose: for a TCP connection to the server the
 # inbound packets always carry dport 8443, so `tcp dport 8443 accept` covers the
 # whole flow without a conntrack module. Load order matches modules.dep.
+#
+# The `inet` table family (not `ip`) filters BOTH IPv4 and IPv6 with the same
+# rules (nft(8), ADDRESS FAMILIES: "The IPv4/IPv6/Inet address families
+# handle IPv4, IPv6 or both types of packets"); `tcp dport 8443` carries no
+# implicit protocol dependency the way e.g. `icmp` would, so it already
+# matches TCP/8443 over both v4 and v6 -- no separate ip6-only rule needed
+# once the interface has a v6 address (see the SLAAC bring-up above).
+#
+# The icmpv6 accept rule is control-plane only (no app data crosses it), but
+# without it the firewall would go up and immediately break IPv6 on its own:
+# Router Advertisements refresh the SLAAC address's lifetime, Neighbor
+# Solicitation/Advertisement resolve and keep resolving the gateway's
+# link-layer address (Neighbor Unreachability Detection re-probes every
+# ~30s of idle), and Packet Too Big drives Path MTU Discovery -- dropping any
+# of those silently blackholes v6 minutes into the VM's life, not at boot.
 setup_firewall() {
     /bin/busybox insmod /lib/modules/nfnetlink.ko 2>&1 || echo "init: warning: insmod nfnetlink.ko failed"
     /bin/busybox insmod /lib/modules/libcrc32c.ko 2>&1 || echo "init: warning: insmod libcrc32c.ko failed"
@@ -171,11 +212,12 @@ table inet filter {
 		type filter hook input priority 0; policy drop;
 		iif "lo" accept
 		tcp dport 8443 accept
+		icmpv6 type { nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert, destination-unreachable, packet-too-big, time-exceeded, parameter-problem } accept
 	}
 }
 NFT
     then
-        echo "init: firewall active (drop inbound except tcp/8443 and loopback)"
+        echo "init: firewall active (drop inbound except tcp/8443, loopback, and ND/PMTU icmpv6)"
     else
         echo "init: FATAL: failed to install guest firewall"
         exec /bin/busybox poweroff -f

--- a/nix/init.sh
+++ b/nix/init.sh
@@ -60,6 +60,9 @@ else
     # The wait below is bounded and non-fatal: with no RA source reachable
     # on this tap the guest simply stays IPv4-only, matching Python's
     # ipv6_forwarding_enabled=False fallback.
+    # FOLLOW-UP: the host does NOT yet run a per-tap RA sender (no radvd /
+    # RA on the tap today), so IPv6 here is INERT until that host-side piece
+    # lands; the guest is ready, the RA source is the missing half.
     echo 0 > "/proc/sys/net/ipv6/conf/${iface}/disable_ipv6" 2>/dev/null || true
     echo 2 > "/proc/sys/net/ipv6/conf/${iface}/accept_ra" 2>/dev/null || true
     n=0

--- a/rust/crates/aleph-attest-agent/src/main.rs
+++ b/rust/crates/aleph-attest-agent/src/main.rs
@@ -73,7 +73,14 @@ async fn main() -> Result<()> {
     let secret_store = web::Data::new(SecretStore::with_default_dir());
 
     // 6. Start actix-web HTTPS server.
-    let bind_addr = format!("0.0.0.0:{}", cli.port);
+    // "[::]" (not "0.0.0.0"): a literal IPv4-only wildcard would silently
+    // refuse every IPv6 client even after the guest gets a routable IPv6
+    // address (nix/init.sh SLAAC bring-up) and the firewall opens the port.
+    // Linux dual-stack sockets bound to "::" accept both v4 (IPv4-mapped)
+    // and v6 by default (IPV6_V6ONLY unset), so this is a strict superset of
+    // the old bind: existing IPv4 clients, including the host's port-map
+    // path, are unaffected.
+    let bind_addr = format!("[::]:{}", cli.port);
     info!(addr = %bind_addr, "binding HTTPS server");
 
     HttpServer::new(move || {

--- a/rust/crates/supervisor-daemon/src/lifecycle.rs
+++ b/rust/crates/supervisor-daemon/src/lifecycle.rs
@@ -435,18 +435,13 @@ fn tap_assignment(state: &DaemonState, vm_id: &str) -> Result<TapAssignment, Str
             ipv6.clone(),
         ));
     }
-    let vm_type = if entry.is_program {
-        VmType::Microvm
-    } else {
-        VmType::Instance
-    };
     let mut world = state.world.blocking_write();
     let mut ordinal = world.ipv6_dynamic_ordinal;
     let (ipv4, ipv6) = world::derive_tap_assignment(
         &state.host.settings,
         entry.vm_index,
         vm_id,
-        vm_type,
+        entry.vm_type(),
         &mut ordinal,
     )?;
     world.ipv6_dynamic_ordinal = ordinal;
@@ -629,11 +624,7 @@ fn guest_ipv4(state: &DaemonState, entry: &VmEntry) -> String {
         &state.host.settings,
         entry.vm_index,
         &entry.vm_hash,
-        if entry.is_program {
-            VmType::Microvm
-        } else {
-            VmType::Instance
-        },
+        entry.vm_type(),
         &mut ordinal,
     )
     .map(|(ipv4, _)| ipv4.address)
@@ -2641,11 +2632,20 @@ fn create_vm_inner(
             .map_err(RpcError::Internal)?;
         let assignment = if state.host.settings.allow_vm_networking {
             let mut ordinal = world.ipv6_dynamic_ordinal;
+            // `snp` (computed above from `request.tee`) is the V-PROGRAM
+            // signal: SEV-SNP measured boot is its exclusive launch path, so
+            // it is the only QEMU-create shape that gets the VProgram
+            // hextet; a plain or SEV/SEV-ES confidential create is Instance.
+            let create_vm_type = if snp {
+                VmType::VProgram
+            } else {
+                VmType::Instance
+            };
             let pair = world::derive_tap_assignment(
                 &state.host.settings,
                 vm_index,
                 &vm_id,
-                VmType::Instance,
+                create_vm_type,
                 &mut ordinal,
             )
             .map_err(RpcError::Internal)?;
@@ -3963,6 +3963,35 @@ mod tests {
             "the dm-verity hash tree is the first host volume"
         );
         assert!(qemu.host_volumes[0].read_only);
+    }
+
+    #[test]
+    fn create_snp_allocates_the_v_program_ipv6_hextet() {
+        // The static IPv6 scheme keys a vm-type hextet into the /124
+        // (world::VmType::prefix). SEV-SNP is the V-PROGRAM's exclusive
+        // launch path (docs/plans/2026-07-11-vprogram-scheduler-support-
+        // design.md section 2), so an SNP create must get the 0x4 nibble
+        // (Python VmType.v_program / scheduler VmType::ipv6_value()), not
+        // the plain-instance 0x3 it used to get before VmType::VProgram
+        // existed.
+        let harness = harness();
+        let state = &harness.state;
+        let root = state.host.settings.execution_root.clone();
+        let vm_id = hash('e');
+        let firmware = root.join("OVMF.fd");
+        std::fs::write(&firmware, b"ovmf").unwrap();
+        let request = snp_spec(&vm_id, &root, &firmware.to_string_lossy());
+
+        let (entry, _running) = create_vm(state, request).unwrap();
+        assert_eq!(entry.vm_type(), world::VmType::VProgram);
+        let ipv6 = entry
+            .ipv6
+            .expect("networking is enabled in the harness; SNP create allocates an IPv6 pair");
+        assert!(
+            ipv6.address.starts_with("fc00:1:2:3:4:"),
+            "an SNP (V-PROGRAM) create must get the 0x4 vm-type hextet, got {}",
+            ipv6.address
+        );
     }
 
     #[test]

--- a/rust/crates/supervisor-daemon/src/world.rs
+++ b/rust/crates/supervisor-daemon/src/world.rs
@@ -141,14 +141,23 @@ pub struct ProgramEntry {
 pub enum VmType {
     Microvm,
     Instance,
+    /// A V-PROGRAM (`aleph_message.models.VerifiableProgramContent`): the
+    /// QEMU SEV-SNP measured-boot launch path is its exclusive hypervisor
+    /// (design doc docs/plans/2026-07-11-vprogram-scheduler-support-design.md
+    /// section 2), so `QemuVmConfig::snp().is_some()` identifies one on this
+    /// side (see [`VmEntry::vm_type`]).
+    VProgram,
 }
 
 impl VmType {
-    /// `StaticIPv6Allocator.VM_TYPE_PREFIX`.
+    /// `StaticIPv6Allocator.VM_TYPE_PREFIX`. Must match the scheduler's
+    /// `VmType::ipv6_value()` (scheduler-events) and the Python
+    /// `StaticIPv6Allocator.VM_TYPE_PREFIX` (hostnetwork.py).
     fn prefix(self) -> u16 {
         match self {
             VmType::Microvm => 0x1,
             VmType::Instance => 0x3,
+            VmType::VProgram => 0x4,
         }
     }
 }
@@ -255,6 +264,22 @@ impl VmEntry {
     /// Python `is_stopping`: stopping_at set, stopped_at not yet.
     pub fn is_stopping(&self) -> bool {
         self.times.stopping_at_ns != 0 && self.times.stopped_at_ns == 0
+    }
+
+    /// The vm-type hextet input to the static IPv6 scheme (mirrors the
+    /// Python `VmType.from_message_content` split, ported as the equivalent
+    /// config shape check: there is no message content on this side). An
+    /// ephemeral Firecracker program is `Microvm`; a QEMU SEV-SNP
+    /// measured-boot config is `VProgram` (its exclusive launch path, see
+    /// [`VmType::VProgram`]); everything else is `Instance`.
+    pub fn vm_type(&self) -> VmType {
+        if self.is_program {
+            VmType::Microvm
+        } else if self.config.snp().is_some() {
+            VmType::VProgram
+        } else {
+            VmType::Instance
+        }
     }
 }
 
@@ -544,11 +569,16 @@ pub fn build_world_view(
                             continue;
                         }
                     }
+                    let adopted_vm_type = if qemu.snp().is_some() {
+                        VmType::VProgram
+                    } else {
+                        VmType::Instance
+                    };
                     let ipv6_result = match settings.ipv6_allocation_policy {
                         Ipv6AllocationPolicy::Static => ipv6_static_assignment(
                             &settings.ipv6_address_pool,
                             &vm_hash,
-                            VmType::Instance,
+                            adopted_vm_type,
                         ),
                         Ipv6AllocationPolicy::Dynamic => {
                             dynamic_ordinal += 1;
@@ -1258,6 +1288,24 @@ mod tests {
         assert!(
             ipv6_static_assignment("fc00:1:2:3::/64", "nothex-----", VmType::Instance).is_err()
         );
+    }
+
+    #[test]
+    fn ipv6_static_math_gives_v_programs_the_0x4_hextet() {
+        // Python: StaticIPv6Allocator(...).allocate_vm_ipv6_subnet(3, hash,
+        // VmType.v_program) uses VM_TYPE_PREFIX[VmType.v_program] == "4"
+        // (hostnetwork.py), matching the scheduler's VmType::ipv6_value().
+        // Same hash as ipv6_static_math_matches_the_python_allocator, only
+        // the vm-type hextet differs: 4 instead of 3.
+        let pair = ipv6_static_assignment(
+            "2a01:240:2:c8::/64",
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+            VmType::VProgram,
+        )
+        .unwrap();
+        assert_eq!(pair.network_cidr, "2a01:240:2:c8:4:abcd:ef01:2340/124");
+        assert_eq!(pair.address, "2a01:240:2:c8:4:abcd:ef01:2341");
+        assert_eq!(pair.gateway, "2a01:240:2:c8:4:abcd:ef01:2340");
     }
 
     #[test]


### PR DESCRIPTION
The IPv6 alternative to Task 1's host-IPv4 port-map (docs/plans/2026-08-05-vprogram-cli-e2e-design.md, deferred IPv6 path). **Guest-side is ready; end-to-end IPv6 is INERT until a host-side RA sender is added** (documented, not half-implemented).

- `nix/init.sh`: obtain IPv6 via **SLAAC** (accept_ra, bounded 2s non-fatal wait) — never a measured cmdline field, so the SNP measurement stays precomputable; added the missing ICMPv6 ND/RA/PMTU accept rule (policy drop preserved; :8443 already covered v6 via the `inet` table).
- `aleph-attest-agent`: bind `[::]:8443` (dual-stack) instead of `0.0.0.0` — was IPv4-only, making the feature inert. Verified NOT v6-only (actix-web leaves IPV6_V6ONLY at Linux dual-stack default), so **the existing IPv4 path / Task 1 port-map is unaffected**.
- daemon: `VmType::VProgram = 0x4` + fixed all v-program create/adopt call sites (create-time and persisted predicates proven identical → no address drift across restart); 2 new tests.

**NOT done (documented follow-ups):** the host per-tap RA sender (radvd/RA) — required for this to actually route. **Measurement impact:** the init.sh + attest-agent changes shift the measured image → a re-pin is required downstream before this ships. This PR deliberately stays OUT of `od/vprogram-integration` for that reason.

shellcheck clean; cargo build/test/clippy clean (325 daemon tests +2). Base is the pre-Task-1 anchor for a clean diff; retarget to dev once the V-PROGRAM stack lands.