### PR TITLE
feat(snp-instances) 2/4: LUKS guest image + instance runtime manifest

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -318,6 +318,13 @@
       instanceMeasurementSmoke = instanceMeasurementFor {
         owner = "0x0000000000000000000000000000000000000000";
       };
+
+      # Test fixture for the confidential-instance E2E scenario (Task 14): a
+      # plain ext4 rootfs booting a statically linked dropbear SSH server.
+      # NOT part of the measured chain (no dm-verity, not referenced by any
+      # cmdline roothash) and NOT bit-reproducible (build-time host key). See
+      # test-rootfs.nix for the full rationale.
+      instanceTestRootfs = pkgs.callPackage ./test-rootfs.nix {};
     in {
       # Only concrete derivations are exposed as packages (a function like
       # measurementFor is not a valid flake package and would fail flake check);
@@ -340,7 +347,8 @@
           workloadMeasurement
           image
           instanceImage
-          instanceMeasurementSmoke;
+          instanceMeasurementSmoke
+          instanceTestRootfs;
         default = image;
       };
 

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -125,6 +125,7 @@
       initrd = pkgs.callPackage ./initrd.nix {
         inherit attest-agent kernel;
         init-script = ./init.sh;
+        init-common-script = ./init-common.sh;
         udhcpc-script = ./udhcpc.script;
         udhcpc6-script = ./udhcpc6.script;
       };

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -288,7 +288,13 @@
       # a valid flake package); `instanceMeasurementSmoke` below gives it
       # build coverage so evaluation and the sev-snp-measure invocation are
       # never dead code.
-      instanceMeasurementFor = { vcpus ? 2, vcpuType ? "EPYC-v4", owner }: let
+      instanceMeasurementFor = { vcpus ? 2, vcpuType ? "EPYC-v4", owner }:
+        # `owner` is interpolated into the measured kernel cmdline (and thus a
+        # shell argument to sev-snp-measure); only trusted nix callers reach
+        # here, but assert the EVM-address shape so a stray value fails the
+        # build rather than producing a bogus measurement or injecting tokens.
+        assert (builtins.match "0x[0-9a-fA-F]{40}" owner) != null;
+        let
         kernelCmdline = "console=ttyS0 luks=1 owner=${owner}";
       in pkgs.runCommand "snp-instance-measurement-${toString vcpus}vcpus-${vcpuType}" {
         nativeBuildInputs = [ sev-snp-measure ];

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -7,9 +7,13 @@
   #   aleph-attest-agent static-musl binary and init.sh) + a minimal
   #   dm-verity-protected rootfs + a precomputed, reproducible sev-snp-measure
   #   launch measurement.
-  # Excluded from the donor: compose-rootfs / compose-demo and the
-  # encrypted-rootfs (LUKS) mode. The fib-service demo app is NOT excluded
-  # here: it now exists as the V-PROGRAM workload (see workload.nix), baked
+  # Excluded from the donor: compose-rootfs / compose-demo. The
+  # encrypted-rootfs (LUKS) mode returns as a second, separate image flavor
+  # for confidential instances (instanceInitrd / instanceImage below), built
+  # from the same initrd.nix with withVerity=false withNft=false withLuks=true;
+  # it does not touch the v-program image's measured initrd contents. The
+  # fib-service demo app is NOT excluded here: it now exists as the V-PROGRAM
+  # workload (see workload.nix), baked
   # into its own measured dm-verity volume that the guest init mounts and
   # execs when a workload_roothash is present on the cmdline. The trivial
   # busybox httpd remains the platform rootfs's baked /sbin/init, used as the
@@ -129,6 +133,21 @@
         udhcpc-script = ./udhcpc.script;
         udhcpc6-script = ./udhcpc6.script;
       };
+
+      # Confidential-instance initrd: LUKS encrypted rootfs, no dm-verity, no
+      # in-guest firewall (firewall policy belongs to the user rootfs on
+      # instances, design section 3 decision 6).
+      instanceInitrd = pkgs.callPackage ./initrd.nix {
+        inherit attest-agent kernel;
+        init-script = ./init-instance.sh;
+        init-common-script = ./init-common.sh;
+        udhcpc-script = ./udhcpc.script;
+        udhcpc6-script = ./udhcpc6.script;
+        withVerity = false;
+        withNft = false;
+        withLuks = true;
+      };
+
       rootfs = pkgs.callPackage ./rootfs.nix {};
 
       # fib-service V-PROGRAM workload volume: a content-only ext4 carrying the
@@ -257,6 +276,31 @@
         cp ${verity}/hashtree $out/rootfs.ext4.verity
         cp ${verity}/roothash $out/rootfs.ext4.roothash
       '';
+
+      # Per-deployment measurement helper for the instance image: the owner
+      # address is a measured cmdline slot, so there is no fixed baked
+      # measurement (unlike the v-program image). Internal, like measurementFor.
+      instanceMeasurementFor = { vcpus ? 2, vcpuType ? "EPYC-v4", owner }: let
+        kernelCmdline = "console=ttyS0 luks=1 owner=${owner}";
+      in pkgs.runCommand "snp-instance-measurement-${toString vcpus}vcpus-${vcpuType}" {
+        nativeBuildInputs = [ sev-snp-measure ];
+      } ''
+        sev-snp-measure --mode snp --vcpus ${toString vcpus} --vcpu-type ${vcpuType} \
+          --ovmf ${ovmfFd} --kernel ${kernel}/bzImage --initrd ${instanceInitrd}/initrd \
+          --append "${kernelCmdline}" | tr -d '\n' > $out
+      '';
+
+      # Confidential-instance image artifacts: OVMF firmware, kernel and
+      # initrd only. Unlike `image`, there is no rootfs and no baked
+      # measurement.hex: the LUKS-encrypted rootfs is provided by the caller
+      # at launch time (whole-device LUKS2 on /dev/vda) and the measurement
+      # depends on the per-deployment owner address (instanceMeasurementFor).
+      instanceImage = pkgs.runCommand "aleph-snp-instance-image" {} ''
+        mkdir -p $out
+        ln -s ${kernel}/bzImage $out/bzImage
+        ln -s ${instanceInitrd}/initrd $out/initrd
+        cp ${ovmfFd} $out/OVMF.fd
+      '';
     in {
       # Only concrete derivations are exposed as packages (a function like
       # measurementFor is not a valid flake package and would fail flake check);
@@ -269,6 +313,7 @@
           ovmf
           kernel
           initrd
+          instanceInitrd
           rootfs
           verity
           workloadImage
@@ -276,7 +321,8 @@
           workload
           measurement
           workloadMeasurement
-          image;
+          image
+          instanceImage;
         default = image;
       };
     };

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -279,7 +279,15 @@
 
       # Per-deployment measurement helper for the instance image: the owner
       # address is a measured cmdline slot, so there is no fixed baked
-      # measurement (unlike the v-program image). Internal, like measurementFor.
+      # measurement (unlike the v-program image). Unlike `measurementFor`
+      # (which callers only ever reach by importing this flake file
+      # directly), Tasks 8/11/13 call this one from ordinary flake
+      # consumers (the daemon's launch path, tests), so it is also exposed
+      # below as `lib.${system}.instanceMeasurementFor`. Its mandatory
+      # `owner` argument still keeps it out of `packages` (a function is not
+      # a valid flake package); `instanceMeasurementSmoke` below gives it
+      # build coverage so evaluation and the sev-snp-measure invocation are
+      # never dead code.
       instanceMeasurementFor = { vcpus ? 2, vcpuType ? "EPYC-v4", owner }: let
         kernelCmdline = "console=ttyS0 luks=1 owner=${owner}";
       in pkgs.runCommand "snp-instance-measurement-${toString vcpus}vcpus-${vcpuType}" {
@@ -301,6 +309,15 @@
         ln -s ${instanceInitrd}/initrd $out/initrd
         cp ${ovmfFd} $out/OVMF.fd
       '';
+
+      # Build-covers instanceMeasurementFor with a fixed placeholder owner
+      # address: a plain `inherit` cannot expose a function through
+      # `packages` (see above), so nothing would otherwise evaluate its body
+      # or invoke sev-snp-measure. `nix build ./nix#instanceMeasurementSmoke`
+      # exercises exactly that.
+      instanceMeasurementSmoke = instanceMeasurementFor {
+        owner = "0x0000000000000000000000000000000000000000";
+      };
     in {
       # Only concrete derivations are exposed as packages (a function like
       # measurementFor is not a valid flake package and would fail flake check);
@@ -322,8 +339,18 @@
           measurement
           workloadMeasurement
           image
-          instanceImage;
+          instanceImage
+          instanceMeasurementSmoke;
         default = image;
+      };
+
+      # instanceMeasurementFor takes a mandatory `owner` argument, so unlike
+      # the packages above it cannot be a flake package; expose it here so
+      # Tasks 8/11/13 (and any other flake consumer, not just direct
+      # importers of this file) can call
+      # `(builtins.getFlake ...).lib.${system}.instanceMeasurementFor { ... }`.
+      lib.${system} = {
+        inherit instanceMeasurementFor;
       };
     };
 }

