### PR TITLE
refactor(daemon): typed DnsError for DNS discovery

### DIFF
--- a/rust/crates/supervisor-daemon/src/error.rs
+++ b/rust/crates/supervisor-daemon/src/error.rs
@@ -54,6 +54,9 @@ pub enum DaemonError {
     Checks(#[from] crate::checks::ChecksError),
 
     #[error(transparent)]
+    Dns(#[from] crate::net::DnsError),
+
+    #[error(transparent)]
     Io(#[from] std::io::Error),
 
     #[error(transparent)]

--- a/rust/crates/supervisor-daemon/src/net.rs
+++ b/rust/crates/supervisor-daemon/src/net.rs
@@ -154,23 +154,46 @@ fn resolv_conf_dns_servers(contents: &str) -> Vec<String> {
         .collect()
 }
 
+/// Failures from DNS nameserver discovery (conf.py `resolvectl_dns_servers`
+/// / `obtain_dns_ips`). Display strings are copied verbatim from the
+/// pre-typed `format!` messages they replace.
+#[derive(Debug, thiserror::Error)]
+pub enum DnsError {
+    #[error("cannot run resolvectl: {source}")]
+    Resolvectl { source: std::io::Error },
+
+    #[error("resolvectl dns -i {interface} failed: {stderr}")]
+    ResolvectlFailed { interface: String, stderr: String },
+
+    #[error("unexpected resolvectl output: {text:?}")]
+    UnexpectedOutput { text: String },
+
+    #[error("cannot read /etc/resolv.conf: {source}")]
+    ReadResolvConf { source: std::io::Error },
+
+    #[error("No DNS resolver found ({source})")]
+    NoResolver { source: Box<DnsError> },
+}
+
 /// conf.py `resolvectl_dns_servers`: `resolvectl dns -i <interface>`,
 /// splitting the "Link N (iface): a b c" output on the first colon.
-fn resolvectl_dns_servers(interface: &str) -> Result<Vec<String>, String> {
+fn resolvectl_dns_servers(interface: &str) -> Result<Vec<String>, DnsError> {
     let output = std::process::Command::new("/usr/bin/resolvectl")
         .args(["dns", "-i", interface])
         .output()
-        .map_err(|error| format!("cannot run resolvectl: {error}"))?;
+        .map_err(|source| DnsError::Resolvectl { source })?;
     if !output.status.success() {
-        return Err(format!(
-            "resolvectl dns -i {interface} failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        ));
+        return Err(DnsError::ResolvectlFailed {
+            interface: interface.to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
     }
     let text = String::from_utf8_lossy(&output.stdout);
     let (_, servers) = text
         .split_once(':')
-        .ok_or_else(|| format!("unexpected resolvectl output: {text:?}"))?;
+        .ok_or_else(|| DnsError::UnexpectedOutput {
+            text: text.to_string(),
+        })?;
     Ok(servers.split_whitespace().map(str::to_string).collect())
 }
 
@@ -180,7 +203,7 @@ fn resolvectl_dns_servers(interface: &str) -> Result<Vec<String>, String> {
 pub fn obtain_dns_ips(
     resolution: crate::config::DnsResolution,
     interface: &str,
-) -> Result<Vec<String>, String> {
+) -> Result<Vec<String>, DnsError> {
     use crate::config::DnsResolution;
     match resolution {
         DnsResolution::Detect => match resolvectl_dns_servers(interface) {
@@ -189,16 +212,18 @@ pub fn obtain_dns_ips(
                 let path = std::path::Path::new("/etc/resolv.conf");
                 if path.exists() {
                     let contents = std::fs::read_to_string(path)
-                        .map_err(|error| format!("cannot read /etc/resolv.conf: {error}"))?;
+                        .map_err(|source| DnsError::ReadResolvConf { source })?;
                     Ok(resolv_conf_dns_servers(&contents))
                 } else {
-                    Err(format!("No DNS resolver found ({error})"))
+                    Err(DnsError::NoResolver {
+                        source: Box::new(error),
+                    })
                 }
             }
         },
         DnsResolution::ResolvConf => {
             let contents = std::fs::read_to_string("/etc/resolv.conf")
-                .map_err(|error| format!("cannot read /etc/resolv.conf: {error}"))?;
+                .map_err(|source| DnsError::ReadResolvConf { source })?;
             Ok(resolv_conf_dns_servers(&contents))
         }
         DnsResolution::Resolvectl => resolvectl_dns_servers(interface),
@@ -263,5 +288,26 @@ mod tests {
     fn missing_interface_is_an_error() {
         let error = get_interface_ipv4("definitely-not-an-iface0").unwrap_err();
         assert!(error.to_string().contains("does not exist"));
+    }
+
+    #[test]
+    fn resolvectl_failure_is_surfaced_with_interface_and_stderr() {
+        // resolvectl_dns_servers shells out to this exact hardcoded path;
+        // skip on hosts/CI images that lack it rather than conflating "no
+        // resolvectl" with the ResolvectlFailed path under test.
+        if !std::path::Path::new("/usr/bin/resolvectl").exists() {
+            eprintln!("skipping: /usr/bin/resolvectl not present on this host");
+            return;
+        }
+        let error = resolvectl_dns_servers("definitely-not-an-iface0").unwrap_err();
+        assert!(matches!(
+            &error,
+            DnsError::ResolvectlFailed { interface, .. } if interface == "definitely-not-an-iface0"
+        ));
+        assert!(
+            error
+                .to_string()
+                .starts_with("resolvectl dns -i definitely-not-an-iface0 failed:")
+        );
     }
 }

--- a/rust/crates/supervisor-daemon/src/service.rs
+++ b/rust/crates/supervisor-daemon/src/service.rs
@@ -86,10 +86,9 @@ impl HostState {
         // when unset; a failure aborts startup, like the Python setup().
         let dns_nameservers = match (&settings.dns_nameservers, &network_interface) {
             (Some(configured), _) => Some(configured.clone()),
-            (None, Some(interface)) => Some(
-                net::obtain_dns_ips(settings.dns_resolution, interface)
-                    .map_err(DaemonError::Internal)?,
-            ),
+            (None, Some(interface)) => {
+                Some(net::obtain_dns_ips(settings.dns_resolution, interface)?)
+            }
             (None, None) => None,
         };
 


### PR DESCRIPTION
PR 8 of the typed-errors series (stacked on #1094).

Converts DNS discovery in \`net.rs\` to a strict thiserror enum:
- \`DnsError\` (Resolvectl/ResolvectlFailed/UnexpectedOutput/ReadResolvConf/NoResolver); the old nested string-wrap becomes a boxed source chain
- \`DaemonError\` gains a transparent \`Dns(#[from] DnsError)\` variant; the \`service.rs\` absorber becomes a bare \`?\`
- new test skips gracefully on hosts without \`/usr/bin/resolvectl\` (the exact path production invokes)

Display byte-identical; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)