### PR TITLE
feat(snp-instances) 4/4: agent launch path for mode=sev_snp

### DIFF
--- a/examples/instance_confidential_snp/build_luks_rootfs.sh
+++ b/examples/instance_confidential_snp/build_luks_rootfs.sh
@@ -21,5 +21,10 @@ printf '%s' "$PASS" | cryptsetup luksFormat --type luks2 --batch-mode "$LOOP" -
 printf '%s' "$PASS" | cryptsetup luksOpen "$LOOP" snp-rootfs-build -
 trap 'cryptsetup luksClose snp-rootfs-build; losetup -d "$LOOP"' EXIT
 dd if="$PLAIN" of=/dev/mapper/snp-rootfs-build bs=4M status=progress conv=fsync
+# resize2fs refuses to grow a filesystem whose last-check time predates its
+# last-modify time (true of any image just copied onto by dd), so force a
+# check first. e2fsck's exit codes 1 and 2 mean errors were found and fixed
+# (not a failure); only bail out above that.
+e2fsck -fp /dev/mapper/snp-rootfs-build || [ $? -le 2 ]
 resize2fs /dev/mapper/snp-rootfs-build
 echo "wrote LUKS2 rootfs to $OUT"

--- a/examples/instance_confidential_snp/build_luks_rootfs.sh
+++ b/examples/instance_confidential_snp/build_luks_rootfs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Build a LUKS2-encrypted SNP instance rootfs from a plain ext4 rootfs image.
+#
+# Usage: build_luks_rootfs.sh <plain-rootfs.ext4> <output.img> [size-mib]
+# Prompts for the passphrase (or reads LUKS_PASSPHRASE from the environment).
+#
+# Contract (docs/plans/2026-08-18-snp-confidential-instances-design.md):
+# whole-device LUKS2 container, ext4 inside, an executable /sbin/init run
+# CHROOTED by the measured init (not PID 1: systemd images will not work),
+# SSH keys and all provisioning inside the image. The CRN never sees the
+# passphrase; it is injected post-attestation via aleph-attest-cli
+# inject-secret --owner-key.
+set -euo pipefail
+PLAIN="$1"; OUT="$2"; SIZE_MIB="${3:-$(( ($(stat -c%s "$PLAIN") / 1048576) + 64 ))}"
+PASS="${LUKS_PASSPHRASE:-}"
+if [ -z "$PASS" ]; then read -r -s -p "LUKS passphrase: " PASS; echo; fi
+truncate -s "${SIZE_MIB}M" "$OUT"
+LOOP=$(losetup --find --show "$OUT")
+trap 'losetup -d "$LOOP"' EXIT
+printf '%s' "$PASS" | cryptsetup luksFormat --type luks2 --batch-mode "$LOOP" -
+printf '%s' "$PASS" | cryptsetup luksOpen "$LOOP" snp-rootfs-build -
+trap 'cryptsetup luksClose snp-rootfs-build; losetup -d "$LOOP"' EXIT
+dd if="$PLAIN" of=/dev/mapper/snp-rootfs-build bs=4M status=progress conv=fsync
+resize2fs /dev/mapper/snp-rootfs-build
+echo "wrote LUKS2 rootfs to $OUT"

--- a/examples/instance_confidential_snp/build_luks_rootfs.sh
+++ b/examples/instance_confidential_snp/build_luks_rootfs.sh
@@ -27,8 +27,10 @@ trap 'cryptsetup luksClose snp-rootfs-build; losetup -d "$LOOP"' EXIT
 dd if="$PLAIN" of=/dev/mapper/snp-rootfs-build bs=4M status=progress conv=fsync
 # resize2fs refuses to grow a filesystem whose last-check time predates its
 # last-modify time (true of any image just copied onto by dd), so force a
-# check first. e2fsck's exit codes 1 and 2 mean errors were found and fixed
-# (not a failure); only bail out above that.
-e2fsck -fp /dev/mapper/snp-rootfs-build || [ $? -le 2 ]
+# check first. e2fsck's exit code is a bitwise OR: 1 = errors corrected,
+# 2 = corrected and a reboot is advised (irrelevant for a loop-mounted build
+# image), 4 = errors left UNCORRECTED, 8 and above = operational failures.
+# So anything below 4 (including 3 = 1|2) means the check succeeded.
+e2fsck -fp /dev/mapper/snp-rootfs-build || [ $? -lt 4 ]
 resize2fs /dev/mapper/snp-rootfs-build
 echo "wrote LUKS2 rootfs to $OUT"

--- a/examples/instance_confidential_snp/build_luks_rootfs.sh
+++ b/examples/instance_confidential_snp/build_luks_rootfs.sh
@@ -11,6 +11,10 @@
 # passphrase; it is injected post-attestation via aleph-attest-cli
 # inject-secret --owner-key.
 set -euo pipefail
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 <plain-rootfs.ext4> <output.img> [size-mib]" >&2
+    exit 1
+fi
 PLAIN="$1"; OUT="$2"; SIZE_MIB="${3:-$(( ($(stat -c%s "$PLAIN") / 1048576) + 64 ))}"
 PASS="${LUKS_PASSPHRASE:-}"
 if [ -z "$PASS" ]; then read -r -s -p "LUKS passphrase: " PASS; echo; fi

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -25,6 +25,11 @@ from multidict import CIMultiDict
 from aleph.vm.agent.aggregate import get_user_settings
 from aleph.vm.agent.capacity import CapacityManager, requested_gpu_ids
 from aleph.vm.agent.expiry import ExpiryManager
+from aleph.vm.agent.snp_instance_launch import (
+    build_snp_instance_spec,
+    is_snp_instance,
+    remove_snp_instance_staging,
+)
 from aleph.vm.agent.translate import build_create_vm_spec, build_program_create_vm_spec
 from aleph.vm.agent.update_watcher import UpdateWatcher
 from aleph.vm.agent.vm.program_client import ProgramGuestClient
