### PR TITLE
feat(agent): specific error when a VM never reaches RUNNING

### DIFF
--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -149,6 +149,16 @@ async def reconcile_port_forwards(supervisor: Supervisor, vm_id: VmId, content) 
             await supervisor.add_port_forward(spec)
 
 
+class VmStartupError(Exception):
+    """A VM was created but never reached the running state: it entered a
+    terminal status (FAILED/STOPPED) or timed out before RUNNING.
+
+    Agent-internal (raised by ``_wait_until_running``, never crosses the
+    Supervisor boundary), so it is not part of the SupervisorError vocabulary.
+    ``create_vm_execution_or_raise_http_error`` maps it to a clear HTTP reason
+    instead of the generic "unhandled error" bucket, for every VM type."""
+
+
 async def _wait_until_running(
     supervisor: Supervisor,
     vm_id: VmId,
@@ -159,8 +169,8 @@ async def _wait_until_running(
     """Poll get_vm until the VM reports RUNNING.
 
     In-process the first poll already reports RUNNING (create_vm blocked until
-    boot); across a future gRPC boundary this does real work. Raises on a
-    terminal status or after `timeout` seconds.
+    boot); across a future gRPC boundary this does real work. Raises
+    VmStartupError on a terminal status or after `timeout` seconds.
 
     `timeout`/`interval` default to the module constants, resolved at call time
     so tests (and operators) can override them by patching the constants.
@@ -176,10 +186,10 @@ async def _wait_until_running(
             return info
         if info.status in (VmStatus.STOPPED, VmStatus.FAILED):
             msg = f"VM {vm_id} entered status {info.status.value} while waiting to start"
-            raise RuntimeError(msg)
+            raise VmStartupError(msg)
         if asyncio.get_running_loop().time() >= deadline:
             msg = f"VM {vm_id} did not reach RUNNING within {timeout}s"
-            raise asyncio.TimeoutError(msg)
+            raise VmStartupError(msg)
         await asyncio.sleep(interval)
 
 
@@ -419,6 +429,11 @@ async def create_vm_execution_or_raise_http_error(
         ) from error
     except FileTooLargeError as error:
         raise HTTPInternalServerError(reason=error.args[0]) from error
+    except VmStartupError as error:
+        # Created but never reached RUNNING (terminal status or start timeout):
+        # a distinct, expected outcome, not the generic "unhandled error".
+        logger.warning("VM %s failed to start: %s", vm_hash, error)
+        raise HTTPInternalServerError(reason="VM failed to start") from error
     except VmSetupError as error:
         logger.exception(error)
         raise HTTPInternalServerError(reason="Error during vm initialisation") from error

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -155,8 +155,10 @@ class VmStartupError(Exception):
 
     Agent-internal (raised by ``_wait_until_running``, never crosses the
     Supervisor boundary), so it is not part of the SupervisorError vocabulary.
-    ``create_vm_execution_or_raise_http_error`` maps it to a clear HTTP reason
-    instead of the generic "unhandled error" bucket, for every VM type."""
+    ``create_vm_execution_or_raise_http_error`` (instances, v-programs) and
+    ``_raise_http_for_program_error`` (on-demand programs) map it to a clear
+    HTTP reason instead of the generic "unhandled error" bucket, so the
+    mapping covers every VM type."""
 
 
 async def _wait_until_running(
@@ -479,6 +481,11 @@ def _raise_http_for_program_error(error: Exception, vm_hash: ItemHash) -> None:
         ) from error
     if isinstance(error, FileTooLargeError):
         raise HTTPInternalServerError(reason=str(error) or "File too large") from error
+    if isinstance(error, VmStartupError):
+        # Created but never reached RUNNING (terminal status or start timeout):
+        # a distinct, expected outcome, not the generic "unhandled error".
+        logger.warning("VM %s failed to start: %s", vm_hash, error)
+        raise HTTPInternalServerError(reason="VM failed to start") from error
     if isinstance(error, VmSetupError):
         logger.exception(error)
         raise HTTPInternalServerError(reason="Error during vm initialisation") from error

--- a/tests/supervisor/test_supervisor_run_helpers.py
+++ b/tests/supervisor/test_supervisor_run_helpers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -77,7 +76,7 @@ async def test_wait_until_running_raises_on_terminal_status(monkeypatch):
     supervisor = SimpleNamespace(get_vm=AsyncMock(return_value=SimpleNamespace(status=VmStatus.FAILED)))
     monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(run_module.VmStartupError):
         await run_module._wait_until_running(supervisor, _VM_ID, timeout=10, interval=0)
 
 
@@ -86,7 +85,7 @@ async def test_wait_until_running_times_out(monkeypatch):
     supervisor = SimpleNamespace(get_vm=AsyncMock(return_value=SimpleNamespace(status=VmStatus.BOOTING)))
     monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
 
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(run_module.VmStartupError):
         await run_module._wait_until_running(supervisor, _VM_ID, timeout=0, interval=0)
 
 

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -194,7 +193,7 @@ async def test_eligible_instance_timeout_tears_down(monkeypatch):
     supervisor = _fake_supervisor(get_status=VmStatus.BOOTING)  # never RUNNING
     registry = AgentVmRegistry()
 
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(run_module.VmStartupError):
         await run_module.create_vm_execution(
             _HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
         )
@@ -614,3 +613,29 @@ async def test_start_persistent_arms_update_watch(monkeypatch):
         update_watcher=watcher,
     )
     watcher.watch.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_startup_failure_maps_to_specific_http_reason(monkeypatch):
+    """A VmStartupError (never reached RUNNING) surfaces as a specific HTTP
+    reason, not the generic 'unhandled error during initialisation' bucket."""
+    from aiohttp.web_exceptions import HTTPInternalServerError
+
+    content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
+    message = MagicMock(content=content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
+    )
+    monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(return_value=_spec()))
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(run_module, "_START_POLL_TIMEOUT_SECONDS", 0)
+
+    supervisor = _fake_supervisor(get_status=VmStatus.BOOTING)  # never RUNNING
+    registry = AgentVmRegistry()
+
+    with pytest.raises(HTTPInternalServerError) as excinfo:
+        await run_module.create_vm_execution_or_raise_http_error(
+            _HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
+        )
+    assert excinfo.value.reason == "VM failed to start"

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -639,3 +639,14 @@ async def test_startup_failure_maps_to_specific_http_reason(monkeypatch):
             _HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
         )
     assert excinfo.value.reason == "VM failed to start"
+
+
+def test_program_error_mapper_maps_startup_failure():
+    """The on-demand program mapper gives VmStartupError the same specific
+    reason as the instance/v-program create path, so the 'every VM type'
+    contract on VmStartupError holds."""
+    from aiohttp.web_exceptions import HTTPInternalServerError
+
+    with pytest.raises(HTTPInternalServerError) as excinfo:
+        run_module._raise_http_for_program_error(run_module.VmStartupError("never reached RUNNING"), ItemHash(_HASH))
+    assert excinfo.value.reason == "VM failed to start"

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -21,7 +21,7 @@ from aleph_message.models import (
 
 from aleph.vm.agent.messages import update_message
 from aleph.vm.agent.resources import Allocation
-from aleph.vm.agent.run import create_vm_execution, run_code_on_request
+from aleph.vm.agent.run import VmStartupError, create_vm_execution, run_code_on_request
 from aleph.vm.agent.supervisor import setup_webapp
 from aleph.vm.agent.tasks import _group_executions_by_payment
 from aleph.vm.agent.vm_registry import AgentVmRecord, AgentVmRegistry
@@ -268,7 +268,7 @@ async def test_create_vm_execution_vprogram_wait_failure_tears_down(mocker):
     )
     registry = AgentVmRegistry()
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(VmStartupError):
         await create_vm_execution(
             vm_hash,
             supervisor=supervisor,


### PR DESCRIPTION
Follow-up from the #1071 review (wait-failure error mapping), done as a standalone change against `dev` because it is cross-cutting, not V-PROGRAM-specific.

## Problem
`_wait_until_running` raised a bare `RuntimeError` (VM entered a terminal FAILED/STOPPED status) or `asyncio.TimeoutError` (never reached RUNNING before the deadline). Neither is caught by any specific arm of `create_vm_execution_or_raise_http_error`, so **every** VM type (program, instance, v-program) surfaced a start failure as the generic `HTTPInternalServerError(reason="Unhandled error during initialisation")` — indistinguishable from a real unexpected crash.

## Change
- Add an agent-side `VmStartupError` (in `run.py`, not the `SupervisorError` boundary vocabulary — it never crosses the supervisor gRPC boundary).
- `_wait_until_running` raises it for both the terminal-status and timeout cases.
- `create_vm_execution_or_raise_http_error` maps it to `reason="VM failed to start"`, ahead of the generic handler.

All three create paths already tear the half-started VM down (`registry.forget` + `delete_vm`) and re-raise, so teardown behaviour is unchanged; only the surfaced HTTP reason improves.

## Tests
- Updated the direct wait-loop tests (`test_supervisor_run_helpers`) and the instance (`test_supervisor_run_routing`) and v-program (`test_vprogram`) failure-path tests to expect `VmStartupError`.
- Added `test_startup_failure_maps_to_specific_http_reason` asserting the `"VM failed to start"` HTTP reason.
