### PR TITLE
feat(vprogram): static IPv6 for confidential guests via per-tap DHCPv6 + RA

### DIFF
--- a/docs/plans/2026-08-13-vprogram-ipv6-dhcpv6-design.md
+++ b/docs/plans/2026-08-13-vprogram-ipv6-dhcpv6-design.md
@@ -59,9 +59,8 @@ guest never autoconfigures.
     allocated address" property as the v4 range;
   - `--enable-ra`: RAs on the tap. With a plain (non-`slaac`, non-`ra-only`)
     DHCPv6 range dnsmasq advertises M=1/A=0: default route yes, SLAAC no.
-  - `--dhcp-option=option6:dns-server,[...]` only if the daemon has
-    v6-capable nameservers; otherwise the guest keeps the v4 DNS servers
-    from udhcpc (acceptable).
+  - v6 DNS is not emitted (no `option6:dns-server`, deferred per section 6);
+    the guest keeps the v4 DNS servers from udhcpc (acceptable).
 - `lifecycle.rs`: no structural change. Same dnsmasq start/stop points,
   same `Type=exec` transient unit, same teardown. The tap already carries
   the host-side gateway (`create_tap` adds `host_ipv6_cidr`), so dnsmasq
@@ -72,9 +71,11 @@ guest never autoconfigures.
 
 - Enable IPv6 on the interface and `accept_ra=2` (kernel installs the
   default route from the RA; reused from the donor branch).
-- `busybox udhcpc6 -i $iface -q -t 5 -A 2 -s /bin/udhcpc6.script`, bounded
-  and non-fatal exactly like the v4 `udhcpc` call: no DHCPv6 server on the
-  tap means the guest simply stays IPv4-only.
+- `busybox udhcpc6 -i $iface -q -n -t 5 -A 2 -s /bin/udhcpc6.script`, bounded
+  and non-fatal exactly like the v4 `udhcpc` call (which also gains `-n`):
+  `-n` makes the client exit 1 once its solicit retries are exhausted
+  instead of looping forever, so `||` in init.sh always runs and no DHCPv6
+  server on the tap means the guest simply stays IPv4-only.
 - `udhcpc6.script` mirrors `udhcpc.script`: applies the leased address to
   the interface. No route handling (the RA covers it), no resolv.conf
   handling unless option6:dns-server was sent.

