### PR TITLE
refactor(controller): typed QmpError for the QMP escalation client

### DIFF
--- a/rust/crates/supervisor-controller/src/qmp.rs
+++ b/rust/crates/supervisor-controller/src/qmp.rs
@@ -22,6 +22,61 @@ use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+/// The closed error vocabulary for the QMP escalation client. Every consumer
+/// (`qemu.rs::send_qmp`) only ever `tracing::warn!`s the rendered message, so
+/// these are display-only, but the `source` fields keep the original error
+/// typed rather than eagerly stringified.
+#[derive(Debug, thiserror::Error)]
+pub enum QmpError {
+    #[error("cannot connect to QMP: {source}")]
+    Connect { source: std::io::Error },
+
+    #[error("cannot set the QMP write timeout: {source}")]
+    WriteTimeout { source: std::io::Error },
+
+    #[error("cannot clone the QMP socket: {source}")]
+    Clone { source: std::io::Error },
+
+    #[error("no QMP greeting: {source}")]
+    NoGreeting { source: Box<QmpError> },
+
+    #[error("cannot send the QMP command {command}: {source}")]
+    Send {
+        command: String,
+        source: std::io::Error,
+    },
+
+    #[error("invalid QMP response: {source}")]
+    InvalidResponse { source: serde_json::Error },
+
+    #[error("QMP error for {command}: {error}")]
+    Protocol {
+        command: String,
+        error: serde_json::Value,
+    },
+
+    #[error("QMP monitor sent {skipped} events without a reply to {command}")]
+    EventsWithoutReply { skipped: usize, command: String },
+
+    #[error("QMP command deadline exceeded")]
+    DeadlineExceeded,
+
+    #[error("cannot set the QMP read timeout: {source}")]
+    ReadTimeout { source: std::io::Error },
+
+    #[error("QMP socket closed")]
+    SocketClosed,
+
+    #[error("QMP reply line exceeded {MAX_REPLY_LINE_BYTES} bytes without a newline")]
+    LineTooLong,
+
+    #[error("QMP read timed out")]
+    TimedOut,
+
+    #[error("cannot read from the QMP socket: {source}")]
+    Read { source: std::io::Error },
+}
+
 /// Total wall-clock budget for one command round-trip (handshake + command +
 /// reply). A wedged monitor that keeps the socket open but never answers is
 /// cut off here rather than parking the blocking-pool thread. The caller's
@@ -43,7 +98,7 @@ const MAX_SKIPPED_EVENTS: usize = 1024;
 /// Send one QMP command over the monitor socket. Returns Ok when the command
 /// was sent (and, for non-`quit` commands, acknowledged); a missing socket is
 /// Ok (the VM is already gone, like Python's `if not socket.exists(): return`).
