### PR TITLE
fix(agent): heal port forwards when re-adopting a running VM

### DIFF
--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -29,7 +29,10 @@ from aleph.vm.agent.translate import build_create_vm_spec, build_program_create_
 from aleph.vm.agent.update_watcher import UpdateWatcher
 from aleph.vm.agent.vm.program_client import ProgramGuestClient
 from aleph.vm.agent.vm_registry import AgentVmRegistry, persist_record
-from aleph.vm.agent.vprogram_launch import build_vprogram_spec
+from aleph.vm.agent.vprogram_launch import (
+    build_vprogram_spec,
+    resolve_vprogram_attestation_port,
+)
 from aleph.vm.conf import settings
 from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.supervisor_interface import errors as supervisor_errors
@@ -97,13 +100,20 @@ def _is_spec_eligible(content) -> bool:
     return isinstance(content, InstanceContent)
 
 
-async def resolve_port_forwards(vm_id: VmId, content) -> list[PortForwardSpec]:
+async def resolve_port_forwards(vm_id: VmId, content, *, strict: bool = False) -> list[PortForwardSpec]:
     """Agent-side policy: translate the user's port-forwarding aggregate settings
     into the set of forwards the hypervisor should apply.
 
     This is the agent half of the old VmExecution.fetch_port_redirect_config_and_setup.
     Nothing here touches nftables; the caller applies each spec through
     supervisor.add_port_forward. host_port is left 0; the hypervisor assigns it.
+
+    ``strict=True`` turns an aggregate-fetch failure into an exception instead
+    of the SSH-only fallback. The fallback is right on create (worst case the
+    VM starts with SSH only), but a convergence caller reconciling an already
+    forwarded VM must not treat "could not fetch" as "the user removed every
+    port": converging on the fallback set would tear the user's forwards down
+    on a transient CCN error. Strict callers skip reconciling instead.
     """
     ports_requests: dict[int, dict[str, bool]] = {}
     try:
@@ -112,6 +122,8 @@ async def resolve_port_forwards(vm_id: VmId, content) -> list[PortForwardSpec]:
         fetched = vm_port_forwarding.get("ports", {})
         ports_requests = {int(port): flags for port, flags in fetched.items()}
     except Exception:
+        if strict:
+            raise
         logger.info("Could not fetch port redirect settings for %s", content.address, exc_info=True)
 
     # Always forward SSH.
@@ -181,11 +193,48 @@ def resolve_vprogram_port_forwards(vm_id: VmId, attest_port: int | None) -> list
 async def reconcile_vprogram_port_forwards(supervisor: Supervisor, vm_id: VmId, attest_port: int | None) -> None:
     """Drive the hypervisor's forwards to match the V-PROGRAM's single
     attestation-port mapping. Reuses ``_reconcile_forwards``, so it is
-    idempotent by construction: a future re-adoption path (a fresh agent
-    process picking the VM back up) can call it safely, though today only
-    the create path does.
+    idempotent by construction: both the create path and the re-adoption
+    path (``reconcile_adopted_port_forwards``) call it safely.
     """
     await _reconcile_forwards(supervisor, vm_id, resolve_vprogram_port_forwards(vm_id, attest_port))