@@ -303,8 +308,22 @@ async def create_vm_execution(
         # state before initializing it; the supervisor machinery never reads this
         # record. Spec-eligible VMs are QEMU instances, always persistent.
         record = registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
+        snp_instance = is_snp_instance(content)
+        attest_port: int | None = None
         try:
-            spec = await build_create_vm_spec(vm_hash, content)
+            if snp_instance:
+                # SEV-SNP confidential instances build through the dedicated
+                # LUKS-rootfs SNP launch path, not build_create_vm_spec (which
+                # would build a SEV spec with no firmware, since these
+                # messages carry no trusted_execution.firmware). GPU
+                # passthrough is not supported yet on this path: reject
+                # before any staging I/O runs.
+                if requested_gpu_ids(content):
+                    msg = "GPU passthrough is not supported on SEV-SNP instances yet"
+                    raise VmSetupError(msg)
+                spec, attest_port = await build_snp_instance_spec(vm_hash, content)
+            else:
+                spec = await build_create_vm_spec(vm_hash, content)
             # Agent-side admission, after the download so a failed download
             # never consumes a GPU hold: bucket from the message type, then
             # resolve the requested device_ids to concrete host cards (owner =
@@ -318,10 +337,13 @@ async def create_vm_execution(
                 is_instance=True,
                 exclude_vm_hash=vm_hash,
             )
-            requested_gpus = requested_gpu_ids(content)
-            if requested_gpus:
-                resolved_gpus = await capacity.resolve_gpus(requested_gpus, owner=content.address)
-                spec = replace(spec, gpus=resolved_gpus)
+            if not snp_instance:
+                # GPU resolution only applies to the legacy spec path: SNP
+                # instances are rejected above before reaching here.
+                requested_gpus = requested_gpu_ids(content)
+                if requested_gpus:
+                    resolved_gpus = await capacity.resolve_gpus(requested_gpus, owner=content.address)
+                    spec = replace(spec, gpus=resolved_gpus)
             info = await supervisor.create_vm(spec)
         except Exception:
             # build or create failed: drop the early record so a failed create
@@ -329,6 +351,11 @@ async def create_vm_execution(
             # VM the supervisor knows about). Nothing is persisted yet, so
             # forgetting the in-memory entry is sufficient.
             registry.forget(vm_hash)
+            if snp_instance:
+                # build_snp_instance_spec may have already extracted the
+                # runtime bundle (e.g. capacity admission fails after
+                # staging): do not leak it.
+                remove_snp_instance_staging(vm_hash)
             raise
         if info.awaiting_confidential_init:
             # A confidential VM is created but not started: only the owner can
@@ -336,11 +363,24 @@ async def create_vm_execution(
             # /confidential/initialize. Waiting for RUNNING would block forever,
             # and there are no port forwards to apply on a VM that is not up.
             # This mirrors the message path, which never waits on a confidential
-            # VM either.
+            # VM either. SNP instances never set this: the daemon boots them
+            # immediately, so this branch is SEV-only.
             await persist_record(vm_hash, record)
             return None
         try:
             await finish_instance_create(supervisor, info.vm_id, content)
+            if attest_port is not None:
+                # The guest attestation service (aleph.ra-tls) the runtime
+                # manifest pinned: forward it alongside SSH and the user's
+                # own aggregate so the owner can attest post-boot.
+                await supervisor.add_port_forward(
+                    PortForwardSpec(
+                        vm_id=info.vm_id,
+                        host_port=HostPort(0),
+                        vm_port=GuestPort(attest_port),
+                        protocol=Protocol.TCP,
+                    )
+                )
         except Exception:
             # Readiness or port-forward setup failed: tear the half-started VM
             # down, but never let a teardown error mask the original failure.
@@ -349,6 +389,8 @@ async def create_vm_execution(
                 await supervisor.delete_vm(info.vm_id)
             except Exception:
                 logger.exception("Teardown of half-started VM %s failed", vm_hash)
+            if snp_instance:
+                remove_snp_instance_staging(vm_hash)
             raise
         # Agent persists its own knowledge; the hypervisor object is not
         # touched. Registry rehydration and past-logs owner-auth read the

--- a/src/aleph/vm/agent/snp_instance_launch.py
+++ b/src/aleph/vm/agent/snp_instance_launch.py
@@ -1,0 +1,208 @@
+"""SEV-SNP launch path for confidential INSTANCE messages: runtime manifest
+fetch, bundle staging and CreateVmSpec construction for the LUKS
+(opaque-cmdline) SNP instance flavor (``environment.trusted_execution.mode ==
+"sev_snp"``).
+
+Unlike a V-PROGRAM (vprogram_launch.py: measured dm-verity platform rootfs,
+no client-supplied disk image), a confidential instance supplies its OWN
+LUKS2-encrypted rootfs as a writable qcow2 volume: the runtime bundle here
+only pins the measured platform (OVMF, kernel, initrd) and the guest-init
+kernel cmdline template. There is no dm-verity platform rootfs and no
+workload block: the guest owns everything past LUKS unlock.
+
+Every check fails closed with VmSetupError: an unmeasured host input, an
+unsupported host, or a malformed manifest must never reach create_vm.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from aleph_message.models.execution.instance import InstanceContent
+from pydantic import ValidationError
+
+from aleph.vm.agent import snp_staging
+from aleph.vm.agent.vm.downloader import QemuDownloader
+from aleph.vm.conf import settings
+from aleph.vm.storage import get_existing_file
+from aleph.vm.supervisor_interface.errors import VmSetupError
+from aleph.vm.supervisor_interface.types import (
+    Backend,
+    CreateVmSpec,
+    DirectoryPath,
+    DiskFormat,
+    DiskRole,
+    DiskSpec,
+    NetworkConfig,
+    SpecVmType,
+    TeeBackend,
+    TeeConfig,
+    VmId,
+)
+from aleph.vm.utils import check_amd_sev_snp_supported, get_hostname_from_hash
+from aleph.vm.vprogram.manifest import InstanceRuntimeManifest
+
+if TYPE_CHECKING:
+    from aleph_message.models import ItemHash
+
+logger = logging.getLogger(__name__)
+
+# A lowercased 0x-prefixed 20-byte hex address: v1 confidential instances are
+# EVM-keyed only (owner-auth is EIP-191; see build_snp_instance_spec).
+_EVM_ADDRESS_PATTERN = re.compile(r"0x[0-9a-f]{40}")
+
+
+def snp_instance_staging_dir(vm_hash: ItemHash) -> Path:
+    """The per-VM directory the instance runtime bundle is extracted into."""
+    return snp_staging.staging_dir("snp-instance", vm_hash)
+
+
+def remove_snp_instance_staging(vm_hash: ItemHash) -> None:
+    """Delete a confidential instance's staging directory once its VM is gone
+    for good.
+
+    The extracted runtime bundle lives at EXECUTION_ROOT/snp-instance/<vm_hash>;
+    the launch path only clears it on re-extraction, so a churned instance
+    would otherwise leak it on disk. Idempotent and safe for any VM type: a
+    non-SNP-instance VM has no such directory, so this is a no-op. Call it
+    from the teardown paths, after the supervisor delete and registry.forget.
+    """
+    snp_staging.remove_staging("snp-instance", vm_hash)
+
+
+def is_snp_instance(content) -> bool:
+    """True for an InstanceContent whose trusted_execution runs the SEV-SNP
+    (mode="sev_snp") flavor, as opposed to legacy SEV or no TEE at all."""
+    return (
+        isinstance(content, InstanceContent)
+        and content.environment.trusted_execution is not None
+        and getattr(content.environment.trusted_execution, "is_snp", False)
+    )
+
+
+async def fetch_instance_runtime_manifest(runtime_ref: str) -> InstanceRuntimeManifest:
+    """Download and parse the instance runtime manifest pinned by
+    ``trusted_execution.runtime``.
+
+    Mirrors vprogram_launch.fetch_runtime_manifest but validates against the
+    aleph-instance-runtime format; a manifest of another format (e.g. a
+    v-program's aleph-vprogram-runtime) fails its ``format`` literal, and the
+    resulting VmSetupError names the expected format.
+    """
+    manifest_path = await get_existing_file(runtime_ref)
+    try:
+        return InstanceRuntimeManifest.model_validate_json(manifest_path.read_bytes())
+    except (ValidationError, ValueError, OSError) as error:
+        msg = f"instance runtime manifest {runtime_ref} is invalid: {error}"
+        raise VmSetupError(msg) from error
+
+
+async def build_snp_instance_spec(vm_hash: ItemHash, content: InstanceContent) -> tuple[CreateVmSpec, int]:
+    """Validate, fetch/stage the runtime bundle, and build the SNP CreateVmSpec
+    for a confidential instance with its own LUKS-encrypted rootfs. Returns
+    the spec and the guest attestation port.
+
+    Rejections fire in this order, all before any staging I/O: an
+    attestation_port override, a host without SNP support, a policy above 32
+    bits, and a non-EVM sender. Because every rejection runs before
+    fetch_instance_runtime_manifest/fetch_and_stage_bundle are ever called, a
+    rejection never leaves a staging directory behind.
+    """
+    trusted_execution = content.environment.trusted_execution
+    if trusted_execution.attestation_port is not None:
+        msg = (
+            "attestation_port overrides are not supported yet; leave it unset "
+            "(the runtime manifest declares the port)"
+        )
+        raise VmSetupError(msg)
+    if not check_amd_sev_snp_supported():
+        msg = "this host does not support SEV-SNP"
+        raise VmSetupError(msg)
+    if int(trusted_execution.policy) >= 2**32:
+        msg = "SNP guest policy above 32 bits is not supported yet"
+        raise VmSetupError(msg)
+    owner = str(content.address).lower()
+    if not _EVM_ADDRESS_PATTERN.fullmatch(owner):
+        msg = "SNP confidential instances require an EVM-keyed sender in v1 (owner-auth is EIP-191)"
+        raise VmSetupError(msg)
+
+    if content.authorized_keys or content.variables:
+        logger.warning(
+            "SNP instance %s: authorized_keys/variables are unmeasured host inputs and are "
+            "ignored; provision inside the encrypted rootfs",
+            vm_hash,
+        )
+
+    manifest = await fetch_instance_runtime_manifest(str(trusted_execution.runtime))
+    bundle_dir = await snp_staging.fetch_and_stage_bundle(
+        vm_hash,
+        kind="snp-instance",
+        ref=manifest.bundle.ref,
+        sha256=manifest.bundle.sha256,
+        size=manifest.bundle.size,
+    )
+    logger.debug("Staged SNP instance %s runtime bundle at %s", vm_hash, bundle_dir)
+
+    members = manifest.bundle.members
+    ovmf_path = snp_staging.member_path(bundle_dir, members.ovmf, "ovmf")
+    kernel_path = snp_staging.member_path(bundle_dir, members.kernel, "kernel")
+    initrd_path = snp_staging.member_path(bundle_dir, members.initrd, "initrd")
+    kernel_cmdline = manifest.boot.cmdline_template.format(owner=owner)
+
+    # Ordered by preference (manifest.attestation): prefer the aleph.ra-tls
+    # descriptor's port; fall back to the first descriptor for a runtime that
+    # only implements another protocol.
+    attest_port = manifest.attestation[0].transport.port
+    for descriptor in manifest.attestation:
+        if descriptor.protocol == "aleph.ra-tls":
+            attest_port = descriptor.transport.port
+            break
+
+    resources = QemuDownloader(content, namespace=str(vm_hash))
+    await resources.download_all()
+    disks = [
+        DiskSpec(path=resources.rootfs_path, readonly=False, format=DiskFormat.QCOW2, role=DiskRole.ROOTFS),
+    ] + [
+        DiskSpec(path=v.path_on_host, readonly=v.read_only, format=DiskFormat.RAW, role=DiskRole.EXTRA)
+        for v in resources.volumes
+    ]
+
+    session_base = settings.CONFIDENTIAL_SESSION_DIRECTORY or (Path(settings.EXECUTION_ROOT) / "sessions")
+
+    spec = CreateVmSpec(
+        vm_id=VmId(str(vm_hash)),
+        backend=Backend.QEMU,
+        kernel_path=kernel_path,
+        initrd_path=initrd_path,
+        disks=disks,
+        vcpus=content.resources.vcpus,
+        memory_mib=content.resources.memory,
+        tee=TeeConfig(
+            backend=TeeBackend.SEV_SNP,
+            policy=str(trusted_execution.policy),
+            # The daemon derives its own CONFIDENTIAL_SESSION_DIRECTORY/<vm_id>
+            # for SNP (lifecycle.rs): required-but-ignored placeholder.
+            session_dir=DirectoryPath(Path(session_base) / str(vm_hash)),
+            firmware_path=ovmf_path,
+            kernel_cmdline=kernel_cmdline,
+        ),
+        network=NetworkConfig(
+            internet_access=bool(content.environment.internet),
+            requested_ipv6="",
+            ipv6_prefix_len=0,
+        ),
+        gpus=[],
+        numa_node=None,
+        # QEMU instances start under systemd only; the daemon rejects a
+        # non-persistent QEMU VM.
+        persistent=True,
+        # authorized_keys are ignored above; the SSH keys live inside the
+        # owner's LUKS-encrypted rootfs.
+        ssh_authorized_keys=[],
+        hostname=get_hostname_from_hash(vm_hash),
+        vm_type=SpecVmType.INSTANCE,
+    )
+    return spec, attest_port

--- a/src/aleph/vm/agent/snp_instance_launch.py
+++ b/src/aleph/vm/agent/snp_instance_launch.py
@@ -25,6 +25,7 @@ from aleph_message.models.execution.instance import InstanceContent
 from pydantic import ValidationError
 
 from aleph.vm.agent import snp_staging
+from aleph.vm.agent.guest_ipv6 import compute_requested_ipv6
 from aleph.vm.agent.vm.downloader import QemuDownloader
 from aleph.vm.conf import settings
 from aleph.vm.storage import get_existing_file
@@ -37,12 +38,12 @@ from aleph.vm.supervisor_interface.types import (
     DiskRole,
     DiskSpec,
     NetworkConfig,
-    SpecVmType,
     TeeBackend,
     TeeConfig,
     VmId,
 )
 from aleph.vm.utils import check_amd_sev_snp_supported, get_hostname_from_hash
+from aleph.vm.vm_type import VmType
 from aleph.vm.vprogram.manifest import InstanceRuntimeManifest
 
 if TYPE_CHECKING:
@@ -172,6 +173,10 @@ async def build_snp_instance_spec(vm_hash: ItemHash, content: InstanceContent) -
 
     session_base = settings.CONFIDENTIAL_SESSION_DIRECTORY or (Path(settings.EXECUTION_ROOT) / "sessions")
 
+    # A confidential instance's static IPv6 depends only on the type and item
+    # hash, so the agent computes it upfront (empty under the dynamic policy).
+    requested_ipv6, ipv6_prefix_len = compute_requested_ipv6(vm_hash, VmType.instance)
+
     spec = CreateVmSpec(
         vm_id=VmId(str(vm_hash)),
         backend=Backend.QEMU,
@@ -191,8 +196,8 @@ async def build_snp_instance_spec(vm_hash: ItemHash, content: InstanceContent) -
         ),
         network=NetworkConfig(
             internet_access=bool(content.environment.internet),
-            requested_ipv6="",
-            ipv6_prefix_len=0,
+            requested_ipv6=requested_ipv6,
+            ipv6_prefix_len=ipv6_prefix_len,
         ),
         gpus=[],
         numa_node=None,
@@ -203,6 +208,5 @@ async def build_snp_instance_spec(vm_hash: ItemHash, content: InstanceContent) -
         # owner's LUKS-encrypted rootfs.
         ssh_authorized_keys=[],
         hostname=get_hostname_from_hash(vm_hash),
-        vm_type=SpecVmType.INSTANCE,
     )
     return spec, attest_port

--- a/src/aleph/vm/agent/snp_staging.py
+++ b/src/aleph/vm/agent/snp_staging.py
@@ -61,7 +61,7 @@ def _sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _verify_bundle(tar_path: Path, *, ref: str, sha256: str, size: int) -> None:
+def verify_bundle(tar_path: Path, *, ref: str, sha256: str, size: int) -> None:
     """The integrity gate: the downloaded tarball must be byte-identical to
     the one pinned by ref/sha256/size (sha256 + size), or nothing gets extracted."""
     actual_size = tar_path.stat().st_size
@@ -76,7 +76,7 @@ def _verify_bundle(tar_path: Path, *, ref: str, sha256: str, size: int) -> None:
         raise VmSetupError(msg)
 
 
-def _extract_bundle(tar_path: Path, dest: Path) -> None:
+def extract_bundle(tar_path: Path, dest: Path) -> None:
     """Extract the verified tarball into a clean staging directory.
 
     ``filter="data"`` is the tarfile safety filter: it rejects absolute
@@ -109,9 +109,9 @@ async def fetch_and_stage_bundle(vm_hash: ItemHash, *, kind: str, ref: str, sha2
     create_vm.
     """
     tar_path = await get_existing_file(ref)
-    _verify_bundle(tar_path, ref=ref, sha256=sha256, size=size)
+    verify_bundle(tar_path, ref=ref, sha256=sha256, size=size)
     dest = staging_dir(kind, vm_hash)
-    _extract_bundle(tar_path, dest)
+    extract_bundle(tar_path, dest)
     return dest
 
 

--- a/src/aleph/vm/agent/snp_staging.py
+++ b/src/aleph/vm/agent/snp_staging.py
@@ -1,0 +1,129 @@
+"""Shared SEV-SNP bundle-staging helpers.
+
+Both the V-PROGRAM launch path (vprogram_launch.py: one runtime bundle per
+VM) and the SNP confidential-instance launch path stage a tar.gz bundle into
+a per-VM directory under EXECUTION_ROOT, verifying it against a pinned
+sha256 + size before extraction. This module holds that shared machinery so
+neither launch path reimplements the integrity gate or the tarfile-safety
+extraction.
+
+Every check fails closed with VmSetupError: a mismeasured or tampered bundle
+must never reach create_vm.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import shutil
+import tarfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from aleph.vm.conf import settings
+from aleph.vm.storage import get_existing_file
+from aleph.vm.supervisor_interface.errors import VmSetupError
+
+if TYPE_CHECKING:
+    from aleph_message.models import ItemHash
+
+logger = logging.getLogger(__name__)
+
+_SHA256_CHUNK_SIZE = 1024 * 1024
+
+
+def staging_dir(kind: str, vm_hash: ItemHash) -> Path:
+    """The per-VM directory a runtime bundle is extracted into."""
+    return Path(settings.EXECUTION_ROOT) / kind / str(vm_hash)
+
+
+def remove_staging(kind: str, vm_hash: ItemHash) -> None:
+    """Delete a VM's staging directory once its VM is gone for good.
+
+    The extracted bundle lives at EXECUTION_ROOT/<kind>/<vm_hash>; the launch
+    path only clears it on re-extraction, so a churned VM would otherwise
+    leak it on disk. Idempotent and safe for any VM type: a VM with no such
+    directory is a no-op. Call it from the teardown paths, after the
+    supervisor delete and registry.forget.
+    """
+    staging = staging_dir(kind, vm_hash)
+    if staging.exists():
+        logger.debug("Removing %s %s staging directory %s", kind, vm_hash, staging)
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fileobj:
+        while chunk := fileobj.read(_SHA256_CHUNK_SIZE):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _verify_bundle(tar_path: Path, *, ref: str, sha256: str, size: int) -> None:
+    """The integrity gate: the downloaded tarball must be byte-identical to
+    the one pinned by ref/sha256/size (sha256 + size), or nothing gets extracted."""
+    actual_size = tar_path.stat().st_size
+    if actual_size != size:
+        msg = f"runtime bundle {ref} size mismatch: expected {size}, got {actual_size}"
+        raise VmSetupError(msg)
+    actual_sha256 = _sha256_file(tar_path)
+    # Constant-time compare: defense-in-depth for the hash gate, even though the
+    # manifest is content-addressed and the timing surface here is negligible.
+    if not hmac.compare_digest(actual_sha256, sha256):
+        msg = f"runtime bundle {ref} sha256 mismatch: expected {sha256}, got {actual_sha256}"
+        raise VmSetupError(msg)
+
+
+def _extract_bundle(tar_path: Path, dest: Path) -> None:
+    """Extract the verified tarball into a clean staging directory.
+
+    ``filter="data"`` is the tarfile safety filter: it rejects absolute
+    member names, upward traversal, links pointing outside the destination,
+    and strips setuid/devices, so a hostile tarball cannot escape ``dest``.
+    """
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.mkdir(parents=True)
+    try:
+        with tarfile.open(tar_path, mode="r:gz") as tar:
+            # filter="data" (PEP 706) needs CPython >= 3.12 / 3.11.4 / 3.10.12.
+            # On an older patch release the keyword is absent and extractall
+            # raises TypeError; catch it so we fail closed as VmSetupError
+            # rather than an opaque error (never extract without the filter).
+            tar.extractall(dest, filter="data")
+    except (tarfile.TarError, OSError, TypeError) as error:
+        # Never leave a partially-populated staging dir behind on failure.
+        shutil.rmtree(dest, ignore_errors=True)
+        msg = f"cannot extract runtime bundle {tar_path} into {dest}: {error}"
+        raise VmSetupError(msg) from error
+
+
+async def fetch_and_stage_bundle(vm_hash: ItemHash, *, kind: str, ref: str, sha256: str, size: int) -> Path:
+    """Download the bundle by ref, verify it against sha256/size, and extract
+    it into a clean per-VM staging directory. Returns the staging directory.
+
+    Every failure (download, integrity mismatch, extraction) is a
+    VmSetupError: a mismeasured or tampered bundle must never reach
+    create_vm.
+    """
+    tar_path = await get_existing_file(ref)
+    _verify_bundle(tar_path, ref=ref, sha256=sha256, size=size)
+    dest = staging_dir(kind, vm_hash)
+    _extract_bundle(tar_path, dest)
+    return dest
+
+
+def member_path(bundle_dir: Path, relative: str, role: str) -> Path:
+    """Resolve a manifest member (already validated relative + no-upward by
+    the model) inside the extracted bundle, failing closed if it is missing
+    or somehow escapes the staging directory."""
+    path = bundle_dir / relative
+    if not path.resolve().is_relative_to(bundle_dir.resolve()):
+        msg = f"bundle member {role} escapes the staging directory: {relative}"
+        raise VmSetupError(msg)
+    if not path.is_file():
+        msg = f"bundle member {role} missing after extraction: {path}"
+        raise VmSetupError(msg)
+    return path

--- a/src/aleph/vm/agent/tasks.py
+++ b/src/aleph/vm/agent/tasks.py
@@ -29,6 +29,7 @@ from yarl import URL
 from aleph.vm.agent.haproxy_sync import sync_domain_mappings
 from aleph.vm.agent.metrics import delete_records_for_vm
 from aleph.vm.agent.run import reconcile_port_forwards
+from aleph.vm.agent.snp_instance_launch import remove_snp_instance_staging
 from aleph.vm.agent.utils import (
     format_cost,
     get_community_wallet_address,
@@ -404,6 +405,7 @@ async def check_payment(supervisor: Supervisor, registry: AgentVmRegistry):
             registry.forget(vm_hash)
             await delete_records_for_vm(str(vm_hash))
             remove_vprogram_staging(vm_hash)
+            remove_snp_instance_staging(vm_hash)
         else:
             # Status is healthy — reset any previous strikes
             _terminal_strike_count.pop(str(vm_hash), None)

--- a/src/aleph/vm/agent/translate.py
+++ b/src/aleph/vm/agent/translate.py
@@ -88,6 +88,13 @@ async def build_create_vm_spec(
     tee: TeeConfig | None = None
     trusted_execution = getattr(message.environment, "trusted_execution", None)
     if trusted_execution is not None:
+        if getattr(trusted_execution, "is_snp", False):
+            # SNP instances are built by build_snp_instance_spec
+            # (snp_instance_launch.py), which supplies the measured runtime
+            # bundle (OVMF/kernel/initrd/cmdline). This path has none of
+            # that: a routing mistake that reached here would silently build
+            # a SEV spec with no firmware. Fail loudly instead.
+            raise InvalidBackendError("SNP instances are built by build_snp_instance_spec, not this path")
         firmware_path = await get_existing_file(trusted_execution.firmware)
         tee = TeeConfig(
             backend=TeeBackend.SEV,

--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -42,6 +42,7 @@ from aleph.vm.agent.run import (
     run_code_on_request,
     start_persistent_vm,
 )
+from aleph.vm.agent.snp_instance_launch import remove_snp_instance_staging
 from aleph.vm.agent.tasks import COMMUNITY_STREAM_RATIO
 from aleph.vm.agent.utils import (
     format_cost,
@@ -608,6 +609,7 @@ async def update_allocations(request: web.Request):
                 registry.forget(vm_hash)
                 await delete_records_for_vm(str(vm_hash))
                 remove_vprogram_staging(vm_hash)
+                remove_snp_instance_staging(vm_hash)
                 stopped_vms.append(vm_hash)
 
         # Second start persistent VMs and instances sequentially to limit resource usage.

--- a/src/aleph/vm/agent/views/operator.py
+++ b/src/aleph/vm/agent/views/operator.py
@@ -22,6 +22,7 @@ from aleph.vm.agent import metrics
 from aleph.vm.agent.custom_logs import set_vm_for_logging
 from aleph.vm.agent.expiry import ExpiryManager
 from aleph.vm.agent.run import create_vm_execution_or_raise_http_error
+from aleph.vm.agent.snp_instance_launch import remove_snp_instance_staging
 from aleph.vm.agent.views.authentication import (
     authenticate_websocket_message,
     require_jwk_authentication,
@@ -667,6 +668,7 @@ async def operate_erase(request: web.Request, authenticated_sender: str) -> web.
         # wipe=True clears the daemon-side disks; the agent-side staging dir
         # (extracted runtime bundle) is ours to remove.
         remove_vprogram_staging(vm_hash)
+        remove_snp_instance_staging(vm_hash)
         return web.Response(status=200, body=f"Erased VM with ref {vm_hash}")
 
 

--- a/src/aleph/vm/agent/vprogram_launch.py
+++ b/src/aleph/vm/agent/vprogram_launch.py
@@ -22,18 +22,16 @@ must never reach create_vm.
 
 from __future__ import annotations
 
-import hashlib
-import hmac
 import logging
 import re
 import shutil
-import tarfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from aleph_message.models.execution.vprogram import VERITY_ROOTHASH_PATTERN
 from pydantic import ValidationError
 
+from aleph.vm.agent import snp_staging
 from aleph.vm.agent.guest_ipv6 import compute_requested_ipv6
 from aleph.vm.conf import settings
 from aleph.vm.storage import get_existing_file
@@ -60,12 +58,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_SHA256_CHUNK_SIZE = 1024 * 1024
-
 
 def vprogram_staging_dir(vm_hash: ItemHash) -> Path:
     """The per-VM directory the runtime bundle is extracted into."""
-    return Path(settings.EXECUTION_ROOT) / "vprogram" / str(vm_hash)
+    return snp_staging.staging_dir("vprogram", vm_hash)
 
 
 def remove_vprogram_staging(vm_hash: ItemHash) -> None:
@@ -77,10 +73,7 @@ def remove_vprogram_staging(vm_hash: ItemHash) -> None:
     non-V-PROGRAM has no such directory, so this is a no-op. Call it from the
     teardown paths, after the supervisor delete and registry.forget.
     """
-    staging = vprogram_staging_dir(vm_hash)
-    if staging.exists():
-        logger.debug("Removing V-PROGRAM %s staging directory %s", vm_hash, staging)
-        shutil.rmtree(staging, ignore_errors=True)
+    snp_staging.remove_staging("vprogram", vm_hash)
 
 
 async def fetch_runtime_manifest(runtime_ref: str) -> RuntimeManifest:
@@ -97,70 +90,6 @@ async def fetch_runtime_manifest(runtime_ref: str) -> RuntimeManifest:
     except (ValidationError, ValueError, OSError) as error:
         msg = f"runtime manifest {runtime_ref} is invalid: {error}"
         raise VmSetupError(msg) from error
-
-
-def _sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as fileobj:
-        while chunk := fileobj.read(_SHA256_CHUNK_SIZE):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _verify_bundle(tar_path: Path, manifest: RuntimeManifest) -> None:
-    """The integrity gate: the downloaded tarball must be byte-identical to
-    the one the manifest measured (sha256 + size), or nothing gets extracted."""
-    actual_size = tar_path.stat().st_size
-    if actual_size != manifest.bundle.size:
-        msg = f"runtime bundle {manifest.bundle.ref} size mismatch: expected {manifest.bundle.size}, got {actual_size}"
-        raise VmSetupError(msg)
-    actual_sha256 = _sha256_file(tar_path)
-    # Constant-time compare: defense-in-depth for the hash gate, even though the
-    # manifest is content-addressed and the timing surface here is negligible.
-    if not hmac.compare_digest(actual_sha256, manifest.bundle.sha256):
-        msg = (
-            f"runtime bundle {manifest.bundle.ref} sha256 mismatch: "
-            f"expected {manifest.bundle.sha256}, got {actual_sha256}"
-        )
-        raise VmSetupError(msg)
-
-
-def _extract_bundle(tar_path: Path, dest: Path) -> None:
-    """Extract the verified tarball into a clean staging directory.
-
-    ``filter="data"`` is the tarfile safety filter: it rejects absolute
-    member names, upward traversal, links pointing outside the destination,
-    and strips setuid/devices, so a hostile tarball cannot escape ``dest``.
-    """
-    if dest.exists():
-        shutil.rmtree(dest)
-    dest.mkdir(parents=True)
-    try:
-        with tarfile.open(tar_path, mode="r:gz") as tar:
-            # filter="data" (PEP 706) needs CPython >= 3.12 / 3.11.4 / 3.10.12.
-            # On an older patch release the keyword is absent and extractall
-            # raises TypeError; catch it so we fail closed as VmSetupError
-            # rather than an opaque error (never extract without the filter).
-            tar.extractall(dest, filter="data")
-    except (tarfile.TarError, OSError, TypeError) as error:
-        # Never leave a partially-populated staging dir behind on failure.
-        shutil.rmtree(dest, ignore_errors=True)
-        msg = f"cannot extract runtime bundle {tar_path} into {dest}: {error}"
-        raise VmSetupError(msg) from error
-
-
-def _member_path(bundle_dir: Path, relative: str, role: str) -> Path:
-    """Resolve a manifest member (already validated relative + no-upward by
-    the model) inside the extracted bundle, failing closed if it is missing
-    or somehow escapes the staging directory."""
-    path = bundle_dir / relative
-    if not path.resolve().is_relative_to(bundle_dir.resolve()):
-        msg = f"bundle member {role} escapes the staging directory: {relative}"
-        raise VmSetupError(msg)
-    if not path.is_file():
-        msg = f"bundle member {role} missing after extraction: {path}"
-        raise VmSetupError(msg)
-    return path
 
 
 def _ensure_verity_sidecars(rootfs_path: Path, hash_tree_path: Path, platform_roothash: str) -> None:
@@ -207,19 +136,25 @@ async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramConte
     """
     manifest = await fetch_runtime_manifest(str(content.runtime.ref))
 
+    # The tarball is fetched here (not via snp_staging.fetch_and_stage_bundle)
+    # so it goes through this module's own get_existing_file: run.py and the
+    # launch-path tests patch aleph.vm.agent.vprogram_launch.get_existing_file
+    # and expect every ref (manifest, bundle, workload) to resolve through it.
     tar_path = await get_existing_file(manifest.bundle.ref)
-    _verify_bundle(tar_path, manifest)
+    snp_staging._verify_bundle(
+        tar_path, ref=manifest.bundle.ref, sha256=manifest.bundle.sha256, size=manifest.bundle.size
+    )
 
     bundle_dir = vprogram_staging_dir(vm_hash)
-    _extract_bundle(tar_path, bundle_dir)
+    snp_staging._extract_bundle(tar_path, bundle_dir)
     logger.debug("Staged V-PROGRAM %s runtime bundle at %s", vm_hash, bundle_dir)
 
     members = manifest.bundle.members
-    ovmf_path = _member_path(bundle_dir, members.ovmf, "ovmf")
-    kernel_path = _member_path(bundle_dir, members.kernel, "kernel")
-    initrd_path = _member_path(bundle_dir, members.initrd, "initrd")
-    rootfs_path = _member_path(bundle_dir, members.platform_rootfs, "platform_rootfs")
-    hash_tree_path = _member_path(bundle_dir, members.platform_hash_tree, "platform_hash_tree")
+    ovmf_path = snp_staging.member_path(bundle_dir, members.ovmf, "ovmf")
+    kernel_path = snp_staging.member_path(bundle_dir, members.kernel, "kernel")
+    initrd_path = snp_staging.member_path(bundle_dir, members.initrd, "initrd")
+    rootfs_path = snp_staging.member_path(bundle_dir, members.platform_rootfs, "platform_rootfs")
+    hash_tree_path = snp_staging.member_path(bundle_dir, members.platform_hash_tree, "platform_hash_tree")
 
     _ensure_verity_sidecars(rootfs_path, hash_tree_path, manifest.boot.platform_roothash)
 

--- a/src/aleph/vm/agent/vprogram_launch.py
+++ b/src/aleph/vm/agent/vprogram_launch.py
@@ -141,12 +141,12 @@ async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramConte
     # launch-path tests patch aleph.vm.agent.vprogram_launch.get_existing_file
     # and expect every ref (manifest, bundle, workload) to resolve through it.
     tar_path = await get_existing_file(manifest.bundle.ref)
-    snp_staging._verify_bundle(
+    snp_staging.verify_bundle(
         tar_path, ref=manifest.bundle.ref, sha256=manifest.bundle.sha256, size=manifest.bundle.size
     )
 
     bundle_dir = vprogram_staging_dir(vm_hash)
-    snp_staging._extract_bundle(tar_path, bundle_dir)
+    snp_staging.extract_bundle(tar_path, bundle_dir)
     logger.debug("Staged V-PROGRAM %s runtime bundle at %s", vm_hash, bundle_dir)
 
     members = manifest.bundle.members

--- a/tests/supervisor/test_snp_instance_launch.py
+++ b/tests/supervisor/test_snp_instance_launch.py
@@ -40,9 +40,10 @@ from aleph.vm.agent.snp_instance_launch import (
     remove_snp_instance_staging,
     snp_instance_staging_dir,
 )
+from aleph.vm.agent.translate import build_create_vm_spec
 from aleph.vm.agent.vm.downloader import QemuDownloader
 from aleph.vm.conf import settings
-from aleph.vm.supervisor_interface.errors import VmSetupError
+from aleph.vm.supervisor_interface.errors import InvalidBackendError, VmSetupError
 from aleph.vm.supervisor_interface.types import DiskFormat, TeeBackend
 from aleph.vm.vprogram.manifest import InstanceRuntimeManifest
 
@@ -319,6 +320,36 @@ async def test_warns_and_ignores_authorized_keys(caplog, staged_instance_bundle)
 
     assert spec.ssh_authorized_keys == []
     assert any("authorized_keys" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_warns_and_ignores_variables(caplog, staged_instance_bundle):
+    """The other side of the `authorized_keys or variables` warning: variables
+    are unmeasured host inputs too, so they are ignored with a warning."""
+    content = snp_instance_content(variables={"SECRET": "value"})
+    with caplog.at_level("WARNING"):
+        await build_snp_instance_spec(VM_HASH, content)
+
+    assert any("authorized_keys" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_build_create_vm_spec_rejects_snp_instance(monkeypatch):
+    """translate.build_create_vm_spec is the legacy SEV/plain path; an SNP
+    instance that reaches it (a routing regression) must fail loud with
+    InvalidBackendError rather than silently build a firmware-less SEV spec."""
+
+    class _NoopDownloader:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def download_all(self):
+            return None
+
+    monkeypatch.setattr("aleph.vm.agent.translate.QemuDownloader", _NoopDownloader)
+    content = snp_instance_content()
+    with pytest.raises(InvalidBackendError, match="build_snp_instance_spec"):
+        await build_create_vm_spec(VM_HASH, content)
 
 
 def test_is_snp_instance_true_for_sev_snp_mode():

--- a/tests/supervisor/test_snp_instance_launch.py
+++ b/tests/supervisor/test_snp_instance_launch.py
@@ -266,6 +266,42 @@ async def test_build_snp_instance_spec_happy_path(staged_instance_bundle):
 
 
 @pytest.mark.asyncio
+async def test_prefers_the_ra_tls_attestation_port(tmp_path, staged_instance_bundle):
+    """manifest.attestation is ordered by preference, but aleph.ra-tls is the
+    descriptor the CRN forwards: a runtime that lists another protocol first
+    must still get its ra-tls port forwarded, not the first descriptor's."""
+    make_manifest(
+        staged_instance_bundle["tar"],
+        tmp_path,
+        attestation=[
+            {"protocol": "vendor.other-attest", "version": "1", "transport": {"type": "tcp", "port": 7000}},
+            {"protocol": "aleph.ra-tls", "version": "1", "transport": {"type": "tcp", "port": 8443}},
+        ],
+    )
+
+    _, attest_port = await build_snp_instance_spec(VM_HASH, snp_instance_content())
+
+    assert attest_port == 8443
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_the_first_attestation_port_without_ra_tls(tmp_path, staged_instance_bundle):
+    """A runtime that implements no aleph.ra-tls descriptor still gets a port
+    forwarded: the first (most preferred) descriptor wins."""
+    make_manifest(
+        staged_instance_bundle["tar"],
+        tmp_path,
+        attestation=[
+            {"protocol": "vendor.other-attest", "version": "1", "transport": {"type": "tcp", "port": 7000}},
+        ],
+    )
+
+    _, attest_port = await build_snp_instance_spec(VM_HASH, snp_instance_content())
+
+    assert attest_port == 7000
+
+
+@pytest.mark.asyncio
 async def test_rejects_attestation_port_set(staged_instance_bundle):
     content = snp_instance_content(trusted_execution_overrides={"attestation_port": 9000})
     with pytest.raises(VmSetupError, match="attestation_port"):
@@ -330,7 +366,7 @@ async def test_warns_and_ignores_variables(caplog, staged_instance_bundle):
     with caplog.at_level("WARNING"):
         await build_snp_instance_spec(VM_HASH, content)
 
-    assert any("authorized_keys" in record.message for record in caplog.records)
+    assert any("variables" in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_snp_instance_launch.py
+++ b/tests/supervisor/test_snp_instance_launch.py
@@ -43,7 +43,7 @@ from aleph.vm.agent.snp_instance_launch import (
 from aleph.vm.agent.vm.downloader import QemuDownloader
 from aleph.vm.conf import settings
 from aleph.vm.supervisor_interface.errors import VmSetupError
-from aleph.vm.supervisor_interface.types import DiskFormat, SpecVmType, TeeBackend
+from aleph.vm.supervisor_interface.types import DiskFormat, TeeBackend
 from aleph.vm.vprogram.manifest import InstanceRuntimeManifest
 
 VM_HASH = ItemHash("deadbeef" * 8)
@@ -250,7 +250,6 @@ async def test_build_snp_instance_spec_happy_path(staged_instance_bundle):
     assert spec.tee.backend is TeeBackend.SEV_SNP
     assert spec.tee.kernel_cmdline == f"console=ttyS0 luks=1 owner={OWNER_LOWER}"
     assert spec.tee.policy == str(DEFAULT_SNP_POLICY)
-    assert spec.vm_type is SpecVmType.INSTANCE
     rootfs = spec.rootfs
     assert rootfs is not None
     assert rootfs.format is DiskFormat.QCOW2

--- a/tests/supervisor/test_snp_instance_launch.py
+++ b/tests/supervisor/test_snp_instance_launch.py
@@ -1,0 +1,373 @@
+"""Tests for the confidential-INSTANCE SEV-SNP launch path (agent side).
+
+Everything runs offline: get_existing_file is monkeypatched (both in this
+module's namespace, for the manifest fetch, and in aleph.vm.agent.snp_staging's
+namespace, for the bundle fetch) to serve a manifest JSON and a locally built
+bundle tarball from tmp_path, mirroring tests/supervisor/test_vprogram_launch.py.
+"""
+
+from __future__ import annotations
+
+import copy
+import gzip
+import hashlib
+import io
+import json
+import shutil
+import tarfile
+from pathlib import Path
+from typing import IO, Any, cast
+
+import pytest
+from aleph_message.models import ItemHash
+from aleph_message.models.execution.base import Payment, PaymentType
+from aleph_message.models.execution.environment import (
+    DEFAULT_SNP_POLICY,
+    HypervisorType,
+    InstanceEnvironment,
+    LaunchMeasurement,
+    MachineResources,
+    TeePlatform,
+    TrustedExecutionEnvironment,
+)
+from aleph_message.models.execution.instance import InstanceContent, RootfsVolume
+from aleph_message.models.execution.volume import ParentVolume, VolumePersistence
+from aleph_message.utils import Mebibytes
+
+from aleph.vm.agent.snp_instance_launch import (
+    build_snp_instance_spec,
+    fetch_instance_runtime_manifest,
+    is_snp_instance,
+    remove_snp_instance_staging,
+    snp_instance_staging_dir,
+)
+from aleph.vm.agent.vm.downloader import QemuDownloader
+from aleph.vm.conf import settings
+from aleph.vm.supervisor_interface.errors import VmSetupError
+from aleph.vm.supervisor_interface.types import DiskFormat, SpecVmType, TeeBackend
+from aleph.vm.vprogram.manifest import InstanceRuntimeManifest
+
+VM_HASH = ItemHash("deadbeef" * 8)
+_FAKE_HASH = ItemHash("cafecafe" * 8)
+MANIFEST_REF = "d00dd00d" * 8
+BUNDLE_REF = "b1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1ee"
+
+OWNER_LOWER = "0x1234567890abcdef1234567890abcdef12345678"
+NON_EVM_ADDRESS = "5FHwkrdxDCvSXWvBaHf3Aq6X8AfUY5vLwLLpAt7dQxCg"
+
+# The reference instance manifest shape (tests/vprogram/test_manifest.py), with
+# the bundle digest/size patched per-test to match the locally built tarball.
+MANIFEST_TEMPLATE: dict[str, Any] = {
+    "format": "aleph-instance-runtime",
+    "format_version": 1,
+    "name": "aleph-snp-instance",
+    "version": "2026.08.18",
+    "platform": "sev_snp",
+    "bundle": {
+        "ref": BUNDLE_REF,
+        "sha256": "0" * 64,
+        "size": 1,
+        "members": {
+            "ovmf": "OVMF.fd",
+            "kernel": "bzImage",
+            "initrd": "initrd",
+        },
+    },
+    "boot": {
+        "method": "qemu-direct-kernel",
+        "kernel_hashes": True,
+        "cpu_models": ["EPYC-v4"],
+        "cmdline_template": "console=ttyS0 luks=1 owner={owner}",
+    },
+    "attestation": [{"protocol": "aleph.ra-tls", "version": "1", "transport": {"type": "tcp", "port": 8443}}],
+    "source": {
+        "repo": "https://github.com/aleph-im/aleph-vm",
+        "rev": "4d90abaf",
+        "build": 'nix build "git+file://$REPO?dir=nix#instance-image"',
+    },
+}
+
+# A v-program-shaped manifest (wrong format): used to prove
+# fetch_instance_runtime_manifest rejects it by name.
+VPROGRAM_MANIFEST: dict[str, Any] = {
+    "format": "aleph-vprogram-runtime",
+    "format_version": 1,
+    "name": "aleph-snp-attest",
+    "version": "2026.07.08",
+    "platform": "sev_snp",
+    "bundle": {
+        "ref": BUNDLE_REF,
+        "sha256": "0" * 64,
+        "size": 1,
+        "members": {
+            "ovmf": "OVMF.fd",
+            "kernel": "bzImage",
+            "initrd": "initrd",
+            "platform_rootfs": "rootfs.ext4",
+            "platform_hash_tree": "rootfs.ext4.verity",
+        },
+    },
+    "boot": {
+        "method": "qemu-direct-kernel",
+        "kernel_hashes": True,
+        "cpu_models": ["EPYC-v4"],
+        "platform_roothash": "a" * 64,
+        "cmdline_template": "console=ttyS0 root=/dev/mapper/verity-root ro roothash={platform_roothash}",
+    },
+    "attestation": [{"protocol": "aleph.ra-tls", "version": "1", "transport": {"type": "tcp", "port": 8443}}],
+    "workload": {"contract": "aleph.builtin/1", "upstream_port": 8080},
+    "source": {
+        "repo": "https://github.com/aleph-im/aleph-vm",
+        "rev": "4d90abaf",
+        "build": 'nix build "git+file://$REPO?dir=nix#image"',
+    },
+}
+
+BUNDLE_FILES: dict[str, bytes] = {
+    "OVMF.fd": b"ovmf firmware blob",
+    "bzImage": b"kernel image",
+    "initrd": b"initial ramdisk",
+}
+
+
+def make_bundle(out_dir: Path, files: dict[str, bytes] | None = None) -> Path:
+    """Build a tar.gz shaped like the instance bundle: OVMF, kernel, initrd only."""
+    files = BUNDLE_FILES if files is None else files
+    tar_path = out_dir / "snp-instance-image.tar.gz"
+    with tar_path.open("wb") as raw:
+        with gzip.GzipFile(filename="", fileobj=raw, mode="wb", mtime=0) as gz:
+            with tarfile.open(fileobj=cast(IO[bytes], gz), mode="w") as tar:
+                for name, data in sorted(files.items()):
+                    member = tarfile.TarInfo(name)
+                    member.size = len(data)
+                    member.mode = 0o644
+                    tar.addfile(member, io.BytesIO(data))
+    return tar_path
+
+
+def make_manifest(
+    tar_path: Path, out_dir: Path, template: dict[str, Any] = MANIFEST_TEMPLATE, **overrides: Any
+) -> Path:
+    """Write a manifest JSON whose bundle digest/size match tar_path."""
+    data = copy.deepcopy(template)
+    raw = tar_path.read_bytes()
+    data["bundle"]["sha256"] = hashlib.sha256(raw).hexdigest()
+    data["bundle"]["size"] = len(raw)
+    for dotted, value in overrides.items():
+        target = data
+        *parents, leaf = dotted.split(".")
+        for key in parents:
+            target = target[key]
+        target[leaf] = value
+    manifest_path = out_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(data))
+    return manifest_path
+
+
+def snp_instance_content(
+    *,
+    address: str = OWNER_LOWER,
+    authorized_keys: list[str] | None = None,
+    variables: dict[str, str] | None = None,
+    trusted_execution_overrides: dict[str, Any] | None = None,
+) -> InstanceContent:
+    trusted_execution_kwargs: dict[str, Any] = {
+        "mode": "sev_snp",
+        "policy": DEFAULT_SNP_POLICY,
+        "runtime": ItemHash(MANIFEST_REF),
+        "measurements": [LaunchMeasurement(platform=TeePlatform.sev_snp, digest="a" * 96, vcpu_type="EPYC-v4")],
+    }
+    trusted_execution_kwargs.update(trusted_execution_overrides or {})
+    return InstanceContent(
+        address=address,
+        time=1.0,
+        allow_amend=False,
+        authorized_keys=authorized_keys,
+        variables=variables,
+        # SEV-SNP confidential instances are credit-only (schema-enforced).
+        payment=Payment(type=PaymentType.credit),
+        environment=InstanceEnvironment(
+            internet=True,
+            aleph_api=False,
+            hypervisor=HypervisorType.qemu,
+            trusted_execution=TrustedExecutionEnvironment(**trusted_execution_kwargs),
+        ),
+        resources=MachineResources(vcpus=2, memory=Mebibytes(2048), seconds=300),
+        volumes=[],
+        rootfs=RootfsVolume(
+            parent=ParentVolume(ref=_FAKE_HASH, use_latest=False),
+            persistence=VolumePersistence.host,
+            size_mib=10000,
+        ),
+    )
+
+
+@pytest.fixture
+def storage_files(monkeypatch) -> dict[str, Path]:
+    """Serve get_existing_file from a local ref -> path map: no network.
+
+    Patches BOTH namespaces the launch path resolves refs through: this
+    module's own get_existing_file (the manifest fetch) and
+    aleph.vm.agent.snp_staging's (the bundle fetch, via fetch_and_stage_bundle).
+    """
+    files: dict[str, Path] = {}
+
+    async def fake_get_existing_file(ref: str) -> Path:
+        return files[str(ref)]
+
+    monkeypatch.setattr("aleph.vm.agent.snp_instance_launch.get_existing_file", fake_get_existing_file)
+    monkeypatch.setattr("aleph.vm.agent.snp_staging.get_existing_file", fake_get_existing_file)
+    return files
+
+
+@pytest.fixture
+def snp_supported(monkeypatch):
+    monkeypatch.setattr("aleph.vm.agent.snp_instance_launch.check_amd_sev_snp_supported", lambda: True)
+
+
+@pytest.fixture
+def staged_instance_bundle(tmp_path, storage_files, snp_supported, monkeypatch) -> dict[str, Path]:
+    tar_path = make_bundle(tmp_path)
+    manifest_path = make_manifest(tar_path, tmp_path)
+    storage_files[MANIFEST_REF] = manifest_path
+    storage_files[BUNDLE_REF] = tar_path
+
+    async def fake_download_all(self) -> None:
+        self.rootfs_path = tmp_path / "instance-rootfs.qcow2"
+        self.rootfs_path.write_bytes(b"writable luks rootfs")
+        self.volumes = []
+
+    monkeypatch.setattr(QemuDownloader, "download_all", fake_download_all)
+
+    staging = snp_instance_staging_dir(VM_HASH)
+    if staging.exists():  # leftover from a previous pytest run: EXECUTION_ROOT persists
+        shutil.rmtree(staging)
+
+    return {"tar": tar_path, "manifest": manifest_path}
+
+
+@pytest.mark.asyncio
+async def test_build_snp_instance_spec_happy_path(staged_instance_bundle):
+    spec, attest_port = await build_snp_instance_spec(VM_HASH, snp_instance_content())
+
+    assert spec.tee is not None
+    assert spec.tee.backend is TeeBackend.SEV_SNP
+    assert spec.tee.kernel_cmdline == f"console=ttyS0 luks=1 owner={OWNER_LOWER}"
+    assert spec.tee.policy == str(DEFAULT_SNP_POLICY)
+    assert spec.vm_type is SpecVmType.INSTANCE
+    rootfs = spec.rootfs
+    assert rootfs is not None
+    assert rootfs.format is DiskFormat.QCOW2
+    assert rootfs.readonly is False
+    assert spec.kernel_path.name == "bzImage"
+    assert spec.initrd_path.name == "initrd"
+    assert spec.tee.firmware_path is not None
+    assert spec.tee.firmware_path.name == "OVMF.fd"
+    assert spec.ssh_authorized_keys == []
+    assert spec.persistent is True
+    assert spec.hostname
+    assert attest_port == 8443
+
+
+@pytest.mark.asyncio
+async def test_rejects_attestation_port_set(staged_instance_bundle):
+    content = snp_instance_content(trusted_execution_overrides={"attestation_port": 9000})
+    with pytest.raises(VmSetupError, match="attestation_port"):
+        await build_snp_instance_spec(VM_HASH, content)
+
+
+@pytest.mark.asyncio
+async def test_rejects_non_evm_sender(snp_supported):
+    content = snp_instance_content(address=NON_EVM_ADDRESS)
+    with pytest.raises(VmSetupError, match="EVM"):
+        await build_snp_instance_spec(VM_HASH, content)
+
+
+@pytest.mark.asyncio
+async def test_rejects_vprogram_manifest(tmp_path, storage_files, snp_supported):
+    """A runtime ref that resolves to an aleph-vprogram-runtime manifest must
+    be rejected by name: fetch_instance_runtime_manifest validates strictly
+    against InstanceRuntimeManifest's format literal."""
+    tar_path = make_bundle(tmp_path)
+    manifest_path = make_manifest(tar_path, tmp_path, template=VPROGRAM_MANIFEST)
+    storage_files[MANIFEST_REF] = manifest_path
+    storage_files[BUNDLE_REF] = tar_path
+
+    content = snp_instance_content()
+    with pytest.raises(VmSetupError, match="aleph-instance-runtime"):
+        await build_snp_instance_spec(VM_HASH, content)
+
+
+@pytest.mark.asyncio
+async def test_rejects_policy_above_u32(snp_supported):
+    # Bit 17 (reserved, must be set) stays set so the message schema itself
+    # accepts the policy; only the launch-path 32-bit cap rejects it.
+    over_u32_policy = (1 << 32) | (1 << 17)
+    content = snp_instance_content(trusted_execution_overrides={"policy": over_u32_policy})
+    with pytest.raises(VmSetupError, match="policy"):
+        await build_snp_instance_spec(VM_HASH, content)
+
+
+@pytest.mark.asyncio
+async def test_rejects_host_without_snp(monkeypatch):
+    monkeypatch.setattr("aleph.vm.agent.snp_instance_launch.check_amd_sev_snp_supported", lambda: False)
+    content = snp_instance_content()
+    with pytest.raises(VmSetupError, match="SEV-SNP"):
+        await build_snp_instance_spec(VM_HASH, content)
+
+
+@pytest.mark.asyncio
+async def test_warns_and_ignores_authorized_keys(caplog, staged_instance_bundle):
+    content = snp_instance_content(authorized_keys=["ssh-ed25519 AAAAB3NzaC1lZDI1NTE5AAAAIAbc owner@example.com"])
+    with caplog.at_level("WARNING"):
+        spec, _ = await build_snp_instance_spec(VM_HASH, content)
+
+    assert spec.ssh_authorized_keys == []
+    assert any("authorized_keys" in record.message for record in caplog.records)
+
+
+def test_is_snp_instance_true_for_sev_snp_mode():
+    assert is_snp_instance(snp_instance_content()) is True
+
+
+def test_is_snp_instance_false_for_non_instance_content():
+    assert is_snp_instance(object()) is False
+
+
+def test_is_snp_instance_false_for_no_trusted_execution():
+    content = snp_instance_content()
+    plain = content.model_copy(
+        update={"environment": content.environment.model_copy(update={"trusted_execution": None})}
+    )
+    assert is_snp_instance(plain) is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_instance_runtime_manifest_parses(tmp_path, storage_files):
+    tar_path = make_bundle(tmp_path)
+    manifest_path = make_manifest(tar_path, tmp_path)
+    storage_files[MANIFEST_REF] = manifest_path
+
+    manifest = await fetch_instance_runtime_manifest(MANIFEST_REF)
+    assert isinstance(manifest, InstanceRuntimeManifest)
+    assert manifest.platform == "sev_snp"
+    assert manifest.bundle.members.kernel == "bzImage"
+
+
+def test_remove_snp_instance_staging_is_idempotent(tmp_path, monkeypatch):
+    """The teardown paths call remove_snp_instance_staging so a churned
+    confidential instance does not leak its extracted bundle. It must remove
+    a populated staging dir and be a no-op (never raise) when there is
+    nothing to remove."""
+    monkeypatch.setattr(settings, "EXECUTION_ROOT", str(tmp_path))
+    staging = snp_instance_staging_dir(VM_HASH)
+    staging.mkdir(parents=True)
+    (staging / "OVMF.fd").write_bytes(b"ovmf firmware blob")
+    assert staging.exists()
+
+    remove_snp_instance_staging(VM_HASH)
+    assert not staging.exists()
+
+    # Already gone (second teardown, or a non-SNP-instance VM with no staging dir).
+    remove_snp_instance_staging(VM_HASH)
+    assert not staging.exists()

--- a/tests/supervisor/test_snp_instance_launch.py
+++ b/tests/supervisor/test_snp_instance_launch.py
@@ -13,7 +13,6 @@ import gzip
 import hashlib
 import io
 import json
-import shutil
 import tarfile
 from pathlib import Path
 from typing import IO, Any, cast
@@ -203,7 +202,7 @@ def snp_instance_content(
 
 
 @pytest.fixture
-def storage_files(monkeypatch) -> dict[str, Path]:
+def storage_files(tmp_path, monkeypatch) -> dict[str, Path]:
     """Serve get_existing_file from a local ref -> path map: no network.
 
     Patches BOTH namespaces the launch path resolves refs through: this
@@ -217,6 +216,7 @@ def storage_files(monkeypatch) -> dict[str, Path]:
 
     monkeypatch.setattr("aleph.vm.agent.snp_instance_launch.get_existing_file", fake_get_existing_file)
     monkeypatch.setattr("aleph.vm.agent.snp_staging.get_existing_file", fake_get_existing_file)
+    monkeypatch.setattr(settings, "EXECUTION_ROOT", str(tmp_path))
     return files
 
 
@@ -238,10 +238,6 @@ def staged_instance_bundle(tmp_path, storage_files, snp_supported, monkeypatch) 
         self.volumes = []
 
     monkeypatch.setattr(QemuDownloader, "download_all", fake_download_all)
-
-    staging = snp_instance_staging_dir(VM_HASH)
-    if staging.exists():  # leftover from a previous pytest run: EXECUTION_ROOT persists
-        shutil.rmtree(staging)
 
     return {"tar": tar_path, "manifest": manifest_path}
 

--- a/tests/supervisor/test_snp_instance_run.py
+++ b/tests/supervisor/test_snp_instance_run.py
@@ -1,0 +1,292 @@
+"""run.create_vm_execution routes mode=sev_snp confidential instances through
+the SNP launch path (build_snp_instance_spec), not the legacy SEV translate.py
+path. Mirrors tests/supervisor/test_supervisor_run_routing.py and
+tests/supervisor/test_vprogram.py's create-path tests, using
+test_snp_instance_launch.snp_instance_content for a schema-valid SNP fixture
+and test_supervisor_translate._make_qemu_instance_message for the legacy SEV
+regression check.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aleph_message.models.execution.environment import (
+    GpuProperties,
+    HostRequirements,
+    TrustedExecutionEnvironment,
+)
+from test_snp_instance_launch import VM_HASH, snp_instance_content
+from test_supervisor_translate import _make_qemu_instance_message
+
+from aleph.vm.agent import run as run_module
+from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor_interface.errors import VmSetupError
+from aleph.vm.supervisor_interface.types import (
+    Backend,
+    CreateVmSpec,
+    DirectoryPath,
+    DiskFormat,
+    DiskRole,
+    DiskSpec,
+    IpAssignment,
+    NetworkConfig,
+    SpecVmType,
+    TeeBackend,
+    TeeConfig,
+    VmId,
+    VmInfo,
+    VmStatus,
+)
+
+_ATTEST_PORT = 8443
+
+
+def _snp_spec() -> CreateVmSpec:
+    return CreateVmSpec(
+        vm_id=VmId(str(VM_HASH)),
+        backend=Backend.QEMU,
+        kernel_path=Path("bzImage"),
+        initrd_path=Path("initrd"),
+        disks=[
+            DiskSpec(
+                path=Path("/data/instance-rootfs.qcow2"),
+                readonly=False,
+                format=DiskFormat.QCOW2,
+                role=DiskRole.ROOTFS,
+            )
+        ],
+        vcpus=2,
+        memory_mib=2048,
+        tee=TeeConfig(
+            backend=TeeBackend.SEV_SNP,
+            policy="196608",
+            session_dir=DirectoryPath(Path("/sessions") / str(VM_HASH)),
+            firmware_path=Path("OVMF.fd"),
+            kernel_cmdline="console=ttyS0 luks=1 owner=0x1234567890abcdef1234567890abcdef12345678",
+        ),
+        network=NetworkConfig(internet_access=True, requested_ipv6="", ipv6_prefix_len=0),
+        gpus=[],
+        numa_node=None,
+        persistent=True,
+        vm_type=SpecVmType.INSTANCE,
+    )
+
+
+def _info(status: VmStatus = VmStatus.RUNNING, *, awaiting_confidential_init: bool = False) -> VmInfo:
+    return VmInfo(
+        vm_id=VmId(str(VM_HASH)),
+        status=status,
+        ipv4=IpAssignment(),
+        ipv6=IpAssignment(),
+        uptime_secs=0,
+        backend=Backend.QEMU,
+        numa_node=None,
+        status_message="",
+        awaiting_confidential_init=awaiting_confidential_init,
+    )
+
+
+def _fake_capacity():
+    return MagicMock(check_capacity=MagicMock(), resolve_gpus=AsyncMock())
+
+
+def _fake_supervisor(*, create_status: VmStatus = VmStatus.RUNNING, get_status: VmStatus = VmStatus.RUNNING):
+    return MagicMock(
+        create_vm=AsyncMock(return_value=_info(create_status)),
+        get_vm=AsyncMock(return_value=_info(get_status)),
+        add_port_forward=AsyncMock(),
+        delete_vm=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_snp_instance_create_uses_snp_builder(monkeypatch):
+    """The SNP builder is used (not build_create_vm_spec), and after RUNNING
+    the recorded port forwards include SSH (22) and the attestation port
+    (8443, from build_snp_instance_spec's returned attest_port)."""
+    content = snp_instance_content()
+    message = MagicMock(content=content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
+    )
+    spec = _snp_spec()
+    build_snp = AsyncMock(return_value=(spec, _ATTEST_PORT))
+    monkeypatch.setattr(run_module, "build_snp_instance_spec", build_snp)
+    build_sev = AsyncMock()
+    monkeypatch.setattr(run_module, "build_create_vm_spec", build_sev)
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(run_module, "persist_record", AsyncMock())
+
+    supervisor = _fake_supervisor()
+    registry = AgentVmRegistry()
+
+    execution = await run_module.create_vm_execution(
+        VM_HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
+    )
+
+    build_snp.assert_awaited_once_with(VM_HASH, content)
+    build_sev.assert_not_awaited()
+    sent_spec = supervisor.create_vm.await_args.args[0]
+    assert sent_spec.tee is not None
+    assert sent_spec.tee.kernel_cmdline
+    assert sent_spec.vm_type is SpecVmType.INSTANCE
+
+    forwarded_ports = {int(call.args[0].vm_port) for call in supervisor.add_port_forward.await_args_list}
+    assert 22 in forwarded_ports
+    assert _ATTEST_PORT in forwarded_ports
+    assert execution is None
+
+
+@pytest.mark.asyncio
+async def test_snp_instance_never_awaits_confidential_init(monkeypatch):
+    """SNP VMs auto-boot: create_vm never reports awaiting_confidential_init,
+    so the path must fall straight through to finish_instance_create / the
+    port-forward stage rather than the SEV await branch."""
+    content = snp_instance_content()
+    message = MagicMock(content=content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
+    )
+    spec = _snp_spec()
+    monkeypatch.setattr(run_module, "build_snp_instance_spec", AsyncMock(return_value=(spec, _ATTEST_PORT)))
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+    persist = AsyncMock()
+    monkeypatch.setattr(run_module, "persist_record", persist)
+
+    info = _info(VmStatus.RUNNING, awaiting_confidential_init=False)
+    supervisor = _fake_supervisor()
+    supervisor.create_vm = AsyncMock(return_value=info)
+    registry = AgentVmRegistry()
+
+    await run_module.create_vm_execution(
+        VM_HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
+    )
+
+    # Reached the port-forward stage: add_port_forward was actually called.
+    assert supervisor.add_port_forward.await_count >= 2
+    persist.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_snp_instance_with_gpus_rejected(monkeypatch):
+    """A GPU-requesting SNP instance is rejected with a clean VmSetupError
+    BEFORE build_snp_instance_spec or create_vm ever run."""
+    content = snp_instance_content().model_copy(
+        update={
+            "requirements": HostRequirements(
+                gpu=[
+                    GpuProperties(
+                        vendor="NVIDIA",
+                        device_name="RTX",
+                        device_class="0300",
+                        device_id="10de:1234",
+                    )
+                ]
+            )
+        }
+    )
+    message = MagicMock(content=content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
+    )
+    build_snp = AsyncMock()
+    monkeypatch.setattr(run_module, "build_snp_instance_spec", build_snp)
+
+    supervisor = _fake_supervisor()
+    registry = AgentVmRegistry()
+
+    with pytest.raises(VmSetupError, match="GPU passthrough is not supported on SEV-SNP"):
+        await run_module.create_vm_execution(
+            VM_HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
+        )
+
+    build_snp.assert_not_awaited()
+    supervisor.create_vm.assert_not_awaited()
+    assert registry.get(VM_HASH) is None
+
+
+@pytest.mark.asyncio
+async def test_legacy_sev_instance_path_untouched(monkeypatch):
+    """A plain/legacy SEV (or non-confidential) instance still routes through
+    build_create_vm_spec, never build_snp_instance_spec; its spec carries no
+    kernel_cmdline (build_create_vm_spec never sets one)."""
+    content = _make_qemu_instance_message(trusted_execution=TrustedExecutionEnvironment())
+    message = MagicMock(content=content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
+    )
+    sev_spec = CreateVmSpec(
+        vm_id=VmId(str(VM_HASH)),
+        backend=Backend.QEMU,
+        kernel_path=Path(""),
+        initrd_path=Path(""),
+        disks=[
+            DiskSpec(path=Path("/data/rootfs.qcow2"), readonly=False, format=DiskFormat.QCOW2, role=DiskRole.ROOTFS)
+        ],
+        vcpus=2,
+        memory_mib=2048,
+        tee=TeeConfig(
+            backend=TeeBackend.SEV,
+            policy="0x1",
+            session_dir=DirectoryPath(Path("/sessions") / str(VM_HASH)),
+            firmware_path=Path("OVMF_SEV.fd"),
+        ),
+        network=NetworkConfig(internet_access=True, requested_ipv6="", ipv6_prefix_len=0),
+        gpus=[],
+        numa_node=None,
+        persistent=True,
+    )
+    build_sev = AsyncMock(return_value=sev_spec)
+    monkeypatch.setattr(run_module, "build_create_vm_spec", build_sev)
+    build_snp = AsyncMock()
+    monkeypatch.setattr(run_module, "build_snp_instance_spec", build_snp)
+    monkeypatch.setattr(run_module, "persist_record", AsyncMock())
+
+    awaiting = _info(VmStatus.BOOTING, awaiting_confidential_init=True)
+    supervisor = _fake_supervisor()
+    supervisor.create_vm = AsyncMock(return_value=awaiting)
+    registry = AgentVmRegistry()
+
+    execution = await run_module.create_vm_execution(
+        VM_HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
+    )
+
+    build_sev.assert_awaited_once_with(VM_HASH, content)
+    build_snp.assert_not_awaited()
+    assert supervisor.create_vm.await_args is not None
+    sent_spec = supervisor.create_vm.await_args.args[0]
+    assert sent_spec.tee.kernel_cmdline == ""
+    assert execution is None
+
+
+@pytest.mark.asyncio
+async def test_snp_instance_failure_cleans_staging(monkeypatch):
+    """supervisor.create_vm raises: the failure path must call
+    remove_snp_instance_staging and forget the registry record, mirroring the
+    V-PROGRAM build/create failure branch."""
+    content = snp_instance_content()
+    message = MagicMock(content=content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
+    )
+    spec = _snp_spec()
+    monkeypatch.setattr(run_module, "build_snp_instance_spec", AsyncMock(return_value=(spec, _ATTEST_PORT)))
+    remove_staging = MagicMock()
+    monkeypatch.setattr(run_module, "remove_snp_instance_staging", remove_staging)
+
+    supervisor = _fake_supervisor()
+    supervisor.create_vm = AsyncMock(side_effect=RuntimeError("qemu spawn failed"))
+    registry = AgentVmRegistry()
+
+    with pytest.raises(RuntimeError, match="qemu spawn failed"):
+        await run_module.create_vm_execution(
+            VM_HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
+        )
+
+    remove_staging.assert_called_once_with(VM_HASH)
+    assert registry.get(VM_HASH) is None

--- a/tests/supervisor/test_snp_instance_run.py
+++ b/tests/supervisor/test_snp_instance_run.py
@@ -33,7 +33,6 @@ from aleph.vm.supervisor_interface.types import (
     DiskSpec,
     IpAssignment,
     NetworkConfig,
-    SpecVmType,
     TeeBackend,
     TeeConfig,
     VmId,
@@ -71,7 +70,6 @@ def _snp_spec() -> CreateVmSpec:
         gpus=[],
         numa_node=None,
         persistent=True,
-        vm_type=SpecVmType.INSTANCE,
     )
 
 
@@ -133,7 +131,6 @@ async def test_snp_instance_create_uses_snp_builder(monkeypatch):
     sent_spec = supervisor.create_vm.await_args.args[0]
     assert sent_spec.tee is not None
     assert sent_spec.tee.kernel_cmdline
-    assert sent_spec.vm_type is SpecVmType.INSTANCE
 
     forwarded_ports = {int(call.args[0].vm_port) for call in supervisor.add_port_forward.await_args_list}
     assert 22 in forwarded_ports

--- a/tests/supervisor/test_snp_instance_run.py
+++ b/tests/supervisor/test_snp_instance_run.py
@@ -287,3 +287,36 @@ async def test_snp_instance_failure_cleans_staging(monkeypatch):
 
     remove_staging.assert_called_once_with(VM_HASH)
     assert registry.get(VM_HASH) is None
+
+
+@pytest.mark.asyncio
+async def test_snp_instance_port_forward_failure_cleans_staging(monkeypatch):
+    """The second teardown path: create_vm succeeds but a later port-forward
+    fails. The half-started VM must be deleted and its staging removed, mirroring
+    the create-failure branch (run.py's finish_instance_create/port-forward
+    except block)."""
+    content = snp_instance_content()
+    message = MagicMock(content=content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
+    )
+    spec = _snp_spec()
+    monkeypatch.setattr(run_module, "build_snp_instance_spec", AsyncMock(return_value=(spec, _ATTEST_PORT)))
+    # finish_instance_create succeeds; the attestation-port forward that follows
+    # raises, so the failure lands in the second except block.
+    monkeypatch.setattr(run_module, "finish_instance_create", AsyncMock())
+    remove_staging = MagicMock()
+    monkeypatch.setattr(run_module, "remove_snp_instance_staging", remove_staging)
+
+    supervisor = _fake_supervisor()  # create_vm returns RUNNING, not awaiting init
+    supervisor.add_port_forward = AsyncMock(side_effect=RuntimeError("nftables rule failed"))
+    registry = AgentVmRegistry()
+
+    with pytest.raises(RuntimeError, match="nftables rule failed"):
+        await run_module.create_vm_execution(
+            VM_HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
+        )
+
+    remove_staging.assert_called_once_with(VM_HASH)
+    supervisor.delete_vm.assert_awaited_once()
+    assert registry.get(VM_HASH) is None

--- a/tests/supervisor/test_snp_staging.py
+++ b/tests/supervisor/test_snp_staging.py
@@ -8,7 +8,6 @@ tests/supervisor/test_vprogram_launch.py.
 import gzip
 import hashlib
 import io
-import shutil
 import tarfile
 from pathlib import Path
 from typing import IO, cast
@@ -16,6 +15,7 @@ from typing import IO, cast
 import pytest
 
 from aleph.vm.agent.snp_staging import fetch_and_stage_bundle, staging_dir
+from aleph.vm.conf import settings
 from aleph.vm.supervisor_interface.errors import VmSetupError
 
 VM_HASH = "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafec"
@@ -43,7 +43,7 @@ def make_bundle(out_dir: Path, files: dict[str, bytes] | None = None) -> Path:
 
 
 @pytest.fixture
-def storage_files(monkeypatch) -> dict[str, Path]:
+def storage_files(tmp_path, monkeypatch) -> dict[str, Path]:
     """Serve get_existing_file from a local ref -> path map: no network."""
     files: dict[str, Path] = {}
 
@@ -51,6 +51,7 @@ def storage_files(monkeypatch) -> dict[str, Path]:
         return files[str(ref)]
 
     monkeypatch.setattr("aleph.vm.agent.snp_staging.get_existing_file", fake_get_existing_file)
+    monkeypatch.setattr(settings, "EXECUTION_ROOT", str(tmp_path))
     return files
 
 
@@ -84,8 +85,6 @@ async def test_fetch_and_stage_bundle_sha256_mismatch_fails_closed(tmp_path, sto
     storage_files[BUNDLE_REF] = tar_path
 
     dest = staging_dir("snp-instance", VM_HASH)
-    if dest.exists():  # leftover from a previous pytest run: EXECUTION_ROOT persists
-        shutil.rmtree(dest)
 
     with pytest.raises(VmSetupError, match="sha256 mismatch"):
         await fetch_and_stage_bundle(

--- a/tests/supervisor/test_snp_staging.py
+++ b/tests/supervisor/test_snp_staging.py
@@ -1,0 +1,98 @@
+"""Tests for the shared SEV-SNP bundle-staging helpers.
+
+Everything runs offline: get_existing_file is monkeypatched to serve a
+locally built bundle tarball from tmp_path, mirroring the pattern in
+tests/supervisor/test_vprogram_launch.py.
+"""
+
+import gzip
+import hashlib
+import io
+import shutil
+import tarfile
+from pathlib import Path
+from typing import IO, cast
+
+import pytest
+
+from aleph.vm.agent.snp_staging import fetch_and_stage_bundle, staging_dir
+from aleph.vm.supervisor_interface.errors import VmSetupError
+
+VM_HASH = "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafec"
+BUNDLE_REF = "87287e4a5c8d7554a50f982cd681b64b2600c0bbb1c0b1e618465e022e01b97"
+
+BUNDLE_FILES: dict[str, bytes] = {
+    "hello.txt": b"hello from the bundle",
+    "nested/inner.bin": b"nested member data",
+}
+
+
+def make_bundle(out_dir: Path, files: dict[str, bytes] | None = None) -> Path:
+    """Build a small tar.gz with a nested member, like the runtime bundle."""
+    files = BUNDLE_FILES if files is None else files
+    tar_path = out_dir / "bundle.tar.gz"
+    with tar_path.open("wb") as raw:
+        with gzip.GzipFile(filename="", fileobj=raw, mode="wb", mtime=0) as gz:
+            with tarfile.open(fileobj=cast(IO[bytes], gz), mode="w") as tar:
+                for name, data in sorted(files.items()):
+                    member = tarfile.TarInfo(name)
+                    member.size = len(data)
+                    member.mode = 0o644
+                    tar.addfile(member, io.BytesIO(data))
+    return tar_path
+
+
+@pytest.fixture
+def storage_files(monkeypatch) -> dict[str, Path]:
+    """Serve get_existing_file from a local ref -> path map: no network."""
+    files: dict[str, Path] = {}
+
+    async def fake_get_existing_file(ref: str) -> Path:
+        return files[str(ref)]
+
+    monkeypatch.setattr("aleph.vm.agent.snp_staging.get_existing_file", fake_get_existing_file)
+    return files
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_stage_bundle_stages_members(tmp_path, storage_files):
+    """The happy path: a verified tarball is fetched and extracted, and the
+    returned directory is exactly staging_dir(kind, vm_hash)."""
+    tar_path = make_bundle(tmp_path)
+    raw = tar_path.read_bytes()
+    storage_files[BUNDLE_REF] = tar_path
+
+    dest = await fetch_and_stage_bundle(
+        VM_HASH,
+        kind="snp-instance",
+        ref=BUNDLE_REF,
+        sha256=hashlib.sha256(raw).hexdigest(),
+        size=len(raw),
+    )
+
+    assert dest == staging_dir("snp-instance", VM_HASH)
+    assert (dest / "hello.txt").read_bytes() == b"hello from the bundle"
+    assert (dest / "nested" / "inner.bin").read_bytes() == b"nested member data"
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_stage_bundle_sha256_mismatch_fails_closed(tmp_path, storage_files):
+    """A tarball whose bytes do not match the pinned sha256 must never be
+    extracted: fail closed and leave no staging directory behind."""
+    tar_path = make_bundle(tmp_path)
+    raw = tar_path.read_bytes()
+    storage_files[BUNDLE_REF] = tar_path
+
+    dest = staging_dir("snp-instance", VM_HASH)
+    if dest.exists():  # leftover from a previous pytest run: EXECUTION_ROOT persists
+        shutil.rmtree(dest)
+
+    with pytest.raises(VmSetupError, match="sha256 mismatch"):
+        await fetch_and_stage_bundle(
+            VM_HASH,
+            kind="snp-instance",
+            ref=BUNDLE_REF,
+            sha256="f" * 64,
+            size=len(raw),
+        )
+    assert not dest.exists()

--- a/tests/supervisor/test_snp_staging.py
+++ b/tests/supervisor/test_snp_staging.py
@@ -14,7 +14,7 @@ from typing import IO, cast
 
 import pytest
 
-from aleph.vm.agent.snp_staging import fetch_and_stage_bundle, staging_dir
+from aleph.vm.agent.snp_staging import fetch_and_stage_bundle, member_path, staging_dir
 from aleph.vm.conf import settings
 from aleph.vm.supervisor_interface.errors import VmSetupError
 
@@ -95,3 +95,37 @@ async def test_fetch_and_stage_bundle_sha256_mismatch_fails_closed(tmp_path, sto
             size=len(raw),
         )
     assert not dest.exists()
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_stage_bundle_size_mismatch_fails_closed(tmp_path, storage_files):
+    """A tarball whose size does not match the pinned size fails the integrity
+    gate before the (more expensive) sha256 read, and extracts nothing."""
+    tar_path = make_bundle(tmp_path)
+    raw = tar_path.read_bytes()
+    storage_files[BUNDLE_REF] = tar_path
+
+    dest = staging_dir("snp-instance", VM_HASH)
+
+    with pytest.raises(VmSetupError, match="size mismatch"):
+        await fetch_and_stage_bundle(
+            VM_HASH,
+            kind="snp-instance",
+            ref=BUNDLE_REF,
+            sha256=hashlib.sha256(raw).hexdigest(),
+            size=len(raw) + 1,
+        )
+    assert not dest.exists()
+
+
+def test_member_path_rejects_an_escaping_member(tmp_path):
+    """member_path is the last line of defense if a member name that escapes
+    the staging directory ever slips past the manifest model: an upward-
+    traversing relative resolves outside bundle_dir and fails closed."""
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    # A sibling file the traversal would otherwise reach.
+    (tmp_path / "secret").write_bytes(b"outside the bundle")
+
+    with pytest.raises(VmSetupError, match="escapes the staging directory"):
+        member_path(bundle_dir, "../secret", "kernel")

--- a/tests/supervisor/test_snp_staging.py
+++ b/tests/supervisor/test_snp_staging.py
@@ -129,3 +129,26 @@ def test_member_path_rejects_an_escaping_member(tmp_path):
 
     with pytest.raises(VmSetupError, match="escapes the staging directory"):
         member_path(bundle_dir, "../secret", "kernel")
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_stage_bundle_corrupt_tarball_fails_closed(tmp_path, storage_files):
+    """A payload that satisfies the pinned size + sha256 but is not a readable
+    gzip stream fails during extraction, and leaves no half-populated staging
+    directory behind for the launch path to read members out of."""
+    corrupt = tmp_path / "bundle.tar.gz"
+    corrupt.write_bytes(b"pinned faithfully, but not a gzip stream")
+    raw = corrupt.read_bytes()
+    storage_files[BUNDLE_REF] = corrupt
+
+    dest = staging_dir("snp-instance", VM_HASH)
+
+    with pytest.raises(VmSetupError, match="cannot extract"):
+        await fetch_and_stage_bundle(
+            VM_HASH,
+            kind="snp-instance",
+            ref=BUNDLE_REF,
+            sha256=hashlib.sha256(raw).hexdigest(),
+            size=len(raw),
+        )
+    assert not dest.exists()


### PR DESCRIPTION
**Stack 4/4 for SEV-SNP confidential instances.** Base: `od/snp-inst-3-supervisor` (PR 3). Reviewer lens: the agent wiring that activates the feature.

Related tickets: ALEPH-XXX

## Changes
- **`snp_staging`**: the bundle fetch/verify/extract helpers factored out of `vprogram_launch` (v-program behavior unchanged; its test file passes unedited), consumed by both paths.
- **`snp_instance_launch.build_snp_instance_spec`**: fetches and validates the `aleph-instance-runtime/1` manifest, stages the bundle, renders the measured `owner=` cmdline from the message sender, and builds the SNP spec. The rejection ladder (attestation_port set, host not SNP-capable, policy ≥ 2^64-unsafe, non-EVM sender) runs before any I/O, so a rejected message never leaves staging behind. The manifest cmdline template is the only source of cmdline tokens and is schema-closed to `{owner}`.
- **`run.py`** routes `mode=sev_snp` instances through this path: boots immediately (no `awaiting_confidential_init`), forwards SSH plus the manifest attestation port, cleans staging on every failure path. `translate.py` gains a fail-loud guard so an SNP instance can never fall through to the legacy SEV path.
- **`examples/instance_confidential_snp/build_luks_rootfs.sh`**: builds a LUKS2 rootfs (with the `e2fsck`-before-`resize2fs` fix). SNP-instance tests are isolated from the real `EXECUTION_ROOT`.

## How to test
`pytest tests/supervisor/test_snp_instance_launch.py tests/supervisor/test_snp_instance_run.py tests/supervisor/test_snp_staging.py` (green, hermetic).

## Notes
- Top of the 4-PR stack. The end-to-end proof is the aleph-testnets scenario (separate repo, unpushed until the artifact pins from PR 2's runbook are uploaded, so a paid SNP CI run does not fire prematurely).
- Deferred/out-of-scope (tracked): pyaleph persistence + CCN measurement validation; reject empty secret values; document/reject `workload_roothash` on the opaque arm; the pre-existing staging-leak on the expiry/tasks delete paths; a design-doc note on the clone-VM residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
