### PR TITLE
refactor(daemon): typed NdppdError for the NDP proxy

### DIFF
--- a/rust/crates/supervisor-daemon/src/lifecycle.rs
+++ b/rust/crates/supervisor-daemon/src/lifecycle.rs
@@ -696,7 +696,7 @@ fn stop_vm_execution(state: &DaemonState, vm_id: &str) -> Result<(), RpcError> {
             std::thread::sleep(state.pacing.tap_delete_delay);
             if let Some(ndp) = &state.ndp {
                 ndp.delete_range(&device, true)
-                    .map_err(RpcError::Internal)?;
+                    .map_err(|error| RpcError::Internal(error.to_string()))?;
             }
             // Only the device name matters for the deletion; the addresses go
             // with the link (a missing device is a warning inside the backend).
@@ -793,7 +793,7 @@ fn stop_program_execution(state: &DaemonState, vm_id: &str) -> Result<(), RpcErr
             std::thread::sleep(state.pacing.tap_delete_delay);
             if let Some(ndp) = &state.ndp {
                 ndp.delete_range(&tap.device_name, true)
-                    .map_err(RpcError::Internal)?;
+                    .map_err(|error| RpcError::Internal(error.to_string()))?;
             }
             if let Err(error) = state.taps.delete_tap(&tap) {
                 tracing::warn!(vm_id, error, "cannot delete the tap interface, continuing");
@@ -921,7 +921,7 @@ fn start_vm_execution(state: &DaemonState, vm_id: &str) -> Result<(), RpcError> 
             state.taps.create_tap(&tap).map_err(RpcError::Internal)?;
             if let Some(ndp) = &state.ndp {
                 ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, true)
-                    .map_err(RpcError::Internal)?;
+                    .map_err(|error| RpcError::Internal(error.to_string()))?;
             }
         }
         // Even when the interface survived, the nftables rules may have
@@ -2401,12 +2401,14 @@ fn readopt_live_controller(state: &DaemonState, vm_id: &str) -> Result<VmEntry, 
             if !state.taps.interface_exists(&tap.device_name) {
                 state.taps.create_tap(&tap)?;
                 if let Some(ndp) = &state.ndp {
-                    ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, true)?;
+                    ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, true)
+                        .map_err(|error| error.to_string())?;
                 }
             } else if let Some(ndp) = &state.ndp {
                 // Prime the ndppd map without touching the service: the
                 // on-disk config already covers this running VM.
-                ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, false)?;
+                ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, false)
+                    .map_err(|error| error.to_string())?;
             }
             nft_setup_vm(state, tap.vm_index, &tap.device_name)?;
         }
@@ -2778,13 +2780,15 @@ fn create_vm_inner(
             if state.taps.interface_exists(&tap.device_name) {
                 std::thread::sleep(state.pacing.tap_delete_delay);
                 if let Some(ndp) = &state.ndp {
-                    ndp.delete_range(&tap.device_name, true)?;
+                    ndp.delete_range(&tap.device_name, true)
+                        .map_err(|error| error.to_string())?;
                 }
                 state.taps.delete_tap(tap)?;
             }
             state.taps.create_tap(tap)?;
             if let Some(ndp) = &state.ndp {
-                ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, true)?;
+                ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, true)
+                    .map_err(|error| error.to_string())?;
             }
             nft_setup_vm(state, vm_index, &tap.device_name)?;
             // SNP measured VMs get their IPv4 via a per-tap DHCP server, not
@@ -2892,7 +2896,7 @@ fn create_vm_inner(
             if let Some(ndp) = &state.ndp
                 && let Err(ndp_error) = ndp.delete_range(&tap.device_name, true)
             {
-                tracing::warn!(ndp_error, "failed to drop the ndp range during cleanup");
+                tracing::warn!(%ndp_error, "failed to drop the ndp range during cleanup");
             }
             if let Err(delete_error) = state.taps.delete_tap(tap) {
                 tracing::warn!(delete_error, "failed to delete the tap during cleanup");
@@ -3055,14 +3059,14 @@ fn create_program_vm(
                     std::thread::sleep(state.pacing.tap_delete_delay);
                     if let Some(ndp) = &state.ndp {
                         ndp.delete_range(&tap.device_name, true)
-                            .map_err(RpcError::Internal)?;
+                            .map_err(|error| RpcError::Internal(error.to_string()))?;
                     }
                     state.taps.delete_tap(tap).map_err(RpcError::Internal)?;
                 }
                 state.taps.create_tap(tap).map_err(RpcError::Internal)?;
                 if let Some(ndp) = &state.ndp {
                     ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, true)
-                        .map_err(RpcError::Internal)?;
+                        .map_err(|error| RpcError::Internal(error.to_string()))?;
                 }
                 nft_setup_vm(state, vm_index, &tap.device_name).map_err(RpcError::Internal)?;
             }
