### PR TITLE
perf(allocations): batch systemd state lookup in update_allocations

### DIFF
--- a/src/aleph/vm/orchestrator/run.py
+++ b/src/aleph/vm/orchestrator/run.py
@@ -267,10 +267,27 @@ async def run_code_on_event(vm_hash: ItemHash, event, pubsub: PubSub, pool: VmPo
             await execution.stop()
 
 
-async def start_persistent_vm(vm_hash: ItemHash, pubsub: PubSub | None, pool: VmPool) -> VmExecution:
+async def start_persistent_vm(
+    vm_hash: ItemHash,
+    pubsub: PubSub | None,
+    pool: VmPool,
+    running_states: dict[str, bool] | None = None,
+) -> VmExecution:
+    """Start (or attach to) a persistent VM.
+
+    ``running_states`` is an optional pre-computed mapping of
+    controller_service name -> active state, used to replace the
+    per-VM ``is_running`` D-Bus round-trip with a dict lookup. Callers
+    reconciling many VMs in a row (``update_allocations``) should pass
+    it to avoid stalling the event loop for seconds at a time.
+    """
     execution: VmExecution | None = pool.executions.get(vm_hash)
     if execution:
-        if execution.is_running:
+        if running_states is not None and execution.persistent:
+            is_running_now = running_states.get(execution.controller_service, False)
+        else:
+            is_running_now = execution.is_running
+        if is_running_now:
             logger.debug(f"{vm_hash} is already running")
         elif execution.is_starting:
             logger.debug(f"{vm_hash} is already starting")

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -528,14 +528,33 @@ async def update_allocations(request: web.Request):
 
     async with allocation_lock:
         logger.debug("Got allocation_lock, updating allocations")
+
+        # Snapshot systemd's ActiveState for every persistent controller
+        # in one batched D-Bus ListUnits() call off the event loop. The
+        # per-VM path (execution.is_running -> is_service_active) would
+        # otherwise issue O(N) synchronous D-Bus round-trips inside this
+        # loop; on CRNs with dozens of persistent VMs that stalls the
+        # loop long enough for the aleph-admin HTTP client to time out.
+        persistent_services = [
+            execution.controller_service for execution in pool.executions.values() if execution.persistent
+        ]
+        running_states: dict[str, bool] = {}
+        if persistent_services and pool.systemd_manager:
+            running_states = await asyncio.to_thread(
+                pool.systemd_manager.get_services_active_states,
+                persistent_services,
+            )
+
         # First, free resources from persistent programs and instances that are not scheduled anymore.
         allocations = allocation.persistent_vms | allocation.instances
         stopped_vms = []
-        # Make a copy since the pool is modified
-        for execution in list(pool.get_persistent_executions()):
+        # Make a copy since the pool is modified. get_persistent_executions
+        # already filtered by "running" via the batched map, so the extra
+        # is_running check the old code did here is both redundant and a
+        # per-VM D-Bus round-trip we now avoid.
+        for execution in list(pool.get_persistent_executions(running_states=running_states)):
             if (
                 execution.vm_hash not in allocations
-                and execution.is_running
                 and not execution.uses_payment_stream
                 and not execution.uses_payment_credit
                 and not execution.gpus
@@ -571,7 +590,7 @@ async def update_allocations(request: web.Request):
                 # a VM; firing an unconditional log here just adds noise
                 # when the scheduler re-pushes the full allocation list.
                 vm_hash = ItemHash(vm_hash)
-                await start_persistent_vm(vm_hash, pubsub, pool)
+                await start_persistent_vm(vm_hash, pubsub, pool, running_states=running_states)
             except vm_creation_exceptions as error:
                 logger.exception("Error while starting VM '%s': %s", vm_hash, error)
                 scheduling_errors[vm_hash] = error
@@ -584,7 +603,7 @@ async def update_allocations(request: web.Request):
         for instance_hash in allocation.instances:
             instance_item_hash = ItemHash(instance_hash)
             try:
-                await start_persistent_vm(instance_item_hash, pubsub, pool)
+                await start_persistent_vm(instance_item_hash, pubsub, pool, running_states=running_states)
             except vm_creation_exceptions as error:
                 logger.exception("Error while starting VM '%s': %s", instance_hash, error)
                 scheduling_errors[instance_item_hash] = error

--- a/src/aleph/vm/orchestrator/views/__init__.py
+++ b/src/aleph/vm/orchestrator/views/__init__.py
@@ -538,7 +538,10 @@ async def update_allocations(request: web.Request):
         persistent_services = [
             execution.controller_service for execution in pool.executions.values() if execution.persistent
         ]
-        running_states: dict[str, bool] = {}
+        # None (not {}) when no batch was performed, so get_persistent_executions
+        # falls back to its per-VM is_running path instead of treating every
+        # service as not-running.
+        running_states: dict[str, bool] | None = None
         if persistent_services and pool.systemd_manager:
             running_states = await asyncio.to_thread(
                 pool.systemd_manager.get_services_active_states,

--- a/src/aleph/vm/pool.py
+++ b/src/aleph/vm/pool.py
@@ -788,13 +788,31 @@ class VmPool:
         )
         return executions or []
 
-    def get_persistent_executions(self) -> Iterable[VmExecution]:
-        executions = (
-            execution
-            for _vm_hash, execution in self.executions.items()
-            if execution.is_running and execution.persistent
-        )
-        return executions or []
+    def get_persistent_executions(
+        self,
+        running_states: dict[str, bool] | None = None,
+    ) -> Iterable[VmExecution]:
+        """Yield persistent executions that are currently running.
+
+        Args:
+            running_states: Optional pre-computed mapping of
+                controller_service name -> active state (e.g. the result
+                of ``SystemDManager.get_services_active_states()``). When
+                provided, replaces the per-VM ``is_running`` D-Bus round-
+                trip with a dict lookup. Callers iterating over many
+                executions should pass this to avoid stalling the event
+                loop, same shortcut used by ``load_persistent_executions``
+                and ``get_executions_by_address``.
+        """
+        for _vm_hash, execution in self.executions.items():
+            if not execution.persistent:
+                continue
+            if running_states is not None:
+                is_running_now = running_states.get(execution.controller_service, False)
+            else:
+                is_running_now = execution.is_running
+            if is_running_now:
+                yield execution
 
     def get_instance_executions(self) -> Iterable[VmExecution]:
         executions = (

--- a/tests/supervisor/test_run.py
+++ b/tests/supervisor/test_run.py
@@ -195,3 +195,91 @@ async def test_start_persistent_vm_stops_and_recreates_on_terminal_systemd_state
     stop_mock.assert_awaited_once()
     create_mock.assert_awaited_once()
     assert result is new_execution
+
+
+# --- Batched running_states lookup -----------------------------------------
+#
+# On CRNs with many persistent VMs, iterating executions and calling
+# execution.is_running per VM issues O(N) synchronous D-Bus round-trips on
+# the event loop. update_allocations now snapshots the state once via
+# get_services_active_states off-thread and passes the map to
+# start_persistent_vm (and to get_persistent_executions). These tests pin
+# the "map wins over D-Bus" invariant so a future refactor can't silently
+# reintroduce the per-VM lookup.
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_vm_uses_running_states_map_for_fast_path(instance_content, mocker):
+    """When running_states says the VM is running, do not touch systemd."""
+    execution = make_execution(instance_content, mocker, controller_active=False)
+    mark_started(execution)
+    execution.vm = mocker.Mock()
+
+    stop_mock = mocker.patch.object(execution, "stop", new=mocker.AsyncMock())
+    create_mock = mocker.patch("aleph.vm.orchestrator.run.create_vm_execution", new=mocker.AsyncMock())
+
+    pool = mocker.Mock(executions={VM_HASH: execution})
+    running_states = {execution.controller_service: True}
+
+    result = await start_persistent_vm(VM_HASH, pubsub=None, pool=pool, running_states=running_states)
+
+    assert result is execution
+    stop_mock.assert_not_called()
+    create_mock.assert_not_called()
+    # Per-VM D-Bus should have been bypassed entirely.
+    execution.systemd_manager.is_service_active.assert_not_called()
+    execution.systemd_manager.get_service_active_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_vm_running_states_missing_service_falls_through(instance_content, mocker):
+    """Missing entry in running_states means 'not running per the batch snapshot'.
+
+    Since this is our controlled fast-path decision, the code should treat
+    it as False (not-running) and follow the same else-branch logic as
+    when execution.is_running would have returned False - i.e. check the
+    real systemd state before deciding to stop or leave alone.
+    """
+    execution = make_execution(instance_content, mocker, active_state="active")
+    mark_started(execution)
+    execution.vm = mocker.Mock()
+
+    stop_mock = mocker.patch.object(execution, "stop", new=mocker.AsyncMock())
+    create_mock = mocker.patch("aleph.vm.orchestrator.run.create_vm_execution", new=mocker.AsyncMock())
+
+    pool = mocker.Mock(executions={VM_HASH: execution})
+    running_states = {}  # deliberately empty: no snapshot for this service
+
+    result = await start_persistent_vm(VM_HASH, pubsub=None, pool=pool, running_states=running_states)
+
+    # Falls through to the transient-state guard which sees 'active' and
+    # returns the execution unchanged. Confirms the map path composes
+    # correctly with the systemd-state check in the else branch.
+    assert result is execution
+    stop_mock.assert_not_called()
+    create_mock.assert_not_called()
+
+
+def test_get_persistent_executions_uses_running_states_map(instance_content, mocker):
+    """pool.get_persistent_executions with a map must NOT call is_running per-VM."""
+    from aleph.vm.pool import VmPool
+
+    execution_up = make_execution(instance_content, mocker)
+    execution_up.vm_hash = ItemHash("a" * 64)
+
+    execution_down = make_execution(instance_content, mocker)
+    execution_down.vm_hash = ItemHash("b" * 64)
+
+    pool = VmPool.__new__(VmPool)
+    pool.executions = {execution_up.vm_hash: execution_up, execution_down.vm_hash: execution_down}
+
+    running_states = {
+        execution_up.controller_service: True,
+        execution_down.controller_service: False,
+    }
+
+    result = list(pool.get_persistent_executions(running_states=running_states))
+
+    assert result == [execution_up]
+    execution_up.systemd_manager.is_service_active.assert_not_called()
+    execution_down.systemd_manager.is_service_active.assert_not_called()

--- a/tests/supervisor/test_run.py
+++ b/tests/supervisor/test_run.py
@@ -248,7 +248,7 @@ async def test_start_persistent_vm_running_states_missing_service_falls_through(
     create_mock = mocker.patch("aleph.vm.orchestrator.run.create_vm_execution", new=mocker.AsyncMock())
 
     pool = mocker.Mock(executions={VM_HASH: execution})
-    running_states = {}  # deliberately empty: no snapshot for this service
+    running_states: dict[str, bool] = {}  # deliberately empty: no snapshot for this service
 
     result = await start_persistent_vm(VM_HASH, pubsub=None, pool=pool, running_states=running_states)
 

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -352,7 +352,12 @@ async def test_allocation_valid_token(aiohttp_client):
     This is a very simple test that don't start or stop any VM so the mock is minimal"""
 
     class FakeVmPool:
-        def get_persistent_executions(self):
+        # update_allocations reads these before get_persistent_executions:
+        # no executions means no batched systemd lookup is attempted.
+        executions: dict = {}
+        systemd_manager = None
+
+        def get_persistent_executions(self, running_states=None):
             return []
 
     settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
@@ -1148,7 +1153,12 @@ async def test_regenerate_proxy_exception(aiohttp_client, mocker, mock_app_with_
 
 
 class _FakeVmPool:
-    def get_persistent_executions(self):
+    # update_allocations reads these before get_persistent_executions:
+    # no executions means no batched systemd lookup is attempted.
+    executions: dict = {}
+    systemd_manager = None
+
+    def get_persistent_executions(self, running_states=None):
         return []
 
 


### PR DESCRIPTION
## Summary

\`POST /control/allocations\` reconciles the scheduler's push against the local pool: walks all persistent executions to find stop candidates, then calls \`start_persistent_vm\` for every hash in the pushed list. Every \`execution.is_running\` call is a synchronous D-Bus round-trip to systemd. On a CRN with 80+ persistent VMs and a full-list push, that's ~2N blocking round-trips on the event loop behind \`allocation_lock\`. Once the total wall time crosses aleph-admin's HTTP client timeout, the request times out; restarting the supervisor \"fixes\" it by cancelling the in-flight allocation and resetting the lock, but the underlying scaling problem returns with the next attempt.

Reported symptom (crn10.leviathan.so, 80+ instances, allocating a fresh instance):
\`\`\`
Error: crn request to https://crn10.leviathan.so/control/allocations failed: timed out
\`\`\`

## Fix

Same shape as #963 for \`monitor_payments\`:

- \`update_allocations\` snapshots systemd's ActiveState for every persistent controller in one \`ListUnits()\` call, off the event loop via \`asyncio.to_thread\`.
- Pass the dict to \`pool.get_persistent_executions\` and \`start_persistent_vm\` via a new \`running_states\` parameter. Both prefer the map lookup over \`execution.is_running\` when it is provided; fall back to the per-VM path when it isn't, so existing callers are unchanged.
- Drop the redundant \`execution.is_running\` check inside the stop loop: \`get_persistent_executions\` already filtered by running via the map, and calling it again inside the loop would be another per-VM D-Bus round-trip we now avoid.

Per-request D-Bus work drops from **~2N synchronous round-trips on the event loop** to **one \`ListUnits\` call off-thread**. On a CRN with 80 VMs the allocation call goes from \"sometimes times out\" to a few hundred milliseconds.

## Test plan
- [x] \`start_persistent_vm\`'s fast-path with a map showing \"running\" bypasses \`is_service_active\` entirely.
- [x] A missing entry in \`running_states\` falls through to #1081's transient-state guard and composes correctly.
- [x] \`pool.get_persistent_executions\` with a map never calls per-VM \`is_running\`.
- [ ] Deploy to a staging CRN, POST /control/allocations with a large list, verify sub-second response time.

## Related
- #963 (\`monitor_payments\` batched via the same pattern)
- #1081 (transient-state guard in \`start_persistent_vm\` — this PR composes with it, not against it)