+
+
+async def reconcile_adopted_port_forwards(supervisor: Supervisor, registry: AgentVmRegistry, vm_hash: ItemHash) -> None:
+    """Best-effort port-forward healing for a VM adopted already-created.
+
+    The create path applies forwards right after the VM first reaches RUNNING;
+    a VM re-adopted on a later allocation (typically after an agent restart)
+    skipped that step in this agent's lifetime. If the previous life crashed
+    in the window between RUNNING and the forward setup, the VM is up but
+    unreachable (no SSH for an instance, no attestation endpoint for a
+    V-PROGRAM); for instances, the port-forwarding aggregate may also have
+    changed while the agent was down, past the live aggregate watcher.
+    Converge the hypervisor state here.
+
+    Best-effort by design, unlike the create path (which fails loudly and
+    tears the VM down): the adopted VM is already up and possibly serving, so
+    a healing failure must never fail the allocation and invite scheduler
+    churn. Skipping leaves exactly the state we found.
+    """
+    record = registry.get(vm_hash)
+    if record is None:
+        # Nothing to derive the desired forward set from (agent DB loss).
+        logger.warning("No agent record for adopted VM %s; port forwards left as found", vm_hash)
+        return
+    vm_id = VmId(str(vm_hash))
+    content = record.message
+    try:
+        if isinstance(content, VerifiableProgramContent):
+            attest_port = await resolve_vprogram_attestation_port(content)
+            await reconcile_vprogram_port_forwards(supervisor, vm_id, attest_port)
+        elif _is_spec_eligible(content):
+            # strict: a failed aggregate fetch must skip healing, not converge
+            # the VM onto the SSH-only fallback set (which would remove the
+            # user's aggregate-declared forwards on a transient CCN error).
+            await _reconcile_forwards(supervisor, vm_id, await resolve_port_forwards(vm_id, content, strict=True))
+        # Programs get no agent-side forwards: nothing to heal.
+    except Exception:
+        logger.warning("Could not reconcile port forwards for adopted VM %s; left as found", vm_hash, exc_info=True)
 
 
 async def _wait_until_running(
@@ -855,6 +904,14 @@ async def start_persistent_vm(
             # them) so the recreated VM reloads the same host ports.
             await supervisor.delete_vm(vm_id, keep_port_mappings=True)
             info = None
+        if info is not None and not info.awaiting_confidential_init:
+            # Every branch that kept `info` ends with a RUNNING VM this agent
+            # did not create in its own lifetime. Only the create path applies
+            # forwards, so heal them here: a previous life crashing between
+            # RUNNING and the forward setup leaves the VM up but unreachable
+            # forever otherwise. Best-effort; never fails the allocation.
+            # The recreate branches (info = None) reconcile in the create path.
+            await reconcile_adopted_port_forwards(supervisor, registry, vm_hash)
 
     if info is None:
         logger.info(f"Starting persistent virtual machine with id: {vm_hash}")

--- a/src/aleph/vm/agent/vprogram_launch.py
+++ b/src/aleph/vm/agent/vprogram_launch.py
@@ -195,6 +195,22 @@ def _select_attestation_port(manifest: RuntimeManifest) -> int | None:
     return None
 
 
+async def resolve_vprogram_attestation_port(content: VerifiableProgramContent) -> int | None:
+    """Re-derive the RA-TLS attestation port from the runtime manifest alone.
+
+    The re-adoption path (an agent picking an already-RUNNING V-PROGRAM back
+    up) needs the port to reconcile the host DNAT mapping, but must not pay
+    for ``build_vprogram_spec``: that stages the whole runtime bundle, which
+    the running VM already booted from. The manifest is a small STORE file:
+    one message-metadata lookup, with the file itself coming from the local
+    download cache after the first create. Raises VmSetupError when the
+    manifest cannot be fetched or parsed; the caller decides whether that is
+    fatal.
+    """
+    manifest = await fetch_runtime_manifest(str(content.runtime.ref))
+    return _select_attestation_port(manifest)
+
+
 async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramContent) -> tuple[CreateVmSpec, int | None]:
     """Fetch, verify and stage the runtime bundle, then build the SNP spec.
 

--- a/tests/supervisor/test_supervisor_run_helpers.py
+++ b/tests/supervisor/test_supervisor_run_helpers.py
@@ -60,6 +60,18 @@ async def test_resolve_port_forwards_tolerates_settings_error(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_resolve_port_forwards_strict_raises_on_settings_error(monkeypatch):
+    """strict=True is for convergence callers: a fetch failure must abort the
+    reconcile, not converge the VM onto the SSH-only fallback set (which would
+    remove the user's aggregate-declared forwards on a transient CCN error)."""
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(side_effect=RuntimeError("boom")))
+    content = SimpleNamespace(address="0xabc")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await run_module.resolve_port_forwards(_VM_ID, content, strict=True)
+
+
+@pytest.mark.asyncio
 async def test_wait_until_running_returns_on_running(monkeypatch):
     booting = SimpleNamespace(status=VmStatus.BOOTING)
     running = SimpleNamespace(status=VmStatus.RUNNING)

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -560,7 +560,9 @@ async def test_start_persistent_readopt_instance_heals_with_strict_resolve(monke
     await _start_persistent(sup, _instance_registry())
 
     resolve.assert_awaited_once()
-    assert resolve.await_args.kwargs.get("strict") is True
+    await_args = resolve.await_args
+    assert await_args is not None
+    assert await_args.kwargs.get("strict") is True
     sup.add_port_forward.assert_awaited_once_with(ssh)
     sup.remove_port_forward.assert_not_awaited()
 

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -28,9 +28,14 @@ from aleph.vm.supervisor_interface.types import (
     DiskRole,
     DiskSpec,
     GpuSpec,
+    GuestPort,
+    HostPort,
     IpAssignment,
     NetworkConfig,
     PciAddress,
+    PortForwardInfo,
+    PortForwardSpec,
+    Protocol,
     VmId,
     VmInfo,
     VmStatus,
@@ -513,6 +518,111 @@ async def test_start_persistent_resumes_stopped(monkeypatch):
     sup.start_vm.assert_awaited_once()  # STOPPED -> resume in place
     sup.delete_vm.assert_not_awaited()  # not deleted
     created.assert_not_awaited()  # not recreated
+
+
+def _readopt_supervisor(*, get_status: VmStatus = VmStatus.RUNNING, current_forwards: list | None = None):
+    sup = _fake_supervisor(get_status=get_status)
+    sup.list_port_forwards = AsyncMock(return_value=current_forwards or [])
+    sup.remove_port_forward = AsyncMock()
+    return sup
+
+
+def _instance_registry() -> AgentVmRegistry:
+    content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
+    registry = AgentVmRegistry()
+    registry.record(_HASH, message=content, original=content, persistent=True)
+    return registry
+
+
+async def _start_persistent(sup, registry):
+    return await run_module.start_persistent_vm(
+        ItemHash(_HASH),
+        None,
+        supervisor=sup,
+        registry=registry,
+        capacity=_fake_capacity(),
+        expiry=MagicMock(),
+        update_watcher=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_readopt_instance_heals_with_strict_resolve(monkeypatch):
+    """An instance adopted already-RUNNING gets its forwards reconciled from
+    the aggregate, resolved strictly: on re-adoption "could not fetch" must
+    mean "skip", never "converge onto the SSH-only fallback"."""
+    sup = _readopt_supervisor()
+    monkeypatch.setattr(run_module, "create_vm_execution", AsyncMock())
+    ssh = PortForwardSpec(vm_id=VmId(str(_HASH)), host_port=HostPort(0), vm_port=GuestPort(22), protocol=Protocol.TCP)
+    resolve = AsyncMock(return_value=[ssh])
+    monkeypatch.setattr(run_module, "resolve_port_forwards", resolve)
+
+    await _start_persistent(sup, _instance_registry())
+
+    resolve.assert_awaited_once()
+    assert resolve.await_args.kwargs.get("strict") is True
+    sup.add_port_forward.assert_awaited_once_with(ssh)
+    sup.remove_port_forward.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_readopt_instance_settings_error_removes_nothing(monkeypatch):
+    """A transient aggregate-fetch failure during re-adoption healing must
+    leave existing forwards exactly as found and never fail the allocation."""
+    existing = PortForwardInfo(
+        vm_id=VmId(str(_HASH)), host_port=HostPort(24080), vm_port=GuestPort(8080), protocol=Protocol.TCP
+    )
+    sup = _readopt_supervisor(current_forwards=[existing])
+    monkeypatch.setattr(run_module, "create_vm_execution", AsyncMock())
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(side_effect=RuntimeError("CCN down")))
+
+    await _start_persistent(sup, _instance_registry())
+
+    sup.remove_port_forward.assert_not_awaited()
+    sup.add_port_forward.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_readopt_awaiting_init_not_healed(monkeypatch):
+    """A confidential VM awaiting its owner's session is left untouched: it is
+    not RUNNING, so there is nothing to heal (the create path applies forwards
+    once it comes up)."""
+    sup = _fake_supervisor()
+    sup.get_vm = AsyncMock(return_value=replace(_info(VmStatus.DEFINED), awaiting_confidential_init=True))
+    heal = AsyncMock()
+    monkeypatch.setattr(run_module, "reconcile_adopted_port_forwards", heal)
+    monkeypatch.setattr(run_module, "create_vm_execution", AsyncMock())
+
+    await _start_persistent(sup, AgentVmRegistry())
+
+    heal.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_readopt_stopped_heals_after_resume(monkeypatch):
+    """The resume-in-place branch ends with a RUNNING VM this agent did not
+    create, so it heals forwards too (idempotent when nothing is missing)."""
+    sup = _fake_supervisor(get_status=VmStatus.STOPPED)
+    heal = AsyncMock()
+    monkeypatch.setattr(run_module, "reconcile_adopted_port_forwards", heal)
+    monkeypatch.setattr(run_module, "create_vm_execution", AsyncMock())
+    monkeypatch.setattr(run_module, "_wait_until_running", AsyncMock())
+
+    await _start_persistent(sup, AgentVmRegistry())
+
+    sup.start_vm.assert_awaited_once()
+    heal.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_adopted_program_content_is_a_noop():
+    """Programs get no agent-side forwards: adoption healing must not touch
+    the supervisor at all (a bare namespace would AttributeError if it did)."""
+    registry = AgentVmRegistry()
+    content = MagicMock(spec=ProgramContent)
+    registry.record(_HASH, message=content, original=content, persistent=True)
+
+    await run_module.reconcile_adopted_port_forwards(SimpleNamespace(), registry, _HASH)
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_vprogram_port_map.py
+++ b/tests/supervisor/test_vprogram_port_map.py
@@ -14,13 +14,21 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aleph_message.models import VerifiableProgramMessage, parse_message
 
-from aleph.vm.agent.run import create_vm_execution, reconcile_vprogram_port_forwards
+from aleph.vm.agent.run import (
+    create_vm_execution,
+    reconcile_vprogram_port_forwards,
+    start_persistent_vm,
+)
 from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor_interface.errors import VmSetupError
 from aleph.vm.supervisor_interface.types import (
     Backend,
     ConfidentialMode,
+    GuestPort,
+    HostPort,
     IpAssignment,
     PortForwardInfo,
+    PortForwardSpec,
     Protocol,
     VmId,
     VmInfo,
@@ -147,3 +155,96 @@ async def test_reconcile_vprogram_no_attestation_port_is_noop():
     await reconcile_vprogram_port_forwards(supervisor, VmId("deadbeef"), None)
     assert supervisor.add_port_forward_calls == []
     assert await supervisor.list_port_forwards(VmId("deadbeef")) == []
+
+
+async def _start_persistent(vm_hash, supervisor, registry):
+    return await start_persistent_vm(
+        vm_hash,
+        None,
+        supervisor=supervisor,
+        registry=registry,
+        capacity=MagicMock(),
+        expiry=MagicMock(),
+        update_watcher=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_readopted_running_vprogram_heals_missing_forward(mocker):
+    """A V-PROGRAM adopted already-RUNNING (agent restart) whose attestation
+    forward is missing (previous life crashed between RUNNING and the forward
+    setup) gets it healed from the manifest, without rebuilding the spec or
+    recreating the VM. A second adoption then no-ops (idempotent heal)."""
+    message = load_vprogram_message()
+    vm_hash = message.item_hash
+    mocker.patch(
+        "aleph.vm.agent.run.resolve_vprogram_attestation_port",
+        new_callable=AsyncMock,
+        return_value=ATTEST_PORT,
+    )
+    create = mocker.patch("aleph.vm.agent.run.create_vm_execution", new_callable=AsyncMock)
+
+    supervisor = FakeSupervisor(_running_vm_info(str(vm_hash)))
+    registry = AgentVmRegistry()
+    registry.record(vm_hash, message=message.content, original=message.content, persistent=True)
+
+    await _start_persistent(vm_hash, supervisor, registry)
+
+    create.assert_not_awaited()
+    assert len(supervisor.add_port_forward_calls) == 1
+    pf = supervisor.add_port_forward_calls[0]
+    assert pf.vm_port == ATTEST_PORT
+    assert pf.protocol is Protocol.TCP
+
+    await _start_persistent(vm_hash, supervisor, registry)
+    assert len(supervisor.add_port_forward_calls) == 1
+    assert len(await supervisor.list_port_forwards(VmId(str(vm_hash)))) == 1
+
+
+@pytest.mark.asyncio
+async def test_readopted_vprogram_manifest_failure_leaves_forwards_as_found(mocker):
+    """Healing is best-effort: when the manifest cannot be re-fetched on
+    re-adoption, the allocation still succeeds and the forwards that exist
+    stay exactly as found (no teardown, no removal)."""
+    message = load_vprogram_message()
+    vm_hash = message.item_hash
+    mocker.patch(
+        "aleph.vm.agent.run.resolve_vprogram_attestation_port",
+        new_callable=AsyncMock,
+        side_effect=VmSetupError("manifest unavailable"),
+    )
+    mocker.patch("aleph.vm.agent.run.create_vm_execution", new_callable=AsyncMock)
+
+    supervisor = FakeSupervisor(_running_vm_info(str(vm_hash)))
+    # An existing (possibly stale) forward that healing must not touch when
+    # it cannot compute the desired set.
+    await supervisor.add_port_forward(
+        PortForwardSpec(
+            vm_id=VmId(str(vm_hash)), host_port=HostPort(0), vm_port=GuestPort(ATTEST_PORT), protocol=Protocol.TCP
+        )
+    )
+    supervisor.add_port_forward_calls.clear()
+    registry = AgentVmRegistry()
+    registry.record(vm_hash, message=message.content, original=message.content, persistent=True)
+
+    await _start_persistent(vm_hash, supervisor, registry)
+
+    assert supervisor.add_port_forward_calls == []
+    assert len(await supervisor.list_port_forwards(VmId(str(vm_hash)))) == 1
+
+
+@pytest.mark.asyncio
+async def test_readopted_vprogram_without_record_leaves_supervisor_untouched(mocker):
+    """No agent record (DB loss): there is nothing to derive the desired set
+    from, so adoption must not touch the forwards at all."""
+    message = load_vprogram_message()
+    vm_hash = message.item_hash
+    resolve = mocker.patch("aleph.vm.agent.run.resolve_vprogram_attestation_port", new_callable=AsyncMock)
+    mocker.patch("aleph.vm.agent.run.create_vm_execution", new_callable=AsyncMock)
+
+    supervisor = FakeSupervisor(_running_vm_info(str(vm_hash)))
+
+    await _start_persistent(vm_hash, supervisor, AgentVmRegistry())
+
+    resolve.assert_not_awaited()
+    assert supervisor.add_port_forward_calls == []


### PR DESCRIPTION
## The gap

Follow-up to #1079, closing the re-adoption case its review noted: only the create path ever applies port forwards (right after the VM first reaches RUNNING). A VM adopted already-created by `start_persistent_vm` (typically after an agent restart) skipped that step in the new agent's lifetime, for instances and V-PROGRAMs alike. Two concrete consequences:

- If the previous agent life crashed in the window between RUNNING and the forward setup, the VM stayed up but permanently unreachable: no SSH for an instance, no attestation endpoint for a V-PROGRAM (whose sole consumer is the CLI's attested call).
- Instances also missed any port-forwarding aggregate change published while the agent was down, past the live aggregate watcher.

## The fix

Every `start_persistent_vm` adoption branch that ends with a RUNNING VM (already running, still booting, resumed from STOPPED) now converges the hypervisor's forwards onto the desired set through the same idempotent `_reconcile_forwards` machinery #1079 introduced (which was written for exactly this call site). The recreate branches already reconcile through the create path.

Deriving the desired set cheaply, per VM type:

- **V-PROGRAM**: new `resolve_vprogram_attestation_port` re-reads the RA-TLS port from the runtime manifest alone (one message-metadata lookup; the manifest file is in the local download cache after the first create). No `build_vprogram_spec`, no bundle staging: the running VM already booted from that bundle.
- **Instance**: re-resolve the user's port-forwarding aggregate, strictly (see below).
- **Program**: no agent-side forwards, nothing to heal.

Two deliberate semantics:

- **Best-effort, unlike the create path.** The adopted VM is already up and possibly serving; a healing failure logs a warning and leaves the forwards exactly as found, rather than failing the allocation and inviting scheduler churn. The create path keeps its loud fail-and-teardown behavior.
- **Strict aggregate resolution on this path** (new `strict` keyword on `resolve_port_forwards`). The create-path fallback turns an aggregate-fetch failure into SSH-only, which is fine when there is nothing to lose; driving a *convergence* with that fallback would remove the user's declared forwards on a transient CCN error. Strict failures skip healing instead.

The `reconcile_vprogram_port_forwards` docstring loses its "though today only the create path does" caveat, which this PR makes true.

## Tests

- Adopted RUNNING V-PROGRAM with a missing forward gets it healed from the manifest; a second adoption no-ops (idempotence), no recreate.
- Manifest re-fetch failure on adoption: allocation still succeeds, existing forwards untouched.
- Missing agent record (DB loss): supervisor not touched at all.
- Adopted RUNNING instance reconciles with `strict=True`; a strict aggregate-fetch failure removes nothing and adds nothing.
- Awaiting-init confidential VMs are not healed (not RUNNING); the STOPPED resume-in-place branch is.
- `resolve_port_forwards(strict=True)` raises on fetch failure; the default fallback behavior is unchanged.

Local run of every test file importing the touched modules: identical results to the base branch plus the 9 new tests (the base's local-only failures are environmental and unchanged).