--- a/docs/plans/2026-08-13-vprogram-ipv6-dhcpv6-design.md
+++ b/docs/plans/2026-08-13-vprogram-ipv6-dhcpv6-design.md
@@ -1,0 +1,159 @@
+# V-PROGRAM guest IPv6: static allocation via per-tap DHCPv6 + RA
+
+Status: approved design, 2026-08-13.
+Supersedes the SLAAC approach of PR #1080 (branch `od/vprogram-ipv6`, to be
+closed). Base branch: `origin/dev`. The old branch is a parts donor only.
+
+## 1. Problem
+
+Confidential V-PROGRAM guests (SEV-SNP measured boot) need inbound IPv6
+reachability to the attestation/serving port `:8443`, without any per-VM data
+in the measured image or kernel cmdline (the publisher precomputes one
+measurement for all deployments).
+
+PR #1080 solved the guest half with SLAAC (dynamic allocation) and left "a
+host RA sender (radvd)" as a follow-up. That follow-up cannot work:
+
+1. Linux only autoconfigures from a prefix advertised as a /64. The CRN
+   model allocates a static /124 per VM out of a single host /64
+   (`StaticIPv6Allocator` vm-type hextet scheme, shared with the scheduler;
+   single-/64-per-host confirmed by the Scaleway experiments,
+   `2026-07-03-scaleway-ipv6-experiments.md`). A /124 can never be handed
+   out via SLAAC.
+2. Advertising the whole /64 on the tap instead would let the guest pick its
+   own interface ID, which never matches the daemon's derived address: the
+   published address would be fiction, the ndppd proxy range for the /124
+   would not cover the guest's real address (unreachable), and the vm-type
+   hextet scheme would be dead for v-programs.
+
+Decision (with Olivier, 2026-08-13): the CRN allocates and knows the exact
+address up front, and the guest must end up with precisely that address.
+Static end-to-end, mirroring the IPv4 design already shipped for SNP guests
+(per-tap dnsmasq handing the guest exactly its allocated IPv4, "Increment
+D2").
+
+## 2. Design
+
+DHCPv6 + Router Advertisements from the existing per-tap dnsmasq. No new
+daemon, no radvd. dnsmasq assigns the exact allocated IPv6 (DHCPv6 assigns
+/128s, so the /124 scheme is irrelevant to the lease, unlike SLAAC); its RA
+provides the default route (DHCPv6 cannot convey routes) with M=1/A=0 so the
+guest never autoconfigures.
+
+### 2.1 Host side (`rust/crates/supervisor-daemon`)
+
+- `world.rs`: add `VmType::VProgram` (hextet 0x4, matching Python
+  `StaticIPv6Allocator.VM_TYPE_PREFIX` and the scheduler's
+  `VmType::ipv6_value()`), plus `VmEntry::vm_type()` keyed on
+  `config.snp().is_some()`. Reused from the donor branch, including the
+  create/adopt call-site threading in `lifecycle.rs` (create-time `snp`
+  predicate identical to the persisted one, no address drift across
+  restart) and its two tests.
+- `dhcp.rs`: `DhcpConfig::for_snp` gains IPv6 fields populated from
+  `TapAssignment.ipv6`. Not optional: `derive_tap_assignment` always
+  produces an IPv6 pair (static or dynamic policy; there is no "no pool"
+  case in the Rust daemon), and non-SNP instances likewise always receive
+  static v6 config via cloud-init. `dnsmasq_args()` additionally emits:
+  - `--dhcp-range=<guest_v6>,<guest_v6>,<prefix_len>,1h`: single-address
+    stateful DHCPv6 range, same "the guest can only ever lease its
+    allocated address" property as the v4 range;
+  - `--enable-ra`: RAs on the tap. With a plain (non-`slaac`, non-`ra-only`)
+    DHCPv6 range dnsmasq advertises M=1/A=0: default route yes, SLAAC no.
+  - `--dhcp-option=option6:dns-server,[...]` only if the daemon has
+    v6-capable nameservers; otherwise the guest keeps the v4 DNS servers
+    from udhcpc (acceptable).
+- `lifecycle.rs`: no structural change. Same dnsmasq start/stop points,
+  same `Type=exec` transient unit, same teardown. The tap already carries
+  the host-side gateway (`create_tap` adds `host_ipv6_cidr`), so dnsmasq
+  can bind; ndppd `add_range`/`delete_range` for the /124 and the nft
+  per-VM rules are already in place and untouched.
+
+### 2.2 Guest side (`nix/init.sh`, new `nix/udhcpc6.script`)
+
+- Enable IPv6 on the interface and `accept_ra=2` (kernel installs the
+  default route from the RA; reused from the donor branch).
+- `busybox udhcpc6 -i $iface -q -t 5 -A 2 -s /bin/udhcpc6.script`, bounded
+  and non-fatal exactly like the v4 `udhcpc` call: no DHCPv6 server on the
+  tap means the guest simply stays IPv4-only.
+- `udhcpc6.script` mirrors `udhcpc.script`: applies the leased address to
+  the interface. No route handling (the RA covers it), no resolv.conf
+  handling unless option6:dns-server was sent.
+- Guest firewall (reused ICMPv6 rule from the donor branch). The stateless
+  `policy drop` input chain gains:
+  - `icmpv6 type { nd-router-advert, nd-neighbor-solicit,
+    nd-neighbor-advert, destination-unreachable, packet-too-big,
+    time-exceeded, parameter-problem } accept`: RA lifetime refresh
+    (periodic RAs keep the default route alive), neighbor discovery/NUD,
+    and PMTU. Without these, v6 blackholes minutes into the VM's life, not
+    at boot.
+  - `tcp dport 8443 accept` already covers v6 (the table is family `inet`).
+  - No DHCP client rules (udp 68/546) are needed: both clients run with
+    `-q` (exit after obtaining the lease), the scripts apply the address
+    permanently, and the exchanges complete before `setup_firewall`
+    installs the ruleset. See section 4.
+
+### 2.3 Attestation agent (`rust/crates/aleph-attest-agent`)
+
+Bind `[::]:{port}` instead of `0.0.0.0:{port}` (reused from the donor
+branch). Dual-stack: Linux default `IPV6_V6ONLY=0`, verified for actix-web,
+so the IPv4 path and the Task-1 host-port map are unaffected.
+
+### 2.4 Image (`nix/`)
+
+Busybox comes from stock `pkgs.busybox`. Verify the `udhcpc6` applet is
+enabled in the nixpkgs build; if not, enable `CONFIG_UDHCPC6` via the
+busybox `extraConfig` override. Ship `udhcpc6.script` in the initrd next to
+`udhcpc.script`.
+
+Measurement impact: init.sh, the new script, and the attest-agent bind all
+shift the measured image, so a downstream measurement re-pin is required
+before shipping (same cost the SLAAC PR already carried).
+
+## 3. What is deliberately unchanged
+
+- The static /124 allocation scheme, vm-type hextets, ndppd ranges, nft
+  rules, `/v2/about/executions/list` discovery: all keep working as-is; the
+  guest simply now ends up holding the address the daemon reports.
+- Plain and SEV/SEV-ES QEMU instances: cloud-init static config, no per-tap
+  dnsmasq, `VmType::Instance`. Firecracker programs: `VmType::Microvm`.
+- Python supervisor: not touched (Rust daemon only, like the donor PR).
+
+## 4. Non-issue: DHCP renewals vs the guest firewall
+
+An earlier draft flagged the ruleset's lack of `udp dport 68 accept` as a
+v4 renewal gap. Reading `init.sh` closed it: `udhcpc` runs with `-q`, so
+the client exits after obtaining the lease and no renewal traffic ever
+occurs; `udhcpc.script` applies the address permanently (`ip addr add`,
+no valid_lft), and the DHCP exchange completes before `setup_firewall`
+installs the ruleset. The same holds for `udhcpc6`. The dnsmasq lease
+expiring server-side is harmless: the single-address range is reserved
+for this guest by construction. What genuinely must survive the firewall
+is the periodic RA flow that refreshes the default route's lifetime,
+which the ICMPv6 rule covers (section 2.2).
+
+## 5. Testing
+
+- `dhcp.rs` unit tests: v6 args (single-address range, `enable-ra`,
+  prefix-len 124) when the tap has IPv6; v4-only args unchanged when it
+  does not (no-pool regression case).
+- `lifecycle.rs`: extend `create_snp_starts_a_per_tap_dhcp_server_...` to
+  assert the v6 half; keep the donor branch's
+  `create_snp_allocates_the_v_program_ipv6_hextet` and persisted-predicate
+  tests.
+- Guest: shellcheck on init.sh + udhcpc6.script.
+- End-to-end (manual, SNP host): boot a v-program, `curl` the published
+  `[guest_v6]:8443` from an external v6 vantage point; confirm the leased
+  address equals the daemon-derived one; confirm both addresses and the
+  v6 default route survive past the 1h lease and RA lifetime (the
+  firewall must not starve the RA refresh).
+
+## 6. Risks and open items
+
+- dnsmasq DHCPv6/RA support requires dnsmasq >= 2.60ish; every supported
+  CRN distro ships far newer. No version gate needed.
+- If `pkgs.busybox` lacks `udhcpc6`, the `extraConfig` override changes the
+  busybox derivation (image shift already accounted for).
+- IPv6 nameservers: deferred unless the daemon already resolves v6-capable
+  ones; guests function with v4 DNS.
+- The Task-1 port-map (#1079) is not on `origin/dev` yet; this work does
+  not depend on it (independent reachability paths).

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -131,6 +131,7 @@
         inherit attest-agent kernel;
         init-script = ./init.sh;
         udhcpc-script = ./udhcpc.script;
+        udhcpc6-script = ./udhcpc6.script;
       };
       rootfs = pkgs.callPackage ./rootfs.nix {};
 

--- a/nix/init.sh
+++ b/nix/init.sh
@@ -47,7 +47,7 @@ else
         # -s: busybox udhcpc leases an address but only APPLIES it (ip addr/route)
         # by running this script; without it the guest would lease from the host's
         # per-tap dnsmasq but never configure its IP. See udhcpc.script.
-        /bin/busybox udhcpc -i "$iface" -q -t 5 -A 2 -s /bin/udhcpc.script 2>&1 || echo "init: DHCP failed on ${iface}"
+        /bin/busybox udhcpc -i "$iface" -q -n -t 5 -A 2 -s /bin/udhcpc.script 2>&1 || echo "init: DHCP failed on ${iface}"
 
         # IPv6: stateful DHCPv6 from the same per-tap dnsmasq that served the
         # IPv4 lease above, handing this guest EXACTLY its allocated
@@ -59,13 +59,15 @@ else
         # uses DHCP. accept_ra=2 keeps RA processing on regardless of
         # forwarding settings; both sysctls are best-effort (a v6-less
         # kernel stays IPv4-only). The client is bounded and non-fatal like
-        # udhcpc above: with no DHCPv6 server on the tap the guest simply
-        # stays IPv4-only. -q exits after the lease (the script applies the
-        # address permanently), so no client survives into the firewalled
-        # steady state and no DHCP firewall rule is needed.
+        # udhcpc above: `-n` makes it exit 1 (instead of retrying forever)
+        # once its solicit retries are exhausted, so `||` below always runs
+        # and the guest simply stays IPv4-only when no DHCPv6 server answers.
+        # -q exits after the lease (the script applies the address
+        # permanently), so no client survives into the firewalled steady
+        # state and no DHCP firewall rule is needed.
         echo 0 > "/proc/sys/net/ipv6/conf/${iface}/disable_ipv6" 2>/dev/null || true
         echo 2 > "/proc/sys/net/ipv6/conf/${iface}/accept_ra" 2>/dev/null || true
-        /bin/busybox udhcpc6 -i "$iface" -q -t 5 -A 2 -s /bin/udhcpc6.script 2>&1 || echo "init: DHCPv6 failed on ${iface}; continuing IPv4-only"
+        /bin/busybox udhcpc6 -i "$iface" -q -n -t 5 -A 2 -s /bin/udhcpc6.script 2>&1 || echo "init: DHCPv6 failed on ${iface}; continuing IPv4-only"
     fi
 fi
 

--- a/nix/init.sh
+++ b/nix/init.sh
@@ -48,6 +48,24 @@ else
         # by running this script; without it the guest would lease from the host's
         # per-tap dnsmasq but never configure its IP. See udhcpc.script.
         /bin/busybox udhcpc -i "$iface" -q -t 5 -A 2 -s /bin/udhcpc.script 2>&1 || echo "init: DHCP failed on ${iface}"
+
+        # IPv6: stateful DHCPv6 from the same per-tap dnsmasq that served the
+        # IPv4 lease above, handing this guest EXACTLY its allocated
+        # /124-scheme address; the default route comes from the kernel
+        # processing that dnsmasq's Router Advertisements (DHCPv6 cannot
+        # convey routes). Never a kernel-cmdline address: baking the per-VM
+        # address into the measured cmdline would break the publisher's
+        # precomputed SNP measurement, the exact reason the IPv4 path above
+        # uses DHCP. accept_ra=2 keeps RA processing on regardless of
+        # forwarding settings; both sysctls are best-effort (a v6-less
+        # kernel stays IPv4-only). The client is bounded and non-fatal like
+        # udhcpc above: with no DHCPv6 server on the tap the guest simply
+        # stays IPv4-only. -q exits after the lease (the script applies the
+        # address permanently), so no client survives into the firewalled
+        # steady state and no DHCP firewall rule is needed.
+        echo 0 > "/proc/sys/net/ipv6/conf/${iface}/disable_ipv6" 2>/dev/null || true
+        echo 2 > "/proc/sys/net/ipv6/conf/${iface}/accept_ra" 2>/dev/null || true
+        /bin/busybox udhcpc6 -i "$iface" -q -t 5 -A 2 -s /bin/udhcpc6.script 2>&1 || echo "init: DHCPv6 failed on ${iface}; continuing IPv4-only"
     fi
 fi
 
@@ -161,6 +179,17 @@ prepare_chroot() {
 # The ruleset is STATELESS on purpose: for a TCP connection to the server the
 # inbound packets always carry dport 8443, so `tcp dport 8443 accept` covers the
 # whole flow without a conntrack module. Load order matches modules.dep.
+#
+# The `inet` table family filters BOTH IPv4 and IPv6 with one ruleset, so
+# `tcp dport 8443` already covers v6 connections. The icmpv6 accept rule is
+# control-plane only (no app data crosses it), but without it the firewall
+# would break IPv6 on its own: Router Advertisements refresh the SLAAC-free
+# default route's lifetime, Neighbor Solicitation/Advertisement keep
+# resolving the gateway (NUD re-probes after ~30s idle), and Packet Too Big
+# drives Path MTU Discovery. Dropping any of those silently blackholes v6
+# minutes into the VM's life, not at boot. No DHCP rules (udp 68/546): both
+# clients run with -q and exit before this firewall exists (see init
+# networking above).
 setup_firewall() {
     /bin/busybox insmod /lib/modules/nfnetlink.ko 2>&1 || echo "init: warning: insmod nfnetlink.ko failed"
     /bin/busybox insmod /lib/modules/libcrc32c.ko 2>&1 || echo "init: warning: insmod libcrc32c.ko failed"
@@ -171,11 +200,12 @@ table inet filter {
 		type filter hook input priority 0; policy drop;
 		iif "lo" accept
 		tcp dport 8443 accept
+		icmpv6 type { nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert, destination-unreachable, packet-too-big, time-exceeded, parameter-problem } accept
 	}
 }
 NFT
     then
-        echo "init: firewall active (drop inbound except tcp/8443 and loopback)"
+        echo "init: firewall active (drop inbound except tcp/8443, loopback, and ND/PMTU icmpv6)"
     else
         echo "init: FATAL: failed to install guest firewall"
         exec /bin/busybox poweroff -f

--- a/nix/initrd.nix
+++ b/nix/initrd.nix
@@ -1,4 +1,4 @@
-{ pkgs, attest-agent, kernel, init-script, udhcpc-script, ... }:
+{ pkgs, attest-agent, kernel, init-script, udhcpc-script, udhcpc6-script, ... }:
 
 let
   # veritysetup needs to be statically linked for the initrd environment.
@@ -47,6 +47,7 @@ pkgs.makeInitrd {
     { object = "${pkgs.busybox}/bin/busybox"; symlink = "/bin/busybox"; }
     { object = init-script; symlink = "/init"; }
     { object = udhcpc-script; symlink = "/bin/udhcpc.script"; }
+    { object = udhcpc6-script; symlink = "/bin/udhcpc6.script"; }
     { object = "${attest-agent}/bin/aleph-attest-agent"; symlink = "/bin/aleph-attest-agent"; }
     { object = "${staticCryptsetup}/bin/veritysetup"; symlink = "/bin/veritysetup"; }
     { object = "${staticNft}/bin/nft"; symlink = "/bin/nft"; }

--- a/nix/initrd.nix
+++ b/nix/initrd.nix
@@ -27,6 +27,22 @@ let
     xz -d -k -c ${modDir}/drivers/md/dm-verity.ko.xz > $out/dm-verity.ko
   '';
 
+  # init.sh treats a failing `udhcpc6` as "stay IPv4-only" (deliberate, to
+  # tolerate daemon/image version skew), so a busybox built without the
+  # applet would silently defeat guest IPv6 instead of failing loudly.
+  # Assert at image build time that the applet is present: the only drift
+  # vector is a nixpkgs flake.lock bump changing the default busybox config,
+  # which is exactly when this check runs again.
+  checkedBusybox = pkgs.runCommand "busybox-with-udhcpc6" { } ''
+    ${pkgs.busybox}/bin/busybox --list | grep -qx udhcpc6 || {
+      echo "error: busybox lacks the udhcpc6 applet; guest DHCPv6 would silently no-op." >&2
+      echo "Enable CONFIG_UDHCPC6 via a busybox extraConfig override." >&2
+      exit 1
+    }
+    mkdir -p $out/bin
+    cp ${pkgs.busybox}/bin/busybox $out/bin/busybox
+  '';
+
   # nftables kernel modules for the guest firewall. NF_TABLES is =m in the
   # kernel config (NETFILTER and NF_TABLES_INET are built in), so the guest
   # firewall needs nf_tables.ko plus its two dependencies (from modules.dep:
@@ -44,7 +60,7 @@ let
 in
 pkgs.makeInitrd {
   contents = [
-    { object = "${pkgs.busybox}/bin/busybox"; symlink = "/bin/busybox"; }
+    { object = "${checkedBusybox}/bin/busybox"; symlink = "/bin/busybox"; }
     { object = init-script; symlink = "/init"; }
     { object = udhcpc-script; symlink = "/bin/udhcpc.script"; }
     { object = udhcpc6-script; symlink = "/bin/udhcpc6.script"; }

--- a/nix/udhcpc6.script
+++ b/nix/udhcpc6.script
@@ -1,0 +1,31 @@
+#!/bin/busybox sh
+# udhcpc6 lease-application script for the measured SNP guest.
+#
+# The v6 twin of udhcpc.script: busybox udhcpc6 obtains a stateful DHCPv6
+# lease from the host's per-tap dnsmasq but does NOT configure the interface
+# itself; init.sh invokes it with `-s /bin/udhcpc6.script` and udhcpc6 runs
+# this with $1 = action (deconfig|bound|renew) and the lease in the
+# environment ($interface, $ipv6). The address is applied as /128, busybox
+# upstream practice (examples/udhcp/d6_simple_script): on-link reachability
+# and the default route both come from the kernel processing the same
+# dnsmasq's Router Advertisements (accept_ra=2 in init.sh), never from the
+# lease, so no route handling belongs here.
+
+# udhcpc6 passes the lease via environment variables ($interface, $ipv6),
+# which shellcheck cannot see assigned.
+# shellcheck disable=SC2154
+case "$1" in
+    deconfig)
+        # Nothing to tear down: the single address is (re)added on bound,
+        # and flushing here would race the still-active IPv4 config.
+        ;;
+    bound | renew)
+        if [ -n "$ipv6" ]; then
+            # EEXIST on a re-bound identical address is fine.
+            /bin/busybox ip -6 addr add "${ipv6}/128" dev "$interface" 2>/dev/null
+            echo "init: DHCPv6 configured ${ipv6} on ${interface}"
+        else
+            echo "init: DHCPv6 bound without an address on ${interface}"
+        fi
+        ;;
+esac

--- a/nix/udhcpc6.script
+++ b/nix/udhcpc6.script
@@ -21,9 +21,14 @@ case "$1" in
         ;;
     bound | renew)
         if [ -n "$ipv6" ]; then
-            # EEXIST on a re-bound identical address is fine.
-            /bin/busybox ip -6 addr add "${ipv6}/128" dev "$interface" 2>/dev/null
-            echo "init: DHCPv6 configured ${ipv6} on ${interface}"
+            # EEXIST on a re-bound identical address is harmless and stays on
+            # the console; any other failure is real and must not be logged
+            # as success below.
+            if /bin/busybox ip -6 addr add "${ipv6}/128" dev "$interface"; then
+                echo "init: DHCPv6 configured ${ipv6} on ${interface}"
+            else
+                echo "init: WARNING: failed to add ${ipv6}/128 on ${interface}"
+            fi
         else
             echo "init: DHCPv6 bound without an address on ${interface}"
         fi

--- a/rust/crates/aleph-attest-agent/src/main.rs
+++ b/rust/crates/aleph-attest-agent/src/main.rs
@@ -73,7 +73,12 @@ async fn main() -> Result<()> {
     let secret_store = web::Data::new(SecretStore::with_default_dir());
 
     // 6. Start actix-web HTTPS server.
-    let bind_addr = format!("0.0.0.0:{}", cli.port);
+    // Dual-stack: [::] accepts IPv6 AND IPv4 connections (Linux default
+    // IPV6_V6ONLY=0; actix-web does not set the sockopt), so the existing
+    // IPv4 reachability path keeps working while the DHCPv6-assigned guest
+    // address is served too. 0.0.0.0 was IPv4-only, which made a routable
+    // guest IPv6 useless for reaching the agent.
+    let bind_addr = format!("[::]:{}", cli.port);
     info!(addr = %bind_addr, "binding HTTPS server");
 
     HttpServer::new(move || {

--- a/rust/crates/supervisor-daemon/src/dhcp.rs
+++ b/rust/crates/supervisor-daemon/src/dhcp.rs
@@ -64,6 +64,14 @@ pub struct DhcpConfig {
     pub gateway: String,
     /// The tap netmask, e.g. "255.255.255.0", the `--dhcp-range` mask.
     pub netmask: String,
+    /// The single IPv6 address the guest may lease (`VmInfo.ipv6.address`).
+    /// Always populated: `derive_tap_assignment` computes an IPv6 pair for
+    /// every VM (static or dynamic policy), like cloud-init always writes
+    /// static v6 config for non-SNP instances.
+    pub guest_ipv6: String,
+    /// The tap IPv6 prefix length (from the /124-per-VM scheme), the
+    /// DHCPv6 `--dhcp-range` prefix and the RA on-link prefix.
+    pub ipv6_prefix_len: u8,
     /// The daemon's resolved nameservers, DHCP option 6. Empty omits the
     /// option (the guest gets no DNS, the same as a nameserver-less host).
     pub nameservers: Vec<String>,
@@ -94,25 +102,16 @@ impl DhcpConfig {
         nameservers: &[String],
         lease_dir: &std::path::Path,
     ) -> Result<Self, DhcpError> {
-        let (_, prefix_str) =
-            tap.ipv4
-                .network_cidr
-                .split_once('/')
-                .ok_or_else(|| DhcpError::CidrNoPrefix {
-                    cidr: tap.ipv4.network_cidr.clone(),
-                })?;
-        let prefix = prefix_str
-            .parse::<u8>()
-            .map_err(|source| DhcpError::CidrBadPrefix {
-                cidr: tap.ipv4.network_cidr.clone(),
-                source,
-            })?;
+        let prefix = cidr_prefix_len(&tap.ipv4.network_cidr, "IPv4")?;
+        let ipv6_prefix_len = cidr_prefix_len(&tap.ipv6.network_cidr, "IPv6")?;
         Ok(Self {
             vm_hash: vm_hash.to_string(),
             device_name: tap.device_name.clone(),
             guest_ip: tap.ipv4.address.clone(),
             gateway: tap.ipv4.gateway.clone(),
             netmask: netmask_for_prefix(prefix),
+            guest_ipv6: tap.ipv6.address.clone(),
+            ipv6_prefix_len,
             nameservers: nameservers.to_vec(),
             lease: DEFAULT_LEASE.to_string(),
             lease_file: lease_file_path(lease_dir, vm_hash)
@@ -157,6 +156,18 @@ impl DhcpConfig {
             ),
             // Option 3: router / default gateway = the host tap address.
             format!("--dhcp-option=3,{}", self.gateway),
+            // The v6 twin of the single-address range above: stateful DHCPv6
+            // (dnsmasq detects the family from the address syntax) handing the
+            // guest EXACTLY its allocated /124-scheme address. --enable-ra
+            // makes dnsmasq advertise on the tap; for a stateful (non-slaac)
+            // range the RA carries M=1/A=0, so the guest takes its default
+            // route from the RA (DHCPv6 cannot convey routes) and never
+            // autoconfigures a second address. No radvd needed.
+            format!(
+                "--dhcp-range={},{},{},{}",
+                self.guest_ipv6, self.guest_ipv6, self.ipv6_prefix_len, self.lease
+            ),
+            "--enable-ra".to_string(),
         ];
         // Option 6: DNS servers, only when the daemon resolved some.
         if !self.nameservers.is_empty() {
@@ -191,6 +202,25 @@ impl DhcpConfig {
     }
 }
 
+/// The prefix length of a CIDR string, fail-closed: a malformed prefix must
+/// surface at config-build time rather than as a dnsmasq startup failure
+/// (v4) or an unroutable netmask (see `for_snp`).
+fn cidr_prefix_len(network_cidr: &str, family: &'static str) -> Result<u8, DhcpError> {
+    let (_, prefix_str) = network_cidr
+        .split_once('/')
+        .ok_or_else(|| DhcpError::CidrNoPrefix {
+            family,
+            cidr: network_cidr.to_string(),
+        })?;
+    prefix_str
+        .parse::<u8>()
+        .map_err(|source| DhcpError::CidrBadPrefix {
+            family,
+            cidr: network_cidr.to_string(),
+            source,
+        })
+}
+
 /// The dotted netmask for an IPv4 prefix length (`/24` -> "255.255.255.0").
 fn netmask_for_prefix(prefix: u8) -> String {
     let bits = if prefix >= 32 {
@@ -222,11 +252,15 @@ pub trait DhcpBackend: Send + Sync {
 /// Failures deriving a [`DhcpConfig`] or driving the per-tap DHCP server.
 #[derive(Debug, thiserror::Error)]
 pub enum DhcpError {
-    #[error("tap IPv4 network CIDR {cidr:?} has no prefix length")]
-    CidrNoPrefix { cidr: String },
+    #[error("tap {family} network CIDR {cidr:?} has no prefix length")]
+    CidrNoPrefix { family: &'static str, cidr: String },
 
-    #[error("tap IPv4 network CIDR {cidr:?} has an invalid prefix length: {source}")]
-    CidrBadPrefix { cidr: String, source: ParseIntError },
+    #[error("tap {family} network CIDR {cidr:?} has an invalid prefix length: {source}")]
+    CidrBadPrefix {
+        family: &'static str,
+        cidr: String,
+        source: ParseIntError,
+    },
 
     #[error("cannot run {program}: {source}")]
     Run {
@@ -616,6 +650,51 @@ mod tests {
             backend.stop(&"e".repeat(64), lease),
             Err(DhcpError::StopFailed { stderr, .. }) if stderr == "nope"
         ));
+    }
+
+    #[test]
+    fn dnsmasq_args_hand_the_guest_exactly_its_allocated_ipv6() {
+        // The v6 twin of the IPv4 single-address range: a stateful DHCPv6
+        // range with low == high == the allocated address, plus --enable-ra.
+        // dnsmasq's RA for a stateful (non-slaac) range carries M=1/A=0, so
+        // the guest gets its default route from the RA (DHCPv6 cannot convey
+        // routes) and never SLAACs a second address.
+        let config = DhcpConfig::for_snp(
+            &"e".repeat(64),
+            &snp_tap(),
+            &["1.1.1.1".to_string()],
+            std::path::Path::new("/run/aleph/dhcp"),
+        )
+        .unwrap();
+        assert_eq!(config.guest_ipv6, "fc00:1:2:3::11");
+        assert_eq!(config.ipv6_prefix_len, 124);
+        let args = config.dnsmasq_args();
+        assert!(args.contains(&"--enable-ra".to_string()));
+        assert!(
+            args.contains(&"--dhcp-range=fc00:1:2:3::11,fc00:1:2:3::11,124,1h".to_string()),
+            "the guest can only lease its allocated IPv6, got {args:?}"
+        );
+    }
+
+    #[test]
+    fn for_snp_rejects_an_ipv6_cidr_without_a_prefix() {
+        // Same fail-closed rule as the v4 CIDR: a malformed prefix must error
+        // rather than silently produce a dnsmasq range dnsmasq would reject at
+        // startup (an Err here surfaces at create; a bad range would instead
+        // fail the transient unit and leave the guest v4-only with no trace in
+        // the create response).
+        let mut tap = snp_tap();
+        tap.ipv6.network_cidr = "fc00:1:2:3::10".into(); // no prefix length
+        assert!(
+            DhcpConfig::for_snp(
+                &"e".repeat(64),
+                &tap,
+                &[],
+                std::path::Path::new("/run/aleph/dhcp"),
+            )
+            .is_err(),
+            "an IPv6 CIDR with no prefix must be rejected"
+        );
     }
 
     #[test]

--- a/rust/crates/supervisor-daemon/src/lifecycle.rs
+++ b/rust/crates/supervisor-daemon/src/lifecycle.rs
@@ -4135,6 +4135,16 @@ mod tests {
             )),
             "the guest can only lease its allocated IP"
         );
+        // The same dnsmasq also serves the allocated IPv6 (stateful DHCPv6 +
+        // RA): the started config carries exactly the entry's derived v6
+        // address, so guest and daemon can never disagree on the address.
+        let entry_ipv6 = entry.ipv6.as_ref().expect("SNP create allocates IPv6");
+        assert_eq!(config.guest_ipv6, entry_ipv6.address);
+        assert!(config.dnsmasq_args().contains(&"--enable-ra".to_string()));
+        assert!(config.dnsmasq_args().contains(&format!(
+            "--dhcp-range={},{},124,1h",
+            entry_ipv6.address, entry_ipv6.address
+        )));
         assert!(harness.dhcp.is_running(&vm_id));
     }
 

--- a/rust/crates/supervisor-daemon/src/lifecycle.rs
+++ b/rust/crates/supervisor-daemon/src/lifecycle.rs
@@ -587,18 +587,13 @@ fn tap_assignment(state: &DaemonState, vm_id: &str) -> Result<TapAssignment, Lif
             ipv6.clone(),
         ));
     }
-    let vm_type = if entry.is_program {
-        VmType::Microvm
-    } else {
-        VmType::Instance
-    };
     let mut world = state.world.blocking_write();
     let mut ordinal = world.ipv6_dynamic_ordinal;
     let (ipv4, ipv6) = world::derive_tap_assignment(
         &state.host.settings,
         entry.vm_index,
         vm_id,
-        vm_type,
+        entry.vm_type(),
         &mut ordinal,
     )?;
     world.ipv6_dynamic_ordinal = ordinal;
@@ -786,11 +781,7 @@ fn guest_ipv4(state: &DaemonState, entry: &VmEntry) -> String {
         &state.host.settings,
         entry.vm_index,
         &entry.vm_hash,
-        if entry.is_program {
-            VmType::Microvm
-        } else {
-            VmType::Instance
-        },
+        entry.vm_type(),
         &mut ordinal,
     )
     .map(|(ipv4, _)| ipv4.address)
@@ -2774,12 +2765,21 @@ fn create_vm_inner(
         });
         let vm_index = world.unique_vm_index(state.host.settings.start_id_index)?;
         let assignment = if state.host.settings.allow_vm_networking {
+            // `snp` (computed above from `request.tee`) is the V-PROGRAM
+            // signal: SEV-SNP measured boot is its exclusive launch path, so
+            // it is the only QEMU-create shape that gets the VProgram
+            // hextet; a plain or SEV/SEV-ES confidential create is Instance.
+            let create_vm_type = if snp {
+                VmType::VProgram
+            } else {
+                VmType::Instance
+            };
             let mut ordinal = world.ipv6_dynamic_ordinal;
             let pair = world::derive_tap_assignment(
                 &state.host.settings,
                 vm_index,
                 &vm_id,
-                VmType::Instance,
+                create_vm_type,
                 &mut ordinal,
             )?;
             world.ipv6_dynamic_ordinal = ordinal;
@@ -4136,6 +4136,35 @@ mod tests {
             "the guest can only lease its allocated IP"
         );
         assert!(harness.dhcp.is_running(&vm_id));
+    }
+
+    #[test]
+    fn create_snp_allocates_the_v_program_ipv6_hextet() {
+        // The static IPv6 scheme keys a vm-type hextet into the /124
+        // (world::VmType::prefix). SEV-SNP is the V-PROGRAM's exclusive
+        // launch path (docs/plans/2026-07-11-vprogram-scheduler-support-
+        // design.md section 2), so an SNP create must get the 0x4 nibble
+        // (Python VmType.v_program / scheduler VmType::ipv6_value()), not
+        // the plain-instance 0x3 it used to get before VmType::VProgram
+        // existed.
+        let harness = harness();
+        let state = &harness.state;
+        let root = state.host.settings.execution_root.clone();
+        let vm_id = hash('e');
+        let firmware = root.join("OVMF.fd");
+        std::fs::write(&firmware, b"ovmf").unwrap();
+        let request = snp_spec(&vm_id, &root, &firmware.to_string_lossy());
+
+        let (entry, _running) = create_vm(state, request).unwrap();
+        assert_eq!(entry.vm_type(), world::VmType::VProgram);
+        let ipv6 = entry
+            .ipv6
+            .expect("networking is enabled in the harness; SNP create allocates an IPv6 pair");
+        assert!(
+            ipv6.address.starts_with("fc00:1:2:3:4:"),
+            "an SNP (V-PROGRAM) create must get the 0x4 vm-type hextet, got {}",
+            ipv6.address
+        );
     }
 
     #[test]

--- a/rust/crates/supervisor-daemon/src/world.rs
+++ b/rust/crates/supervisor-daemon/src/world.rs
@@ -1139,6 +1139,71 @@ mod tests {
     }
 
     #[test]
+    fn adopting_a_persisted_snp_config_gives_the_v_program_ipv6_hextet() {
+        // The adoption arm derives adopted_vm_type from
+        // `qemu.snp().is_some()` (world.rs, around the QEMU adoption match
+        // arm); a persisted SNP controller config must adopt with the
+        // VProgram (0x4) hextet, not the plain-instance (0x3) one. This is
+        // the branch's central no-drift invariant: reverting that
+        // derivation to `VmType::Instance` must fail this test while
+        // leaving every other test green.
+        let tmp = tempfile::tempdir().unwrap();
+        let snp_hash = "d".repeat(64);
+        let fixture = std::fs::read_to_string(
+            test_fixtures::fixtures_dir()
+                .join(format!("{}-controller.json", test_fixtures::QEMU_HASH)),
+        )
+        .unwrap();
+        let mut value: serde_json::Value = serde_json::from_str(&fixture).unwrap();
+        value["vm_id"] = 9.into();
+        value["vm_hash"] = snp_hash.clone().into();
+        // Persisted SNP measured-boot slice, matching what the QEMU config
+        // writer (lifecycle.rs snp_config_slice / create_vm) stamps for an
+        // SNP VM: `sev_snp: true` plus the four measured-boot fields, so
+        // `QemuVmConfig::snp()` resolves `Some`.
+        let config = value["vm_configuration"].as_object_mut().unwrap();
+        config.insert("sev_snp".to_string(), true.into());
+        config.insert("kernel_path".to_string(), "/boot/bzImage".into());
+        config.insert("initrd_path".to_string(), "/boot/initrd".into());
+        config.insert("kernel_cmdline".to_string(), "console=ttyS0".into());
+        config.insert(
+            "ovmf_path".to_string(),
+            "/opt/aleph-vm/firmware/OVMF.fd".into(),
+        );
+        config.insert("sev_policy".to_string(), 196608.into());
+        std::fs::write(
+            tmp.path().join(format!("{snp_hash}-controller.json")),
+            value.to_string(),
+        )
+        .unwrap();
+
+        let settings = test_settings(tmp.path());
+        let units = StaticUnitStates::with_active_vms(&[snp_hash.as_str()]);
+        let world = build_world_view(&settings, &units, &[]);
+
+        let entry = &world.entries[snp_hash.as_str()];
+        assert!(entry.adopted_running);
+        assert!(
+            entry.config.snp().is_some(),
+            "the persisted config must resolve as SNP"
+        );
+        let expected =
+            ipv6_static_assignment(&settings.ipv6_address_pool, &snp_hash, VmType::VProgram)
+                .unwrap();
+        assert_eq!(
+            entry.ipv6,
+            Some(expected),
+            "an adopted SNP VM must carry the V-PROGRAM (0x4) ipv6 hextet, \
+             not the plain-instance (0x3) one"
+        );
+        let address = entry.ipv6.as_ref().unwrap().address.clone();
+        assert!(
+            address.split(':').nth(4) == Some("4"),
+            "ipv6 address {address} must carry the 0x4 vm-type hextet"
+        );
+    }
+
+    #[test]
     fn an_empty_or_missing_execution_root_is_an_empty_world() {
         let tmp = tempfile::tempdir().unwrap();
         let settings = test_settings(&tmp.path().join("does-not-exist"));

--- a/rust/crates/supervisor-daemon/src/world.rs
+++ b/rust/crates/supervisor-daemon/src/world.rs
@@ -217,6 +217,19 @@ impl VmType {
             VmType::VProgram => 0x4,
         }
     }
+
+    /// The vm type of a QEMU controller config: SEV-SNP measured boot is the
+    /// exclusive V-PROGRAM launch path (see [`VmType::VProgram`]), everything
+    /// else is a plain instance. Shared by [`VmEntry::vm_type`] and the
+    /// adoption path in [`build_world_view`], which classifies persisted
+    /// configs before any `VmEntry` exists, so the two can never diverge.
+    pub fn of_qemu(config: &QemuVmConfig) -> VmType {
+        if config.snp().is_some() {
+            VmType::VProgram
+        } else {
+            VmType::Instance
+        }
+    }
 }
 
 /// One adopted VM.
@@ -332,10 +345,8 @@ impl VmEntry {
     pub fn vm_type(&self) -> VmType {
         if self.is_program {
             VmType::Microvm
-        } else if self.config.snp().is_some() {
-            VmType::VProgram
         } else {
-            VmType::Instance
+            VmType::of_qemu(&self.config)
         }
     }
 }
@@ -626,11 +637,7 @@ pub fn build_world_view(
                             continue;
                         }
                     }
-                    let adopted_vm_type = if qemu.snp().is_some() {
-                        VmType::VProgram
-                    } else {
-                        VmType::Instance
-                    };
+                    let adopted_vm_type = VmType::of_qemu(&qemu);
                     let ipv6_result = match settings.ipv6_allocation_policy {
                         Ipv6AllocationPolicy::Static => ipv6_static_assignment(
                             &settings.ipv6_address_pool,

--- a/rust/crates/supervisor-daemon/src/world.rs
+++ b/rust/crates/supervisor-daemon/src/world.rs
@@ -198,14 +198,23 @@ pub struct ProgramEntry {
 pub enum VmType {
     Microvm,
     Instance,
+    /// A V-PROGRAM (`aleph_message.models.VerifiableProgramContent`): the
+    /// QEMU SEV-SNP measured-boot launch path is its exclusive hypervisor
+    /// (design doc docs/plans/2026-07-11-vprogram-scheduler-support-design.md
+    /// section 2), so `QemuVmConfig::snp().is_some()` identifies one on this
+    /// side (see [`VmEntry::vm_type`]).
+    VProgram,
 }
 
 impl VmType {
-    /// `StaticIPv6Allocator.VM_TYPE_PREFIX`.
+    /// `StaticIPv6Allocator.VM_TYPE_PREFIX`. Must match the scheduler's
+    /// `VmType::ipv6_value()` (scheduler-events) and the Python
+    /// `StaticIPv6Allocator.VM_TYPE_PREFIX` (hostnetwork.py).
     fn prefix(self) -> u16 {
         match self {
             VmType::Microvm => 0x1,
             VmType::Instance => 0x3,
+            VmType::VProgram => 0x4,
         }
     }
 }
@@ -312,6 +321,22 @@ impl VmEntry {
     /// Python `is_stopping`: stopping_at set, stopped_at not yet.
     pub fn is_stopping(&self) -> bool {
         self.times.stopping_at_ns != 0 && self.times.stopped_at_ns == 0
+    }
+
+    /// The vm-type hextet input to the static IPv6 scheme (mirrors the
+    /// Python `VmType.from_message_content` split, ported as the equivalent
+    /// config shape check: there is no message content on this side). An
+    /// ephemeral Firecracker program is `Microvm`; a QEMU SEV-SNP
+    /// measured-boot config is `VProgram` (its exclusive launch path, see
+    /// [`VmType::VProgram`]); everything else is `Instance`.
+    pub fn vm_type(&self) -> VmType {
+        if self.is_program {
+            VmType::Microvm
+        } else if self.config.snp().is_some() {
+            VmType::VProgram
+        } else {
+            VmType::Instance
+        }
     }
 }
 
@@ -601,11 +626,16 @@ pub fn build_world_view(
                             continue;
                         }
                     }
+                    let adopted_vm_type = if qemu.snp().is_some() {
+                        VmType::VProgram
+                    } else {
+                        VmType::Instance
+                    };
                     let ipv6_result = match settings.ipv6_allocation_policy {
                         Ipv6AllocationPolicy::Static => ipv6_static_assignment(
                             &settings.ipv6_address_pool,
                             &vm_hash,
-                            VmType::Instance,
+                            adopted_vm_type,
                         ),
                         Ipv6AllocationPolicy::Dynamic => {
                             dynamic_ordinal += 1;
@@ -1358,6 +1388,24 @@ mod tests {
         assert!(
             ipv6_static_assignment("fc00:1:2:3::/64", "nothex-----", VmType::Instance).is_err()
         );
+    }
+
+    #[test]
+    fn ipv6_static_math_gives_v_programs_the_0x4_hextet() {
+        // Python: StaticIPv6Allocator(...).allocate_vm_ipv6_subnet(3, hash,
+        // VmType.v_program) uses VM_TYPE_PREFIX[VmType.v_program] == "4"
+        // (hostnetwork.py), matching the scheduler's VmType::ipv6_value().
+        // Same hash as ipv6_static_math_matches_the_python_allocator, only
+        // the vm-type hextet differs: 4 instead of 3.
+        let pair = ipv6_static_assignment(
+            "2a01:240:2:c8::/64",
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+            VmType::VProgram,
+        )
+        .unwrap();
+        assert_eq!(pair.network_cidr, "2a01:240:2:c8:4:abcd:ef01:2340/124");
+        assert_eq!(pair.address, "2a01:240:2:c8:4:abcd:ef01:2341");
+        assert_eq!(pair.gateway, "2a01:240:2:c8:4:abcd:ef01:2340");
     }
 
     #[test]


### PR DESCRIPTION
Supersedes #1080 (SLAAC), which could not compose with the static /124
model: SLAAC needs a /64 PIO, so a host RA sender could never deliver the
daemon-allocated /124 address, and a shared-/64 SLAAC address would escape
the ndppd proxy range and the vm-type hextet scheme. Design:
docs/plans/2026-08-13-vprogram-ipv6-dhcpv6-design.md.

Static end-to-end instead, mirroring the shipped IPv4 SNP path:

- daemon: `VmType::VProgram` (0x4 hextet) at create and adoption (both
  paths regression-tested, including red-on-revert for the adoption
  predicate); the existing per-tap dnsmasq additionally serves a
  single-address stateful DHCPv6 range + `--enable-ra` (M=1/A=0: default
  route from the RA, no SLAAC). No new daemon, no radvd. `dnsmasq --test`
  accepts the generated v4+v6 ranges.
- guest (`nix/`): `udhcpc6` alongside `udhcpc`, both now with `-n` so a
  missing DHCP server bounds out to IPv4-only (or no-net) instead of
  hanging PID 1; new `udhcpc6.script`; ICMPv6 ND/RA/PMTU accept rule
  (policy drop preserved). No udp 68/546 rules: both clients run `-q` and
  exit before the firewall exists.
- attest-agent: bind `[::]:8443` dual-stack (Linux `IPV6_V6ONLY=0`
  default, verified for actix-web), so the IPv4 path and host port-map
  are unaffected.

**Measurement impact:** init.sh + udhcpc6.script + attest-agent shift the
measured image; a downstream measurement re-pin is required before this
ships.

**Not verified in CI (manual E2E on an SNP host):** external
`curl https://[guest_v6]:8443` reaching the agent; leased address equals
the daemon-derived one; v6 default route surviving past the RA lifetime;
upgraded daemon + old image (v4-only, no hang) and old daemon + new image
(bounded udhcpc6 timeout, IPv4-only) skew cases.
