### PR TITLE
fix(nix): move the SNP guest kernel from LTS 6.12 to LTS 6.18

### DIFF
--- a/nix/init.sh
+++ b/nix/init.sh
@@ -194,7 +194,6 @@ prepare_chroot() {
 # networking above).
 setup_firewall() {
     /bin/busybox insmod /lib/modules/nfnetlink.ko 2>&1 || echo "init: warning: insmod nfnetlink.ko failed"
-    /bin/busybox insmod /lib/modules/libcrc32c.ko 2>&1 || echo "init: warning: insmod libcrc32c.ko failed"
     /bin/busybox insmod /lib/modules/nf_tables.ko 2>&1 || echo "init: warning: insmod nf_tables.ko failed"
     if /bin/nft -f - <<'NFT'
 table inet filter {

--- a/nix/initrd.nix
+++ b/nix/initrd.nix
@@ -47,16 +47,16 @@ let
 
   # nftables kernel modules for the guest firewall. NF_TABLES is =m in the
   # kernel config (NETFILTER and NF_TABLES_INET are built in), so the guest
-  # firewall needs nf_tables.ko plus its two dependencies (from modules.dep:
-  # nf_tables.ko -> nfnetlink.ko, libcrc32c.ko). A stateless input filter
-  # (iif lo / tcp dport accept, drop policy) needs no conntrack module.
-  # Load order: nfnetlink -> libcrc32c -> nf_tables.
+  # firewall needs nf_tables.ko plus its dependency (from modules.dep:
+  # nf_tables.ko -> nfnetlink.ko). libcrc32c.ko is gone: kernels >= 6.15
+  # removed it and provide crc32c as a built-in library (NET_CRC32C=y here).
+  # A stateless input filter (iif lo / tcp dport accept, drop policy) needs
+  # no conntrack module. Load order: nfnetlink -> nf_tables.
   nftModules = pkgs.runCommand "nft-modules" {
     nativeBuildInputs = [ pkgs.xz ];
   } ''
     mkdir -p $out
     xz -d -k -c ${modDir}/net/netfilter/nfnetlink.ko.xz > $out/nfnetlink.ko
-    xz -d -k -c ${modDir}/lib/libcrc32c.ko.xz > $out/libcrc32c.ko
     xz -d -k -c ${modDir}/net/netfilter/nf_tables.ko.xz > $out/nf_tables.ko
   '';
 in
@@ -75,7 +75,6 @@ pkgs.makeInitrd {
     { object = "${dmModules}/dm-verity.ko"; symlink = "/lib/modules/dm-verity.ko"; }
     # netfilter modules for the guest firewall (loaded by init.sh).
     { object = "${nftModules}/nfnetlink.ko"; symlink = "/lib/modules/nfnetlink.ko"; }
-    { object = "${nftModules}/libcrc32c.ko"; symlink = "/lib/modules/libcrc32c.ko"; }
     { object = "${nftModules}/nf_tables.ko"; symlink = "/lib/modules/nf_tables.ko"; }
   ];
 }

--- a/nix/kernel.nix
+++ b/nix/kernel.nix
@@ -1,10 +1,15 @@
 { pkgs, lib, ... }:
 
-# LTS 6.12, not 6.6: the #VC-handler hardening against malicious-hypervisor
-# interrupt/exception injection (HECKLER CVE-2024-25743/25744, WeSee
-# CVE-2024-25742) landed in 6.7-rc5/6.9-rc1 and was never backported to 6.6,
-# and the pvalidate cache-line-eviction fix (CVE-2025-38560) needs >= 6.12.93.
-pkgs.linuxPackages_6_12.kernel.override {
+# LTS 6.18 (the 2025 LTS line), not 6.6 or 6.12: the #VC-handler hardening
+# against malicious-hypervisor interrupt/exception injection (HECKLER
+# CVE-2024-25743/25744, WeSee CVE-2024-25742) landed in 6.7-rc5/6.9-rc1 and
+# was never backported to 6.6, and the pvalidate cache-line-eviction fix
+# (CVE-2025-38560) landed in mainline before 6.18.0 (6.12 needed the
+# 6.12.93 backport). 6.12 reaches EOL around Dec 2026; 6.18 is maintained
+# until ~end of 2027. Newer non-LTS lines (7.x) add nothing from that list
+# and would EOL under us within months, recreating the frozen-EOL-kernel
+# failure mode the nixos-26.05 re-pin fixed.
+pkgs.linuxPackages_6_18.kernel.override {
   structuredExtraConfig = with lib.kernel; {
     # SEV-SNP guest support (mkForce to override base config "m" → "y")
     AMD_MEM_ENCRYPT = lib.mkForce yes;


### PR DESCRIPTION
## What

Moves the measured guest kernel from `linuxPackages_6_12` (merged in #1119) to `linuxPackages_6_18` (6.18.44 on nixos-26.05), and drops `libcrc32c.ko` from the initrd and the init.sh firewall load sequence: kernels >= 6.15 removed it (crc32c is a built-in library now, `NET_CRC32C=y`), so `nf_tables.ko` depends only on `nfnetlink.ko`.

## Why 6.18 and not 6.12 or 7.x

- 6.12 reaches EOL around Dec 2026, which would soon recreate the frozen-EOL-kernel failure mode the nixos-26.05 re-pin (#1117) just fixed.
- 6.18 is the 2025 LTS line (maintained until ~end of 2027) and 6.18.0 already carries every guest-side fix on the audit list (HECKLER/WeSee #VC-handler hardening, pvalidate cache-line-eviction fix).
- Non-LTS 7.x lines add nothing from that list and EOL within months of the next release, trading nothing for a forced-rebump treadmill where every bump changes the launch measurement.

## Consequences

Launch measurement changes; `measurement.hex` regenerates in-flake, downstream pins must be refreshed.

Stacked on #1120; the floor assertion (#1121) sits on top and now asserts >= 6.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)