### PR TITLE
fix(agent): remove V-PROGRAM staging dir on teardown

### DIFF
--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -29,7 +29,7 @@ from aleph.vm.agent.translate import build_create_vm_spec, build_program_create_
 from aleph.vm.agent.update_watcher import UpdateWatcher
 from aleph.vm.agent.vm.program_client import ProgramGuestClient
 from aleph.vm.agent.vm_registry import AgentVmRegistry, persist_record
-from aleph.vm.agent.vprogram_launch import build_vprogram_spec
+from aleph.vm.agent.vprogram_launch import build_vprogram_spec, remove_vprogram_staging
 from aleph.vm.conf import settings
 from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.supervisor_interface import errors as supervisor_errors
@@ -368,6 +368,9 @@ async def create_vm_execution(
             info = await supervisor.create_vm(spec)
         except Exception:
             registry.forget(vm_hash)
+            # build_vprogram_spec may have already extracted the bundle (e.g.
+            # capacity admission fails after staging): do not leak it.
+            remove_vprogram_staging(vm_hash)
             raise
         try:
             await _wait_until_running(supervisor, info.vm_id)
@@ -377,6 +380,7 @@ async def create_vm_execution(
                 await supervisor.delete_vm(info.vm_id)
             except Exception:
                 logger.exception("Teardown of half-started V-PROGRAM %s failed", vm_hash)
+            remove_vprogram_staging(vm_hash)
             raise
         await persist_record(vm_hash, record)
         return None

--- a/src/aleph/vm/agent/tasks.py
+++ b/src/aleph/vm/agent/tasks.py
@@ -35,6 +35,7 @@ from aleph.vm.agent.utils import (
     is_after_community_wallet_start,
 )
 from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.agent.vprogram_launch import remove_vprogram_staging
 from aleph.vm.conf import settings
 from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.supervisor_interface.errors import VmNotFoundError
@@ -402,6 +403,7 @@ async def check_payment(supervisor: Supervisor, registry: AgentVmRegistry):
             await supervisor.delete_vm(VmId(str(vm_hash)))
             registry.forget(vm_hash)
             await delete_records_for_vm(str(vm_hash))
+            remove_vprogram_staging(vm_hash)
         else:
             # Status is healthy — reset any previous strikes
             _terminal_strike_count.pop(str(vm_hash), None)

--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -62,6 +62,7 @@ from aleph.vm.agent.views.host_status import (
 )
 from aleph.vm.agent.views.operator import get_itemhash_or_400
 from aleph.vm.agent.vm_registry import AgentVmRecord, AgentVmRegistry
+from aleph.vm.agent.vprogram_launch import remove_vprogram_staging
 from aleph.vm.chains import STREAM_CHAINS
 from aleph.vm.conf import settings
 from aleph.vm.resources import InsufficientResourcesError
@@ -608,6 +609,7 @@ async def update_allocations(request: web.Request):
                     pass
                 registry.forget(vm_hash)
                 await delete_records_for_vm(str(vm_hash))
+                remove_vprogram_staging(vm_hash)
                 stopped_vms.append(vm_hash)
 
         # Second start persistent VMs and instances sequentially to limit resource usage.

--- a/src/aleph/vm/agent/views/operator.py
+++ b/src/aleph/vm/agent/views/operator.py
@@ -27,6 +27,7 @@ from aleph.vm.agent.views.authentication import (
     require_jwk_authentication,
 )
 from aleph.vm.agent.vm_registry import AgentVmRecord
+from aleph.vm.agent.vprogram_launch import remove_vprogram_staging
 from aleph.vm.backup_staging import download_volume_by_ref, get_backup_directory
 from aleph.vm.conf import settings
 from aleph.vm.supervisor_interface.abc import Supervisor
@@ -663,6 +664,9 @@ async def operate_erase(request: web.Request, authenticated_sender: str) -> web.
             raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_hash}") from None
         request.app["vm_registry"].forget(vm_hash)
         await metrics.delete_records_for_vm(str(vm_hash))
+        # wipe=True clears the daemon-side disks; the agent-side staging dir
+        # (extracted runtime bundle) is ours to remove.
+        remove_vprogram_staging(vm_hash)
         return web.Response(status=200, body=f"Erased VM with ref {vm_hash}")
 
 

--- a/src/aleph/vm/agent/vprogram_launch.py
+++ b/src/aleph/vm/agent/vprogram_launch.py
@@ -66,6 +66,21 @@ def vprogram_staging_dir(vm_hash: ItemHash) -> Path:
     return Path(settings.EXECUTION_ROOT) / "vprogram" / str(vm_hash)
 
 
+def remove_vprogram_staging(vm_hash: ItemHash) -> None:
+    """Delete a V-PROGRAM's staging directory once its VM is gone for good.
+
+    The extracted runtime bundle lives at EXECUTION_ROOT/vprogram/<vm_hash>;
+    the launch path only clears it on re-extraction, so a churned V-PROGRAM
+    would otherwise leak it on disk. Idempotent and safe for any VM type: a
+    non-V-PROGRAM has no such directory, so this is a no-op. Call it from the
+    teardown paths, after the supervisor delete and registry.forget.
+    """
+    staging = vprogram_staging_dir(vm_hash)
+    if staging.exists():
+        logger.debug("Removing V-PROGRAM %s staging directory %s", vm_hash, staging)
+        shutil.rmtree(staging, ignore_errors=True)
+
+
 async def fetch_runtime_manifest(runtime_ref: str) -> RuntimeManifest:
     """Download and parse the runtime manifest pinned by ``runtime.ref``.
 

--- a/tests/supervisor/test_vprogram_launch.py
+++ b/tests/supervisor/test_vprogram_launch.py
@@ -22,8 +22,10 @@ from aleph_message.models import VerifiableProgramMessage, parse_message
 from aleph.vm.agent.vprogram_launch import (
     build_vprogram_spec,
     fetch_runtime_manifest,
+    remove_vprogram_staging,
     vprogram_staging_dir,
 )
+from aleph.vm.conf import settings
 from aleph.vm.supervisor_interface.errors import VmSetupError
 from aleph.vm.supervisor_interface.types import (
     Backend,
@@ -414,3 +416,22 @@ async def test_workload_roothash_non_hex_fails_closed(staged_bundle, bad_roothas
     staging = vprogram_staging_dir(message.item_hash)
     rootfs = staging / "image" / "rootfs.ext4"
     assert not rootfs.with_name(rootfs.name + ".workload_roothash").is_file()
+
+
+def test_remove_vprogram_staging_is_idempotent(tmp_path, monkeypatch):
+    """The teardown paths call remove_vprogram_staging so a churned V-PROGRAM
+    does not leak its extracted bundle. It must remove a populated staging
+    dir and be a no-op (never raise) when there is nothing to remove."""
+    monkeypatch.setattr(settings, "EXECUTION_ROOT", str(tmp_path))
+    vm_hash = load_vprogram_message().item_hash
+    staging = vprogram_staging_dir(vm_hash)
+    (staging / "image").mkdir(parents=True)
+    (staging / "image" / "rootfs.ext4").write_bytes(b"platform rootfs")
+    assert staging.exists()
+
+    remove_vprogram_staging(vm_hash)
+    assert not staging.exists()
+
+    # Already gone (second teardown, or a non-V-PROGRAM VM with no staging dir).
+    remove_vprogram_staging(vm_hash)
+    assert not staging.exists()


### PR DESCRIPTION
Follow-up to #1071 (raised in review): the V-PROGRAM runtime bundle is extracted into `EXECUTION_ROOT/vprogram/<vm_hash>`, but the launch path only clears it on *re-extraction*. A churned or permanently-descheduled V-PROGRAM therefore leaks its extracted bundle on disk over time.

## Change
Add an idempotent `remove_vprogram_staging(vm_hash)` helper (in `vprogram_launch.py`) and call it from every path that permanently removes a V-PROGRAM:

**Teardown / deschedule paths**
- **allocation deschedule** (`views/__init__.py`) — the case the reviewer cited (V-PROGRAM dropped from the scheduler allocation).
- **terminal-status stop** (`tasks.py`) — VM stopped after repeated REJECTED/FORGOTTEN/REMOVED confirmations.
- **operator erase** (`operator.py`) — `supervisor.delete_vm(wipe=True)` clears the *daemon-side* disks, but the *agent-side* staging dir is ours to remove.

**Create-time failure paths** (`run.py`, also flagged in review) — `build_vprogram_spec` extracts the bundle before agent-side capacity admission runs, so a create-path failure (capacity refused, or a post-extraction spec build error) and the wait-failure teardown both now clean the staging dir.

The helper is safe for any VM type: a non-V-PROGRAM has no such directory, so the call is a no-op (guards on existence, `rmtree(ignore_errors=True)`).

## Tests
`test_remove_vprogram_staging_is_idempotent`: removes a populated staging dir and is a no-op (never raises) when there is nothing to remove.

## Base
Stacked on `od/vprogram-launch` (#1071) since it depends on `vprogram_staging_dir`. Retarget to `dev` once #1071 merges.
