### PR TITLE
refactor(daemon): typed failure injection; drop the Injected variants

### DIFF
--- a/rust/crates/supervisor-daemon/src/dhcp.rs
+++ b/rust/crates/supervisor-daemon/src/dhcp.rs
@@ -245,11 +245,6 @@ pub enum DhcpError {
 
     #[error("systemctl stop {unit} failed: {stderr}")]
     StopFailed { unit: String, stderr: String },
-
-    /// A fabricated error for test `DhcpBackend` fakes that need to report a
-    /// specific failure without shelling out to real `systemd-run`/`systemctl`.
-    #[error("{0}")]
-    Injected(String),
 }
 
 /// Whether a `systemctl stop` stderr describes a unit systemd never knew (it
@@ -343,19 +338,26 @@ impl DhcpBackend for SystemdRunDhcp {
 /// Test backend: records every started [`DhcpConfig`] and stopped hash, with
 /// an optional shared [`crate::test_fixtures::EventLog`] to interleave with
 /// the tap/nft fakes for ordering checks. Failures are injectable.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct FakeDhcpBackend {
     inner: std::sync::Mutex<FakeDhcpState>,
     event_log: std::sync::OnceLock<crate::test_fixtures::EventLog>,
 }
 
-#[derive(Debug, Default)]
+/// A builder rather than a stored `DhcpError`: `DhcpError` deliberately has
+/// no `Clone` impl (its `io::Error` sources must stay real, non-reconstructed
+/// errors everywhere outside this test-only injection path), so repeated
+/// failures are produced by calling the closure again instead of cloning a
+/// stored value.
+type DhcpErrorFn = Box<dyn Fn() -> DhcpError + Send + Sync>;
+
+#[derive(Default)]
 struct FakeDhcpState {
     started: Vec<DhcpConfig>,
     stopped: Vec<String>,
     running: std::collections::HashSet<String>,
-    fail_start: Option<String>,
-    fail_stop: Option<String>,
+    fail_start: Option<DhcpErrorFn>,
+    fail_stop: Option<DhcpErrorFn>,
 }
 
 impl FakeDhcpBackend {
@@ -384,14 +386,16 @@ impl FakeDhcpBackend {
         self.lock().running.contains(vm_hash)
     }
 
-    /// Every `start` fails with this message until cleared.
-    pub fn fail_start(&self, message: &str) {
-        self.lock().fail_start = Some(message.to_string());
+    /// Every `start` fails with the error `make` builds, until cleared. A
+    /// builder (not a stored error) so each call gets its own real
+    /// `DhcpError`, e.g. `backend.fail_start(|| DhcpError::StartFailed { .. })`.
+    pub fn fail_start(&self, make: impl Fn() -> DhcpError + Send + Sync + 'static) {
+        self.lock().fail_start = Some(Box::new(make));
     }
 
-    /// Every `stop` fails with this message until cleared.
-    pub fn fail_stop(&self, message: &str) {
-        self.lock().fail_stop = Some(message.to_string());
+    /// Every `stop` fails with the error `make` builds, until cleared.
+    pub fn fail_stop(&self, make: impl Fn() -> DhcpError + Send + Sync + 'static) {
+        self.lock().fail_stop = Some(Box::new(make));
     }
 
     /// Attach a shared chronological event log.
@@ -409,8 +413,8 @@ impl FakeDhcpBackend {
 impl DhcpBackend for FakeDhcpBackend {
     fn start(&self, config: &DhcpConfig) -> Result<(), DhcpError> {
         let mut inner = self.lock();
-        if let Some(message) = &inner.fail_start {
-            return Err(DhcpError::Injected(message.clone()));
+        if let Some(make) = &inner.fail_start {
+            return Err(make());
         }
         inner.started.push(config.clone());
         inner.running.insert(config.vm_hash.clone());
@@ -421,8 +425,8 @@ impl DhcpBackend for FakeDhcpBackend {
 
     fn stop(&self, vm_hash: &str, _lease_file: &std::path::Path) -> Result<(), DhcpError> {
         let mut inner = self.lock();
-        if let Some(message) = &inner.fail_stop {
-            return Err(DhcpError::Injected(message.clone()));
+        if let Some(make) = &inner.fail_stop {
+            return Err(make());
         }
         inner.stopped.push(vm_hash.to_string());
         inner.running.remove(vm_hash);
@@ -594,15 +598,23 @@ mod tests {
         )
         .unwrap();
         let lease = std::path::Path::new(&config.lease_file);
-        backend.fail_start("boom");
+        let unit = config.unit_name();
+        backend.fail_start(move || DhcpError::StartFailed {
+            unit: unit.clone(),
+            stderr: "boom".to_string(),
+        });
         assert!(matches!(
             backend.start(&config),
-            Err(DhcpError::Injected(m)) if m == "boom"
+            Err(DhcpError::StartFailed { stderr, .. }) if stderr == "boom"
         ));
-        backend.fail_stop("nope");
+        let unit = config.unit_name();
+        backend.fail_stop(move || DhcpError::StopFailed {
+            unit: unit.clone(),
+            stderr: "nope".to_string(),
+        });
         assert!(matches!(
             backend.stop(&"e".repeat(64), lease),
-            Err(DhcpError::Injected(m)) if m == "nope"
+            Err(DhcpError::StopFailed { stderr, .. }) if stderr == "nope"
         ));
     }
 

--- a/rust/crates/supervisor-daemon/src/lifecycle.rs
+++ b/rust/crates/supervisor-daemon/src/lifecycle.rs
@@ -3743,7 +3743,7 @@ mod tests {
     use crate::config::Settings;
     use crate::logs::StaticLogSource;
     use crate::service::{HostState, vm_spec_message};
-    use crate::tap::{FakeTapBackend, TapBackend};
+    use crate::tap::{FakeTapBackend, TapBackend, TapError};
     use crate::test_fixtures;
     use crate::units::{FakeSystemd, UnitStateSource};
 
@@ -5293,9 +5293,10 @@ mod tests {
         let root = state.host.settings.execution_root.clone();
         let vm_id = hash('8');
         create_vm(state, spec(&vm_id, &root)).unwrap();
-        harness
-            .taps
-            .fail_delete("injected: Device or resource busy");
+        harness.taps.fail_delete(|| TapError::Command {
+            argv: "link del vmtap4".to_string(),
+            stderr: "Device or resource busy".to_string(),
+        });
         let entry = stop_vm(state, &vm_id).unwrap();
         assert_ne!(entry.times.stopped_at_ns, 0);
         // The fake still holds the device (delete failed), like a stuck tap.
@@ -5429,7 +5430,12 @@ mod tests {
         let state = &harness.state;
         let root = state.host.settings.execution_root.clone();
         create_vm(state, spec(&hash('a'), &root)).unwrap();
-        harness.nft.fail_batches_containing("aleph-vm-nat-3");
+        harness
+            .nft
+            .fail_batches_containing("aleph-vm-nat-3", || nft::NftError::ApplyFailed {
+                status: std::process::ExitStatus::default(),
+                stderr: "aleph-vm-nat-3: rule busy".to_string(),
+            });
 
         let summary = recreate_network(state).unwrap();
         let removed: Vec<&str> = summary["removed_chains"]
@@ -5626,7 +5632,10 @@ mod tests {
                 .unwrap(),
         );
         harness.taps.delete_tap(&tap).unwrap();
-        harness.taps.fail_create("injected: cannot create tap");
+        harness.taps.fail_create(|| TapError::Command {
+            argv: "tuntap add name vmtap mode tap".to_string(),
+            stderr: "Operation not permitted".to_string(),
+        });
 
         reconcile_boot(state);
         let world = state.world.blocking_read();
@@ -6410,7 +6419,10 @@ mod tests {
         harness
             .systemd
             .set_state(&controller_unit_name(&vm_id), "active");
-        harness.taps.fail_create("injected tap failure");
+        harness.taps.fail_create(|| TapError::Command {
+            argv: "tuntap add name vmtap mode tap".to_string(),
+            stderr: "Operation not permitted".to_string(),
+        });
 
         retry_failed_reattachments_once(state);
 
@@ -6476,7 +6488,10 @@ mod tests {
             &state.host.gpus,
         );
         *state.world.blocking_write() = adopted;
-        harness.taps.fail_create("injected tap failure");
+        harness.taps.fail_create(|| TapError::Command {
+            argv: "tuntap add name vmtap mode tap".to_string(),
+            stderr: "Operation not permitted".to_string(),
+        });
 
         reconcile_boot(state);
 
@@ -7502,7 +7517,10 @@ mod tests {
             .systemd
             .set_state(&controller_unit_name(vm_id), "active");
         // Fail the network restore that runs after placement is reconstructed.
-        harness.taps.fail_create("injected tap failure");
+        harness.taps.fail_create(|| TapError::Command {
+            argv: "tuntap add name vmtap mode tap".to_string(),
+            stderr: "Operation not permitted".to_string(),
+        });
 
         let _ = create_vm(state, spec(vm_id, &root));
 

--- a/rust/crates/supervisor-daemon/src/lifecycle.rs
+++ b/rust/crates/supervisor-daemon/src/lifecycle.rs
@@ -5433,7 +5433,7 @@ mod tests {
         harness
             .nft
             .fail_batches_containing("aleph-vm-nat-3", || nft::NftError::ApplyFailed {
-                status: std::process::ExitStatus::default(),
+                status: std::os::unix::process::ExitStatusExt::from_raw(1 << 8),
                 stderr: "aleph-vm-nat-3: rule busy".to_string(),
             });
 

--- a/rust/crates/supervisor-daemon/src/lifecycle.rs
+++ b/rust/crates/supervisor-daemon/src/lifecycle.rs
@@ -5633,7 +5633,7 @@ mod tests {
         );
         harness.taps.delete_tap(&tap).unwrap();
         harness.taps.fail_create(|| TapError::Command {
-            argv: "tuntap add name vmtap mode tap".to_string(),
+            argv: "tuntap add name vmtap4 mode tap".to_string(),
             stderr: "Operation not permitted".to_string(),
         });
 
@@ -6420,7 +6420,7 @@ mod tests {
             .systemd
             .set_state(&controller_unit_name(&vm_id), "active");
         harness.taps.fail_create(|| TapError::Command {
-            argv: "tuntap add name vmtap mode tap".to_string(),
+            argv: "tuntap add name vmtap4 mode tap".to_string(),
             stderr: "Operation not permitted".to_string(),
         });
 
@@ -6489,7 +6489,7 @@ mod tests {
         );
         *state.world.blocking_write() = adopted;
         harness.taps.fail_create(|| TapError::Command {
-            argv: "tuntap add name vmtap mode tap".to_string(),
+            argv: "tuntap add name vmtap4 mode tap".to_string(),
             stderr: "Operation not permitted".to_string(),
         });
 
@@ -7518,7 +7518,7 @@ mod tests {
             .set_state(&controller_unit_name(vm_id), "active");
         // Fail the network restore that runs after placement is reconstructed.
         harness.taps.fail_create(|| TapError::Command {
-            argv: "tuntap add name vmtap mode tap".to_string(),
+            argv: "tuntap add name vmtap4 mode tap".to_string(),
             stderr: "Operation not permitted".to_string(),
         });
 

--- a/rust/crates/supervisor-daemon/src/logs.rs
+++ b/rust/crates/supervisor-daemon/src/logs.rs
@@ -45,11 +45,6 @@ pub enum LogsError {
 
     #[error("journalctl --follow has no stdout")]
     NoStdout,
-
-    /// A fabricated error for test `LogSource` fakes that need to report a
-    /// specific failure without shelling out to a real `journalctl`.
-    #[error("{0}")]
-    Injected(String),
 }
 
 /// Which stream a journal entry came from (by SYSLOG_IDENTIFIER match).

--- a/rust/crates/supervisor-daemon/src/ndppd.rs
+++ b/rust/crates/supervisor-daemon/src/ndppd.rs
@@ -25,8 +25,6 @@ const RESTART_DEBOUNCE: Duration = Duration::from_millis(500);
 pub enum NdppdError {
     #[error("cannot write /etc/ndppd.conf: {source}")]
     WriteConf { source: std::io::Error },
-    #[error("{0}")]
-    Injected(String),
 }
 
 /// Where the config lands and how the service restarts.
@@ -272,7 +270,9 @@ mod tests {
 
     impl NdppdEdge for FailingEdge {
         fn write_conf(&self, _contents: &str) -> Result<(), NdppdError> {
-            Err(NdppdError::Injected("read-only /etc".to_string()))
+            Err(NdppdError::WriteConf {
+                source: std::io::Error::other("read-only /etc"),
+            })
         }
         fn restart_service(&self) {}
     }

--- a/rust/crates/supervisor-daemon/src/nft.rs
+++ b/rust/crates/supervisor-daemon/src/nft.rs
@@ -65,11 +65,6 @@ pub enum NftError {
         status: std::process::ExitStatus,
         stderr: String,
     },
-
-    /// A fabricated error for test `NftExecutor` fakes that need to report a
-    /// specific failure without shelling out to a real `nft`.
-    #[error("injected nft failure (matched {needle:?})")]
-    Injected { needle: String },
 }
 
 // ── Entity presence (the dedup) ─────────────────────────────────────────
@@ -881,6 +876,13 @@ impl NftExecutor for NftCli {
     }
 }
 
+/// A builder rather than a stored `NftError`: `NftError` deliberately has no
+/// `Clone` impl (its `io::Error`/`serde_json::Error` sources must stay real,
+/// non-reconstructed errors everywhere outside this test-only injection
+/// path), so a matching batch calls the closure again instead of cloning a
+/// stored value.
+type NftErrorFn = Box<dyn Fn() -> NftError + Send + Sync>;
+
 /// Test executor: a frozen ruleset, recorded command batches, an optional
 /// shared event log interleaving nft batches with the other fakes' calls.
 #[derive(Default)]
@@ -888,7 +890,7 @@ pub struct StaticRuleset {
     pub entries: Vec<Value>,
     pub batches: std::sync::Mutex<Vec<Vec<Value>>>,
     event_log: std::sync::OnceLock<crate::test_fixtures::EventLog>,
-    fail_matching: std::sync::Mutex<Option<String>>,
+    fail_matching: std::sync::Mutex<Option<(String, NftErrorFn)>>,
 }
 
 impl StaticRuleset {
@@ -907,12 +909,18 @@ impl StaticRuleset {
     }
 
     /// Failure injection: every run_commands whose serialized batch
-    /// contains `needle` errors instead of recording.
-    pub fn fail_batches_containing(&self, needle: &str) {
+    /// contains `needle` returns the error `make` builds, instead of
+    /// recording.
+    pub fn fail_batches_containing(
+        &self,
+        needle: &str,
+        make: impl Fn() -> NftError + Send + Sync + 'static,
+    ) {
         *self
             .fail_matching
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(needle.to_string());
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Some((needle.to_string(), Box::new(make)));
     }
 }
 
@@ -942,18 +950,16 @@ impl NftExecutor for StaticRuleset {
                 serde_json::to_string(commands).unwrap_or_default()
             ));
         }
-        if let Some(needle) = self
+        if let Some((needle, make)) = self
             .fail_matching
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .as_deref()
+            .as_ref()
             && serde_json::to_string(commands)
                 .unwrap_or_default()
-                .contains(needle)
+                .contains(needle.as_str())
         {
-            return Err(NftError::Injected {
-                needle: needle.to_string(),
-            });
+            return Err(make());
         }
         self.batches
             .lock()
@@ -1152,15 +1158,15 @@ mod tests {
     #[test]
     fn fail_batches_containing_injects_a_typed_error() {
         let executor = StaticRuleset::new(Vec::new());
-        executor.fail_batches_containing("supervisor-nat");
+        executor.fail_batches_containing("supervisor-nat", || NftError::ApplyFailed {
+            status: std::process::ExitStatus::default(),
+            stderr: "supervisor-nat: rule busy".to_string(),
+        });
         let error = executor
             .run_commands(&[json!({"add": {"chain": {"name": "aleph-supervisor-nat"}}})])
             .unwrap_err();
-        assert!(matches!(error, NftError::Injected { .. }));
-        assert_eq!(
-            error.to_string(),
-            "injected nft failure (matched \"supervisor-nat\")"
-        );
+        assert!(matches!(error, NftError::ApplyFailed { .. }));
+        assert!(error.to_string().contains("supervisor-nat: rule busy"));
     }
 
     #[test]

--- a/rust/crates/supervisor-daemon/src/nft.rs
+++ b/rust/crates/supervisor-daemon/src/nft.rs
@@ -1159,7 +1159,7 @@ mod tests {
     fn fail_batches_containing_injects_a_typed_error() {
         let executor = StaticRuleset::new(Vec::new());
         executor.fail_batches_containing("supervisor-nat", || NftError::ApplyFailed {
-            status: std::process::ExitStatus::default(),
+            status: std::os::unix::process::ExitStatusExt::from_raw(1 << 8),
             stderr: "supervisor-nat: rule busy".to_string(),
         });
         let error = executor

--- a/rust/crates/supervisor-daemon/src/tap.rs
+++ b/rust/crates/supervisor-daemon/src/tap.rs
@@ -92,11 +92,6 @@ pub enum TapError {
 
     #[error("ip {argv} failed: {stderr}")]
     Command { argv: String, stderr: String },
-
-    /// A fabricated error for test `TapBackend` fakes that need to report a
-    /// specific failure without shelling out to a real `ip`.
-    #[error("{0}")]
-    Injected(String),
 }
 
 /// Production backend over `ip(8)`.
@@ -217,18 +212,25 @@ impl TapBackend for IpCommand {
 /// Test backend: an in-memory device set, every call recorded. Failures
 /// are injectable per operation, and an optional shared [`EventLog`]
 /// interleaves the tap calls with the other fakes' for ordering checks.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct FakeTapBackend {
     inner: std::sync::Mutex<FakeTapState>,
     event_log: std::sync::OnceLock<crate::test_fixtures::EventLog>,
 }
 
-#[derive(Debug, Default)]
+/// A builder rather than a stored `TapError`: `TapError` deliberately has no
+/// `Clone` impl (its `io::Error` source must stay a real, non-reconstructed
+/// error everywhere outside this test-only injection path), so repeated
+/// failures are produced by calling the closure again instead of cloning a
+/// stored value.
+type TapErrorFn = Box<dyn Fn() -> TapError + Send + Sync>;
+
+#[derive(Default)]
 struct FakeTapState {
     devices: std::collections::HashSet<String>,
     pub actions: Vec<String>,
-    fail_create: Option<String>,
-    fail_delete: Option<String>,
+    fail_create: Option<TapErrorFn>,
+    fail_delete: Option<TapErrorFn>,
     panic_on_create: bool,
 }
 
@@ -257,14 +259,16 @@ impl FakeTapBackend {
         self.lock().devices.clone()
     }
 
-    /// Every create_tap fails with this message until cleared.
-    pub fn fail_create(&self, message: &str) {
-        self.lock().fail_create = Some(message.to_string());
+    /// Every create_tap fails with the error `make` builds, until cleared.
+    /// A builder (not a stored error) so each call gets its own real
+    /// `TapError`, e.g. `backend.fail_create(|| TapError::Command { .. })`.
+    pub fn fail_create(&self, make: impl Fn() -> TapError + Send + Sync + 'static) {
+        self.lock().fail_create = Some(Box::new(make));
     }
 
-    /// Every delete_tap fails with this message until cleared.
-    pub fn fail_delete(&self, message: &str) {
-        self.lock().fail_delete = Some(message.to_string());
+    /// Every delete_tap fails with the error `make` builds, until cleared.
+    pub fn fail_delete(&self, make: impl Fn() -> TapError + Send + Sync + 'static) {
+        self.lock().fail_delete = Some(Box::new(make));
     }
 
     /// The next create_tap panics (for unwind-safety tests).
@@ -296,8 +300,8 @@ impl TapBackend for FakeTapBackend {
             drop(inner);
             panic!("injected tap creation panic");
         }
-        if let Some(message) = &inner.fail_create {
-            return Err(TapError::Injected(message.clone()));
+        if let Some(make) = &inner.fail_create {
+            return Err(make());
         }
         inner.actions.push(format!(
             "create {} {} {}",
@@ -313,8 +317,8 @@ impl TapBackend for FakeTapBackend {
 
     fn delete_tap(&self, tap: &TapAssignment) -> Result<(), TapError> {
         let mut inner = self.lock();
-        if let Some(message) = &inner.fail_delete {
-            return Err(TapError::Injected(message.clone()));
+        if let Some(make) = &inner.fail_delete {
+            return Err(make());
         }
         inner.actions.push(format!("delete {}", tap.device_name));
         inner.devices.remove(&tap.device_name);
@@ -369,10 +373,16 @@ mod tests {
     fn fail_create_injects_a_typed_error() {
         let backend = FakeTapBackend::new();
         let tap = assignment();
-        backend.fail_create("injected: cannot create tap");
+        backend.fail_create(|| TapError::Command {
+            argv: "tuntap add name vmtap3 mode tap".to_string(),
+            stderr: "Operation not permitted".to_string(),
+        });
         let error = backend.create_tap(&tap).unwrap_err();
-        assert!(matches!(error, TapError::Injected(_)));
-        assert_eq!(error.to_string(), "injected: cannot create tap");
+        assert!(matches!(error, TapError::Command { .. }));
+        assert_eq!(
+            error.to_string(),
+            "ip tuntap add name vmtap3 mode tap failed: Operation not permitted"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up 2/3 to the typed-errors series (stacked on #1110).

Deletes all five \`Injected(String)\` variants: the fake backends' failure-injection API is now typed — a test injects the real variant it simulates (via a builder closure, so the error enums stay \`!Clone\` and source identity is never lossily reconstructed on a public type). Assertions follow the three-category rule from the design discussion: wire-pinning production-Display tests untouched; sentinel-propagation checks keep equivalent strength; circular fake-boundary string checks became variant assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)