### PR TITLE
fix(nix): bump guest-image nixpkgs from EOL 24.11 to nixos-26.05

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -17,16 +17,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751274312,
-        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "lastModified": 1786943417,
+        "narHash": "sha256-b4qgjdFtlz5TAZ1Hi7DFJeqX3sjaDUnrwr9OO+O1rM0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "rev": "0dd31db7e6dbf9ce05697c4545f6fe01accec994",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -16,7 +16,7 @@
   # no-workload fallback. See rust-port-divergences.
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     rust-overlay.url = "github:oxalica/rust-overlay";
     crane.url = "github:ipetkov/crane";
   };

--- a/nix/init.sh
+++ b/nix/init.sh
@@ -218,7 +218,6 @@ NFT
 # and/or workload volume: either token alone is enough to need dm-verity).
 if [ -n "$roothash" ] || [ -n "$workload_roothash" ]; then
     echo "init: loading dm-verity kernel modules"
-    /bin/busybox insmod /lib/modules/dax.ko 2>&1 || echo "init: warning: insmod dax.ko failed"
     /bin/busybox insmod /lib/modules/dm-mod.ko 2>&1 || echo "init: warning: insmod dm-mod.ko failed"
     /bin/busybox insmod /lib/modules/dm-bufio.ko 2>&1 || echo "init: warning: insmod dm-bufio.ko failed"
     /bin/busybox insmod /lib/modules/dm-verity.ko 2>&1 || echo "init: warning: insmod dm-verity.ko failed"

--- a/nix/initrd.nix
+++ b/nix/initrd.nix
@@ -10,18 +10,20 @@ let
   staticNft = pkgs.pkgsStatic.nftables.override { withCli = false; };
 
   # dm-verity kernel modules (default =m in the kernel config).
-  # Load order: dax -> dm-mod -> dm-bufio -> dm-verity.
+  # Load order: dm-mod -> dm-bufio -> dm-verity. dax.ko is gone: nixos-26.05
+  # kernels build CONFIG_DAX=y (built in), so dm-mod no longer has a dax
+  # module dependency. Modules also moved out of the kernel's main output
+  # into a dedicated `modules` output on that channel.
   #
   # The measured-boot chain here is dm-verity for rootfs INTEGRITY only. The
   # aleph-cvm donor also baked dm-crypt.ko for its LUKS encrypted-rootfs mode;
   # that mode is out of scope for this backport (design section 6 non-goals),
   # so dm-crypt is deliberately NOT included. See rust-port-divergences.
-  modDir = "${kernel}/lib/modules/${kernel.modDirVersion}/kernel";
+  modDir = "${kernel.modules}/lib/modules/${kernel.modDirVersion}/kernel";
   dmModules = pkgs.runCommand "dm-modules" {
     nativeBuildInputs = [ pkgs.xz ];
   } ''
     mkdir -p $out
-    xz -d -k -c ${modDir}/drivers/dax/dax.ko.xz > $out/dax.ko
     xz -d -k -c ${modDir}/drivers/md/dm-mod.ko.xz > $out/dm-mod.ko
     xz -d -k -c ${modDir}/drivers/md/dm-bufio.ko.xz > $out/dm-bufio.ko
     xz -d -k -c ${modDir}/drivers/md/dm-verity.ko.xz > $out/dm-verity.ko
@@ -68,7 +70,6 @@ pkgs.makeInitrd {
     { object = "${staticCryptsetup}/bin/veritysetup"; symlink = "/bin/veritysetup"; }
     { object = "${staticNft}/bin/nft"; symlink = "/bin/nft"; }
     # dm-verity kernel modules (loaded by init.sh).
-    { object = "${dmModules}/dax.ko"; symlink = "/lib/modules/dax.ko"; }
     { object = "${dmModules}/dm-mod.ko"; symlink = "/lib/modules/dm-mod.ko"; }
     { object = "${dmModules}/dm-bufio.ko"; symlink = "/lib/modules/dm-bufio.ko"; }
     { object = "${dmModules}/dm-verity.ko"; symlink = "/lib/modules/dm-verity.ko"; }


### PR DESCRIPTION
## What

Re-pins the measured-guest flake's nixpkgs input from `nixos-24.11` (EOL, frozen at a June 2025 rev) to current stable `nixos-26.05` and refreshes `flake.lock`.

## Why

The EOL pin could never advance again, freezing the guest kernel at 6.6.94 and edk2 below 202505. This is the enabling step for the guest-kernel CVE fixes in the stacked PRs above this one; on its own it moves the same 6.6 kernel line to 6.6.151 and edk2 to 202602 (covers the OVMF fixes the SEV-SNP audit calls for, findings E-1/E-2).

## Consequences

The launch measurement changes (kernel/OVMF bits change), `measurement.hex` is recomputed by the flake. There is no backward compatibility to preserve yet; deployed image tarballs must be rebuilt once the stack lands.

Stack: PR 1/5 (base of `od/nix-sev-snp-measure-unpin` → `od/nix-guest-kernel-6-12` → `od/nix-guest-no-ia32` → `od/nix-kernel-floor-assert`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)