### PR TITLE
feat(nix): compile 32-bit syscall entry paths out of the guest kernel

### DIFF
--- a/nix/kernel.nix
+++ b/nix/kernel.nix
@@ -54,6 +54,15 @@ pkgs.linuxPackages_6_12.kernel.override {
     FORTIFY_SOURCE = lib.mkForce yes;
     HARDENED_USERCOPY = lib.mkForce yes;
 
+    # Compile out the 32-bit syscall entry paths entirely. Since 6.9 the
+    # kernel disables them at runtime on SEV/TDX guests (the CVE-2024-25744
+    # mitigation for HECKLER-style int 0x80 injection); removing the code
+    # from the build makes that stance unbypassable and shrinks the #VC
+    # attack surface. The guest userland is 64-bit-only static musl, so
+    # nothing needs compat.
+    IA32_EMULATION = lib.mkForce no;
+    X86_X32_ABI = lib.mkForce no;
+
     # Note: MODULES left as default (yes) to avoid interactive config questions.
     # For a minimal production kernel, use a fully custom .config instead.
   };


### PR DESCRIPTION
## What

Adds `IA32_EMULATION = no` and `X86_X32_ABI = no` to the guest kernel config, removing the 32-bit/compat syscall entry paths from the build. Verified in the generated .config (`CONFIG_IA32_EMULATION is not set`, `CONFIG_X86_X32_ABI is not set`).

## Why

Since 6.9 the kernel runtime-disables int 0x80 entry on SEV/TDX guests (the CVE-2024-25744 HECKLER mitigation). Compiling the paths out makes that stance unbypassable (no cmdline/sysctl reopens them) and shrinks the #VC attack surface. The guest userland is 64-bit-only static musl; nothing needs compat. Audit finding C-1.

Stack: PR 4/5 on #1119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)