### PR TITLE
refactor(daemon): typed TapError for tap-device management

### DIFF
--- a/rust/crates/supervisor-daemon/src/lifecycle.rs
+++ b/rust/crates/supervisor-daemon/src/lifecycle.rs
@@ -717,7 +717,7 @@ fn stop_vm_execution(state: &DaemonState, vm_id: &str) -> Result<(), RpcError> {
                 // Python's TapInterface.delete swallows every deletion
                 // failure with a warning (interfaces.py); a stop must not
                 // fail on a stuck tap device.
-                tracing::warn!(vm_id, error, "cannot delete the tap interface, continuing");
+                tracing::warn!(vm_id, %error, "cannot delete the tap interface, continuing");
             }
         }
     }
@@ -796,7 +796,7 @@ fn stop_program_execution(state: &DaemonState, vm_id: &str) -> Result<(), RpcErr
                     .map_err(RpcError::Internal)?;
             }
             if let Err(error) = state.taps.delete_tap(&tap) {
-                tracing::warn!(vm_id, error, "cannot delete the tap interface, continuing");
+                tracing::warn!(vm_id, %error, "cannot delete the tap interface, continuing");
             }
         }
     }
@@ -918,7 +918,10 @@ fn start_vm_execution(state: &DaemonState, vm_id: &str) -> Result<(), RpcError> 
         let tap = tap_assignment(state, vm_id).map_err(RpcError::Internal)?;
         let _net = net_lock(state);
         if !state.taps.interface_exists(&tap.device_name) {
-            state.taps.create_tap(&tap).map_err(RpcError::Internal)?;
+            state
+                .taps
+                .create_tap(&tap)
+                .map_err(|error| RpcError::Internal(error.to_string()))?;
             if let Some(ndp) = &state.ndp {
                 ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, true)
                     .map_err(RpcError::Internal)?;
@@ -2399,7 +2402,10 @@ fn readopt_live_controller(state: &DaemonState, vm_id: &str) -> Result<VmEntry, 
             let tap = tap_assignment(state, vm_id)?;
             let _net = net_lock(state);
             if !state.taps.interface_exists(&tap.device_name) {
-                state.taps.create_tap(&tap)?;
+                state
+                    .taps
+                    .create_tap(&tap)
+                    .map_err(|error| error.to_string())?;
                 if let Some(ndp) = &state.ndp {
                     ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, true)?;
                 }
@@ -2780,9 +2786,15 @@ fn create_vm_inner(
                 if let Some(ndp) = &state.ndp {
                     ndp.delete_range(&tap.device_name, true)?;
                 }
-                state.taps.delete_tap(tap)?;
+                state
+                    .taps
+                    .delete_tap(tap)
+                    .map_err(|error| error.to_string())?;
             }
-            state.taps.create_tap(tap)?;
+            state
+                .taps
+                .create_tap(tap)
+                .map_err(|error| error.to_string())?;
             if let Some(ndp) = &state.ndp {
                 ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, true)?;
             }
@@ -2895,7 +2907,7 @@ fn create_vm_inner(
                 tracing::warn!(ndp_error, "failed to drop the ndp range during cleanup");
             }
             if let Err(delete_error) = state.taps.delete_tap(tap) {
-                tracing::warn!(delete_error, "failed to delete the tap during cleanup");
+                tracing::warn!(%delete_error, "failed to delete the tap during cleanup");
             }
         }
         // Release the reserved vCPUs and drop the AllowedCPUs drop-in (if the
@@ -3057,9 +3069,15 @@ fn create_program_vm(
                         ndp.delete_range(&tap.device_name, true)
                             .map_err(RpcError::Internal)?;
                     }
-                    state.taps.delete_tap(tap).map_err(RpcError::Internal)?;
+                    state
+                        .taps
+                        .delete_tap(tap)
+                        .map_err(|error| RpcError::Internal(error.to_string()))?;
                 }
-                state.taps.create_tap(tap).map_err(RpcError::Internal)?;
+                state
+                    .taps
+                    .create_tap(tap)
+                    .map_err(|error| RpcError::Internal(error.to_string()))?;
                 if let Some(ndp) = &state.ndp {
                     ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, true)
                         .map_err(RpcError::Internal)?;
@@ -3151,7 +3169,7 @@ fn create_program_vm(
                         tracing::warn!(ndp_error, "failed to drop the ndp range during cleanup");
                     }
                     if let Err(delete_error) = state.taps.delete_tap(tap) {
-                        tracing::warn!(delete_error, "failed to delete the tap during cleanup");
+                        tracing::warn!(%delete_error, "failed to delete the tap during cleanup");
                     }
                 }
             }