@@ -3148,7 +3152,7 @@ fn create_program_vm(
                     if let Some(ndp) = &state.ndp
                         && let Err(ndp_error) = ndp.delete_range(&tap.device_name, true)
                     {
-                        tracing::warn!(ndp_error, "failed to drop the ndp range during cleanup");
+                        tracing::warn!(%ndp_error, "failed to drop the ndp range during cleanup");
                     }
                     if let Err(delete_error) = state.taps.delete_tap(tap) {
                         tracing::warn!(delete_error, "failed to delete the tap during cleanup");
@@ -3426,7 +3430,8 @@ pub fn reconcile_boot(state: &DaemonState) {
                 if !state.taps.interface_exists(&tap.device_name) {
                     state.taps.create_tap(&tap)?;
                     if let Some(ndp) = &state.ndp {
-                        ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, true)?;
+                        ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, true)
+                            .map_err(|error| error.to_string())?;
                     }
                 }
                 if let Some(ndp) = &state.ndp
@@ -3435,7 +3440,8 @@ pub fn reconcile_boot(state: &DaemonState) {
                     // Prime the in-memory map without a config rewrite or
                     // service restart: the on-disk ndppd.conf already covers
                     // running VMs (update_service=False in Python).
-                    ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, false)?;
+                    ndp.add_range(&tap.device_name, &tap.ipv6.network_cidr, false)
+                        .map_err(|error| error.to_string())?;
                 }
                 nft_setup_vm(state, tap.vm_index, &tap.device_name)?;
             }

--- a/rust/crates/supervisor-daemon/src/ndppd.rs
+++ b/rust/crates/supervisor-daemon/src/ndppd.rs
@@ -20,9 +20,18 @@ use std::time::Duration;
 /// startup or teardown) coalesce into a single ndppd restart.
 const RESTART_DEBOUNCE: Duration = Duration::from_millis(500);
 
+/// Error type for NDP proxy operations.
+#[derive(Debug, thiserror::Error)]
+pub enum NdppdError {
+    #[error("cannot write /etc/ndppd.conf: {source}")]
+    WriteConf { source: std::io::Error },
+    #[error("{0}")]
+    Injected(String),
+}
+
 /// Where the config lands and how the service restarts.
 pub trait NdppdEdge: Send + Sync {
-    fn write_conf(&self, contents: &str) -> Result<(), String>;
+    fn write_conf(&self, contents: &str) -> Result<(), NdppdError>;
     fn restart_service(&self);
 }
 
@@ -31,9 +40,9 @@ pub trait NdppdEdge: Send + Sync {
 pub struct SystemNdppd;
 
 impl NdppdEdge for SystemNdppd {
-    fn write_conf(&self, contents: &str) -> Result<(), String> {
+    fn write_conf(&self, contents: &str) -> Result<(), NdppdError> {
         std::fs::write("/etc/ndppd.conf", contents)
-            .map_err(|error| format!("cannot write /etc/ndppd.conf: {error}"))
+            .map_err(|source| NdppdError::WriteConf { source })
     }
 
     fn restart_service(&self) {
@@ -74,7 +83,7 @@ impl FakeNdppd {
 }
 
 impl NdppdEdge for FakeNdppd {
-    fn write_conf(&self, contents: &str) -> Result<(), String> {
+    fn write_conf(&self, contents: &str) -> Result<(), NdppdError> {
         self.writes
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
@@ -126,7 +135,7 @@ impl NdpProxy {
         config
     }
 
-    fn update_conf(&self, state: &mut NdpState) -> Result<(), String> {
+    fn update_conf(&self, state: &mut NdpState) -> Result<(), NdppdError> {
         let contents = self.render(&state.ranges);
         // A failed config write propagates and fails the calling RPC,
         // exactly like the Python `Path.write_text` in _update_ndppd_conf.
@@ -156,7 +165,7 @@ impl NdpProxy {
         interface: &str,
         address_range: &str,
         update_service: bool,
-    ) -> Result<(), String> {
+    ) -> Result<(), NdppdError> {
         let mut state = self.lock();
         tracing::debug!(interface, address_range, "proxying range");
         match state
@@ -176,7 +185,7 @@ impl NdpProxy {
     }
 
     /// Python `delete_range`: absent interfaces are a silent no-op.
-    pub fn delete_range(&self, interface: &str, update_service: bool) -> Result<(), String> {
+    pub fn delete_range(&self, interface: &str, update_service: bool) -> Result<(), NdppdError> {
         let mut state = self.lock();
         let Some(position) = state
             .ranges
@@ -262,8 +271,8 @@ mod tests {
     struct FailingEdge;
 
     impl NdppdEdge for FailingEdge {
-        fn write_conf(&self, _contents: &str) -> Result<(), String> {
-            Err("read-only /etc".to_string())
+        fn write_conf(&self, _contents: &str) -> Result<(), NdppdError> {
+            Err(NdppdError::Injected("read-only /etc".to_string()))
         }
         fn restart_service(&self) {}
     }
@@ -274,10 +283,10 @@ mod tests {
         let error = proxy
             .add_range("vmtap3", "fc00:1:2:3::10/124", true)
             .unwrap_err();
-        assert!(error.contains("read-only /etc"));
+        assert!(error.to_string().contains("read-only /etc"));
         // Priming (update_service=false) never writes, so it cannot fail.
         proxy.add_range("vmtap4", "fc00::20/124", false).unwrap();
         let error = proxy.delete_range("vmtap4", true).unwrap_err();
-        assert!(error.contains("read-only /etc"));
+        assert!(error.to_string().contains("read-only /etc"));
     }
 }


### PR DESCRIPTION
PR 13 of the typed-errors series (stacked on #1099). \`NdppdEdge::write_conf\` and \`NdpProxy::{update_conf, add_range, delete_range}\` return typed \`NdppdError\` (WriteConf + Injected); all three edge impls converted; 13 lifecycle call sites shimmed.

Display byte-identical; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)