### PR TITLE
feat(supervisor-cli): log output sanitization and RPC timeouts

### DIFF
--- a/rust/crates/supervisor-cli/src/cli.rs
+++ b/rust/crates/supervisor-cli/src/cli.rs
@@ -21,6 +21,11 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub json: bool,
 
+    /// Seconds before a call to a wedged supervisor is abandoned (0 waits
+    /// forever). Streaming commands (logs -f, events) are never cut short.
+    #[arg(long, global = true, default_value_t = 10)]
+    pub timeout: u64,
+
     #[command(subcommand)]
     pub command: Command,
 }
@@ -49,6 +54,14 @@ pub enum Command {
     /// Port forwards.
     #[command(subcommand)]
     Ports(PortsCommand),
+}
+
+impl Command {
+    /// Long-lived server streams that must outlive any per-request
+    /// deadline; main.rs skips the request timeout for these.
+    pub fn is_streaming(&self) -> bool {
+        matches!(self, Command::Events | Command::Logs { follow: true, .. })
+    }
 }
 
 #[derive(Subcommand, Debug)]
@@ -110,5 +123,23 @@ mod tests {
         let error = Cli::try_parse_from(["alephctl", "logs", "vm-1", "--follow", "--tail", "10"])
             .unwrap_err();
         assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn timeout_defaults_to_ten_seconds() {
+        let cli = Cli::try_parse_from(["alephctl", "health"]).unwrap();
+        assert_eq!(cli.timeout, 10);
+        let cli = Cli::try_parse_from(["alephctl", "--timeout", "0", "health"]).unwrap();
+        assert_eq!(cli.timeout, 0);
+    }
+
+    #[test]
+    fn only_follow_and_events_are_streaming() {
+        let streaming = |args: &[&str]| Cli::try_parse_from(args).unwrap().command.is_streaming();
+        assert!(streaming(&["alephctl", "events"]));
+        assert!(streaming(&["alephctl", "logs", "vm-1", "--follow"]));
+        assert!(!streaming(&["alephctl", "logs", "vm-1"]));
+        assert!(!streaming(&["alephctl", "logs", "vm-1", "--tail", "5"]));
+        assert!(!streaming(&["alephctl", "health"]));
     }
 }

--- a/rust/crates/supervisor-cli/src/client.rs
+++ b/rust/crates/supervisor-cli/src/client.rs
@@ -1,6 +1,7 @@
 //! Socket-path resolution and the UDS gRPC client plumbing.
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use anyhow::Context as _;
 use hyper_util::rt::TokioIo;
@@ -10,15 +11,28 @@ use tonic::transport::{Channel, Endpoint, Uri};
 use tower::service_fn;
 
 const DEFAULT_EXECUTION_ROOT: &str = "/var/lib/aleph/vm";
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub type SupervisorClient = pb::supervisor_client::SupervisorClient<Channel>;
 
 /// Connect to the supervisor over its Unix socket. The endpoint URI is a
 /// placeholder tonic requires; every connection goes to the socket.
