### PR TITLE
fix(nix): scope the udhcpc deconfig flush to IPv4

### DIFF
--- a/nix/udhcpc.script
+++ b/nix/udhcpc.script
@@ -34,7 +34,15 @@ mask2prefix() {
 # shellcheck disable=SC2154
 case "$1" in
     deconfig)
-        /bin/busybox ip addr flush dev "$interface" 2>/dev/null
+        # v4 only: udhcpc runs deconfig at STARTUP, and an unscoped flush
+        # also deletes the interface's IPv6 link-local, which the kernel
+        # only regenerates on a link bounce, never after a flush. udhcpc6
+        # (which runs right after the v4 lease, init.sh) needs that
+        # link-local as its solicit source address and bails with "can't
+        # get link-local IPv6 address" without it. Root cause of the
+        # guest-side IPv6 failure in aleph-testnets runs 32147657203 /
+        # 32164852981; reproduced and verified in a local qemu boot.
+        /bin/busybox ip -4 addr flush dev "$interface" 2>/dev/null
         /bin/busybox ip link set "$interface" up
         ;;
     bound | renew)


### PR DESCRIPTION
Follow-up to #1125, which treated a symptom: the real root cause of the guest's DHCPv6 failure is `udhcpc.script`'s startup `deconfig` doing an unscoped `ip addr flush`, deleting the IPv6 link-local the kernel had just created. The kernel never regenerates a link-local after a flush (only on a link bounce), so by the time `udhcpc6` runs there is no solicit source address, and it bails with `can't get link-local IPv6 address` regardless of the DAD wait, as testnets run 32164852981 showed.

Debugged by booting the published kernel+initrd in plain qemu (no SEV needed for the network init):
- reproduced the exact failure;
- proved a link bounce restores the link-local (kernel regenerates on down/up);
- bisected to the deconfig flush and verified `ip -4 addr flush` fixes it: link-local survives, DAD completes during the ~3s v4 exchange, udhcpc6 solicits normally (lease acquisition needs the real per-tap dnsmasq, exercised on the testnet).

The #1125 DAD wait stays: with the flush scoped it passes instantly, and it still guards the enable-then-solicit timing on its own.

Measurement impact: initrd content shifts; new runtime publish + fixture re-pin needed (same cycle as #1125).

🤖 Generated with [Claude Code](https://claude.com/claude-code)