--- a/nix/init-common.sh
+++ b/nix/init-common.sh
@@ -1,0 +1,180 @@
+#!/bin/busybox sh
+# /bin/init-common.sh - shared prologue sourced by both measured-guest inits
+# (nix/init.sh for the platform image, nix/init-instance.sh for instances).
+#
+# Sourced with `. /bin/init-common.sh` from busybox sh, so this runs in the
+# caller's own shell: everything below runs immediately, in order, at source
+# time, right through the DHCPv6 block, and plain (non-`local`) assignments
+# (e.g. $iface, $gateway) stay set in the caller after the source returns.
+# The functions defined at the end (wait_for_rootfs_blkdev, wait_for_dev,
+# prepare_chroot) are only defined here; the caller decides when to call them.
+
+# Mount essential filesystems.
+/bin/busybox mount -t proc proc /proc
+/bin/busybox mount -t sysfs sysfs /sys
+/bin/busybox mount -t devtmpfs devtmpfs /dev
+/bin/busybox mkdir -p /etc /tmp
+
+# Bring up loopback.
+/bin/busybox ip link set lo up
+
+# Wait for a network interface to appear (virtio-net may take a moment).
+n=0
+while [ "$n" -lt 30 ]; do
+    iface=$(/bin/busybox ls /sys/class/net/ | /bin/busybox grep -v lo | /bin/busybox head -1)
+    if [ -n "$iface" ]; then
+        break
+    fi
+    /bin/busybox sleep 0.1
+    n=$((n + 1))
+done
+
+if [ -z "$iface" ]; then
+    echo "init: no network interface found"
+else
+    # Parse ip= from kernel command line: ip=<client>:::<gateway>:<mask>::<iface>:off
+    kernel_ip=$(/bin/busybox sed -n 's/.*ip=\([^ ]*\).*/\1/p' /proc/cmdline)
+    if [ -n "$kernel_ip" ]; then
+        client_ip=$(echo "$kernel_ip" | /bin/busybox cut -d: -f1)
+        gateway=$(echo "$kernel_ip" | /bin/busybox cut -d: -f4)
+        mask=$(echo "$kernel_ip" | /bin/busybox cut -d: -f5)
+        echo "init: static IP ${client_ip}/${mask} gw ${gateway} on ${iface}"
+        /bin/busybox ip link set "$iface" up
+        /bin/busybox ip addr add "${client_ip}/${mask}" dev "$iface"
+        /bin/busybox ip route add default via "$gateway"
+    else
+        echo "init: bringing up ${iface} via DHCP"
+        /bin/busybox ip link set "$iface" up
+        # -s: busybox udhcpc leases an address but only APPLIES it (ip addr/route)
+        # by running this script; without it the guest would lease from the host's
+        # per-tap dnsmasq but never configure its IP. See udhcpc.script.
+        /bin/busybox udhcpc -i "$iface" -q -n -t 5 -A 2 -s /bin/udhcpc.script 2>&1 || echo "init: DHCP failed on ${iface}"
+
+        # IPv6: stateful DHCPv6 from the same per-tap dnsmasq that served the
+        # IPv4 lease above, handing this guest EXACTLY its allocated
+        # /124-scheme address; the default route comes from the kernel
+        # processing that dnsmasq's Router Advertisements (DHCPv6 cannot
+        # convey routes). Never a kernel-cmdline address: baking the per-VM
+        # address into the measured cmdline would break the publisher's
+        # precomputed SNP measurement, the exact reason the IPv4 path above
+        # uses DHCP. accept_ra=2 keeps RA processing on regardless of
+        # forwarding settings; both sysctls are best-effort (a v6-less
+        # kernel stays IPv4-only). The client is bounded and non-fatal like
+        # udhcpc above: `-n` makes it exit 1 (instead of retrying forever)
+        # once its solicit retries are exhausted, so `||` below always runs
+        # and the guest simply stays IPv4-only when no DHCPv6 server answers.
+        # -q exits after the lease (the script applies the address
+        # permanently), so no client survives into the firewalled steady
+        # state and no DHCP firewall rule is needed.
+        echo 0 > "/proc/sys/net/ipv6/conf/${iface}/disable_ipv6" 2>/dev/null || true
+        echo 2 > "/proc/sys/net/ipv6/conf/${iface}/accept_ra" 2>/dev/null || true
+        # udhcpc6 needs a usable link-local source address and bails out with
+        # "can't get link-local IPv6 address" while the freshly created
+        # link-local is still tentative: the sysctl above (re-)enables IPv6
+        # moments before, so DAD (~1s) is still running when udhcpc6 starts
+        # (seen on the SNP testnet, run 32147657203). Wait for DAD to finish,
+        # bounded: v6 stays best-effort and a v6-less environment must not
+        # stall boot.
+        dad_tries=5
+        while [ "$dad_tries" -gt 0 ]; do
+            ll=$(/bin/busybox ip addr show dev "$iface" 2>/dev/null | /bin/busybox grep 'inet6 fe80' || true)
+            if [ -n "$ll" ] && ! echo "$ll" | /bin/busybox grep -q tentative; then
+                break
+            fi
+            dad_tries=$((dad_tries - 1))
+            /bin/busybox sleep 1
+        done
+        /bin/busybox udhcpc6 -i "$iface" -q -n -t 5 -A 2 -s /bin/udhcpc6.script 2>&1 || echo "init: DHCPv6 failed on ${iface}; continuing IPv4-only"
+    fi
+fi
+
+# Wait for the rootfs block device to appear, scanning /dev/vda then
+# /dev/sda on each pass (30 x 0.1s, i.e. up to 3s). Sets $blkdev to the
+# device found; leaves it empty on timeout. The CALLER decides fatality
+# (both inits poweroff on empty), so this function only reshapes the wait
+# loop, it does not exec poweroff itself.
+wait_for_rootfs_blkdev() {
+    blkdev=""
+    n=0
+    while [ "$n" -lt 30 ]; do
+        for dev in /dev/vda /dev/sda; do
+            if [ -b "$dev" ]; then
+                # shellcheck disable=SC2034  # blkdev is consumed by the caller (init.sh), not here
+                blkdev="$dev"
+                return 0
+            fi
+        done
+        /bin/busybox sleep 0.1
+        n=$((n + 1))
+    done
+}
+
+# Wait (up to 3s) for a block device to appear, e.g. a dm-verity hash tree
+# disk attached by QEMU as an extra virtio-blk device. Used for both the
+# platform hash tree (/dev/vdb) and the workload data + hash tree devices
+# (/dev/vdc, /dev/vdd) below, so each disk is waited for explicitly instead
+# of assuming a single fixed device name.
+wait_for_dev() {
+    local dev n
+    dev="$1"
+    n=0
+    while [ "$n" -lt 30 ]; do
+        if [ -b "$dev" ]; then
+            return 0
+        fi
+        /bin/busybox sleep 0.1
+        n=$((n + 1))
+    done
+    return 1
+}
+
+# Prepare a chroot environment: bind-mount /proc, /sys, /dev, the secret dir,
+# and set up DNS in the given target. Called with the chroot that will
+# actually run its /sbin/init (/mnt/workload when a V-PROGRAM workload volume
+# is mounted, /mnt/root otherwise), after mounting it.
+#
+# The target is mounted read-only under dm-verity, so the mkdirs below cannot
+# create anything there: the mount-point directories (and the resolv.conf
+# placeholder file) are shipped in the image (rootfs.nix / workload.nix) and
+# the mkdirs no-op. They only do real work on the legacy writable-mount path.
+prepare_chroot() {
+    local target
+    target="$1"
+    /bin/busybox mkdir -p "$target/proc" "$target/sys" "$target/dev" "$target/etc"
+    /bin/busybox mount --bind /proc "$target/proc"
+    /bin/busybox mount --bind /sys "$target/sys"
+    /bin/busybox mount --bind /dev "$target/dev"
+    # Secret delivery: the attest-agent writes injected secrets under /tmp/secrets
+    # in THIS (initramfs) mount namespace, but the workload runs chrooted into
+    # the target, where /tmp/secrets is a different filesystem. Bind-mount the
+    # agent's secret dir into the chroot so the app reads exactly what the agent
+    # writes. The source path matches the agent's DEFAULT_SECRETS_DIR
+    # (/tmp/secrets in secrets.rs); pre-create it 0700 so the agent's hardened
+    # directory check accepts it (real dir, agent-owned, owner-only).
+    /bin/busybox mkdir -m 0700 -p /tmp/secrets
+    /bin/busybox mkdir -m 0700 -p "$target/tmp/secrets"
+    /bin/busybox mount --bind /tmp/secrets "$target/tmp/secrets"
+    # DNS for the chrooted workload. The target is mounted read-only under
+    # dm-verity, so writing its /etc/resolv.conf directly cannot work
+    # there (the old `echo >` only ever worked on legacy writable mounts).
+    # Instead, expose the initramfs /etc/resolv.conf (written by udhcpc.script
+    # from the DHCP option-6 nameservers) via a file bind-mount over the
+    # image's placeholder. On the static ip= path there is no DHCP lease, so
+    # seed the initramfs copy from the gateway first (common for VM bridges).
+    if [ ! -f /etc/resolv.conf ] && [ -n "$gateway" ]; then
+        /bin/busybox mkdir -p /etc
+        echo "nameserver ${gateway}" > /etc/resolv.conf
+    fi
+    if [ -f /etc/resolv.conf ]; then
+        if [ -f "$target/etc/resolv.conf" ]; then
+            /bin/busybox mount --bind /etc/resolv.conf "$target/etc/resolv.conf" \
+                || echo "init: WARNING: resolv.conf bind-mount failed; workload DNS unavailable"
+        else
+            # Legacy image without the placeholder: best-effort copy (works
+            # only if the target is mounted writable).
+            /bin/busybox cp /etc/resolv.conf "$target/etc/resolv.conf" 2>/dev/null \
+                || echo "init: WARNING: ${target} has no /etc/resolv.conf placeholder; workload DNS unavailable"
+        fi
+    fi
+    echo "init: chroot environment prepared at ${target} (proc, sys, dev, secrets, DNS)"
+}