-pub fn send_command(qmp_socket_path: &str, command: &str) -> Result<(), String> {
+pub fn send_command(qmp_socket_path: &str, command: &str) -> Result<(), QmpError> {
     send_command_within(qmp_socket_path, command, COMMAND_DEADLINE)
 }
 
@@ -53,25 +108,26 @@ fn send_command_within(
     qmp_socket_path: &str,
     command: &str,
     budget: Duration,
-) -> Result<(), String> {
+) -> Result<(), QmpError> {
     let path = Path::new(qmp_socket_path);
     if !path.exists() {
         return Ok(());
     }
     let deadline = Instant::now() + budget;
 
-    let stream =
-        UnixStream::connect(path).map_err(|error| format!("cannot connect to QMP: {error}"))?;
+    let stream = UnixStream::connect(path).map_err(|source| QmpError::Connect { source })?;
     stream
         .set_write_timeout(Some(READ_INACTIVITY_TIMEOUT))
-        .map_err(|error| format!("cannot set the QMP write timeout: {error}"))?;
+        .map_err(|source| QmpError::WriteTimeout { source })?;
     let mut writer = stream
         .try_clone()
-        .map_err(|error| format!("cannot clone the QMP socket: {error}"))?;
+        .map_err(|source| QmpError::Clone { source })?;
     let mut reader = BufReader::new(stream);
 
     // Greeting, then the qmp_capabilities handshake into command mode.
-    read_line(&mut reader, deadline).map_err(|error| format!("no QMP greeting: {error}"))?;
+    read_line(&mut reader, deadline).map_err(|error| QmpError::NoGreeting {
+        source: Box::new(error),
+    })?;
     send(&mut writer, "qmp_capabilities")?;
     read_reply(&mut reader, "qmp_capabilities", deadline)?;
 
@@ -85,12 +141,15 @@ fn send_command_within(
     }
 }
 
-fn send(writer: &mut UnixStream, command: &str) -> Result<(), String> {
+fn send(writer: &mut UnixStream, command: &str) -> Result<(), QmpError> {
     let request = format!("{{\"execute\": \"{command}\"}}\n");
     writer
         .write_all(request.as_bytes())
         .and_then(|_| writer.flush())
-        .map_err(|error| format!("cannot send the QMP command {command}: {error}"))
+        .map_err(|source| QmpError::Send {
+            command: command.to_string(),
+            source,
+        })
 }
 
 /// Read reply lines until a `return`/`error` for the command, skipping any
@@ -100,14 +159,17 @@ fn read_reply(
     reader: &mut BufReader<UnixStream>,
     command: &str,
     deadline: Instant,
-) -> Result<(), String> {
+) -> Result<(), QmpError> {
     let mut skipped = 0usize;
     loop {
         let line = read_line(reader, deadline)?;
         let value: serde_json::Value = serde_json::from_str(line.trim())
-            .map_err(|error| format!("invalid QMP response: {error}"))?;
+            .map_err(|source| QmpError::InvalidResponse { source })?;
         if let Some(error) = value.get("error") {
-            return Err(format!("QMP error for {command}: {error}"));
+            return Err(QmpError::Protocol {
+                command: command.to_string(),
+                error: error.clone(),
+            });
         }
         if value.get("return").is_some() {
             return Ok(());
@@ -116,9 +178,10 @@ fn read_reply(
         // not let a monitor that never returns spin here forever.
         skipped += 1;
         if skipped > MAX_SKIPPED_EVENTS {
-            return Err(format!(
-                "QMP monitor sent {skipped} events without a reply to {command}"
-            ));
+            return Err(QmpError::EventsWithoutReply {
+                skipped,
+                command: command.to_string(),
+            });
         }
     }
 }
@@ -126,33 +189,31 @@ fn read_reply(
 /// Read one newline-terminated line, enforcing the wall-clock `deadline` (no
 /// single read blocks past the remaining budget) and the [`MAX_REPLY_LINE_BYTES`]
 /// byte cap (a never-terminated line returns an Err instead of growing memory).
-fn read_line(reader: &mut BufReader<UnixStream>, deadline: Instant) -> Result<String, String> {
+fn read_line(reader: &mut BufReader<UnixStream>, deadline: Instant) -> Result<String, QmpError> {
     let mut buffer: Vec<u8> = Vec::new();
     loop {
         let remaining = deadline
             .checked_duration_since(Instant::now())
             .filter(|left| !left.is_zero())
-            .ok_or_else(|| "QMP command deadline exceeded".to_string())?;
+            .ok_or(QmpError::DeadlineExceeded)?;
         // A single read waits no longer than the remaining budget, so the
         // total round-trip cannot exceed the deadline.
         let read_timeout = remaining.min(READ_INACTIVITY_TIMEOUT);
         reader
             .get_ref()
             .set_read_timeout(Some(read_timeout))
-            .map_err(|error| format!("cannot set the QMP read timeout: {error}"))?;
+            .map_err(|source| QmpError::ReadTimeout { source })?;
 
         let mut byte = [0u8; 1];
         match reader.read(&mut byte) {
-            Ok(0) => return Err("QMP socket closed".to_string()),
+            Ok(0) => return Err(QmpError::SocketClosed),
             Ok(_) => {
                 if byte[0] == b'\n' {
                     return Ok(String::from_utf8_lossy(&buffer).into_owned());
                 }
                 buffer.push(byte[0]);
                 if buffer.len() > MAX_REPLY_LINE_BYTES {
-                    return Err(format!(
-                        "QMP reply line exceeded {MAX_REPLY_LINE_BYTES} bytes without a newline"
-                    ));
+                    return Err(QmpError::LineTooLong);
                 }
             }
             Err(error)
@@ -161,9 +222,9 @@ fn read_line(reader: &mut BufReader<UnixStream>, deadline: Instant) -> Result<St
                     std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
                 ) =>
             {
-                return Err("QMP read timed out".to_string());
+                return Err(QmpError::TimedOut);
             }
-            Err(error) => return Err(format!("cannot read from the QMP socket: {error}")),
+            Err(source) => return Err(QmpError::Read { source }),
         }
     }
 }
@@ -174,6 +235,24 @@ mod tests {
     use std::os::unix::net::UnixListener;
     use std::sync::{Arc, Mutex};
     use std::thread;
+
+    #[test]
+    fn qmp_error_display_matches_the_deleted_string_templates() {
+        assert_eq!(QmpError::SocketClosed.to_string(), "QMP socket closed");
+        assert_eq!(
+            QmpError::EventsWithoutReply {
+                skipped: 3,
+                command: "system_powerdown".to_string(),
+            }
+            .to_string(),
+            "QMP monitor sent 3 events without a reply to system_powerdown"
+        );
+        assert!(matches!(QmpError::LineTooLong, QmpError::LineTooLong));
+        assert_eq!(
+            QmpError::LineTooLong.to_string(),
+            "QMP reply line exceeded 65536 bytes without a newline"
+        );
+    }
 
     #[test]
     fn a_missing_socket_is_ok() {


### PR DESCRIPTION
PR 19 of the typed-errors series (stacked on #1105). The controller's QMP shutdown-escalation client goes typed: 5 fns return \`Result<_, QmpError>\` (14 variants, io/serde_json sources, the nested greeting wrap becomes a boxed source chain); the \`quit\`-tolerance match is untouched and \`qemu.rs\`'s warn interpolation needed zero edits (Display-based).

Display byte-identical; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)