@@ -3424,7 +3442,10 @@ pub fn reconcile_boot(state: &DaemonState) {
             {
                 let _net = net_lock(state);
                 if !state.taps.interface_exists(&tap.device_name) {
-                    state.taps.create_tap(&tap)?;
+                    state
+                        .taps
+                        .create_tap(&tap)
+                        .map_err(|error| error.to_string())?;
                     if let Some(ndp) = &state.ndp {
                         ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, true)?;
                     }

--- a/rust/crates/supervisor-daemon/src/tap.rs
+++ b/rust/crates/supervisor-daemon/src/tap.rs
@@ -76,12 +76,27 @@ pub trait TapBackend: Send + Sync {
     /// ndppd): create the tap, add both host addresses, set the link up.
     /// An already-existing device or address is tolerated with a warning,
     /// like the pyroute2 EEXIST handling.
-    fn create_tap(&self, tap: &TapAssignment) -> Result<(), String>;
+    fn create_tap(&self, tap: &TapAssignment) -> Result<(), TapError>;
 
     /// Python `TapInterface.delete` minus the NDP range: remove the
     /// addresses and the device. A missing device is a warning, not an
     /// error.
-    fn delete_tap(&self, tap: &TapAssignment) -> Result<(), String>;
+    fn delete_tap(&self, tap: &TapAssignment) -> Result<(), TapError>;
+}
+
+/// Failures creating or deleting a tap device via `ip(8)`.
+#[derive(Debug, thiserror::Error)]
+pub enum TapError {
+    #[error("cannot run ip: {source}")]
+    Run { source: std::io::Error },
+
+    #[error("ip {argv} failed: {stderr}")]
+    Command { argv: String, stderr: String },
+
+    /// A fabricated error for test `TapBackend` fakes that need to report a
+    /// specific failure without shelling out to a real `ip`.
+    #[error("{0}")]
+    Injected(String),
 }
 
 /// Production backend over `ip(8)`.
@@ -111,11 +126,11 @@ fn classify_ip_failure(stderr: &str) -> IpFailure {
     }
 }
 
-fn run_ip(args: &[&str]) -> Result<(), String> {
+fn run_ip(args: &[&str]) -> Result<(), TapError> {
     let output = Command::new("ip")
         .args(args)
         .output()
-        .map_err(|error| format!("cannot run ip: {error}"))?;
+        .map_err(|source| TapError::Run { source })?;
     if output.status.success() {
         return Ok(());
     }
@@ -135,7 +150,10 @@ fn run_ip(args: &[&str]) -> Result<(), String> {
             );
             Ok(())
         }
-        IpFailure::Other => Err(format!("ip {} failed: {stderr}", args.join(" "))),
+        IpFailure::Other => Err(TapError::Command {
+            argv: args.join(" "),
+            stderr,
+        }),
     }
 }
 
@@ -146,7 +164,7 @@ impl TapBackend for IpCommand {
             .exists()
     }
 
-    fn create_tap(&self, tap: &TapAssignment) -> Result<(), String> {
+    fn create_tap(&self, tap: &TapAssignment) -> Result<(), TapError> {
         run_ip(&["tuntap", "add", "name", &tap.device_name, "mode", "tap"])?;
         // Address failures are logged and tolerated in Python
         // (add_ip_address catches every NetlinkError); mirror that.
@@ -155,7 +173,7 @@ impl TapBackend for IpCommand {
                 tracing::error!(
                     device = tap.device_name,
                     address,
-                    error,
+                    %error,
                     "cannot add address to tap interface"
                 );
             }
@@ -166,14 +184,14 @@ impl TapBackend for IpCommand {
         if let Err(error) = run_ip(&["link", "set", &tap.device_name, "up"]) {
             tracing::error!(
                 device = tap.device_name,
-                error,
+                %error,
                 "cannot set the tap interface up"
             );
         }
         Ok(())
     }
 
-    fn delete_tap(&self, tap: &TapAssignment) -> Result<(), String> {
+    fn delete_tap(&self, tap: &TapAssignment) -> Result<(), TapError> {
         if !self.interface_exists(&tap.device_name) {
             tracing::warn!(
                 device = tap.device_name,
@@ -188,7 +206,7 @@ impl TapBackend for IpCommand {
         if let Err(error) = run_ip(&["link", "del", &tap.device_name]) {
             tracing::warn!(
                 device = tap.device_name,
-                error,
+                %error,
                 "interface cannot be deleted"
             );
         }
@@ -271,7 +289,7 @@ impl TapBackend for FakeTapBackend {
         self.lock().devices.contains(device_name)
     }
 
-    fn create_tap(&self, tap: &TapAssignment) -> Result<(), String> {
+    fn create_tap(&self, tap: &TapAssignment) -> Result<(), TapError> {
         let mut inner = self.lock();
         if inner.panic_on_create {
             inner.panic_on_create = false;
@@ -279,7 +297,7 @@ impl TapBackend for FakeTapBackend {
             panic!("injected tap creation panic");
         }
         if let Some(message) = &inner.fail_create {
-            return Err(message.clone());
+            return Err(TapError::Injected(message.clone()));
         }
         inner.actions.push(format!(
             "create {} {} {}",
@@ -293,10 +311,10 @@ impl TapBackend for FakeTapBackend {
         Ok(())
     }
 
-    fn delete_tap(&self, tap: &TapAssignment) -> Result<(), String> {
+    fn delete_tap(&self, tap: &TapAssignment) -> Result<(), TapError> {
         let mut inner = self.lock();
         if let Some(message) = &inner.fail_delete {
-            return Err(message.clone());
+            return Err(TapError::Injected(message.clone()));
         }
         inner.actions.push(format!("delete {}", tap.device_name));
         inner.devices.remove(&tap.device_name);
@@ -345,6 +363,16 @@ mod tests {
         assert!(backend.interface_exists("vmtap3"));
         backend.delete_tap(&tap).unwrap();
         assert!(!backend.interface_exists("vmtap3"));
+    }
+
+    #[test]
+    fn fail_create_injects_a_typed_error() {
+        let backend = FakeTapBackend::new();
+        let tap = assignment();
+        backend.fail_create("injected: cannot create tap");
+        let error = backend.create_tap(&tap).unwrap_err();
+        assert!(matches!(error, TapError::Injected(_)));
+        assert_eq!(error.to_string(), "injected: cannot create tap");
     }
 
     #[test]


### PR DESCRIPTION
PR 10 of the typed-errors series (stacked on #1096). \`TapBackend::{create_tap, delete_tap}\` return \`Result<(), TapError>\` (Run/Command/Injected variants) across \`IpCommand\` and \`FakeTapBackend\` (injection API unchanged); \`run_ip\` typed; the \`IpFailure\` stderr classifier untouched; lifecycle callers shimmed and warn sites log with \`%error\`.

Display byte-identical; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)