--- a/nix/init-instance.sh
+++ b/nix/init-instance.sh
@@ -52,7 +52,13 @@ zeroize_passphrase() {
 echo "init: waiting for LUKS passphrase at /tmp/secrets/luks_passphrase (no timeout)"
 waited=0
 while true; do
-    if [ -f /tmp/secrets/luks_passphrase ]; then
+    # The agent writes the passphrase atomically (temp file + rename() into
+    # place), so this poll never has to worry about landing mid-write; [ -s ]
+    # (non-empty, not just present) is defense in depth against a legacy or
+    # third-party agent build that writes create+truncate-then-write_all,
+    # where a poll landing right after the truncate would otherwise see an
+    # empty file and feed cryptsetup zero bytes.
+    if [ -s /tmp/secrets/luks_passphrase ]; then
         echo "init: unlocking LUKS volume on ${blkdev}"
         if /bin/cryptsetup luksOpen "$blkdev" cryptroot < /tmp/secrets/luks_passphrase 2>&1; then
             zeroize_passphrase

--- a/nix/init-instance.sh
+++ b/nix/init-instance.sh
@@ -86,7 +86,14 @@ if [ -x /mnt/root/sbin/init ]; then
     echo "init: starting /sbin/init from rootfs"
     /bin/busybox chroot /mnt/root /sbin/init &
 else
-    echo "init: WARNING: no /sbin/init found in rootfs"
+    # A missing /sbin/init means the owner's decrypted rootfs is malformed
+    # (the same failure class as a v-program workload with no /sbin/init, which
+    # also powers off). Fail closed rather than leaving a RUNNING-but-useless VM
+    # that looks healthy: the FATAL line is captured on the guest serial (owner-
+    # readable via the logs endpoint), and a STOPPED VM is an unambiguous signal
+    # to redeploy a fixed rootfs.
+    echo "init: FATAL: no /sbin/init in the unlocked rootfs (malformed user image)"
+    exec /bin/busybox poweroff -f
 fi
 
 # Wait for children (the attest-agent keeps serving re-attestation for the

--- a/nix/init-instance.sh
+++ b/nix/init-instance.sh
@@ -1,0 +1,89 @@
+#!/bin/busybox sh
+# /init for the SNP confidential-INSTANCE image: LUKS encrypted-rootfs boot.
+#
+# The owner verifies the launch measurement over attested TLS, then injects
+# the LUKS passphrase (EIP-191 owner-signed, enforced by the attest-agent's
+# --owner mode). The init waits INDEFINITELY: a host reboot re-enters this
+# wait until the owner re-injects. A wrong passphrase zeroizes the attempt
+# and resumes waiting (the agent allows authenticated re-injection).
+# No guest firewall in this mode: firewall policy belongs to the user rootfs,
+# as on classic instances (design section 3, decision 6).
+
+# shellcheck disable=SC1091  # /bin/init-common.sh only exists inside the initrd
+. /bin/init-common.sh
+
+# Parse the luks-mode cmdline (normative template: console=ttyS0 luks=1
+# owner=0x<40 hex>). This image boots ONLY in luks mode: fail closed on
+# anything else rather than half-boot an unmeasurable configuration.
+luks=$(/bin/busybox sed -n 's/.*\bluks=\([^ ]*\).*/\1/p' /proc/cmdline)
+owner=$(/bin/busybox sed -n 's/.*\bowner=\(0x[0-9a-fA-F]*\).*/\1/p' /proc/cmdline)
+if [ "$luks" != "1" ] || [ -z "$owner" ]; then
+    echo "init: FATAL: instance image booted without luks=1 owner=0x... cmdline"
+    exec /bin/busybox poweroff -f
+fi
+
+echo "init: loading dm-crypt kernel modules"
+/bin/busybox insmod /lib/modules/dm-mod.ko 2>&1 || echo "init: warning: insmod dm-mod.ko failed"
+/bin/busybox insmod /lib/modules/dm-crypt.ko 2>&1 || echo "init: warning: insmod dm-crypt.ko failed"
+/bin/busybox mkdir -p /dev/mapper /run/cryptsetup
+/bin/busybox mknod /dev/mapper/control c 10 236 2>/dev/null
+
+wait_for_rootfs_blkdev
+if [ -z "$blkdev" ]; then
+    echo "init: FATAL: no block device found"
+    exec /bin/busybox poweroff -f
+fi
+
+# Start the attestation agent EARLY, in owner-auth mode, so the owner can
+# verify and inject the passphrase. 0700 pre-creation matches the agent's
+# hardened directory check.
+/bin/busybox mkdir -m 0700 -p /tmp/secrets
+echo "init: starting attestation agent (owner-auth mode, owner=${owner})"
+/bin/aleph-attest-agent --port 8443 --upstream http://127.0.0.1:8080 --owner "$owner" &
+
+zeroize_passphrase() {
+    size=$(/bin/busybox stat -c%s /tmp/secrets/luks_passphrase 2>/dev/null)
+    if [ -n "$size" ]; then
+        /bin/busybox dd if=/dev/zero of=/tmp/secrets/luks_passphrase bs=1 count="$size" conv=notrunc 2>/dev/null
+    fi
+    /bin/busybox rm -f /tmp/secrets/luks_passphrase
+}
+
+echo "init: waiting for LUKS passphrase at /tmp/secrets/luks_passphrase (no timeout)"
+waited=0
+while true; do
+    if [ -f /tmp/secrets/luks_passphrase ]; then
+        echo "init: unlocking LUKS volume on ${blkdev}"
+        if /bin/cryptsetup luksOpen "$blkdev" cryptroot < /tmp/secrets/luks_passphrase 2>&1; then
+            zeroize_passphrase
+            break
+        fi
+        zeroize_passphrase
+        echo "init: cryptsetup luksOpen failed (wrong passphrase or corrupt header); waiting for a new injection"
+    fi
+    /bin/busybox sleep 1
+    waited=$((waited + 1))
+    if [ $((waited % 60)) -eq 0 ]; then
+        echo "init: still waiting for LUKS passphrase (${waited}s)"
+    fi
+done
+
+/bin/busybox mkdir -p /mnt/root
+echo "init: mounting /dev/mapper/cryptroot"
+if ! /bin/busybox mount -t ext4 /dev/mapper/cryptroot /mnt/root; then
+    echo "init: FATAL: failed to mount /dev/mapper/cryptroot"
+    exec /bin/busybox poweroff -f
+fi
+
+prepare_chroot /mnt/root
+if [ -x /mnt/root/sbin/init ]; then
+    echo "init: starting /sbin/init from rootfs"
+    /bin/busybox chroot /mnt/root /sbin/init &
+else
+    echo "init: WARNING: no /sbin/init found in rootfs"
+fi
+
+# Wait for children (the attest-agent keeps serving re-attestation for the
+# VM's lifetime; the initramfs /tmp/secrets is invisible to the chroot except
+# through prepare_chroot's bind mount).
+wait

--- a/nix/init.sh
+++ b/nix/init.sh
@@ -7,85 +7,12 @@
 # core measured-boot chain: bring up networking, verify + mount the
 # dm-verity-protected rootfs (or plain-mount if no roothash), chroot into it,
 # and start the attestation agent. See rust-port-divergences.
+#
+# The mounts/networking prologue and the wait_for_rootfs_blkdev/wait_for_dev/
+# prepare_chroot helpers live in init-common.sh, shared with init-instance.sh.
 
-# Mount essential filesystems.
-/bin/busybox mount -t proc proc /proc
-/bin/busybox mount -t sysfs sysfs /sys
-/bin/busybox mount -t devtmpfs devtmpfs /dev
-/bin/busybox mkdir -p /etc /tmp
-
-# Bring up loopback.
-/bin/busybox ip link set lo up
-
-# Wait for a network interface to appear (virtio-net may take a moment).
-n=0
-while [ "$n" -lt 30 ]; do
-    iface=$(/bin/busybox ls /sys/class/net/ | /bin/busybox grep -v lo | /bin/busybox head -1)
-    if [ -n "$iface" ]; then
-        break
-    fi
-    /bin/busybox sleep 0.1
-    n=$((n + 1))
-done
-
-if [ -z "$iface" ]; then
-    echo "init: no network interface found"
-else
-    # Parse ip= from kernel command line: ip=<client>:::<gateway>:<mask>::<iface>:off
-    kernel_ip=$(/bin/busybox sed -n 's/.*ip=\([^ ]*\).*/\1/p' /proc/cmdline)
-    if [ -n "$kernel_ip" ]; then
-        client_ip=$(echo "$kernel_ip" | /bin/busybox cut -d: -f1)
-        gateway=$(echo "$kernel_ip" | /bin/busybox cut -d: -f4)
-        mask=$(echo "$kernel_ip" | /bin/busybox cut -d: -f5)
-        echo "init: static IP ${client_ip}/${mask} gw ${gateway} on ${iface}"
-        /bin/busybox ip link set "$iface" up
-        /bin/busybox ip addr add "${client_ip}/${mask}" dev "$iface"
-        /bin/busybox ip route add default via "$gateway"
-    else
-        echo "init: bringing up ${iface} via DHCP"
-        /bin/busybox ip link set "$iface" up
-        # -s: busybox udhcpc leases an address but only APPLIES it (ip addr/route)
-        # by running this script; without it the guest would lease from the host's
-        # per-tap dnsmasq but never configure its IP. See udhcpc.script.
-        /bin/busybox udhcpc -i "$iface" -q -n -t 5 -A 2 -s /bin/udhcpc.script 2>&1 || echo "init: DHCP failed on ${iface}"
-
-        # IPv6: stateful DHCPv6 from the same per-tap dnsmasq that served the
-        # IPv4 lease above, handing this guest EXACTLY its allocated
-        # /124-scheme address; the default route comes from the kernel
-        # processing that dnsmasq's Router Advertisements (DHCPv6 cannot
-        # convey routes). Never a kernel-cmdline address: baking the per-VM
-        # address into the measured cmdline would break the publisher's
-        # precomputed SNP measurement, the exact reason the IPv4 path above
-        # uses DHCP. accept_ra=2 keeps RA processing on regardless of
-        # forwarding settings; both sysctls are best-effort (a v6-less
-        # kernel stays IPv4-only). The client is bounded and non-fatal like
-        # udhcpc above: `-n` makes it exit 1 (instead of retrying forever)
-        # once its solicit retries are exhausted, so `||` below always runs
-        # and the guest simply stays IPv4-only when no DHCPv6 server answers.
-        # -q exits after the lease (the script applies the address
-        # permanently), so no client survives into the firewalled steady
-        # state and no DHCP firewall rule is needed.
-        echo 0 > "/proc/sys/net/ipv6/conf/${iface}/disable_ipv6" 2>/dev/null || true
-        echo 2 > "/proc/sys/net/ipv6/conf/${iface}/accept_ra" 2>/dev/null || true
-        # udhcpc6 needs a usable link-local source address and bails out with
-        # "can't get link-local IPv6 address" while the freshly created
-        # link-local is still tentative: the sysctl above (re-)enables IPv6
-        # moments before, so DAD (~1s) is still running when udhcpc6 starts
-        # (seen on the SNP testnet, run 32147657203). Wait for DAD to finish,
-        # bounded: v6 stays best-effort and a v6-less environment must not
-        # stall boot.
-        dad_tries=5
-        while [ "$dad_tries" -gt 0 ]; do
-            ll=$(/bin/busybox ip addr show dev "$iface" 2>/dev/null | /bin/busybox grep 'inet6 fe80' || true)
-            if [ -n "$ll" ] && ! echo "$ll" | /bin/busybox grep -q tentative; then
-                break
-            fi
-            dad_tries=$((dad_tries - 1))
-            /bin/busybox sleep 1
-        done
-        /bin/busybox udhcpc6 -i "$iface" -q -n -t 5 -A 2 -s /bin/udhcpc6.script 2>&1 || echo "init: DHCPv6 failed on ${iface}; continuing IPv4-only"
-    fi
-fi
+# shellcheck disable=SC1091  # /bin/init-common.sh only exists inside the initrd
+. /bin/init-common.sh
 
 # Parse boot mode from kernel command line.
 roothash=$(/bin/busybox sed -n 's/.*\broothash=\([0-9a-fA-F]*\).*/\1/p' /proc/cmdline)
@@ -98,95 +25,13 @@ roothash=$(/bin/busybox sed -n 's/.*\broothash=\([0-9a-fA-F]*\).*/\1/p' /proc/cm
 workload_roothash=$(/bin/busybox sed -n 's/.*\bworkload_roothash=\([0-9a-fA-F]*\).*/\1/p' /proc/cmdline)
 
 # Wait for the rootfs block device to appear.
-blkdev=""
-n=0
-while [ "$n" -lt 30 ]; do
-    for dev in /dev/vda /dev/sda; do
-        if [ -b "$dev" ]; then
-            blkdev="$dev"
-            break 2
-        fi
-    done
-    /bin/busybox sleep 0.1
-    n=$((n + 1))
-done
-
+wait_for_rootfs_blkdev
 if [ -z "$blkdev" ]; then
     echo "init: FATAL: no block device found"
     exec /bin/busybox poweroff -f
 fi
 
-# Wait (up to 3s) for a block device to appear, e.g. a dm-verity hash tree
-# disk attached by QEMU as an extra virtio-blk device. Used for both the
-# platform hash tree (/dev/vdb) and the workload data + hash tree devices
-# (/dev/vdc, /dev/vdd) below, so each disk is waited for explicitly instead
-# of assuming a single fixed device name.
-wait_for_dev() {
-    local dev n
-    dev="$1"
-    n=0
-    while [ "$n" -lt 30 ]; do
-        if [ -b "$dev" ]; then
-            return 0
-        fi
-        /bin/busybox sleep 0.1
-        n=$((n + 1))
-    done
-    return 1
-}
-
 /bin/busybox mkdir -p /mnt/root
-
-# Prepare a chroot environment: bind-mount /proc, /sys, /dev, the secret dir,
-# and set up DNS in the given target. Called with the chroot that will
-# actually run its /sbin/init (/mnt/workload when a V-PROGRAM workload volume
-# is mounted, /mnt/root otherwise), after mounting it.
-#
-# The target is mounted read-only under dm-verity, so the mkdirs below cannot
-# create anything there: the mount-point directories (and the resolv.conf
-# placeholder file) are shipped in the image (rootfs.nix / workload.nix) and
-# the mkdirs no-op. They only do real work on the legacy writable-mount path.
-prepare_chroot() {
-    local target
-    target="$1"
-    /bin/busybox mkdir -p "$target/proc" "$target/sys" "$target/dev" "$target/etc"
-    /bin/busybox mount --bind /proc "$target/proc"
-    /bin/busybox mount --bind /sys "$target/sys"
-    /bin/busybox mount --bind /dev "$target/dev"
-    # Secret delivery: the attest-agent writes injected secrets under /tmp/secrets
-    # in THIS (initramfs) mount namespace, but the workload runs chrooted into
-    # the target, where /tmp/secrets is a different filesystem. Bind-mount the
-    # agent's secret dir into the chroot so the app reads exactly what the agent
-    # writes. The source path matches the agent's DEFAULT_SECRETS_DIR
-    # (/tmp/secrets in secrets.rs); pre-create it 0700 so the agent's hardened
-    # directory check accepts it (real dir, agent-owned, owner-only).
-    /bin/busybox mkdir -m 0700 -p /tmp/secrets
-    /bin/busybox mkdir -m 0700 -p "$target/tmp/secrets"
-    /bin/busybox mount --bind /tmp/secrets "$target/tmp/secrets"
-    # DNS for the chrooted workload. The target is mounted read-only under
-    # dm-verity, so writing its /etc/resolv.conf directly cannot work
-    # there (the old `echo >` only ever worked on legacy writable mounts).
-    # Instead, expose the initramfs /etc/resolv.conf (written by udhcpc.script
-    # from the DHCP option-6 nameservers) via a file bind-mount over the
-    # image's placeholder. On the static ip= path there is no DHCP lease, so
-    # seed the initramfs copy from the gateway first (common for VM bridges).
-    if [ ! -f /etc/resolv.conf ] && [ -n "$gateway" ]; then
-        /bin/busybox mkdir -p /etc
-        echo "nameserver ${gateway}" > /etc/resolv.conf
-    fi
-    if [ -f /etc/resolv.conf ]; then
-        if [ -f "$target/etc/resolv.conf" ]; then
-            /bin/busybox mount --bind /etc/resolv.conf "$target/etc/resolv.conf" \
-                || echo "init: WARNING: resolv.conf bind-mount failed; workload DNS unavailable"
-        else
-            # Legacy image without the placeholder: best-effort copy (works
-            # only if the target is mounted writable).
-            /bin/busybox cp /etc/resolv.conf "$target/etc/resolv.conf" 2>/dev/null \
-                || echo "init: WARNING: ${target} has no /etc/resolv.conf placeholder; workload DNS unavailable"
-        fi
-    fi
-    echo "init: chroot environment prepared at ${target} (proc, sys, dev, secrets, DNS)"
-}
 
 # Install a minimal guest firewall so only the attested TLS port is reachable
 # from outside the VM. Everything the workload binds (e.g. the upstream on

--- a/nix/initrd.nix
+++ b/nix/initrd.nix
@@ -1,7 +1,11 @@
-{ pkgs, attest-agent, kernel, init-script, init-common-script, udhcpc-script, udhcpc6-script, ... }:
+{ pkgs, attest-agent, kernel, init-script, init-common-script, udhcpc-script, udhcpc6-script
+, withVerity ? true, withNft ? true, withLuks ? false, ... }:
 
 let
-  # veritysetup needs to be statically linked for the initrd environment.
+  # veritysetup/cryptsetup need to be statically linked for the initrd
+  # environment. One derivation covers both: the cryptsetup package builds
+  # cryptsetup, veritysetup and integritysetup as separate binaries from the
+  # same source tree and output.
   staticCryptsetup = pkgs.pkgsStatic.cryptsetup;
 
   # Statically-linked nft for the guest firewall (init.sh). withCli = false drops
@@ -9,16 +13,17 @@ let
   # batch mode via `nft -f -`), which also lets it link statically for the initrd.
   staticNft = pkgs.pkgsStatic.nftables.override { withCli = false; };
 
-  # dm-verity kernel modules (default =m in the kernel config).
-  # Load order: dm-mod -> dm-bufio -> dm-verity. dax.ko is gone: nixos-26.05
-  # kernels build CONFIG_DAX=y (built in), so dm-mod no longer has a dax
-  # module dependency. Modules also moved out of the kernel's main output
-  # into a dedicated `modules` output on that channel.
+  # dm-* kernel modules (default =m in the kernel config). Load order:
+  # dm-mod -> dm-bufio -> dm-verity (verity mode) / dm-mod -> dm-crypt (luks
+  # mode). dax.ko is gone: nixos-26.05 kernels build CONFIG_DAX=y (built in),
+  # so dm-mod no longer has a dax module dependency. Modules also moved out
+  # of the kernel's main output into a dedicated `modules` output on that
+  # channel.
   #
-  # The measured-boot chain here is dm-verity for rootfs INTEGRITY only. The
-  # aleph-cvm donor also baked dm-crypt.ko for its LUKS encrypted-rootfs mode;
-  # that mode is out of scope for this backport (design section 6 non-goals),
-  # so dm-crypt is deliberately NOT included. See rust-port-divergences.
+  # dm-mod and dm-bufio are in the always-on base module set below: dm-bufio
+  # is needed only by dm-verity, but it is harmless (unused) on a luks-only
+  # image, and keeping it out of the per-flavor split avoids a third
+  # conditional list for a single small module.
   modDir = "${kernel.modules}/lib/modules/${kernel.modDirVersion}/kernel";
   dmModules = pkgs.runCommand "dm-modules" {
     nativeBuildInputs = [ pkgs.xz ];
@@ -27,6 +32,22 @@ let
     xz -d -k -c ${modDir}/drivers/md/dm-mod.ko.xz > $out/dm-mod.ko
     xz -d -k -c ${modDir}/drivers/md/dm-bufio.ko.xz > $out/dm-bufio.ko
     xz -d -k -c ${modDir}/drivers/md/dm-verity.ko.xz > $out/dm-verity.ko
+  '';
+
+  # dm-crypt kernel module for the LUKS instance image. modules.dep is the
+  # source of truth for its dependency closure; the build fails loudly if it
+  # ever grows beyond dm-mod (which the instance initrd ships anyway).
+  dmCryptModules = pkgs.runCommand "dm-crypt-modules" {
+    nativeBuildInputs = [ pkgs.xz ];
+  } ''
+    dep=$(grep '/dm-crypt.ko.xz:' ${kernel.modules}/lib/modules/${kernel.modDirVersion}/modules.dep)
+    extra=$(echo "$dep" | cut -d: -f2- | tr ' ' '\n' | grep -v '^$' | grep -v 'dm-mod.ko' || true)
+    if [ -n "$extra" ]; then
+      echo "error: dm-crypt.ko has unexpected module deps: $extra" >&2
+      exit 1
+    fi
+    mkdir -p $out
+    xz -d -k -c ${modDir}/drivers/md/dm-crypt.ko.xz > $out/dm-crypt.ko
   '';
 
   # init.sh treats a failing `udhcpc6` as "stay IPv4-only" (deliberate, to
@@ -61,21 +82,35 @@ let
   '';
 in
 pkgs.makeInitrd {
-  contents = [
-    { object = "${checkedBusybox}/bin/busybox"; symlink = "/bin/busybox"; }
-    { object = init-script; symlink = "/init"; }
-    { object = init-common-script; symlink = "/bin/init-common.sh"; }
-    { object = udhcpc-script; symlink = "/bin/udhcpc.script"; }
-    { object = udhcpc6-script; symlink = "/bin/udhcpc6.script"; }
-    { object = "${attest-agent}/bin/aleph-attest-agent"; symlink = "/bin/aleph-attest-agent"; }
-    { object = "${staticCryptsetup}/bin/veritysetup"; symlink = "/bin/veritysetup"; }
-    { object = "${staticNft}/bin/nft"; symlink = "/bin/nft"; }
-    # dm-verity kernel modules (loaded by init.sh).
-    { object = "${dmModules}/dm-mod.ko"; symlink = "/lib/modules/dm-mod.ko"; }
-    { object = "${dmModules}/dm-bufio.ko"; symlink = "/lib/modules/dm-bufio.ko"; }
-    { object = "${dmModules}/dm-verity.ko"; symlink = "/lib/modules/dm-verity.ko"; }
-    # netfilter modules for the guest firewall (loaded by init.sh).
-    { object = "${nftModules}/nfnetlink.ko"; symlink = "/lib/modules/nfnetlink.ko"; }
-    { object = "${nftModules}/nf_tables.ko"; symlink = "/lib/modules/nf_tables.ko"; }
-  ];
+  contents =
+    # Base: shared by every flavor (v-program and instance images alike).
+    [
+      { object = "${checkedBusybox}/bin/busybox"; symlink = "/bin/busybox"; }
+      { object = init-script; symlink = "/init"; }
+      { object = init-common-script; symlink = "/bin/init-common.sh"; }
+      { object = udhcpc-script; symlink = "/bin/udhcpc.script"; }
+      { object = udhcpc6-script; symlink = "/bin/udhcpc6.script"; }
+      { object = "${attest-agent}/bin/aleph-attest-agent"; symlink = "/bin/aleph-attest-agent"; }
+      # dm-mod/dm-bufio are always shipped: dm-bufio is dm-verity-only but
+      # harmless on a luks image (see the dmModules comment above).
+      { object = "${dmModules}/dm-mod.ko"; symlink = "/lib/modules/dm-mod.ko"; }
+      { object = "${dmModules}/dm-bufio.ko"; symlink = "/lib/modules/dm-bufio.ko"; }
+    ]
+    # dm-verity rootfs integrity (v-program image).
+    ++ pkgs.lib.optionals withVerity [
+      { object = "${staticCryptsetup}/bin/veritysetup"; symlink = "/bin/veritysetup"; }
+      { object = "${dmModules}/dm-verity.ko"; symlink = "/lib/modules/dm-verity.ko"; }
+    ]
+    # Guest firewall (v-program image only; instances get no in-guest
+    # firewall, see init-instance.sh).
+    ++ pkgs.lib.optionals withNft [
+      { object = "${staticNft}/bin/nft"; symlink = "/bin/nft"; }
+      { object = "${nftModules}/nfnetlink.ko"; symlink = "/lib/modules/nfnetlink.ko"; }
+      { object = "${nftModules}/nf_tables.ko"; symlink = "/lib/modules/nf_tables.ko"; }
+    ]
+    # LUKS encrypted rootfs (confidential-instance image).
+    ++ pkgs.lib.optionals withLuks [
+      { object = "${staticCryptsetup}/bin/cryptsetup"; symlink = "/bin/cryptsetup"; }
+      { object = "${dmCryptModules}/dm-crypt.ko"; symlink = "/lib/modules/dm-crypt.ko"; }
+    ];
 }

--- a/nix/initrd.nix
+++ b/nix/initrd.nix
@@ -1,4 +1,4 @@
-{ pkgs, attest-agent, kernel, init-script, udhcpc-script, udhcpc6-script, ... }:
+{ pkgs, attest-agent, kernel, init-script, init-common-script, udhcpc-script, udhcpc6-script, ... }:
 
 let
   # veritysetup needs to be statically linked for the initrd environment.
@@ -64,6 +64,7 @@ pkgs.makeInitrd {
   contents = [
     { object = "${checkedBusybox}/bin/busybox"; symlink = "/bin/busybox"; }
     { object = init-script; symlink = "/init"; }
+    { object = init-common-script; symlink = "/bin/init-common.sh"; }
     { object = udhcpc-script; symlink = "/bin/udhcpc.script"; }
     { object = udhcpc6-script; symlink = "/bin/udhcpc6.script"; }
     { object = "${attest-agent}/bin/aleph-attest-agent"; symlink = "/bin/aleph-attest-agent"; }

--- a/nix/kernel.nix
+++ b/nix/kernel.nix
@@ -51,10 +51,10 @@ base.override {
     TRUSTED_KEYS = lib.mkForce no;
     ENCRYPTED_KEYS = lib.mkForce no;
 
-    # The current rootfs integrity chain is dm-verity, which needs CRYPTO_SHA256
-    # only. CRYPTO_AES/XTS/ESSIV are LUKS/dm-crypt algorithms (aes-xts-plain64),
-    # retained for a possible future encrypted-rootfs path; LUKS is a non-goal
-    # today, so they are not exercised by the verity-only chain.
+    # The platform rootfs integrity chain is dm-verity, which needs
+    # CRYPTO_SHA256 only. CRYPTO_AES/XTS/ESSIV are the LUKS2/dm-crypt
+    # algorithms (aes-xts-plain64), built in so the confidential-instance
+    # image's cryptsetup luksOpen never needs a crypto module load.
     CRYPTO_AES = lib.mkForce yes;
     CRYPTO_XTS = lib.mkForce yes;
     CRYPTO_SHA256 = lib.mkForce yes;

--- a/nix/test-rootfs.nix
+++ b/nix/test-rootfs.nix
@@ -1,0 +1,163 @@
+{ pkgs, ... }:
+
+# Test fixture: a plain (NOT dm-verity, NOT measured) ext4 rootfs that boots
+# a statically linked dropbear SSH server. This is what the aleph-testnets
+# SNP-instance E2E scenario (Task 14) LUKS2-wraps at RUN time (a fresh,
+# per-run passphrase) and publishes as the instance's `rootfs.parent`; the
+# per-run SSH public key is written into /root/.ssh/authorized_keys inside
+# the opened LUKS container before boot. The measured instance init
+# (init-instance.sh) chroots into it and execs this image's /sbin/init,
+# itself, NOT as PID 1 and with no systemd (see init-instance.sh).
+#
+# Unlike rootfs.nix / workload.nix, this is deliberately NOT part of the
+# measured chain: it carries no dm-verity hash tree, it is never referenced
+# by a kernel cmdline roothash, and its own launch measurement is irrelevant
+# (instanceMeasurementFor only covers OVMF+kernel+instanceInitrd+cmdline; the
+# LUKS-encrypted rootfs contents are explicitly NOT measured, design section
+# 3). It exists purely so the E2E harness has something to SSH into and
+# assert against inside the confidential instance.
+#
+# Bit-reproducibility is NOT a goal here (and is impossible in the way that
+# matters): the dropbear host key is generated at BUILD time below, so two
+# builds never produce byte-identical images. The deterministic-mkfs flags
+# (fixed UUID/hash_seed, no journal, SOURCE_DATE_EPOCH) are kept anyway, for
+# consistency with rootfs.nix/workload.nix and because they cost nothing.
+#
+# Chroot environment recap (see init-common.sh's prepare_chroot): ONLY
+# /proc, /sys, /dev, /tmp/secrets and /etc/resolv.conf are bind-mounted in
+# from the initramfs. Nothing else is shared. Every binary this image's
+# /sbin/init needs at runtime (busybox, dropbear) must therefore ship here.
+let
+  staticBusybox = pkgs.busybox.override { enableStatic = true; };
+  staticDropbear = pkgs.pkgsStatic.dropbear;
+
+  # The build script below runs under `fakeroot` (see the runCommand call):
+  # a build that genuinely ran as uid 0 inside its own user namespace could
+  # skip this, but this Nix installation cannot create nested user
+  # namespaces here (no CAP_SYS_ADMIN), so it falls back to building as the
+  # plain invoking user -- a non-zero uid/gid. `mkfs.ext4 -d` bakes whatever
+  # uid/gid it reads from the source directory into the image verbatim, and
+  # dropbear enforces strict ownership on the host key file and on
+  # ~/.ssh/authorized_keys (checkpubkeyperms-style checks): at guest runtime
+  # "owned by root" means numeric uid/gid 0 in the image's OWN namespace, not
+  # whatever uid happened to build it on this machine. `fakeroot` intercepts
+  # stat()/chown(), so the `chown -R 0:0` below and mke2fs's read of that
+  # metadata -- run in the SAME fakeroot session -- agree on uid/gid 0 for
+  # everything, without needing real root privilege.
+  buildScript = pkgs.writeShellScript "build-test-rootfs" ''
+    set -euo pipefail
+
+    mkdir -p rootfs/sbin rootfs/bin rootfs/etc/dropbear rootfs/root/.ssh
+    mkdir -p rootfs/proc rootfs/sys rootfs/dev rootfs/run rootfs/var rootfs/tmp/secrets
+
+    cp ${staticBusybox}/bin/busybox rootfs/bin/
+    # dropbear looks up the shell named in /etc/passwd (/bin/sh below) and
+    # execs it directly; busybox dispatches on argv[0], so a plain symlink
+    # named "sh" is enough to make it behave as the ash applet.
+    ln -s busybox rootfs/bin/sh
+
+    cp ${staticDropbear}/bin/dropbear rootfs/bin/dropbear
+    chmod +x rootfs/bin/dropbear
+
+    # Host key generated at BUILD time (see file header: this is why the
+    # image is not bit-reproducible). dropbear (like openssh) refuses a host
+    # key file with loose permissions or wrong ownership, hardened below via
+    # 0600 + the blanket `chown -R 0:0` near the end of this script.
+    dropbearkey -t ed25519 -f rootfs/etc/dropbear/dropbear_ed25519_host_key
+    chmod 0600 rootfs/etc/dropbear/dropbear_ed25519_host_key
+    chmod 0700 rootfs/etc/dropbear
+
+    # Empty placeholder: the E2E harness overwrites this with the real,
+    # per-run public key after LUKS2-opening the volume (see file header).
+    # 0700/0600 because dropbear is picky about both the ~/.ssh directory
+    # and the authorized_keys file it reads from it (root ownership is
+    # handled by the blanket chown below).
+    touch rootfs/root/.ssh/authorized_keys
+    chmod 0600 rootfs/root/.ssh/authorized_keys
+    chmod 0700 rootfs/root/.ssh
+    chmod 0700 rootfs/root
+
+    # dropbear parses /etc/passwd directly (no NSS in a static musl build) to
+    # resolve root's home directory and login shell; the shell path it names
+    # must exist in this image (bin/sh above). Heredoc bodies below must not
+    # be indented: this is a Nix indented string, and any indentation on
+    # these lines would land literally inside /etc/passwd et al, which
+    # getpwnam-style parsers do not tolerate (same reasoning as the /sbin/init
+    # heredoc further down).
+    cat > rootfs/etc/passwd <<'PASSWD'
+root:x:0:0:root:/root:/bin/sh
+PASSWD
+    cat > rootfs/etc/group <<'GROUP'
+root:x:0:
+GROUP
+    # Locked password (no valid hash): this fixture is pubkey-only. dropbear
+    # tolerates a missing /etc/shadow too, but a locked entry is the more
+    # standard/explicit way to say "no password login".
+    cat > rootfs/etc/shadow <<'SHADOW'
+root:!:1:0:99999:7:::
+SHADOW
+    chmod 0600 rootfs/etc/shadow
+
+    # Bind-mount target for prepare_chroot's /etc/resolv.conf file bind-mount
+    # (same reasoning as rootfs.nix: needs an existing target file).
+    touch rootfs/etc/resolv.conf
+
+    chmod 1777 rootfs/tmp
+    chmod 0700 rootfs/tmp/secrets
+
+    # dropbear's compiled-in default pidfile path is /var/run/dropbear.pid
+    # (see `dropbear -h`); /sbin/init below mounts a tmpfs on /run, so
+    # symlinking /var/run -> /run keeps the pidfile on that tmpfs (never
+    # persisted into the image) without needing an explicit -P flag, matching
+    # the brief's minimal invocation.
+    ln -s /run rootfs/var/run
+
+    # Heredoc must not be indented (shebang needs to start at column 0).
+    cat > rootfs/sbin/init <<'INIT'
+#!/bin/busybox sh
+# Test-instance init: run chrooted by the measured instance init. Networking
+# is already configured by the initramfs; just serve SSH.
+#
+# prepare_chroot (init-common.sh) bind-mounts /dev in from the initramfs,
+# but never mounts devpts anywhere, so /dev/pts (and thus pty allocation for
+# an interactive `ssh` session) would otherwise be missing. Best-effort mount
+# it here: a non-interactive `ssh host cmd` does not need a pty, so this must
+# never block boot -- hence `|| true` throughout.
+/bin/busybox mkdir -p /dev/pts 2>/dev/null || true
+/bin/busybox mount -t devpts devpts /dev/pts 2>/dev/null || true
+
+/bin/busybox mount -t tmpfs tmpfs /run 2>/dev/null
+exec /bin/dropbear -F -E -p 22 -r /etc/dropbear/dropbear_ed25519_host_key
+INIT
+    chmod +x rootfs/sbin/init
+
+    # Blanket root ownership (see the comment above buildScript): this must
+    # run, under fakeroot, in the SAME process tree as the mke2fs -d call
+    # below so the faked uid/gid 0 is what mke2fs actually reads back.
+    chown -R 0:0 rootfs
+
+    # Fixed, generous size (this is a test fixture, not a tightly packed
+    # measured image): actual content is a few MB, but the E2E harness
+    # LUKS2-wraps this image and needs headroom for the LUKS header plus
+    # whatever else gets written into the opened container at test time.
+    truncate -s 96M "$out"
+    # Deterministic-mkfs flags kept for consistency with rootfs.nix/workload.nix
+    # even though the host key above already makes this image non-reproducible
+    # (see file header). Note: the hash_seed must be NON-zero (mke2fs treats an
+    # all-zero hash_seed as "unset" and randomizes it); the UUID may be all-zero.
+    mkfs.ext4 -b 4096 -U 00000000-0000-0000-0000-000000000000 \
+      -E hash_seed=a1e5c0de-1111-2222-3333-444455556666,lazy_itable_init=0,lazy_journal_init=0 \
+      -O ^has_journal \
+      -d rootfs "$out"
+  '';
+in
+pkgs.runCommand "test-rootfs.ext4" {
+  # dropbearkey (host-key generation) and mkfs.ext4 are build-time tools
+  # invoked by buildScript; the same static dropbear package also supplies
+  # the /bin/dropbear runtime binary that script copies in. fakeroot fakes
+  # the ownership mkfs.ext4 -d bakes into the image (see buildScript above).
+  nativeBuildInputs = [ pkgs.e2fsprogs staticDropbear pkgs.fakeroot ];
+  SOURCE_DATE_EPOCH = "0";
+} ''
+  fakeroot ${buildScript}
+''

--- a/scripts/vprogram_bundle.py
+++ b/scripts/vprogram_bundle.py
@@ -31,7 +31,9 @@ from aleph.vm.vprogram.bundle import (  # noqa: E402
     BUNDLE_NAME,
     MANIFEST_NAME,
     BundleInfo,
+    InstanceBundleInfo,
     build_bundle,
+    make_instance_manifest,
     make_manifest,
     verify_bundle_info,
 )
@@ -57,6 +59,10 @@ def _source_epoch(repo: Path) -> int:
     return int(_git(repo, "log", "-1", "--format=%ct"))
 
 
+def _nix_target(flavor: str) -> str:
+    return "instanceImage" if flavor == "instance" else "image"
+
+
 def cmd_build(args: argparse.Namespace) -> int:
     repo = args.repo.resolve()
     out: Path = args.out
@@ -68,7 +74,7 @@ def cmd_build(args: argparse.Namespace) -> int:
             [  # noqa: S603, S607
                 "nix",
                 "build",
-                f"git+file://{repo}?dir=nix#image",
+                f"git+file://{repo}?dir=nix#{_nix_target(args.flavor)}",
                 "--extra-experimental-features",
                 "nix-command flakes",
                 "-o",
@@ -82,11 +88,14 @@ def cmd_build(args: argparse.Namespace) -> int:
         rev=_git(repo, "rev-parse", "--short", "HEAD"),
         build=BUILD_COMMAND,
     )
-    info = build_bundle(image_dir=image_dir, out_dir=out, source_epoch=_source_epoch(repo), source=source)
+    info = build_bundle(
+        image_dir=image_dir, out_dir=out, source_epoch=_source_epoch(repo), source=source, flavor=args.flavor
+    )
     print(f"bundle:   {out / BUNDLE_NAME}")  # noqa: T201
     print(f"sha256:   {info.sha256}")  # noqa: T201
     print(f"size:     {info.size}")  # noqa: T201
-    print(f"roothash: {info.platform_roothash}")  # noqa: T201
+    if isinstance(info, BundleInfo):
+        print(f"roothash: {info.platform_roothash}")  # noqa: T201
     print()  # noqa: T201
     print("Next: upload the bundle and note the STORE item hash it prints:")  # noqa: T201
     print(f"  aleph file upload {out / BUNDLE_NAME}")  # noqa: T201
@@ -94,19 +103,30 @@ def cmd_build(args: argparse.Namespace) -> int:
 
 
 def cmd_manifest(args: argparse.Namespace) -> int:
-    info = BundleInfo.model_validate_json(args.bundle_info.read_text())
+    if args.flavor == "instance":
+        info: BundleInfo | InstanceBundleInfo = InstanceBundleInfo.model_validate_json(args.bundle_info.read_text())
+    else:
+        info = BundleInfo.model_validate_json(args.bundle_info.read_text())
     tar_path = args.bundle_info.parent / BUNDLE_NAME
     if tar_path.is_file():
         verify_bundle_info(info, tar_path)
     else:
         print(f"note: {tar_path} not found, skipping bundle cross-check")  # noqa: T201
-    manifest = make_manifest(
-        info=info,
-        bundle_ref=args.bundle_ref,
-        name=args.name,
-        runtime_version=args.runtime_version,
-        exec_runtime=args.exec_runtime,
-    )
+    if args.flavor == "instance":
+        manifest = make_instance_manifest(
+            info,
+            bundle_ref=args.bundle_ref,
+            name=args.name,
+            version=args.runtime_version,
+        )
+    else:
+        manifest = make_manifest(
+            info=info,
+            bundle_ref=args.bundle_ref,
+            name=args.name,
+            runtime_version=args.runtime_version,
+            exec_runtime=args.exec_runtime,
+        )
     out: Path = args.out if args.out is not None else args.bundle_info.parent / MANIFEST_NAME
     out.write_text(manifest.to_canonical_json())
     print(f"manifest: {out}")  # noqa: T201
@@ -129,6 +149,12 @@ def main(argv: list[str] | None = None) -> int:
         help="package an existing nix image output instead of building",
     )
     p_build.add_argument("--out", type=Path, required=True, help="output directory")
+    p_build.add_argument(
+        "--flavor",
+        choices=("vprogram", "instance"),
+        default="vprogram",
+        help="bundle flavor: vprogram (default, nix#image) or instance (nix#instanceImage, no verity sidecars)",
+    )
     p_build.set_defaults(func=cmd_build)
 
     p_manifest = subparsers.add_parser("manifest", help="generate the runtime manifest for an uploaded bundle")
@@ -138,11 +164,18 @@ def main(argv: list[str] | None = None) -> int:
     p_manifest.add_argument("--runtime-version", required=True, help="runtime version string, e.g. 2026.07.08")
     p_manifest.add_argument("--out", type=Path, default=None, help="manifest path (default: next to bundle-info)")
     p_manifest.add_argument(
+        "--flavor",
+        choices=("vprogram", "instance"),
+        default="vprogram",
+        help="manifest flavor: vprogram (default, aleph-vprogram-runtime) or "
+        "instance (aleph-instance-runtime, luks cmdline template)",
+    )
+    p_manifest.add_argument(
         "--exec",
         dest="exec_runtime",
         action="store_true",
         help="build the aleph.exec/1 workload-runtime manifest (workload_roothash in the "
-        "cmdline template) instead of the builtin no-workload form",
+        "cmdline template) instead of the builtin no-workload form; ignored with --flavor instance",
     )
     p_manifest.set_defaults(func=cmd_manifest)
 

--- a/scripts/vprogram_bundle.py
+++ b/scripts/vprogram_bundle.py
@@ -39,7 +39,12 @@ from aleph.vm.vprogram.bundle import (  # noqa: E402
 )
 from aleph.vm.vprogram.manifest import SourceInfo  # noqa: E402
 
-BUILD_COMMAND = 'nix build "git+file://$REPO?dir=nix#image"'
+
+def _build_command(flavor: str) -> str:
+    """The `source.build` provenance recorded in the manifest: the exact nix
+    target for this flavor, so an auditor rebuilds the same bundle (the
+    instance flavor builds `nix#instanceImage`, not `nix#image`)."""
+    return f'nix build "git+file://$REPO?dir=nix#{_nix_target(flavor)}"'
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -86,7 +91,7 @@ def cmd_build(args: argparse.Namespace) -> int:
     source = SourceInfo(
         repo="https://github.com/aleph-im/aleph-vm",
         rev=_git(repo, "rev-parse", "--short", "HEAD"),
-        build=BUILD_COMMAND,
+        build=_build_command(args.flavor),
     )
     info = build_bundle(
         image_dir=image_dir, out_dir=out, source_epoch=_source_epoch(repo), source=source, flavor=args.flavor

--- a/scripts/vprogram_bundle.py
+++ b/scripts/vprogram_bundle.py
@@ -185,6 +185,11 @@ def main(argv: list[str] | None = None) -> int:
     p_manifest.set_defaults(func=cmd_manifest)
 
     args = parser.parse_args(argv)
+    # --exec builds the aleph.exec/1 workload-runtime manifest, which has no
+    # meaning for an instance (LUKS) manifest; reject the combination rather
+    # than silently ignoring the flag.
+    if getattr(args, "exec_runtime", False) and args.flavor == "instance":
+        parser.error("--exec is incompatible with --flavor instance")
     return int(args.func(args))
 
 

--- a/src/aleph/vm/vprogram/bundle.py
+++ b/src/aleph/vm/vprogram/bundle.py
@@ -26,6 +26,10 @@ from aleph.vm.vprogram.manifest import (
     AttestationTransport,
     BootSpec,
     BundleMembers,
+    InstanceBootSpec,
+    InstanceBundleMembers,
+    InstanceRuntimeBundle,
+    InstanceRuntimeManifest,
     RuntimeBundle,
     RuntimeManifest,
     SourceInfo,
@@ -49,6 +53,16 @@ MEMBER_FILES = {
 ROOTHASH_FILE = "rootfs.ext4.roothash"
 MEASUREMENT_FILE = "measurement.hex"
 
+# Role -> file name inside the nix `instanceImage` output directory: OVMF,
+# kernel, initrd only. No rootfs, no hash tree, no verity sidecars: the
+# instance init has no verity branch (the guest supplies its own LUKS rootfs
+# at runtime).
+INSTANCE_MEMBER_FILES = {
+    "ovmf": "OVMF.fd",
+    "kernel": "bzImage",
+    "initrd": "initrd",
+}
+
 
 class BundleInfo(StrictModel):
     """Sidecar record of a `build` run: everything `manifest` needs except
@@ -63,6 +77,16 @@ class BundleInfo(StrictModel):
     source: SourceInfo
 
 
+class InstanceBundleInfo(StrictModel):
+    """Sidecar record of an instance-flavor `build` run: no platform_roothash,
+    no measurement (the instance image has no verity branch to measure)."""
+
+    sha256: str = Field(pattern=SHA256_HEX_PATTERN)
+    size: int = Field(gt=0)
+    members: InstanceBundleMembers
+    source: SourceInfo
+
+
 def _read_sidecar(image_dir: Path, name: str, pattern: str | None) -> str:
     value = (image_dir / name).read_text().strip()
     if pattern is not None and not re.fullmatch(pattern, value):
@@ -71,19 +95,7 @@ def _read_sidecar(image_dir: Path, name: str, pattern: str | None) -> str:
     return value
 
 
-def build_bundle(image_dir: Path, out_dir: Path, source_epoch: int, source: SourceInfo) -> BundleInfo:
-    """Package a nix image output directory as a deterministic tar.gz and
-    write the bundle-info sidecar. Returns the recorded facts."""
-    file_names = sorted({*MEMBER_FILES.values(), ROOTHASH_FILE, MEASUREMENT_FILE})
-    for name in file_names:
-        if not (image_dir / name).is_file():
-            msg = f"expected image file missing: {image_dir / name}"
-            raise FileNotFoundError(msg)
-
-    platform_roothash = _read_sidecar(image_dir, ROOTHASH_FILE, SHA256_HEX_PATTERN)
-    measurement = _read_sidecar(image_dir, MEASUREMENT_FILE, None)
-
-    tar_path = out_dir / BUNDLE_NAME
+def _write_tar(image_dir: Path, tar_path: Path, source_epoch: int, file_names: list[str]) -> None:
     with tar_path.open("wb") as raw:
         # filename="" keeps the output path out of the gzip header (FNAME);
         # mtime=0 pins the gzip timestamp. Both are required for determinism.
@@ -102,6 +114,61 @@ def build_bundle(image_dir: Path, out_dir: Path, source_epoch: int, source: Sour
                     member.mtime = source_epoch
                     with path.open("rb") as fileobj:
                         tar.addfile(member, fileobj)
+
+
+def build_bundle(
+    image_dir: Path,
+    out_dir: Path,
+    source_epoch: int,
+    source: SourceInfo,
+    flavor: str = "vprogram",
+) -> BundleInfo | InstanceBundleInfo:
+    """Package a nix image output directory as a deterministic tar.gz and
+    write the bundle-info sidecar. Returns the recorded facts.
+
+    `flavor="vprogram"` (default) expects the platform rootfs, its dm-verity
+    hash tree, and the roothash/measurement sidecars, matching today's byte
+    layout exactly. `flavor="instance"` expects only OVMF/kernel/initrd (the
+    nix `instanceImage` output) and never reads a verity sidecar.
+    """
+    if flavor not in ("vprogram", "instance"):
+        msg = f"unknown bundle flavor: {flavor!r}"
+        raise ValueError(msg)
+
+    if flavor == "instance":
+        file_names = sorted(INSTANCE_MEMBER_FILES.values())
+        for name in file_names:
+            if not (image_dir / name).is_file():
+                msg = f"expected image file missing: {image_dir / name}"
+                raise FileNotFoundError(msg)
+
+        tar_path = out_dir / BUNDLE_NAME
+        _write_tar(image_dir, tar_path, source_epoch, file_names)
+
+        data = tar_path.read_bytes()
+        instance_info = InstanceBundleInfo(
+            sha256=hashlib.sha256(data).hexdigest(),
+            size=len(data),
+            members=InstanceBundleMembers(
+                **{role: f"{TAR_PREFIX}/{name}" for role, name in INSTANCE_MEMBER_FILES.items()}
+            ),
+            source=source,
+        )
+        info_path = out_dir / BUNDLE_INFO_NAME
+        info_path.write_text(json.dumps(instance_info.model_dump(mode="json"), indent=2, sort_keys=True) + "\n")
+        return instance_info
+
+    file_names = sorted({*MEMBER_FILES.values(), ROOTHASH_FILE, MEASUREMENT_FILE})
+    for name in file_names:
+        if not (image_dir / name).is_file():
+            msg = f"expected image file missing: {image_dir / name}"
+            raise FileNotFoundError(msg)
+
+    platform_roothash = _read_sidecar(image_dir, ROOTHASH_FILE, SHA256_HEX_PATTERN)
+    measurement = _read_sidecar(image_dir, MEASUREMENT_FILE, None)
+
+    tar_path = out_dir / BUNDLE_NAME
+    _write_tar(image_dir, tar_path, source_epoch, file_names)
 
     data = tar_path.read_bytes()
     info = BundleInfo(
@@ -139,6 +206,10 @@ DEFAULT_WORKLOAD = WorkloadSpec(contract="aleph.builtin/1", upstream_port=8080)
 # Exec-runtime workload contract: a plain executable/command workload rather
 # than the builtin no-workload runtime.
 EXEC_WORKLOAD = WorkloadSpec(contract="aleph.exec/1", upstream_port=8080)
+# Instance-runtime luks-mode cmdline template (format version 1): the
+# instance init parses `luks=` and `owner=` off /proc/cmdline (design section
+# 4.1). No platform_roothash slot: the instance image has no verity rootfs.
+CMDLINE_TEMPLATE_LUKS_V1 = "console=ttyS0 luks=1 owner={owner}"
 
 
 def make_manifest(
@@ -175,7 +246,36 @@ def make_manifest(
     )
 
 
-def verify_bundle_info(info: BundleInfo, tar_path: Path) -> None:
+def make_instance_manifest(
+    info: InstanceBundleInfo, bundle_ref: str, name: str, version: str
+) -> InstanceRuntimeManifest:
+    """Build the aleph-instance-runtime manifest for an uploaded instance
+    bundle. Validation is the constructor: any inconsistency raises pydantic
+    ValidationError.
+
+    Fixed to the luks-mode boot recipe (`{owner}`-only cmdline template); no
+    workload contract, no platform_roothash (the instance image has no
+    verity rootfs to measure).
+    """
+    return InstanceRuntimeManifest(
+        format="aleph-instance-runtime",
+        format_version=1,
+        name=name,
+        version=version,
+        platform="sev_snp",
+        bundle=InstanceRuntimeBundle(ref=bundle_ref, sha256=info.sha256, size=info.size, members=info.members),
+        boot=InstanceBootSpec(
+            method="qemu-direct-kernel",
+            kernel_hashes=True,
+            cpu_models=list(DEFAULT_CPU_MODELS),
+            cmdline_template=CMDLINE_TEMPLATE_LUKS_V1,
+        ),
+        attestation=[protocol.model_copy(deep=True) for protocol in DEFAULT_ATTESTATION],
+        source=info.source,
+    )
+
+
+def verify_bundle_info(info: BundleInfo | InstanceBundleInfo, tar_path: Path) -> None:
     """Cross-check a bundle-info sidecar against the tarball on disk."""
     data = tar_path.read_bytes()
     digest = hashlib.sha256(data).hexdigest()

--- a/src/aleph/vm/vprogram/manifest.py
+++ b/src/aleph/vm/vprogram/manifest.py
@@ -29,10 +29,59 @@ CONTRACT_PATTERN = r"^[a-z0-9][a-z0-9_-]*(\.[a-z0-9][a-z0-9_-]*)+/[0-9]+$"
 # The template is the normative cmdline recipe: restricting its slots is what
 # prevents a malicious manifest from smuggling arbitrary kernel parameters.
 CMDLINE_PLACEHOLDERS_V1 = frozenset({"platform_roothash", "workload_roothash", "verified_volumes"})
+# The closed placeholder set for the aleph-instance-runtime luks cmdline
+# template (format version 1): the instance init parses only `owner=` off
+# /proc/cmdline, so that is the only slot a manifest may fill.
+CMDLINE_PLACEHOLDERS_LUKS_V1 = frozenset({"owner"})
 
 
 class StrictModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
+
+
+def _validate_member_path(value: str) -> str:
+    if not value:
+        msg = "member path must not be empty"
+        raise ValueError(msg)
+    if value.startswith("/"):
+        msg = f"member path must be relative: {value}"
+        raise ValueError(msg)
+    if ".." in value.split("/"):
+        msg = f"member path must not traverse upward: {value}"
+        raise ValueError(msg)
+    return value
+
+
+def _validate_cmdline_template(value: str, allowed: frozenset[str], required: str) -> str:
+    """Shared cmdline-template validator: parses `value` as a str.format
+    template, rejects positional/format-spec/conversion placeholders, and
+    checks the placeholder set against `allowed` (closed set) with `required`
+    mandatory. Used by both BootSpec (v-program) and InstanceBootSpec so the
+    two formats cannot drift apart."""
+    placeholders: set[str] = set()
+    try:
+        parsed = list(string.Formatter().parse(value))
+    except ValueError as exc:
+        msg = f"malformed cmdline template: {exc}"
+        raise ValueError(msg) from exc
+    for _literal, field_name, format_spec, conversion in parsed:
+        if field_name is None:
+            continue
+        if field_name == "":
+            msg = "cmdline template must not use positional placeholders"
+            raise ValueError(msg)
+        if format_spec or conversion:
+            msg = f"cmdline placeholder must be plain (no format spec / conversion): {field_name}"
+            raise ValueError(msg)
+        placeholders.add(field_name)
+    unknown = placeholders - allowed
+    if unknown:
+        msg = f"unknown cmdline placeholders for format version 1: {sorted(unknown)}"
+        raise ValueError(msg)
+    if required not in placeholders:
+        msg = f"cmdline template must contain {{{required}}}"
+        raise ValueError(msg)
+    return value
 
 
 class BundleMembers(StrictModel):
@@ -48,16 +97,22 @@ class BundleMembers(StrictModel):
     @field_validator("ovmf", "kernel", "initrd", "platform_rootfs", "platform_hash_tree")
     @classmethod
     def check_member_path(cls, value: str) -> str:
-        if not value:
-            msg = "member path must not be empty"
-            raise ValueError(msg)
-        if value.startswith("/"):
-            msg = f"member path must be relative: {value}"
-            raise ValueError(msg)
-        if ".." in value.split("/"):
-            msg = f"member path must not traverse upward: {value}"
-            raise ValueError(msg)
-        return value
+        return _validate_member_path(value)
+
+
+class InstanceBundleMembers(StrictModel):
+    """Role -> path map inside the instance bundle tarball: OVMF, kernel,
+    initrd only (no rootfs, no hash tree; the instance image has no verity
+    branch)."""
+
+    ovmf: str
+    kernel: str
+    initrd: str
+
+    @field_validator("ovmf", "kernel", "initrd")
+    @classmethod
+    def check_member_path(cls, value: str) -> str:
+        return _validate_member_path(value)
 
 
 class RuntimeBundle(StrictModel):
@@ -80,30 +135,7 @@ class BootSpec(StrictModel):
     @field_validator("cmdline_template")
     @classmethod
     def check_cmdline_template(cls, value: str) -> str:
-        placeholders: set[str] = set()
-        try:
-            parsed = list(string.Formatter().parse(value))
-        except ValueError as exc:
-            msg = f"malformed cmdline template: {exc}"
-            raise ValueError(msg) from exc
-        for _literal, field_name, format_spec, conversion in parsed:
-            if field_name is None:
-                continue
-            if field_name == "":
-                msg = "cmdline template must not use positional placeholders"
-                raise ValueError(msg)
-            if format_spec or conversion:
-                msg = f"cmdline placeholder must be plain (no format spec / conversion): {field_name}"
-                raise ValueError(msg)
-            placeholders.add(field_name)
-        unknown = placeholders - CMDLINE_PLACEHOLDERS_V1
-        if unknown:
-            msg = f"unknown cmdline placeholders for format version 1: {sorted(unknown)}"
-            raise ValueError(msg)
-        if "platform_roothash" not in placeholders:
-            msg = "cmdline template must contain {platform_roothash}"
-            raise ValueError(msg)
-        return value
+        return _validate_cmdline_template(value, CMDLINE_PLACEHOLDERS_V1, "platform_roothash")
 
 
 class AttestationTransport(StrictModel):
@@ -142,6 +174,57 @@ class RuntimeManifest(StrictModel):
     # V-PROGRAM messages (rejected as denormalization in the protocol design).
     attestation: list[AttestationProtocol] = Field(min_length=1)
     workload: WorkloadSpec
+    source: SourceInfo
+
+    def to_canonical_json(self) -> str:
+        """The exact bytes to publish: compact separators, sorted keys, so
+        independently regenerated manifests hash identically."""
+        return json.dumps(self.model_dump(mode="json"), separators=(",", ":"), sort_keys=True)
+
+
+class InstanceRuntimeBundle(StrictModel):
+    ref: str = Field(pattern=SHA256_HEX_PATTERN, description="Item hash of the bundle STORE message")
+    sha256: str = Field(pattern=SHA256_HEX_PATTERN, description="sha256 of the bundle tarball file")
+    size: int = Field(gt=0, description="Size of the bundle tarball in bytes")
+    members: InstanceBundleMembers
+
+
+class InstanceBootSpec(StrictModel):
+    """Boot recipe for the aleph-instance-runtime format. TEE-agnostic name;
+    no platform_roothash (the instance image has no verity rootfs to
+    measure), no workload block (the guest owns its own rootfs via LUKS)."""
+
+    method: Literal["qemu-direct-kernel"]
+    kernel_hashes: Literal[True]
+    cpu_models: list[str] = Field(min_length=1)
+    cmdline_template: str
+
+    @field_validator("cmdline_template")
+    @classmethod
+    def check_cmdline_template(cls, value: str) -> str:
+        return _validate_cmdline_template(value, CMDLINE_PLACEHOLDERS_LUKS_V1, "owner")
+
+
+class InstanceRuntimeManifest(StrictModel):
+    """Typed model of the aleph-instance-runtime manifest format (version 1).
+
+    Points at the instance bundle (OVMF, kernel, initrd; no rootfs, no hash
+    tree: the guest supplies its own LUKS-encrypted rootfs at runtime) and
+    declares the luks-mode cmdline template, the attestation protocols the
+    runtime implements, and its build provenance. Platform is a field (not
+    baked into the format name) so a future TEE backend reuses this format.
+
+    Design: docs/plans/2026-08-18-snp-confidential-instances-design.md section 5.1
+    """
+
+    format: Literal["aleph-instance-runtime"]
+    format_version: Literal[1]
+    name: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+    platform: Literal["sev_snp"]
+    bundle: InstanceRuntimeBundle
+    boot: InstanceBootSpec
+    attestation: list[AttestationProtocol] = Field(min_length=1)
     source: SourceInfo
 
     def to_canonical_json(self) -> str:

--- a/src/aleph/vm/vprogram/manifest.py
+++ b/src/aleph/vm/vprogram/manifest.py
@@ -76,7 +76,7 @@ def _validate_cmdline_template(value: str, allowed: frozenset[str], required: st
         placeholders.add(field_name)
     unknown = placeholders - allowed
     if unknown:
-        msg = f"unknown cmdline placeholders for format version 1: {sorted(unknown)}"
+        msg = f"unknown cmdline placeholders {sorted(unknown)}; allowed: {sorted(allowed)}"
         raise ValueError(msg)
     if required not in placeholders:
         msg = f"cmdline template must contain {{{required}}}"

--- a/tests/vprogram/test_bundle.py
+++ b/tests/vprogram/test_bundle.py
@@ -11,12 +11,19 @@ from aleph.vm.vprogram.bundle import (
     BUNDLE_INFO_NAME,
     BUNDLE_NAME,
     CMDLINE_TEMPLATE_EXEC_V1,
+    CMDLINE_TEMPLATE_LUKS_V1,
     BundleInfo,
+    InstanceBundleInfo,
     build_bundle,
+    make_instance_manifest,
     make_manifest,
     verify_bundle_info,
 )
-from aleph.vm.vprogram.manifest import RuntimeManifest, SourceInfo
+from aleph.vm.vprogram.manifest import (
+    InstanceRuntimeManifest,
+    RuntimeManifest,
+    SourceInfo,
+)
 
 ROOTHASH = "cb121a317be7dc7969dd633ca9b6c3718ffe9ea6715b64e0e35a871d484b56b8"
 MEASUREMENT = "de" * 48
@@ -180,3 +187,79 @@ def test_verify_bundle_info_rejects_tampered(image_dir: Path, tmp_path: Path) ->
     tar_path.write_bytes(tar_path.read_bytes() + b"x")
     with pytest.raises(ValueError, match="does not match"):
         verify_bundle_info(info, tar_path)
+
+
+@pytest.fixture()
+def instance_image_dir(tmp_path: Path) -> Path:
+    """The nix instanceImage output: OVMF/kernel/initrd only, no verity sidecars."""
+    d = tmp_path / "instance-image"
+    d.mkdir()
+    (d / "OVMF.fd").write_bytes(b"ovmf firmware")
+    (d / "bzImage").write_bytes(b"kernel")
+    (d / "initrd").write_bytes(b"initrd contents")
+    return d
+
+
+def test_build_bundle_instance_flavor(instance_image_dir: Path, tmp_path: Path) -> None:
+    out = _out(tmp_path, "out")
+    info = build_bundle(image_dir=instance_image_dir, out_dir=out, source_epoch=EPOCH, source=SOURCE, flavor="instance")
+    data = (out / BUNDLE_NAME).read_bytes()
+    assert isinstance(info, InstanceBundleInfo)
+    assert info.sha256 == hashlib.sha256(data).hexdigest()
+    assert info.size == len(data)
+    assert info.members.ovmf == "image/OVMF.fd"
+    assert info.members.kernel == "image/bzImage"
+    assert info.members.initrd == "image/initrd"
+    assert not hasattr(info, "platform_roothash")
+    assert not hasattr(info, "measurement")
+    with tarfile.open(out / BUNDLE_NAME, "r:gz") as tar:
+        assert tar.getnames() == ["image", "image/OVMF.fd", "image/bzImage", "image/initrd"]
+    on_disk = InstanceBundleInfo.model_validate_json((out / BUNDLE_INFO_NAME).read_text())
+    assert on_disk == info
+
+
+def test_build_bundle_instance_flavor_ignores_verity_sidecars(instance_image_dir: Path, tmp_path: Path) -> None:
+    """The instance image dir never has roothash/measurement sidecars; a
+    vprogram-flavor build against the same dir would fail, proving the
+    instance flavor does not read them."""
+    with pytest.raises(FileNotFoundError):
+        build_bundle(image_dir=instance_image_dir, out_dir=_out(tmp_path, "out"), source_epoch=EPOCH, source=SOURCE)
+    # But the instance flavor succeeds against the very same directory.
+    build_bundle(
+        image_dir=instance_image_dir,
+        out_dir=_out(tmp_path, "out2"),
+        source_epoch=EPOCH,
+        source=SOURCE,
+        flavor="instance",
+    )
+
+
+def test_build_bundle_instance_flavor_missing_file_is_an_error(instance_image_dir: Path, tmp_path: Path) -> None:
+    (instance_image_dir / "bzImage").unlink()
+    with pytest.raises(FileNotFoundError):
+        build_bundle(
+            image_dir=instance_image_dir,
+            out_dir=_out(tmp_path, "out"),
+            source_epoch=EPOCH,
+            source=SOURCE,
+            flavor="instance",
+        )
+
+
+INSTANCE_BUNDLE_REF = "87287e4a5c8d7554a50f982cd681b64b2600c0bbb1c0b1e618465e022e01b977"
+
+
+def test_make_instance_manifest_from_bundle_info(instance_image_dir: Path, tmp_path: Path) -> None:
+    out = _out(tmp_path, "out")
+    info = build_bundle(image_dir=instance_image_dir, out_dir=out, source_epoch=EPOCH, source=SOURCE, flavor="instance")
+    manifest = make_instance_manifest(info, bundle_ref=INSTANCE_BUNDLE_REF, name="aleph-snp-luks", version="2026.08.18")
+    reparsed = InstanceRuntimeManifest.model_validate_json(manifest.to_canonical_json())
+    assert reparsed == manifest
+    assert manifest.format == "aleph-instance-runtime"
+    assert manifest.bundle.ref == INSTANCE_BUNDLE_REF
+    assert manifest.bundle.sha256 == info.sha256
+    assert manifest.bundle.size == info.size
+    assert manifest.bundle.members == info.members
+    assert manifest.boot.cmdline_template == CMDLINE_TEMPLATE_LUKS_V1
+    assert "{owner}" in manifest.boot.cmdline_template
+    assert manifest.source == SOURCE

--- a/tests/vprogram/test_cli.py
+++ b/tests/vprogram/test_cli.py
@@ -155,3 +155,24 @@ def test_build_then_manifest_instance_flavor(instance_image_dir: Path, tmp_path:
     assert manifest.format == "aleph-instance-runtime"
     assert manifest.bundle.ref == BUNDLE_REF
     assert manifest.boot.cmdline_template == "console=ttyS0 luks=1 owner={owner}"
+
+
+def test_manifest_rejects_exec_with_instance_flavor(tmp_path: Path) -> None:
+    # The combination is rejected before the subcommand runs, so the
+    # bundle-info path is never read.
+    result = _run(
+        "manifest",
+        "--bundle-info",
+        str(tmp_path / "bundle-info.json"),
+        "--bundle-ref",
+        BUNDLE_REF,
+        "--name",
+        "aleph-snp-luks",
+        "--runtime-version",
+        "2026.08.18",
+        "--flavor",
+        "instance",
+        "--exec",
+    )
+    assert result.returncode == 2
+    assert "--exec is incompatible with --flavor instance" in result.stderr

--- a/tests/vprogram/test_cli.py
+++ b/tests/vprogram/test_cli.py
@@ -8,12 +8,22 @@ from pathlib import Path
 
 import pytest
 
-from aleph.vm.vprogram.manifest import RuntimeManifest
+from aleph.vm.vprogram.manifest import InstanceRuntimeManifest, RuntimeManifest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "vprogram_bundle.py"
 ROOTHASH = "cb121a317be7dc7969dd633ca9b6c3718ffe9ea6715b64e0e35a871d484b56b8"
 BUNDLE_REF = "87287e4a5c8d7554a50f982cd681b64b2600c0bbb1c0b1e618465e022e01b977"
+
+
+@pytest.fixture()
+def instance_image_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "instance-image"
+    d.mkdir()
+    (d / "OVMF.fd").write_bytes(b"ovmf firmware")
+    (d / "bzImage").write_bytes(b"kernel")
+    (d / "initrd").write_bytes(b"initrd contents")
+    return d
 
 
 @pytest.fixture()
@@ -116,3 +126,32 @@ def test_build_missing_image_file_fails(image_dir: Path, tmp_path: Path) -> None
     (image_dir / "bzImage").unlink()
     result = _run("build", "--image-dir", str(image_dir), "--out", str(tmp_path / "out"))
     assert result.returncode != 0
+
+
+def test_build_then_manifest_instance_flavor(instance_image_dir: Path, tmp_path: Path) -> None:
+    out = tmp_path / "out"
+    result = _run("build", "--image-dir", str(instance_image_dir), "--out", str(out), "--flavor", "instance")
+    assert result.returncode == 0, result.stderr
+    assert (out / "snp-image.tar.gz").is_file()
+    info = json.loads((out / "bundle-info.json").read_text())
+    assert "platform_roothash" not in info
+    assert info["members"] == {"ovmf": "image/OVMF.fd", "kernel": "image/bzImage", "initrd": "image/initrd"}
+
+    result = _run(
+        "manifest",
+        "--bundle-info",
+        str(out / "bundle-info.json"),
+        "--bundle-ref",
+        BUNDLE_REF,
+        "--name",
+        "aleph-snp-luks",
+        "--runtime-version",
+        "2026.08.18",
+        "--flavor",
+        "instance",
+    )
+    assert result.returncode == 0, result.stderr
+    manifest = InstanceRuntimeManifest.model_validate_json((out / "manifest.json").read_text())
+    assert manifest.format == "aleph-instance-runtime"
+    assert manifest.bundle.ref == BUNDLE_REF
+    assert manifest.boot.cmdline_template == "console=ttyS0 luks=1 owner={owner}"

--- a/tests/vprogram/test_manifest.py
+++ b/tests/vprogram/test_manifest.py
@@ -3,12 +3,13 @@
 import copy
 import json
 from collections.abc import Callable
+from copy import deepcopy
 from typing import Any
 
 import pytest
 from pydantic import ValidationError
 
-from aleph.vm.vprogram.manifest import RuntimeManifest
+from aleph.vm.vprogram.manifest import InstanceRuntimeManifest, RuntimeManifest
 
 # The reference manifest from the design doc, with the real mainnet bundle values.
 REFERENCE_MANIFEST: dict[str, Any] = {
@@ -110,3 +111,97 @@ def test_rejections(description: str, mutate: Callable[[dict[str, Any]], None]) 
     mutate(data)
     with pytest.raises(ValidationError):
         RuntimeManifest.model_validate(data)
+
+
+def test_vprogram_manifest_rejects_instance_format() -> None:
+    """Symmetry guard: the two formats must not accept each other's literal."""
+    bad = copy.deepcopy(REFERENCE_MANIFEST)
+    bad["format"] = "aleph-instance-runtime"
+    with pytest.raises(ValidationError):
+        RuntimeManifest.model_validate(bad)
+
+
+# The reference manifest for the aleph-instance-runtime format: TEE-agnostic
+# in format name, no platform_roothash, no workload block, bundle members
+# limited to ovmf/kernel/initrd (no rootfs, no hash tree).
+MINIMAL_INSTANCE_MANIFEST: dict[str, Any] = {
+    "format": "aleph-instance-runtime",
+    "format_version": 1,
+    "name": "aleph-snp-luks",
+    "version": "2026.08.18",
+    "platform": "sev_snp",
+    "bundle": {
+        "ref": "87287e4a5c8d7554a50f982cd681b64b2600c0bbb1c0b1e618465e022e01b977",
+        "sha256": "1db0d69c96dc7ed6c8a6cbb8c63f8de516ef4ed668e95c468cc216e4c44d911b",
+        "size": 57522386,
+        "members": {
+            "ovmf": "image/OVMF.fd",
+            "kernel": "image/bzImage",
+            "initrd": "image/initrd",
+        },
+    },
+    "boot": {
+        "method": "qemu-direct-kernel",
+        "kernel_hashes": True,
+        "cpu_models": ["EPYC-v4"],
+        "cmdline_template": "console=ttyS0 luks=1 owner={owner}",
+    },
+    "attestation": [{"protocol": "aleph.ra-tls", "version": "1", "transport": {"type": "tcp", "port": 8443}}],
+    "source": {
+        "repo": "https://github.com/aleph-im/aleph-vm",
+        "rev": "4d90abaf",
+        "build": 'nix build "git+file://$REPO?dir=nix#image"',
+    },
+}
+
+
+@pytest.fixture()
+def minimal_instance_manifest_dict() -> dict[str, Any]:
+    return copy.deepcopy(MINIMAL_INSTANCE_MANIFEST)
+
+
+def test_instance_manifest_roundtrip(minimal_instance_manifest_dict: dict[str, Any]) -> None:
+    manifest = InstanceRuntimeManifest.model_validate(minimal_instance_manifest_dict)
+    assert manifest.platform == "sev_snp"
+    assert "{owner}" in manifest.boot.cmdline_template
+    assert InstanceRuntimeManifest.model_validate_json(manifest.to_canonical_json()) == manifest
+
+
+def test_instance_manifest_rejects_vprogram_format(minimal_instance_manifest_dict: dict[str, Any]) -> None:
+    bad = {**minimal_instance_manifest_dict, "format": "aleph-vprogram-runtime"}
+    with pytest.raises(ValidationError):
+        InstanceRuntimeManifest.model_validate(bad)
+
+
+def test_instance_template_rejects_roothash_placeholder(minimal_instance_manifest_dict: dict[str, Any]) -> None:
+    bad = deepcopy(minimal_instance_manifest_dict)
+    bad["boot"]["cmdline_template"] = "console=ttyS0 luks=1 owner={owner} roothash={platform_roothash}"
+    with pytest.raises(ValidationError, match="unknown cmdline placeholder"):
+        InstanceRuntimeManifest.model_validate(bad)
+
+
+def test_instance_template_requires_owner(minimal_instance_manifest_dict: dict[str, Any]) -> None:
+    bad = deepcopy(minimal_instance_manifest_dict)
+    bad["boot"]["cmdline_template"] = "console=ttyS0 luks=1"
+    with pytest.raises(ValidationError, match="owner"):
+        InstanceRuntimeManifest.model_validate(bad)
+
+
+def test_instance_manifest_rejects_workload_field(minimal_instance_manifest_dict: dict[str, Any]) -> None:
+    bad = {**minimal_instance_manifest_dict, "workload": {"contract": "aleph.builtin/1", "upstream_port": 8080}}
+    with pytest.raises(ValidationError):
+        InstanceRuntimeManifest.model_validate(bad)
+
+
+def test_instance_manifest_rejects_platform_roothash_field(minimal_instance_manifest_dict: dict[str, Any]) -> None:
+    bad = deepcopy(minimal_instance_manifest_dict)
+    bad["boot"]["platform_roothash"] = "cb121a317be7dc7969dd633ca9b6c3718ffe9ea6715b64e0e35a871d484b56b8"
+    with pytest.raises(ValidationError):
+        InstanceRuntimeManifest.model_validate(bad)
+
+
+def test_instance_manifest_rejects_extra_bundle_member(minimal_instance_manifest_dict: dict[str, Any]) -> None:
+    bad = deepcopy(minimal_instance_manifest_dict)
+    bad["bundle"]["members"]["platform_rootfs"] = "image/rootfs.ext4"
+    with pytest.raises(ValidationError):
+        InstanceRuntimeManifest.model_validate(bad)


### PR DESCRIPTION
**Stack 2/4 for SEV-SNP confidential instances.** Base: `od/snp-inst-1-ownerauth` (PR 1). Reviewer lens: the measured guest image and its manifest, pure nix + Python, no supervisor/agent code.

Related tickets: ALEPH-XXX

## Changes
- **Shared init prologue**: the v-program `init.sh` prologue (mounts, networking, chroot helpers) is factored verbatim, statement-for-statement, into `nix/init-common.sh` so both images share it. The v-program image is unchanged in behavior (proven by an identical measurement + cpio listing across the refactor).
- **Instance guest image** (`nix/init-instance.sh`, a dedicated initrd): boots only in LUKS mode (fail-closed poweroff without `luks=1 owner=0x...`), starts the attest-agent early with `--owner`, waits indefinitely for the passphrase (heartbeat log, wrong-passphrase retry), unlocks `cryptsetup` and chroots in. No platform firewall (firewall policy belongs to the user rootfs). Carries `cryptsetup`/`dm-crypt`, drops veritysetup/nft. A distinct bundle from the v-program image so neither product's TCB carries the other's code. Includes the guest-side `[ -s ]` non-empty passphrase guard (the nix half of the passphrase-race fix whose agent half is in PR 1).
- **`aleph-instance-runtime/1` manifest** (`src/aleph/vm/vprogram/`): a TEE-agnostic manifest flavor (platform is a field), LUKS cmdline template `console=ttyS0 luks=1 owner={owner}` with a closed placeholder set, sharing the template validator with the v-program flavor so the two cannot drift. `vprogram_bundle.py --flavor instance`.
- **Test rootfs**: a dropbear test rootfs (nix) for the E2E harness.

## How to test
`nix build ./nix#instanceImage ./nix#image` (both green); `pytest tests/vprogram/`.

## Notes
- Stacks on PR 1. The instance image references the attest-agent binary whose `--owner` support lands in PR 1.
- The refreshed v-program image measurement changes (shared-init refactor + PR 1's atomic-write). The pin/re-pin procedure and the artifact-upload steps live in a separate operator runbook kept outside this PR (untracked, alongside the design and plan docs), not in the reviewed diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)