### PR TITLE
feat(vprogram): add --exec to the bundle CLI manifest subcommand

### DIFF
--- a/scripts/vprogram_bundle.py
+++ b/scripts/vprogram_bundle.py
@@ -9,7 +9,7 @@ item hash, which only exists after uploading):
      -> DIR/snp-image.tar.gz + DIR/bundle-info.json; upload the tarball with
         the printed `aleph file upload` command and note the item hash.
   2. python scripts/vprogram_bundle.py manifest --bundle-info DIR/bundle-info.json \
-         --bundle-ref ITEM_HASH --name NAME --runtime-version VERSION
+         --bundle-ref ITEM_HASH --name NAME --runtime-version VERSION [--exec]
      -> DIR/manifest.json; upload it. Its STORE item hash is what V-PROGRAM
         messages pin as runtime.ref.
 
@@ -101,7 +101,11 @@ def cmd_manifest(args: argparse.Namespace) -> int:
     else:
         print(f"note: {tar_path} not found, skipping bundle cross-check")  # noqa: T201
     manifest = make_manifest(
-        info=info, bundle_ref=args.bundle_ref, name=args.name, runtime_version=args.runtime_version
+        info=info,
+        bundle_ref=args.bundle_ref,
+        name=args.name,
+        runtime_version=args.runtime_version,
+        exec_runtime=args.exec_runtime,
     )
     out: Path = args.out if args.out is not None else args.bundle_info.parent / MANIFEST_NAME
     out.write_text(manifest.to_canonical_json())
@@ -133,6 +137,13 @@ def main(argv: list[str] | None = None) -> int:
     p_manifest.add_argument("--name", required=True, help="runtime name, e.g. aleph-snp-attest")
     p_manifest.add_argument("--runtime-version", required=True, help="runtime version string, e.g. 2026.07.08")
     p_manifest.add_argument("--out", type=Path, default=None, help="manifest path (default: next to bundle-info)")
+    p_manifest.add_argument(
+        "--exec",
+        dest="exec_runtime",
+        action="store_true",
+        help="build the aleph.exec/1 workload-runtime manifest (workload_roothash in the "
+        "cmdline template) instead of the builtin no-workload form",
+    )
     p_manifest.set_defaults(func=cmd_manifest)
 
     args = parser.parse_args(argv)

--- a/tests/vprogram/test_cli.py
+++ b/tests/vprogram/test_cli.py
@@ -66,6 +66,30 @@ def test_build_then_manifest(image_dir: Path, tmp_path: Path) -> None:
     manifest = RuntimeManifest.model_validate_json((out / "manifest.json").read_text())
     assert manifest.bundle.ref == BUNDLE_REF
     assert manifest.boot.platform_roothash == ROOTHASH
+    # Without --exec the default stays the builtin no-workload runtime.
+    assert manifest.workload.contract == "aleph.builtin/1"
+    assert "{workload_roothash}" not in manifest.boot.cmdline_template
+
+
+def test_manifest_exec_runtime(image_dir: Path, tmp_path: Path) -> None:
+    out = tmp_path / "out"
+    assert _run("build", "--image-dir", str(image_dir), "--out", str(out)).returncode == 0
+    result = _run(
+        "manifest",
+        "--bundle-info",
+        str(out / "bundle-info.json"),
+        "--bundle-ref",
+        BUNDLE_REF,
+        "--name",
+        "aleph-snp-attest",
+        "--runtime-version",
+        "2026.08.18",
+        "--exec",
+    )
+    assert result.returncode == 0, result.stderr
+    manifest = RuntimeManifest.model_validate_json((out / "manifest.json").read_text())
+    assert manifest.workload.contract == "aleph.exec/1"
+    assert "{workload_roothash}" in manifest.boot.cmdline_template
 
 
 def test_manifest_rejects_tampered_bundle(image_dir: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Exposes `make_manifest`'s existing `exec_runtime` option as a `--exec` flag on `scripts/vprogram_bundle.py manifest`, producing the `aleph.exec/1` workload-runtime manifest (`{workload_roothash}` in the cmdline template). The default remains the builtin no-workload form, now locked in by an explicit assertion in the CLI test.

## Why

The 2026-08-18 runtime republish (kernel 6.18 image) needed the exec-form manifest and had to drive `make_manifest(exec_runtime=True)` by hand because the CLI only produced the builtin form. On current dev every V-PROGRAM message carries a workload, so the exec form is what a production republish actually publishes.

## Testing

`tests/vprogram/test_cli.py::test_manifest_exec_runtime` (subprocess end-to-end, no nix/network); full `tests/vprogram/` suite: 51 passed. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)