-pub async fn connect(path: &Path) -> anyhow::Result<SupervisorClient> {
+///
+/// `request_timeout` bounds each RPC so a wedged supervisor (the kernel
+/// queues UDS connections even when the daemon never accepts) cannot hang
+/// the CLI forever. None for streaming commands, which run indefinitely.
+pub async fn connect(
+    path: &Path,
+    request_timeout: Option<Duration>,
+) -> anyhow::Result<SupervisorClient> {
     let socket = path.to_path_buf();
-    let channel = Endpoint::try_from("http://socket.invalid")
+    let mut endpoint = Endpoint::try_from("http://socket.invalid")
         .context("static endpoint")?
+        .connect_timeout(CONNECT_TIMEOUT);
+    if let Some(timeout) = request_timeout {
+        endpoint = endpoint.timeout(timeout);
+    }
+    let channel = endpoint
         .connect_with_connector(service_fn(move |_: Uri| {
             let socket = socket.clone();
             async move {
@@ -131,7 +145,7 @@ mod tests {
 
     #[tokio::test]
     async fn connect_reports_a_missing_socket_clearly() {
-        let error = connect(std::path::Path::new("/nonexistent/supervisor.sock"))
+        let error = connect(std::path::Path::new("/nonexistent/supervisor.sock"), None)
             .await
             .unwrap_err();
         let text = format!("{error:#}");

--- a/rust/crates/supervisor-cli/src/commands/logs.rs
+++ b/rust/crates/supervisor-cli/src/commands/logs.rs
@@ -47,13 +47,14 @@ pub async fn logs(
     Ok(())
 }
 
-/// NDJSON in --json mode (streams must stay line-oriented), bare line
-/// otherwise.
+/// NDJSON in --json mode (streams must stay line-oriented); otherwise the
+/// line with control characters escaped, because guest serial output is
+/// untrusted input to the operator's terminal.
 fn write_log_chunk(out: &mut impl Write, chunk: &pb::LogChunk, json: bool) -> Result<()> {
     if json {
         writeln!(out, "{}", serde_json::to_string(chunk)?)?;
     } else {
-        writeln!(out, "{}", chunk.line)?;
+        writeln!(out, "{}", output::sanitize_line(&chunk.line))?;
     }
     Ok(())
 }

--- a/rust/crates/supervisor-cli/src/main.rs
+++ b/rust/crates/supervisor-cli/src/main.rs
@@ -16,7 +16,9 @@ async fn main() {
 
 async fn run(cli: Cli) -> anyhow::Result<()> {
     let socket = client::resolve_socket_path(cli.socket.clone(), |name| std::env::var(name).ok());
-    let mut client = client::connect(&socket).await?;
+    let request_timeout = (cli.timeout > 0 && !cli.command.is_streaming())
+        .then(|| std::time::Duration::from_secs(cli.timeout));
+    let mut client = client::connect(&socket, request_timeout).await?;
     let mut out = std::io::stdout().lock();
     let json = cli.json;
     match cli.command {

--- a/rust/crates/supervisor-cli/src/output.rs
+++ b/rust/crates/supervisor-cli/src/output.rs
@@ -59,6 +59,23 @@ pub fn or_dash(value: &str) -> &str {
     if value.is_empty() { "-" } else { value }
 }
 
+/// Guest log lines reach the operator's terminal, and a hostile guest can
+/// embed ANSI/OSC escape sequences in its serial output (title spoofing,
+/// screen manipulation, OSC 52 clipboard writes). Render every control
+/// character except tab in escaped form so the sequences arrive inert and
+/// visible. The --json paths need no such step: serde escapes everything.
+pub fn sanitize_line(line: &str) -> String {
+    let mut clean = String::with_capacity(line.len());
+    for character in line.chars() {
+        if character.is_control() && character != '\t' {
+            clean.extend(character.escape_debug());
+        } else {
+            clean.push(character);
+        }
+    }
+    clean
+}
+
 /// fn(i32) -> String rendering a proto enum by name, minus the proto
 /// prefix; out-of-range values render as UNKNOWN(n) instead of panicking.
 macro_rules! enum_name {
@@ -149,6 +166,23 @@ mod tests {
     fn or_dash_replaces_empty_strings() {
         assert_eq!(or_dash(""), "-");
         assert_eq!(or_dash("value"), "value");
+    }
+
+    #[test]
+    fn sanitize_line_escapes_control_characters() {
+        // C0 escapes (the ANSI/OSC introducers) print as \u{..}.
+        assert_eq!(
+            sanitize_line("\x1b]0;evil title\x07done"),
+            "\\u{1b}]0;evil title\\u{7}done"
+        );
+        assert_eq!(sanitize_line("a\rb\u{0}c"), "a\\rb\\0c");
+        // C1 controls (e.g. CSI as a single character) are covered too.
+        assert_eq!(sanitize_line("x\u{9b}31my"), "x\\u{9b}31my");
+    }
+
+    #[test]
+    fn sanitize_line_keeps_tabs_and_printable_text() {
+        assert_eq!(sanitize_line("col1\tcol2 café"), "col1\tcol2 café");
     }
 
     #[test]

--- a/rust/crates/supervisor-cli/tests/cli.rs
+++ b/rust/crates/supervisor-cli/tests/cli.rs
@@ -50,7 +50,7 @@ async fn health_prints_status_and_vm_count() {
         ..Default::default()
     };
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::host::health(&mut client, &mut out, false)
         .await
@@ -62,7 +62,7 @@ async fn health_prints_status_and_vm_count() {
 async fn health_json_is_the_raw_response() {
     let fake = FakeSupervisor::default();
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::host::health(&mut client, &mut out, true)
         .await
@@ -73,13 +73,35 @@ async fn health_json_is_the_raw_response() {
 }
 
 #[tokio::test]
+async fn unary_calls_time_out_on_a_stalled_supervisor() {
+    let fake = FakeSupervisor {
+        health_stall: Some(std::time::Duration::from_secs(30)),
+        ..Default::default()
+    };
+    let (_dir, socket) = spawn(fake).await;
+    let mut client = client::connect(&socket, Some(std::time::Duration::from_millis(200)))
+        .await
+        .unwrap();
+    let mut out = Vec::new();
+    let error = commands::host::health(&mut client, &mut out, false)
+        .await
+        .unwrap_err();
+    let text = error.to_string().to_lowercase();
+    assert!(
+        text.contains("timeout") || text.contains("timed out"),
+        "{text}"
+    );
+    assert!(out.is_empty());
+}
+
+#[tokio::test]
 async fn host_info_prints_a_key_value_block() {
     let fake = FakeSupervisor {
         host: fake_host(),
         ..Default::default()
     };
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::host::host_info(&mut client, &mut out, false)
         .await
@@ -125,7 +147,7 @@ async fn vm_list_renders_an_aligned_table() {
         ..Default::default()
     };
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::vm::list(&mut client, &mut out, false)
         .await
@@ -144,7 +166,7 @@ async fn vm_get_renders_a_key_value_block() {
         ..Default::default()
     };
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::vm::get(&mut client, &mut out, "vm-1", false)
         .await
@@ -164,7 +186,7 @@ async fn vm_get_renders_a_key_value_block() {
 async fn vm_get_unknown_id_maps_the_error_trailer() {
     let fake = FakeSupervisor::default();
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     let error = commands::vm::get(&mut client, &mut out, "ghost", false)
         .await
@@ -182,7 +204,7 @@ async fn vm_spec_renders_disks_and_network() {
         ..Default::default()
     };
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::vm::spec(&mut client, &mut out, "vm-1", false)
         .await
@@ -207,7 +229,7 @@ async fn vm_stop_reports_the_returned_status() {
         ..Default::default()
     };
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::vm::stop(&mut client, &mut out, "vm-1", false)
         .await
@@ -226,7 +248,7 @@ async fn vm_delete_aborts_when_not_confirmed() {
     };
     let deleted = fake.deleted.clone();
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::vm::delete(
         &mut client,
@@ -250,7 +272,7 @@ async fn vm_delete_proceeds_on_y() {
     };
     let deleted = fake.deleted.clone();
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::vm::delete(
         &mut client,
@@ -274,7 +296,7 @@ async fn vm_delete_with_yes_skips_the_prompt() {
     };
     let deleted = fake.deleted.clone();
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::vm::delete(
         &mut client,
@@ -310,7 +332,7 @@ async fn ports_list_filters_by_vm_and_renders_a_table() {
         ..Default::default()
     };
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::ports::list(&mut client, &mut out, Some("vm-1".to_string()), false)
         .await
@@ -337,7 +359,7 @@ async fn logs_prints_plain_lines() {
         ..Default::default()
     };
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::logs::logs(&mut client, &mut out, "vm-1", false, None, false)
         .await
@@ -352,7 +374,7 @@ async fn logs_escape_guest_control_characters() {
         ..Default::default()
     };
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::logs::logs(&mut client, &mut out, "vm-1", false, None, false)
         .await
@@ -368,7 +390,7 @@ async fn logs_tail_maps_to_max_lines_from_tail() {
     let fake = FakeSupervisor::default();
     let requests = fake.log_requests.clone();
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::logs::logs(&mut client, &mut out, "vm-1", false, Some(50), false)
         .await
@@ -387,7 +409,7 @@ async fn logs_follow_streams_until_the_server_closes() {
         ..Default::default()
     };
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::logs::logs(&mut client, &mut out, "vm-1", true, None, false)
         .await
@@ -407,7 +429,7 @@ async fn events_prints_one_transition_per_line() {
         ..Default::default()
     };
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::logs::events(&mut client, &mut out, false)
         .await
@@ -435,7 +457,7 @@ async fn events_json_is_ndjson() {
         ..Default::default()
     };
     let (_dir, socket) = spawn(fake).await;
-    let mut client = client::connect(&socket).await.unwrap();
+    let mut client = client::connect(&socket, None).await.unwrap();
     let mut out = Vec::new();
     commands::logs::events(&mut client, &mut out, true)
         .await

--- a/rust/crates/supervisor-cli/tests/cli.rs
+++ b/rust/crates/supervisor-cli/tests/cli.rs
@@ -346,6 +346,24 @@ async fn logs_prints_plain_lines() {
 }
 
 #[tokio::test]
+async fn logs_escape_guest_control_characters() {
+    let fake = FakeSupervisor {
+        logs: vec![log_chunk("\x1b]52;c;ZXZpbA==\x07pwned?")],
+        ..Default::default()
+    };
+    let (_dir, socket) = spawn(fake).await;
+    let mut client = client::connect(&socket).await.unwrap();
+    let mut out = Vec::new();
+    commands::logs::logs(&mut client, &mut out, "vm-1", false, None, false)
+        .await
+        .unwrap();
+    assert_eq!(
+        String::from_utf8(out).unwrap(),
+        "\\u{1b}]52;c;ZXZpbA==\\u{7}pwned?\n"
+    );
+}
+
+#[tokio::test]
 async fn logs_tail_maps_to_max_lines_from_tail() {
     let fake = FakeSupervisor::default();
     let requests = fake.log_requests.clone();

--- a/rust/crates/supervisor-cli/tests/support/fake.rs
+++ b/rust/crates/supervisor-cli/tests/support/fake.rs
@@ -32,6 +32,9 @@ pub struct FakeSupervisor {
     pub deleted: Arc<Mutex<Vec<String>>>,
     /// Every GetLogsRequest received; tests assert tail/from_tail mapping.
     pub log_requests: Arc<Mutex<Vec<pb::GetLogsRequest>>>,
+    /// Sleep this long before answering Health: a wedged supervisor for
+    /// the request-timeout test.
+    pub health_stall: Option<std::time::Duration>,
 }
 
 impl FakeSupervisor {
@@ -63,6 +66,9 @@ impl Supervisor for FakeSupervisor {
         &self,
         _request: Request<pb::HealthRequest>,
     ) -> Result<Response<pb::HealthResponse>, Status> {
+        if let Some(stall) = self.health_stall {
+            tokio::time::sleep(stall).await;
+        }
         Ok(Response::new(pb::HealthResponse {
             status: pb::HealthStatus::Ok as i32,
             vm_count: self.vms.len() as u32,


### PR DESCRIPTION
Follow-up to #1039, addressing two review findings.

## Log sanitization

Guest serial output is untrusted input to the operator's terminal: a hostile VM can embed ANSI/OSC escape sequences in its log lines (window title spoofing, screen manipulation, OSC 52 clipboard writes; same class as kubectl's CVE-2021-25743). `alephctl logs` now renders every control character except tab in escaped form (`\u{1b}]0;...` instead of a live escape) on the plain-text path. `--json` output was already safe through serde escaping.

## RPC timeouts

The CLI's main use case is poking a possibly-sick daemon, and the kernel queues UDS connections even when the process never calls accept, so every command previously hung forever on a wedged supervisor. Unary RPCs are now bounded by a global `--timeout` flag (default 10s, `--timeout 0` disables), plus a 5s connect timeout on the endpoint. Streaming commands (`logs -f`, `events`) are exempt and still run until interrupted.

## Tests

- `sanitize_line` unit tests (C0, C1, tab/UTF-8 preservation) and an end-to-end test streaming an OSC 52 payload through the fake supervisor.
- Timeout test against a fake whose `Health` handler stalls 30s: the call fails within the 200ms deadline.
- `--timeout` parsing and the streaming-command exemption are unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)