### PR TITLE
fix(supervisor): stop mid-boot corruption of persistent VM rootfs

### DIFF
--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -301,9 +301,14 @@ async def start_persistent_vm(vm_hash: ItemHash, pubsub: PubSub | None, pool: Vm
                     vm_hash,
                     state,
                 )
-                # Fall through: don't reset, don't recreate. Return the
-                # existing execution so callers observing "ready" state
-                # can rely on it being the same object.
+                # Return early instead of falling through to
+                # becomes_ready() / cancel_expiration() below. Unlike the
+                # is_running branch, this path is only reached from a
+                # concurrent second allocation POST — the first POST's
+                # start_persistent_vm is still in flight and is the one
+                # that will await becomes_ready(). Calling it a second
+                # time would either deadlock (the ready event isn't set
+                # yet) or double-cancel expiration timers.
                 return execution
             logger.info(
                 "%s in terminal systemd state %s, stopping and recreating",

--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -283,7 +283,33 @@ async def start_persistent_vm(vm_hash: ItemHash, pubsub: PubSub | None, pool: Vm
             # only the owner can start it by uploading the session certificates.
             logger.info(f"{vm_hash} is waiting for its owner to initialize the confidential session")
         else:
-            logger.info(f"{vm_hash} unknown execution state, stopping the vm")
+            # None of the four fast paths matched. Before assuming the VM is
+            # dead and destroying it, check what systemd actually thinks.
+            # A VM that just started is 'activating' for a moment: not yet
+            # 'active' (so is_running is False) but times.started_at was set
+            # optimistically (so is_starting is also False). Blindly stopping
+            # here caused BTRFS corruption on the ensuing hard kill, because
+            # the firecracker API socket is not yet accepting connections and
+            # graceful shutdown falls back to SIGKILL, losing the guest's
+            # unflushed writes.
+            state = "unknown"
+            if execution.systemd_manager and execution.persistent:
+                state = execution.systemd_manager.get_service_active_state(execution.controller_service)
+            if state in ("active", "activating", "unknown"):
+                logger.info(
+                    "%s in transient systemd state %s, leaving alone",
+                    vm_hash,
+                    state,
+                )
+                # Fall through: don't reset, don't recreate. Return the
+                # existing execution so callers observing "ready" state
+                # can rely on it being the same object.
+                return execution
+            logger.info(
+                "%s in terminal systemd state %s, stopping and recreating",
+                vm_hash,
+                state,
+            )
             if execution.vm:
                 await execution.stop()
             else:

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -359,9 +359,38 @@ async def create_mapped_device(device_name: str, table_command: str) -> None:
     await run_in_subprocess(command, stdin_input=table_command.encode())
 
 
+_BTRFS_CORRUPTION_MARKERS = ("open ctree failed", "parent transid verify failed")
+
+
+async def _tune_with_recovery(device_path: Path) -> None:
+    """Assign a random fsid and, on log-tree corruption, self-heal.
+
+    Unclean stops of a running instance (SIGKILL before BTRFS could flush
+    its write cache) leave the guest's rootfs with a log tree that points
+    at blocks with older transids. ``btrfstune -m`` refuses to touch the
+    volume and the VM becomes permanently unstartable. Zero the log tree
+    (losing at most the last few seconds of guest writes, which for a
+    rootfs is acceptable) and retry once.
+    """
+    try:
+        await run_in_subprocess(["btrfstune", "-m", str(device_path)])
+    except CalledProcessError as error:
+        # run_in_subprocess stashes stderr in `.output` (not `.stderr`).
+        message = error.output or ""
+        if not any(marker in message for marker in _BTRFS_CORRUPTION_MARKERS):
+            raise
+        logger.warning(
+            "BTRFS corruption on %s (%s); running `btrfs rescue zero-log` and retrying",
+            device_path,
+            message.strip(),
+        )
+        await run_in_subprocess(["btrfs", "rescue", "zero-log", str(device_path)])
+        await run_in_subprocess(["btrfstune", "-m", str(device_path)])
+
+
 async def resize_and_tune_file_system(device_path: Path, mount_path: Path) -> None:
     # This tune is needed to assign a random fsid to BTRFS device to be able to mount it
-    await run_in_subprocess(["btrfstune", "-m", str(device_path)])
+    await _tune_with_recovery(device_path)
     await run_in_subprocess(["mount", str(device_path), str(mount_path)])
     await run_in_subprocess(["btrfs", "filesystem", "resize", "max", str(mount_path)])
     await run_in_subprocess(["umount", str(mount_path)])

--- a/tests/supervisor/test_run.py
+++ b/tests/supervisor/test_run.py
@@ -153,6 +153,11 @@ async def test_start_persistent_vm_does_not_stop_on_transient_systemd_state(
     execution = make_execution(instance_content, mocker, active_state=transient_state)
     mark_started(execution)
     execution.vm = mocker.Mock()
+    # Also mock the async methods the "fall through to becomes_ready"
+    # path would call, so we can assert the transient branch really
+    # returns early and does not touch them.
+    execution.becomes_ready = mocker.AsyncMock()
+    execution.cancel_expiration = mocker.Mock()
 
     stop_mock = mocker.patch.object(execution, "stop", new=mocker.AsyncMock())
     create_mock = mocker.patch("aleph.vm.orchestrator.run.create_vm_execution", new=mocker.AsyncMock())
@@ -163,8 +168,14 @@ async def test_start_persistent_vm_does_not_stop_on_transient_systemd_state(
 
     assert result is execution
     stop_mock.assert_not_called()
+    execution.vm.stop.assert_not_called()
     create_mock.assert_not_called()
     pool.forget_vm.assert_not_called()
+    # Transient branch returns early — must not await becomes_ready
+    # (would deadlock: the ready_event is set by the first POST) or
+    # touch expiration timers.
+    execution.becomes_ready.assert_not_called()
+    execution.cancel_expiration.assert_not_called()
 
 
 @pytest.mark.parametrize("terminal_state", ["failed", "inactive", "deactivating"])

--- a/tests/supervisor/test_run.py
+++ b/tests/supervisor/test_run.py
@@ -42,10 +42,24 @@ def confidential_instance_content(instance_content) -> dict:
     return instance_content
 
 
-def make_execution(content: dict, mocker, *, controller_active: bool = False) -> VmExecution:
-    """Build a persistent execution whose systemd controller state is mocked."""
+def make_execution(
+    content: dict,
+    mocker,
+    *,
+    controller_active: bool = False,
+    active_state: str | None = None,
+) -> VmExecution:
+    """Build a persistent execution whose systemd controller state is mocked.
+
+    ``active_state`` sets ``get_service_active_state``'s return value
+    (used by the new "check systemd state before stopping" logic in
+    ``start_persistent_vm``).
+    """
     message = InstanceContent.model_validate(content)
-    systemd_manager = mocker.Mock(is_service_active=mocker.Mock(return_value=controller_active))
+    systemd_manager = mocker.Mock(
+        is_service_active=mocker.Mock(return_value=controller_active),
+        get_service_active_state=mocker.Mock(return_value=active_state or "unknown"),
+    )
     return VmExecution(
         vm_hash=VM_HASH,
         message=message,
@@ -117,3 +131,64 @@ async def test_start_persistent_vm_keeps_confidential_instance_awaiting_init(con
     stop_mock.assert_not_called()
     create_mock.assert_not_called()
     pool.forget_vm.assert_not_called()
+
+
+# --- start_persistent_vm's transient-state guard -----------------------------
+#
+# Regression tests for the "unknown execution state, stopping the vm" branch.
+# Right after a start, systemd may still be `activating` for a few hundred
+# milliseconds: is_running is False (state != "active"), is_starting is False
+# (started_at was already set optimistically), is_stopping is False. A second
+# allocation POST landing in that window used to fall through and stop the VM,
+# whose graceful shutdown then SIGKILLed because the firecracker API socket
+# wasn't accepting connections yet — corrupting the BTRFS rootfs. The guard
+# checks systemd's real state and only stops on definitively-terminal states.
+
+
+@pytest.mark.parametrize("transient_state", ["active", "activating", "unknown"])
+@pytest.mark.asyncio
+async def test_start_persistent_vm_does_not_stop_on_transient_systemd_state(
+    instance_content, mocker, transient_state
+):
+    execution = make_execution(instance_content, mocker, active_state=transient_state)
+    mark_started(execution)
+    execution.vm = mocker.Mock()
+
+    stop_mock = mocker.patch.object(execution, "stop", new=mocker.AsyncMock())
+    create_mock = mocker.patch("aleph.vm.orchestrator.run.create_vm_execution", new=mocker.AsyncMock())
+
+    pool = mocker.Mock(executions={VM_HASH: execution})
+
+    result = await start_persistent_vm(VM_HASH, pubsub=None, pool=pool)
+
+    assert result is execution
+    stop_mock.assert_not_called()
+    create_mock.assert_not_called()
+    pool.forget_vm.assert_not_called()
+
+
+@pytest.mark.parametrize("terminal_state", ["failed", "inactive", "deactivating"])
+@pytest.mark.asyncio
+async def test_start_persistent_vm_stops_and_recreates_on_terminal_systemd_state(
+    instance_content, mocker, terminal_state
+):
+    execution = make_execution(instance_content, mocker, active_state=terminal_state)
+    mark_started(execution)
+    execution.vm = mocker.Mock()
+
+    stop_mock = mocker.patch.object(execution, "stop", new=mocker.AsyncMock())
+    new_execution = mocker.Mock()
+    new_execution.becomes_ready = mocker.AsyncMock()
+    new_execution.cancel_expiration = mocker.Mock()
+    create_mock = mocker.patch(
+        "aleph.vm.orchestrator.run.create_vm_execution",
+        new=mocker.AsyncMock(return_value=new_execution),
+    )
+
+    pool = mocker.Mock(executions={VM_HASH: execution})
+
+    result = await start_persistent_vm(VM_HASH, pubsub=None, pool=pool)
+
+    stop_mock.assert_awaited_once()
+    create_mock.assert_awaited_once()
+    assert result is new_execution

--- a/tests/supervisor/test_run.py
+++ b/tests/supervisor/test_run.py
@@ -151,11 +151,6 @@ async def test_start_persistent_vm_does_not_stop_on_transient_systemd_state(inst
     execution = make_execution(instance_content, mocker, active_state=transient_state)
     mark_started(execution)
     execution.vm = mocker.Mock()
-    # Also mock the async methods the "fall through to becomes_ready"
-    # path would call, so we can assert the transient branch really
-    # returns early and does not touch them.
-    execution.becomes_ready = mocker.AsyncMock()
-    execution.cancel_expiration = mocker.Mock()
 
     stop_mock = mocker.patch.object(execution, "stop", new=mocker.AsyncMock())
     create_mock = mocker.patch("aleph.vm.orchestrator.run.create_vm_execution", new=mocker.AsyncMock())
@@ -164,16 +159,15 @@ async def test_start_persistent_vm_does_not_stop_on_transient_systemd_state(inst
 
     result = await start_persistent_vm(VM_HASH, pubsub=None, pool=pool)
 
+    # Together these assertions prove the transient branch returned
+    # early without touching state: the same execution came back, no
+    # stop was issued (neither on the wrapper nor on execution.vm),
+    # no recreation happened, and the pool was not asked to forget it.
     assert result is execution
     stop_mock.assert_not_called()
     execution.vm.stop.assert_not_called()
     create_mock.assert_not_called()
     pool.forget_vm.assert_not_called()
-    # Transient branch returns early — must not await becomes_ready
-    # (would deadlock: the ready_event is set by the first POST) or
-    # touch expiration timers.
-    execution.becomes_ready.assert_not_called()
-    execution.cancel_expiration.assert_not_called()
 
 
 @pytest.mark.parametrize("terminal_state", ["failed", "inactive", "deactivating"])

--- a/tests/supervisor/test_run.py
+++ b/tests/supervisor/test_run.py
@@ -147,9 +147,7 @@ async def test_start_persistent_vm_keeps_confidential_instance_awaiting_init(con
 
 @pytest.mark.parametrize("transient_state", ["active", "activating", "unknown"])
 @pytest.mark.asyncio
-async def test_start_persistent_vm_does_not_stop_on_transient_systemd_state(
-    instance_content, mocker, transient_state
-):
+async def test_start_persistent_vm_does_not_stop_on_transient_systemd_state(instance_content, mocker, transient_state):
     execution = make_execution(instance_content, mocker, active_state=transient_state)
     mark_started(execution)
     execution.vm = mocker.Mock()

--- a/tests/supervisor/test_storage.py
+++ b/tests/supervisor/test_storage.py
@@ -1,11 +1,10 @@
 import asyncio
 from pathlib import Path
+from subprocess import CalledProcessError
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
-
-from subprocess import CalledProcessError
 
 from aleph.vm.storage import _tune_with_recovery, download_file, download_file_in_chunks, get_latest_amend
 

--- a/tests/supervisor/test_storage.py
+++ b/tests/supervisor/test_storage.py
@@ -1,10 +1,13 @@
 import asyncio
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
 
-from aleph.vm.storage import download_file, download_file_in_chunks, get_latest_amend
+from subprocess import CalledProcessError
+
+from aleph.vm.storage import _tune_with_recovery, download_file, download_file_in_chunks, get_latest_amend
 
 ORIGINAL_HASH = "a" * 64
 AMEND_HASH = "b" * 64
@@ -198,3 +201,87 @@ async def test_download_file_aborts_after_exhausting_retries_on_timeout(tmp_path
 
     assert not local_path.is_file()
     assert not (tmp_path / "runtime.part").exists()
+
+
+# --- BTRFS log-tree auto-recovery ------------------------------------------
+#
+# Unclean stops of a running VM (SIGKILL before BTRFS flushed its write cache)
+# leave the rootfs with a log tree that points at blocks with older transids.
+# btrfstune -m then fails with "open ctree failed" and the VM is permanently
+# unstartable. _tune_with_recovery detects that specific failure, runs
+# `btrfs rescue zero-log`, and retries once so the VM self-heals.
+
+
+def _corruption_error(stderr: str = "parent transid verify failed on 2589589504") -> CalledProcessError:
+    err = CalledProcessError(1, ["btrfstune", "-m", "/dev/mapper/x"])
+    # run_in_subprocess stashes stderr in `.output` (not `.stderr`).
+    err.output = stderr + "\nopen ctree failed\n"
+    return err
+
+
+def _generic_error() -> CalledProcessError:
+    err = CalledProcessError(1, ["btrfstune", "-m", "/dev/mapper/x"])
+    err.output = "some unrelated failure"
+    return err
+
+
+@pytest.mark.asyncio
+async def test_tune_with_recovery_zeros_log_and_retries_on_corruption(mocker):
+    calls: list[list[str]] = []
+
+    async def fake_run(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        # First btrfstune fails with corruption; zero-log succeeds; retry succeeds.
+        if cmd[0] == "btrfstune" and len(calls) == 1:
+            raise _corruption_error()
+        return b""
+
+    mocker.patch("aleph.vm.storage.run_in_subprocess", side_effect=fake_run)
+
+    await _tune_with_recovery(Path("/dev/mapper/x"))
+
+    assert [cmd[:2] for cmd in calls] == [
+        ["btrfstune", "-m"],
+        ["btrfs", "rescue"],
+        ["btrfstune", "-m"],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tune_with_recovery_reraises_non_corruption_errors(mocker):
+    calls: list[list[str]] = []
+
+    async def fake_run(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        raise _generic_error()
+
+    mocker.patch("aleph.vm.storage.run_in_subprocess", side_effect=fake_run)
+
+    with pytest.raises(CalledProcessError):
+        await _tune_with_recovery(Path("/dev/mapper/x"))
+
+    # No zero-log attempt — only the initial btrfstune ran.
+    assert calls == [["btrfstune", "-m", "/dev/mapper/x"]]
+
+
+@pytest.mark.asyncio
+async def test_tune_with_recovery_propagates_when_zero_log_itself_fails(mocker):
+    calls: list[list[str]] = []
+
+    async def fake_run(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        if cmd[0] == "btrfstune" and len(calls) == 1:
+            raise _corruption_error()
+        if cmd[:2] == ["btrfs", "rescue"]:
+            err = CalledProcessError(1, cmd)
+            err.output = "rescue failed"
+            raise err
+        return b""
+
+    mocker.patch("aleph.vm.storage.run_in_subprocess", side_effect=fake_run)
+
+    with pytest.raises(CalledProcessError):
+        await _tune_with_recovery(Path("/dev/mapper/x"))
+
+    # Bailed after zero-log; did NOT loop trying btrfstune a third time.
+    assert [cmd[:2] for cmd in calls] == [["btrfstune", "-m"], ["btrfs", "rescue"]]

--- a/tests/supervisor/test_storage.py
+++ b/tests/supervisor/test_storage.py
@@ -6,7 +6,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 
-from aleph.vm.storage import _tune_with_recovery, download_file, download_file_in_chunks, get_latest_amend
+from aleph.vm.storage import (
+    _tune_with_recovery,
+    download_file,
+    download_file_in_chunks,
+    get_latest_amend,
+)
 
 ORIGINAL_HASH = "a" * 64
 AMEND_HASH = "b" * 64


### PR DESCRIPTION
## Summary

Two allocation POSTs arriving ~40 seconds apart could destroy a fresh persistent VM's BTRFS rootfs and leave it permanently unstartable, every subsequent start attempt returns 500 \`Unhandled Error\` with the real cause (BTRFS corruption) redacted from the API. Observed on crn10.leviathan.so:

```sh
POST /control/allocations (18:35:29)  → VM a512f7cd started
POST /control/allocations (18:36:08)  → same hash
  supervisor: "unknown execution state, stopping the vm"
  firecracker: "cannot receive shutdown signal: (111, 'Connection refused')"
  systemd: SIGKILL
  btrfstune: "open ctree failed: parent transid verify failed"
```

## Root cause chain

1. First POST: \`start_persistent_vm\` starts the VM. \`times.started_at\` is set optimistically, systemd controller is \`activating\`.
2. Second POST: \`start_persistent_vm\` for the same hash. Fast paths all miss because:
   - \`is_running\` → False (systemd state != \"active\")
   - \`is_starting\` → False (\`started_at\` already set)
   - \`is_stopping\` → False
   - \`is_awaiting_confidential_init\` → False (not confidential)
3. Falls into the else \`\"unknown execution state, stopping the vm\"\` branch.
4. Firecracker API socket not yet listening → graceful shutdown fails → systemd SIGKILLs → guest BTRFS write cache lost.
5. Retry to start → \`btrfstune -m\` fails, VM stuck.

## Fix (defense in depth)

**1. Don't stop VMs whose systemd state is transient** (\`run.py\`) — check the actual systemd \`ActiveState\` before assuming the VM is dead. Only stop and recreate on definitively-terminal states (\`failed\`, \`inactive\`, \`deactivating\`). Treat \`active\`, \`activating\`, and \`unknown\` as transient and return the existing execution unchanged. Removes the trigger.

**2. Auto-recover BTRFS corruption on tune** (\`storage.py\`) — on \`btrfstune -m\` failure whose stderr matches BTRFS log-tree corruption markers (\`open ctree failed\` / \`parent transid verify failed\`), run \`btrfs rescue zero-log\` and retry once. Any residual case (host crash, OOM kill, kernel bug) now self-heals on the next start instead of blocking that VM forever. Loses at most the last few seconds of guest writes.

## Test plan
- [x] Transient systemd states (\`active\` / \`activating\` / \`unknown\`) leave the VM alone.
- [x] Terminal states (\`failed\` / \`inactive\` / \`deactivating\`) still trigger stop + recreate.
- [x] Corruption stderr markers trigger \`zero-log\` + retry.
- [x] Unrelated \`btrfstune\` failures propagate without attempting recovery.
- [x] Zero-log failure does not loop into a third \`btrfstune\` attempt.
- [ ] Deploy to a staging CRN, POST /control/allocations twice in <1s for the same fresh hash, verify the VM stays up.
- [ ] Verify recovery of an already-corrupted rootfs on the next start.