### PR TITLE
fix(nix): wait out link-local DAD before the guest's DHCPv6 solicit

### DIFF
--- a/nix/init.sh
+++ b/nix/init.sh
@@ -67,6 +67,22 @@ else
         # state and no DHCP firewall rule is needed.
         echo 0 > "/proc/sys/net/ipv6/conf/${iface}/disable_ipv6" 2>/dev/null || true
         echo 2 > "/proc/sys/net/ipv6/conf/${iface}/accept_ra" 2>/dev/null || true
+        # udhcpc6 needs a usable link-local source address and bails out with
+        # "can't get link-local IPv6 address" while the freshly created
+        # link-local is still tentative: the sysctl above (re-)enables IPv6
+        # moments before, so DAD (~1s) is still running when udhcpc6 starts
+        # (seen on the SNP testnet, run 32147657203). Wait for DAD to finish,
+        # bounded: v6 stays best-effort and a v6-less environment must not
+        # stall boot.
+        dad_tries=5
+        while [ "$dad_tries" -gt 0 ]; do
+            ll=$(/bin/busybox ip addr show dev "$iface" 2>/dev/null | /bin/busybox grep 'inet6 fe80' || true)
+            if [ -n "$ll" ] && ! echo "$ll" | /bin/busybox grep -q tentative; then
+                break
+            fi
+            dad_tries=$((dad_tries - 1))
+            /bin/busybox sleep 1
+        done
         /bin/busybox udhcpc6 -i "$iface" -q -n -t 5 -A 2 -s /bin/udhcpc6.script 2>&1 || echo "init: DHCPv6 failed on ${iface}; continuing IPv4-only"
     fi
 fi


### PR DESCRIPTION
Found by the first E2E IPv6 probe on the SNP testnet (aleph-testnets run 32147657203, guest console: `udhcpc6: can't get link-local IPv6 address` -> `init: DHCPv6 failed on eth0; continuing IPv4-only`).

init.sh flips `disable_ipv6=0` and calls `udhcpc6` immediately; the link-local created by that flip is still in DAD (~1s), and busybox udhcpc6 refuses to solicit without a usable link-local source address. The bounded failure path worked exactly as designed (IPv4-only, no boot stall), which is why every attested-call test stayed green while v6 silently never came up.

Diagnostics from the same run confirmed the rest of the chain is correct and waiting: dnsmasq serving the single-address DHCPv6 range on the tap, ndppd proxying the guest /124 on the uplink (`proxy eno... rule 2001:bc8:701:40e::60/124 iface vmtap4`), host route in place; the TEE-host-side probe of the guest v6 timed out (guest-side fault isolated), matching the missing lease.

Fix: bounded (5s) wait for a non-tentative link-local before the solicit; a v6-less environment still cannot stall boot.

Verification: shellcheck clean; `nix build ./nix#initrd` green. Runtime measurement shifts (init.sh is measured): needs a runtime rebuild + re-publish + measurement re-pin before the testnet can exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)