### PR TITLE
fix(nix): move the SNP guest kernel from LTS 6.6 to LTS 6.12

### DIFF
--- a/nix/kernel.nix
+++ b/nix/kernel.nix
@@ -1,6 +1,10 @@
 { pkgs, lib, ... }:
 
-pkgs.linuxPackages_6_6.kernel.override {
+# LTS 6.12, not 6.6: the #VC-handler hardening against malicious-hypervisor
+# interrupt/exception injection (HECKLER CVE-2024-25743/25744, WeSee
+# CVE-2024-25742) landed in 6.7-rc5/6.9-rc1 and was never backported to 6.6,
+# and the pvalidate cache-line-eviction fix (CVE-2025-38560) needs >= 6.12.93.
+pkgs.linuxPackages_6_12.kernel.override {
   structuredExtraConfig = with lib.kernel; {
     # SEV-SNP guest support (mkForce to override base config "m" → "y")
     AMD_MEM_ENCRYPT = lib.mkForce yes;


### PR DESCRIPTION
## What

Switches the measured guest kernel from `linuxPackages_6_6` to `linuxPackages_6_12` (6.12.103 on the new pin).

## Why

Linux 6.6 predates guest-kernel mitigations at the core of the CVM threat model, and none of them were backported to 6.6:

- **HECKLER (CVE-2024-25743/25744) and WeSee (CVE-2024-25742)**: #VC-handler hardening against malicious-hypervisor interrupt/exception injection, landed 6.7-rc5 / 6.9-rc1 (audit findings C-1/C-2/E-7).
- **CVE-2025-38560**: pvalidate cache-line-eviction fix, in 6.12.x since 6.12.93 (audit finding E-5).

## Consequences

The launch measurement changes; `measurement.hex` is recomputed by the flake and downstream pins must be refreshed (no backward compatibility to preserve yet).

Stack: PR 3/5 on the sev-snp-measure unpin PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)