### PR TITLE
refactor(daemon): drop dead error variants and unify the panic-prefix literal

### DIFF
--- a/rust/crates/supervisor-daemon/src/cloudinit.rs
+++ b/rust/crates/supervisor-daemon/src/cloudinit.rs
@@ -413,15 +413,23 @@ mod tests {
     #[test]
     fn cloud_init_error_messages_are_correct() {
         use std::io;
-
-        let io_error = io::Error::new(io::ErrorKind::PermissionDenied, "no perms");
+        use std::os::unix::process::ExitStatusExt;
 
         let temp_create = CloudInitError::TempCreate {
-            source: io_error.kind().into(),
+            source: io::Error::new(io::ErrorKind::PermissionDenied, "no perms"),
         };
         assert_eq!(
             temp_create.to_string(),
-            format!("cannot create a temp file: {}", io_error.kind())
+            "cannot create a temp file: no perms"
+        );
+
+        let failed = CloudInitError::Failed {
+            status: std::process::ExitStatus::from_raw(1 << 8),
+            stderr: "boom".to_string(),
+        };
+        assert_eq!(
+            failed.to_string(),
+            "cloud-localds failed (exit status: 1): boom"
         );
     }
 }

--- a/rust/crates/supervisor-daemon/src/controller_config.rs
+++ b/rust/crates/supervisor-daemon/src/controller_config.rs
@@ -567,7 +567,7 @@ pub fn remove_controller_configuration(
             && error.kind() != std::io::ErrorKind::NotFound
         {
             return Err(ConfigWriteError::RemoveArtifact {
-                path: path.clone(),
+                path,
                 source: error,
             });
         }

--- a/rust/crates/supervisor-daemon/src/hugepages.rs
+++ b/rust/crates/supervisor-daemon/src/hugepages.rs
@@ -95,10 +95,7 @@ pub fn allocate_2m_pages_on_node(
         })?
         .trim()
         .parse()
-        .map_err(|source| HugepagesError::Parse {
-            path: path.clone(),
-            source,
-        })?;
+        .map_err(|source| HugepagesError::Parse { path, source })?;
     Ok(actual)
 }
 

--- a/rust/crates/supervisor-daemon/src/lifecycle.rs
+++ b/rust/crates/supervisor-daemon/src/lifecycle.rs
@@ -138,8 +138,6 @@ pub enum LifecycleError {
     CloudInit(#[from] cloudinit::CloudInitError),
     #[error(transparent)]
     ControllerConfig(#[from] controller_config::ConfigWriteError),
-    #[error(transparent)]
-    Backup(#[from] crate::backup::BackupError),
 }
 
 impl From<LifecycleError> for RpcError {
@@ -3252,10 +3250,9 @@ fn create_program_vm(
         },
     ))
     .unwrap_or_else(|panic| {
-        Err(RpcError::Internal(format!(
-            "CreateVm panicked: {}",
-            panic_message(&*panic)
-        )))
+        Err(RpcError::from(LifecycleError::Panic(panic_message(
+            &*panic,
+        ))))
     });
 
     match boot {
@@ -5160,6 +5157,23 @@ mod tests {
         }
         assert!(state.world.blocking_read().is_empty(), "the entry leaked");
         assert!(harness.taps.devices().is_empty());
+    }
+
+    #[test]
+    fn create_program_vm_panic_wire_text_is_unchanged() {
+        // Pins that routing create_program_vm's panic path through
+        // LifecycleError::Panic + From<LifecycleError> for RpcError (instead
+        // of the old inline `RpcError::Internal(format!("CreateVm panicked:
+        // {}", ...))`) renders byte-identical wire text.
+        let payload: Box<dyn std::any::Any + Send> = Box::new("boom");
+        let message = panic_message(&*payload);
+        let error = RpcError::from(LifecycleError::Panic(message.clone()));
+        match error {
+            RpcError::Internal(text) => {
+                assert_eq!(text, format!("CreateVm panicked: {message}"));
+            }
+            other => panic!("expected Internal, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Replaces #1112, which GitHub auto-marked as merged (and auto-deleted its branch) when a branch-pointer mistake briefly pushed its head commit onto its base branch. Nothing actually landed in dev; identical content, same branch name, still stacked on #1111 — merge #1111 first, then this.

Original description: drops the never-constructed \`LifecycleError::Backup\`; routes the program-path panic through \`LifecycleError::Panic\` so the "CreateVm panicked: " template exists once (wire text byte-identical, pinned by a new test); moves two last-use \`path\` clones; fixes the cloudinit Display test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)