### PR TITLE
refactor(auth): drop the legacy X-Auth-Signature allocation auth path

### DIFF
--- a/.github/scripts/test_runtime_on_droplet.sh
+++ b/.github/scripts/test_runtime_on_droplet.sh
@@ -58,9 +58,33 @@ if ! curl --retry 5 --retry-delay 10 --retry-connrefused --max-time 120 --fail "
 fi
 
 echo "==> Scheduling an instance via /control/allocations"
-curl --retry 5 --retry-delay 10 --retry-connrefused --max-time 120 --fail -X POST -H "Content-Type: application/json" \
-    -H "X-Auth-Signature: test" \
-    -d "{\"persistent_vms\": [], \"instances\": [\"${ITEM_HASH}\"]}" \
-    "http://${DROPLET_IPV4}:4020/control/allocations"
+# Throwaway CI signer, authorized via ALEPH_VM_AUTHORIZED_ALLOCATION_SIGNERS in
+# the install step. It only ever reaches a short-lived test droplet, so it is
+# checked in rather than kept as a secret. Signing happens per request: the
+# payload embeds `iat`, which the supervisor rejects once stale.
+ALLOCATION_SIGNER_KEY="0x4c0883a69102937d6231471b5dbb6204fe512961708279aeb8f1a4b0b8b0e5c1"
+ALLOCATION_BODY="{\"persistent_vms\": [], \"instances\": [\"${ITEM_HASH}\"]}"
+
+# Retry in the shell rather than with curl's --retry: the supervisor rejects a
+# replayed signed payload, so every attempt must carry a freshly signed header.
+allocation_attempt=0
+until [ $allocation_attempt -ge 5 ]; do
+    allocation_auth="$(printf '%s' "${ALLOCATION_BODY}" | \
+        python3 "$(dirname "$0")/../../scripts/sign_allocation_request.py" \
+            --key "${ALLOCATION_SIGNER_KEY}" --path /control/allocations)"
+    if curl --max-time 120 --fail -X POST -H "Content-Type: application/json" \
+        -H "Authorization: ${allocation_auth}" \
+        -d "${ALLOCATION_BODY}" \
+        "http://${DROPLET_IPV4}:4020/control/allocations"; then
+        break
+    fi
+    allocation_attempt=$((allocation_attempt + 1))
+    if [ $allocation_attempt -ge 5 ]; then
+        echo "==> ERROR: /control/allocations failed after ${allocation_attempt} attempts"
+        exit 1
+    fi
+    echo "==> /control/allocations attempt ${allocation_attempt} failed, retrying in 10s"
+    sleep 10
+done
 
 echo "==> Runtime ${ITEM_HASH} OK"

--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -212,7 +212,10 @@ jobs:
 
           ## Build configuration file and copy it on Droplet
           echo ALEPH_VM_SUPERVISOR_HOST=0.0.0.0 >> supervisor.env
-          echo ALEPH_VM_ALLOCATION_TOKEN_HASH=9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08 >> supervisor.env
+          # Authorize the throwaway CI signer for the scheduler-only endpoints.
+          # Its private key is in .github/scripts/test_runtime_on_droplet.sh; it
+          # guards a short-lived test droplet and is deliberately not a secret.
+          echo 'ALEPH_VM_AUTHORIZED_ALLOCATION_SIGNERS=["0x16Ed780b77450eb216F768E5676e874389f0511f"]' >> supervisor.env
           echo ALEPH_VM_SENTRY_DSN=${{ secrets.SENTRY_DSN }} >> supervisor.env
           # Pin public resolvers for guest VMs: DNS auto-detection on the droplet
           # picks up DigitalOcean's VPC-internal resolver (e.g. 10.110.15.254),
@@ -263,6 +266,9 @@ jobs:
           # the agent, so capture its status and journal too.
           ssh root@${DROPLET_IPV4} "systemctl status aleph-vm-agent --no-pager" || true
           ssh root@${DROPLET_IPV4} "journalctl -u aleph-vm-agent -n 200 --no-pager" || true
+
+      - name: Install eth-account, used to sign requests to /control/allocations
+        run: python3 -m pip install --upgrade --ignore-installed eth-account
 
       - name: "Test runtime: Debian 12, SDK 0.9.0"
         run: ./.github/scripts/test_runtime_on_droplet.sh "${DROPLET_IPV4}" "63faf8b5db1cf8d965e6a464a0cb8062af8e7df131729e48738342d956f29ace"

--- a/doc/confidential.md
+++ b/doc/confidential.md
@@ -197,21 +197,18 @@ For example using :
 Ensure the VM controller is stopped before!
 `sudo systemctl stop aleph-vm-controller@decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca.service`
 
- Between your test you can also stop the execution using
- ```http
- ### Stop all VMs
-POST http://localhost:4020/control/allocations
-Content-Type: application/json
-X-Auth-Signature: test
-Accept: application/json
+ Between your test you can also stop the execution by sending an empty allocation.
+ `/control/allocations` requires an EIP-191 signature from a signer listed in
+ `ALEPH_VM_AUTHORIZED_ALLOCATION_SIGNERS`; `scripts/sign_allocation_request.py`
+ builds the header:
 
-
-{
-  "persistent_vms": [],
-  "instances": [
-  ]
-}
-
+```shell
+### Stop all VMs
+BODY='{"persistent_vms": [], "instances": []}'
+AUTH=$(printf '%s' "$BODY" | python3 scripts/sign_allocation_request.py \
+    --key 0xYourSignerPrivateKey --path /control/allocations)
+curl -X POST -H "Content-Type: application/json" -H "Authorization: $AUTH" \
+    -d "$BODY" http://localhost:4020/control/allocations
 ```
 
 ## Sevctl

--- a/scripts/sign_allocation_request.py
+++ b/scripts/sign_allocation_request.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Produce an `Aleph-EIP191-V1` Authorization header for a scheduler-only endpoint.
+
+The supervisor's allocation endpoints (`/control/allocations`, the migration
+routes, `/control/proxy/regenerate`, ...) authenticate an EIP-191 signature over
+a JSON payload binding the request's method, path and body hash. This helper
+signs that payload so shell callers (CI, manual operator checks) can reach those
+endpoints without reimplementing the scheme.
+
+The signed payload embeds `iat`, which the supervisor rejects outside
+ALEPH_VM_ALLOCATION_SIGNATURE_MAX_AGE_SECONDS, so sign at request time rather
+than baking a header into a script.
+
+Usage:
+    printf '%s' "$BODY" | scripts/sign_allocation_request.py \\
+        --key 0x<private-key> --method POST --path /control/allocations
+
+Prints the header value on stdout, e.g.
+    Aleph-EIP191-V1 sig=<hex>,payload=<hex>
+
+See :mod:`aleph.vm.agent.views.allocation_auth` for the verifier.
+"""
+
+import argparse
+import json
+import sys
+import time
+from hashlib import sha256
+
+from eth_account import Account
+from eth_account.messages import encode_defunct
+
+
+def build_header(private_key: str, method: str, path: str, body: bytes) -> str:
+    payload = {
+        "method": method,
+        "path": path,
+        "body_sha256": sha256(body).hexdigest(),
+        "iat": int(time.time()),
+    }
+    # The signature covers these exact bytes, which travel in the header, so the
+    # verifier re-parses whatever we send and any JSON encoding would work. Sort
+    # and strip anyway: it keeps the payload compact, and makes the hash used by
+    # the supervisor's replay cache depend only on the fields, not on formatting.
+    payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    signed = Account.from_key(private_key).sign_message(encode_defunct(payload_bytes))
+    return f"Aleph-EIP191-V1 sig={signed.signature.hex()},payload={payload_bytes.hex()}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--key", required=True, help="signer private key, hex (0x-prefixed or not)")
+    parser.add_argument("--path", required=True, help="request path, matched exactly (no query string allowed)")
+    parser.add_argument("--method", default="POST", help="HTTP method (default: POST)")
+    parser.add_argument(
+        "--body-file",
+        default="-",
+        help="file holding the request body; '-' reads stdin (default), '' signs an empty body",
+    )
+    args = parser.parse_args()
+
+    if args.body_file == "":
+        body = b""
+    elif args.body_file == "-":
+        body = sys.stdin.buffer.read()
+    else:
+        with open(args.body_file, "rb") as handle:
+            body = handle.read()
+
+    print(build_header(args.key, args.method, args.path, body))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -362,7 +362,7 @@ def setup_webapp(supervisor: Supervisor):
         web.post("/control/allocations", update_allocations),
         web.post("/control/network/recreate", recreate_network),
         web.post("/control/proxy/regenerate", regenerate_proxy),
-        # Migration endpoints (scheduler-only, uses ALLOCATION_TOKEN_HASH auth)
+        # Migration endpoints (scheduler-only, uses Aleph-EIP191-V1 auth)
         web.post("/control/machine/{ref}/migration/export", migration_export),
         web.get("/control/machine/{ref}/migration/export/status", migration_export_status),
         web.get("/control/machine/{ref}/migration/disk/{filename}", migration_disk_download),

--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -543,11 +543,9 @@ async def update_allocations(request: web.Request):
     """Main entry for the start of persistence VM and instance, called by the Scheduler,
     POST /control/allocations
 
-    Auth via either:
-    - `Authorization: Aleph-EIP191-V1 sig=...,payload=...` (recommended)
-    - `X-Auth-Signature` matching `settings.ALLOCATION_TOKEN_HASH` (DEPRECATED)
+    Auth via `Authorization: Aleph-EIP191-V1 sig=...,payload=...`.
 
-    See :mod:`aleph.vm.agent.views.allocation_auth` for the dispatcher.
+    See :mod:`aleph.vm.agent.views.allocation_auth` for the verifier.
     Receive a list of vm and instance that should be present and then match
     that state by stopping and launching VMs.
     """

--- a/src/aleph/vm/agent/views/allocation_auth.py
+++ b/src/aleph/vm/agent/views/allocation_auth.py
@@ -1,10 +1,11 @@
 """Authentication for scheduler-only control endpoints.
 
-Currently the scheduler authenticates with a shared bearer token whose
-SHA-256 hash is configured on the supervisor as
-:data:`aleph.vm.conf.settings.ALLOCATION_TOKEN_HASH`. This module hosts
-the verifier and the decorator so they can be evolved (signature-based
-auth, key rotation, etc.) without touching the views package's `__init__`.
+The scheduler authenticates with an EIP-191 signature over the request
+(`Authorization: Aleph-EIP191-V1 sig=...,payload=...`), checked against the
+authorized signer addresses resolved by
+:func:`aleph.vm.agent.utils.get_authorized_allocation_signers`. This module
+hosts the verifier and the decorator so they can be evolved (key rotation,
+new schemes) without touching the views package's `__init__`.
 """
 
 import asyncio
@@ -210,49 +211,29 @@ async def _verify_aleph_signature(request: web.Request, auth_header: str) -> boo
         return False
 
 
-def _verify_legacy_token(request: web.Request) -> bool:
-    """Authenticate via SHA-256(X-Auth-Signature) == ALLOCATION_TOKEN_HASH.
-
-    DEPRECATED: scheduled for removal once all schedulers have migrated to
-    Aleph-EIP191-V1. See AUTHORIZED_ALLOCATION_SIGNERS.
-    """
-    signature: bytes = request.headers.get("X-Auth-Signature", "").encode()
-    if not signature:
-        return False
-    return sha256(signature).hexdigest() == settings.ALLOCATION_TOKEN_HASH
-
-
 async def authenticate_api_request(request: web.Request) -> bool:
-    """Dispatch between Aleph-EIP191-V1 (new) and legacy X-Auth-Signature.
+    """Authenticate a scheduler-only request via Aleph-EIP191-V1.
 
-    The presence of an `Authorization` header (any value) is authoritative —
-    a malformed/invalid signature is rejected, with no fallback to the
-    legacy `X-Auth-Signature` path. The scheme name is matched
-    case-insensitively (RFC 7235 §2.1). Deprecation of the legacy path is
-    surfaced once at supervisor boot via `log_allocation_auth_config`, not
-    per-request, to keep production logs readable.
+    An `Authorization` header carrying any other scheme, or no `Authorization`
+    header at all, is rejected: Aleph-EIP191-V1 is the only accepted scheme.
+    The scheme name is matched case-insensitively (RFC 7235 §2.1).
     """
     auth = request.headers.get("Authorization", "")
-    if auth:
-        scheme, sep, _ = auth.partition(" ")
-        if not sep or scheme.casefold() != ALEPH_EIP191_V1_SCHEME.casefold():
-            return False
-        return await _verify_aleph_signature(request, auth)
-    if "X-Auth-Signature" in request.headers:
-        return _verify_legacy_token(request)
-    return False
+    if not auth:
+        return False
+    scheme, sep, _ = auth.partition(" ")
+    if not sep or scheme.casefold() != ALEPH_EIP191_V1_SCHEME.casefold():
+        return False
+    return await _verify_aleph_signature(request, auth)
 
 
 def log_allocation_auth_config() -> None:
-    """Summarize the allocation-auth configuration once at supervisor boot, so
-    operators see the deprecation notice exactly once per process lifetime —
-    not flooded per-request.
+    """Summarize the allocation-auth configuration once at supervisor boot.
 
     Note this can only report the *local* configuration: the aggregate-sourced
     signer list (used when no local override is set) is fetched lazily at
     request time, so its contents aren't known here."""
     has_signers = bool(settings.AUTHORIZED_ALLOCATION_SIGNERS)
-    has_legacy = bool(settings.ALLOCATION_TOKEN_HASH)
     if has_signers:
         logger.info(
             "Allocation auth: Aleph-EIP191-V1 enabled with %d locally-configured "
@@ -266,20 +247,13 @@ def log_allocation_auth_config() -> None:
             "falling back to %d built-in default signer(s).",
             len(settings.DEFAULT_ALLOCATION_SIGNERS),
         )
-    if has_legacy:
-        logger.warning(
-            "Allocation auth: legacy X-Auth-Signature path is still enabled "
-            "(ALLOCATION_TOKEN_HASH is set). Remove it once all schedulers "
-            "have migrated to Aleph-EIP191-V1.",
-        )
 
 
 def requires_allocation_auth(handler):
     """Decorator: reject the request with 401 unless the auth check passes.
 
-    Accepts either `Authorization: Aleph-EIP191-V1 ...` or the legacy
-    `X-Auth-Signature` token. Apply BELOW any CORS decorator so OPTIONS
-    preflights pass through unauthenticated.
+    Requires `Authorization: Aleph-EIP191-V1 sig=...,payload=...`. Apply BELOW
+    any CORS decorator so OPTIONS preflights pass through unauthenticated.
     """
 
     @functools.wraps(handler)

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -365,11 +365,6 @@ class Settings(BaseSettings):
         description="TTL in seconds for cached message statuses",
     )
 
-    ALLOCATION_TOKEN_HASH: str = "151ba92f2eb90bce67e912af2f7a5c17d8654b3d29895b042107ea312a7eebda"
-    """DEPRECATED: SHA-256 of the shared bearer token used by the legacy
-    `X-Auth-Signature` allocation auth path. Slated for removal once all
-    schedulers migrate to AUTHORIZED_ALLOCATION_SIGNERS / Aleph-EIP191-V1."""
-
     AUTHORIZED_ALLOCATION_SIGNERS: list[str] = []
     """Local override of the ETH addresses authorized to sign requests to
     scheduler-only endpoints (Aleph-EIP191-V1 scheme).

--- a/src/aleph/vm/supervisor/controllers/qemu/QEMU.md
+++ b/src/aleph/vm/supervisor/controllers/qemu/QEMU.md
@@ -19,8 +19,10 @@ Launch the agent (`python3 -m aleph.vm.agent`) with the following environment va
 ALEPH_VM_FAKE_INSTANCE_BASE=/home/olivier/Projects/qemu-quickstart/jammy-server-cloudimg-amd64.img
 ALEPH_VM_FAKE_INSTANCE_MESSAGE=/home/olivier/Projects/aleph/aleph-vm/examples/qemu_message_from_aleph.json
 ALEPH_VM_USE_FAKE_INSTANCE_BASE=1
-# set test as the allocation password
-ALEPH_VM_ALLOCATION_TOKEN_HASH=9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+# Authorize a local signer for the scheduler-only endpoints. Generate a keypair
+# with `python3 -c 'from eth_account import Account; a = Account.create(); print(a.key.hex(), a.address)'`
+# and put the address here, keeping the private key to sign requests with.
+ALEPH_VM_AUTHORIZED_ALLOCATION_SIGNERS=["0xYourSignerAddress"]
 
 ```
 
@@ -35,16 +37,17 @@ To only launch the VM instance, use the parameter:
 
 You can then try to connect via ssh to it's ip. Wait a minute or so for it to set up properly with the network
 
-Or launching the whole supervisor server (no params), then launch the VM via http
+Or launching the whole supervisor server (no params), then launch the VM via http.
+`/control/allocations` requires an EIP-191 signature from an authorized signer,
+which `scripts/sign_allocation_request.py` produces:
 
-```http request
+```shell
 ### Start fake VM
-POST http://localhost:4020/control/allocations
-Content-Type: application/json
-X-Auth-Signature: test
-Accept: application/json
-
-{"persistent_vms": [], "instances": ["decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"]}
+BODY='{"persistent_vms": [], "instances": ["decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"]}'
+AUTH=$(printf '%s' "$BODY" | python3 scripts/sign_allocation_request.py \
+    --key 0xYourSignerPrivateKey --path /control/allocations)
+curl -X POST -H "Content-Type: application/json" -H "Authorization: $AUTH" \
+    -d "$BODY" http://localhost:4020/control/allocations
 ```
 
 After a minutes or two you should be able to SSH into the VM. Check in the log for the VM ip. 

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -1221,6 +1221,7 @@ async def test_sign_allocation_request_helper_authenticates(aiohttp_client, monk
 
     script = Path(__file__).parent.parent.parent / "scripts" / "sign_allocation_request.py"
     spec = importlib.util.spec_from_file_location("sign_allocation_request", script)
+    assert spec is not None and spec.loader is not None
     signer = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(signer)
 

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -32,6 +32,40 @@ from aleph.vm.supervisor_interface.types import (
 )
 
 
+def _make_aleph_eip191_v1_header(account, *, method="POST", path="/control/allocations", body=b"", iat=None) -> str:
+    payload = {
+        "method": method,
+        "path": path,
+        "body_sha256": sha256(body).hexdigest(),
+        "iat": iat if iat is not None else int(time_module.time()),
+    }
+    payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    signed = account.sign_message(encode_defunct(payload_bytes))
+    return f"Aleph-EIP191-V1 sig={signed.signature.hex()},payload={payload_bytes.hex()}"
+
+
+@pytest.fixture()
+def scheduler_auth(monkeypatch):
+    """Authorize a throwaway scheduler key and sign requests as it.
+
+    Returns a callable that serializes the body and produces the matching
+    `Aleph-EIP191-V1` headers. The signature binds method, path and body hash,
+    so the caller must send the returned bytes verbatim (`data=`, not `json=`).
+    """
+    account = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [account.address])
+
+    def _sign(body_dict=None, *, path="/control/allocations", method="POST"):
+        body = b"" if body_dict is None else json.dumps(body_dict).encode()
+        header = _make_aleph_eip191_v1_header(account, method=method, path=path, body=body)
+        headers = {"Authorization": header}
+        if body_dict is not None:
+            headers["Content-Type"] = "application/json"
+        return body, headers
+
+    return _sign
+
+
 def _views_tee() -> TeeConfig:
     return TeeConfig(
         backend=TeeBackend.SEV,
@@ -69,14 +103,12 @@ def mock_instance_content():
 
 
 @pytest.mark.asyncio
-async def test_allocation_fails_on_invalid_item_hash(aiohttp_client):
+async def test_allocation_fails_on_invalid_item_hash(aiohttp_client, scheduler_auth):
     """Test that the allocation endpoint fails when an invalid item_hash is provided."""
     app = setup_webapp(supervisor=LocalSupervisor(None))
     client = await aiohttp_client(app)
-    settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
-    response: web.Response = await client.post(
-        "/control/allocations", json={"persistent_vms": ["not-an-ItemHash"]}, headers={"X-Auth-Signature": "test"}
-    )
+    body, headers = scheduler_auth({"persistent_vms": ["not-an-ItemHash"]})
+    response: web.Response = await client.post("/control/allocations", data=body, headers=headers)
     assert response.status == 400
     response = await response.json()
     for error in response:
@@ -339,15 +371,20 @@ async def test_system_capability_real(aiohttp_client, mocker):
 
 
 @pytest.mark.asyncio
-async def test_allocation_invalid_auth_token(aiohttp_client):
-    """Test that the allocation endpoint fails when an invalid auth token is provided."""
-    settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
+async def test_allocation_invalid_auth_token(aiohttp_client, monkeypatch):
+    """Test that the allocation endpoint fails when the signer is not authorized."""
+    unauthorized = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [Account.create().address])
     app = setup_webapp(supervisor=LocalSupervisor(None))
     client = await aiohttp_client(app)
+    body = json.dumps({"persistent_vms": []}).encode()
     response = await client.post(
         "/control/allocations",
-        json={"persistent_vms": []},
-        headers={"X-Auth-Signature": "notTest"},
+        data=body,
+        headers={
+            "Authorization": _make_aleph_eip191_v1_header(unauthorized, body=body),
+            "Content-Type": "application/json",
+        },
     )
     assert response.status == 401
     assert await response.json() == {"error": "Authentication token received is invalid"}
@@ -367,21 +404,17 @@ async def test_allocation_missing_auth_token(aiohttp_client):
 
 
 @pytest.mark.asyncio
-async def test_allocation_valid_token(aiohttp_client):
-    """Test that the allocation endpoint fails when an invalid auth is provided.
+async def test_allocation_valid_token(aiohttp_client, scheduler_auth):
+    """Test that the allocation endpoint accepts a correctly signed request.
 
     This is a very simple test that don't start or stop any VM so the mock is minimal"""
 
-    settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
     app = setup_webapp(supervisor=LocalSupervisor(_FakeVmPool()))
     app["pubsub"] = None
     client = await aiohttp_client(app)
 
-    response: web.Response = await client.post(
-        "/control/allocations",
-        json={"persistent_vms": []},
-        headers={"X-Auth-Signature": "test"},
-    )
+    body, headers = scheduler_auth({"persistent_vms": []})
+    response: web.Response = await client.post("/control/allocations", data=body, headers=headers)
     assert response.status == 200
     assert await response.json() == {"success": True, "successful": [], "failing": [], "errors": {}, "stopped": []}
 
@@ -1058,33 +1091,31 @@ async def test_regenerate_proxy_missing_auth_token(aiohttp_client):
 
 
 @pytest.mark.asyncio
-async def test_regenerate_proxy_invalid_auth_token(aiohttp_client):
-    """Test that the regenerate_proxy endpoint fails when an invalid auth token is provided."""
-    settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
+async def test_regenerate_proxy_invalid_auth_token(aiohttp_client, monkeypatch):
+    """Test that the regenerate_proxy endpoint fails when the signer is not authorized."""
+    unauthorized = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [Account.create().address])
     app = setup_webapp(supervisor=LocalSupervisor(None))
     client = await aiohttp_client(app)
     response = await client.post(
         "/control/proxy/regenerate",
-        headers={"X-Auth-Signature": "notTest"},
+        headers={"Authorization": _make_aleph_eip191_v1_header(unauthorized, path="/control/proxy/regenerate")},
     )
     assert response.status == 401
     assert await response.json() == {"error": "Authentication token received is invalid"}
 
 
 @pytest.mark.asyncio
-async def test_regenerate_proxy_valid_token(aiohttp_client, mocker, mock_app_with_pool):
-    """Test that the regenerate_proxy endpoint succeeds with a valid auth token."""
-    settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
+async def test_regenerate_proxy_valid_token(aiohttp_client, mocker, mock_app_with_pool, scheduler_auth):
+    """Test that the regenerate_proxy endpoint succeeds with a valid signature."""
     web_app = await mock_app_with_pool
 
     # Mock the agent-side HAProxy sync to avoid actual HAProxy operations.
     sync = mocker.patch("aleph.vm.agent.views.sync_domain_mappings", new=mocker.AsyncMock(return_value=True))
 
     client = await aiohttp_client(web_app)
-    response: web.Response = await client.post(
-        "/control/proxy/regenerate",
-        headers={"X-Auth-Signature": "test"},
-    )
+    _, headers = scheduler_auth(path="/control/proxy/regenerate")
+    response: web.Response = await client.post("/control/proxy/regenerate", headers=headers)
     assert response.status == 200
     resp = await response.json()
     assert resp == {"success": True, "message": "HAProxy configuration regenerated successfully"}
@@ -1092,28 +1123,24 @@ async def test_regenerate_proxy_valid_token(aiohttp_client, mocker, mock_app_wit
 
 
 @pytest.mark.asyncio
-async def test_regenerate_proxy_no_haproxy_socket(aiohttp_client, mocker, mock_app_with_pool):
+async def test_regenerate_proxy_no_haproxy_socket(aiohttp_client, mocker, mock_app_with_pool, scheduler_auth):
     """Test that regenerate_proxy handles missing HAProxy socket gracefully."""
-    settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
     web_app = await mock_app_with_pool
 
     # Sync returns False (socket not found): endpoint still reports success.
     mocker.patch("aleph.vm.agent.views.sync_domain_mappings", new=mocker.AsyncMock(return_value=False))
 
     client = await aiohttp_client(web_app)
-    response: web.Response = await client.post(
-        "/control/proxy/regenerate",
-        headers={"X-Auth-Signature": "test"},
-    )
+    _, headers = scheduler_auth(path="/control/proxy/regenerate")
+    response: web.Response = await client.post("/control/proxy/regenerate", headers=headers)
     assert response.status == 200
     resp = await response.json()
     assert resp == {"success": True, "message": "HAProxy configuration regenerated successfully"}
 
 
 @pytest.mark.asyncio
-async def test_regenerate_proxy_exception(aiohttp_client, mocker, mock_app_with_pool):
+async def test_regenerate_proxy_exception(aiohttp_client, mocker, mock_app_with_pool, scheduler_auth):
     """Test that regenerate_proxy handles exceptions gracefully."""
-    settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
     web_app = await mock_app_with_pool
 
     mocker.patch(
@@ -1122,10 +1149,8 @@ async def test_regenerate_proxy_exception(aiohttp_client, mocker, mock_app_with_
     )
 
     client = await aiohttp_client(web_app)
-    response: web.Response = await client.post(
-        "/control/proxy/regenerate",
-        headers={"X-Auth-Signature": "test"},
-    )
+    _, headers = scheduler_auth(path="/control/proxy/regenerate")
+    response: web.Response = await client.post("/control/proxy/regenerate", headers=headers)
     assert response.status == 500
     resp = await response.json()
     assert resp == {"success": False, "error": "Failed to regenerate HAProxy configuration: HAProxy connection failed"}
@@ -1137,18 +1162,6 @@ class _FakeVmPool:
 
     def get_persistent_executions(self):
         return []
-
-
-def _make_aleph_eip191_v1_header(account, *, method="POST", path="/control/allocations", body=b"", iat=None) -> str:
-    payload = {
-        "method": method,
-        "path": path,
-        "body_sha256": sha256(body).hexdigest(),
-        "iat": iat if iat is not None else int(time_module.time()),
-    }
-    payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
-    signed = account.sign_message(encode_defunct(payload_bytes))
-    return f"Aleph-EIP191-V1 sig={signed.signature.hex()},payload={payload_bytes.hex()}"
 
 
 @pytest.fixture(autouse=True)
@@ -1183,53 +1196,76 @@ async def test_allocation_aleph_eip191_v1_valid(aiohttp_client, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_allocation_aleph_eip191_v1_invalid_no_fallback(aiohttp_client, monkeypatch):
-    """Garbage Aleph-EIP191-V1 + valid legacy token → 401 (no fallback)."""
-    monkeypatch.setattr(
-        settings,
-        "ALLOCATION_TOKEN_HASH",
-        sha256(b"test").hexdigest(),
-    )
-
+async def test_allocation_aleph_eip191_v1_invalid_is_rejected(aiohttp_client):
+    """Garbage Aleph-EIP191-V1 → 401."""
     app = setup_webapp(supervisor=LocalSupervisor(_FakeVmPool()))
     app["pubsub"] = None
     client = await aiohttp_client(app)
     response = await client.post(
         "/control/allocations",
         json={"persistent_vms": []},
-        headers={
-            "Authorization": "Aleph-EIP191-V1 sig=0xdead,payload=0xbeef",
-            "X-Auth-Signature": "test",  # would be valid via legacy
-        },
+        headers={"Authorization": "Aleph-EIP191-V1 sig=0xdead,payload=0xbeef"},
     )
     assert response.status == 401
 
 
 @pytest.mark.asyncio
-async def test_allocation_legacy_token_no_per_request_log(aiohttp_client, monkeypatch, caplog):
-    """No Aleph-EIP191-V1 + valid legacy token → 200, no per-request log.
+async def test_sign_allocation_request_helper_authenticates(aiohttp_client, monkeypatch):
+    """`scripts/sign_allocation_request.py` produces a header the verifier accepts.
 
-    Deprecation surfaces once at boot via `log_allocation_auth_config`,
-    not on every request — busy schedulers would otherwise flood logs.
+    CI and operators reach the scheduler-only endpoints through that helper, so
+    its payload encoding has to stay byte-compatible with the verifier's. A
+    drift on either side would only show up as a red integration job otherwise.
     """
-    monkeypatch.setattr(
-        settings,
-        "ALLOCATION_TOKEN_HASH",
-        sha256(b"test").hexdigest(),
-    )
+    import importlib.util
+
+    script = Path(__file__).parent.parent.parent / "scripts" / "sign_allocation_request.py"
+    spec = importlib.util.spec_from_file_location("sign_allocation_request", script)
+    signer = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(signer)
+
+    account = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [account.address])
+    body = json.dumps({"persistent_vms": []}).encode()
+    header = signer.build_header(account.key.hex(), "POST", "/control/allocations", body)
 
     app = setup_webapp(supervisor=LocalSupervisor(_FakeVmPool()))
     app["pubsub"] = None
     client = await aiohttp_client(app)
 
-    with caplog.at_level("WARNING"):
-        response = await client.post(
-            "/control/allocations",
-            json={"persistent_vms": []},
-            headers={"X-Auth-Signature": "test"},
-        )
+    response = await client.post(
+        "/control/allocations",
+        data=body,
+        headers={"Authorization": header, "Content-Type": "application/json"},
+    )
     assert response.status == 200
-    assert not any("legacy" in r.message.lower() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_legacy_allocation_token_env_var_grants_no_access(aiohttp_client, monkeypatch):
+    """A CRN still setting ALEPH_VM_ALLOCATION_TOKEN_HASH gets no access from it.
+
+    The shared-bearer-token path (`X-Auth-Signature`) was replaced by
+    Aleph-EIP191-V1 and removed. Operators whose `supervisor.env` still carries
+    the old variable must not silently keep a working authentication bypass, so
+    this drives the setting the way an operator does, through the environment,
+    rather than through a Python attribute that no longer exists.
+    """
+    from aleph.vm.conf import Settings
+
+    monkeypatch.setenv("ALEPH_VM_ALLOCATION_TOKEN_HASH", sha256(b"test").hexdigest())
+    monkeypatch.setattr("aleph.vm.agent.views.allocation_auth.settings", Settings())
+
+    app = setup_webapp(supervisor=LocalSupervisor(_FakeVmPool()))
+    app["pubsub"] = None
+    client = await aiohttp_client(app)
+
+    response = await client.post(
+        "/control/allocations",
+        json={"persistent_vms": []},
+        headers={"X-Auth-Signature": "test"},
+    )
+    assert response.status == 401
 
 
 @pytest.mark.asyncio
@@ -1277,7 +1313,7 @@ async def test_restore_rejects_invalid_image_format(aiohttp_client, mocker, tmp_
 
 
 @pytest.mark.asyncio
-async def test_update_allocations_stop_loop_uses_supervisor(aiohttp_client, mocker):
+async def test_update_allocations_stop_loop_uses_supervisor(aiohttp_client, mocker, scheduler_auth):
     """update_allocations stop loop must call supervisor.delete_vm + registry.forget
     (permanent dealloc) for executions no longer in the allocation. Port-mapping
     cleanup is owned by supervisor.delete_vm (hypervisor-side).
@@ -1341,15 +1377,11 @@ async def test_update_allocations_stop_loop_uses_supervisor(aiohttp_client, mock
     app["supervisor"] = fake_supervisor
 
     mock_delete_records = mocker.patch("aleph.vm.agent.views.delete_records_for_vm", new_callable=AsyncMock)
-    settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
     client = await aiohttp_client(app)
 
     # Empty allocation — vm_hash is not in persistent_vms or instances, so it must be stopped.
-    response = await client.post(
-        "/control/allocations",
-        json={"persistent_vms": []},
-        headers={"X-Auth-Signature": "test"},
-    )
+    body, headers = scheduler_auth({"persistent_vms": []})
+    response = await client.post("/control/allocations", data=body, headers=headers)
     assert response.status == 200
     resp_json = await response.json()
     assert vm_hash in resp_json["stopped"]
@@ -1465,7 +1497,7 @@ async def test_v2_executions_list_omits_ghost_mapped_ports(aiohttp_client, mocke
 
 
 @pytest.mark.asyncio
-async def test_update_allocations_spares_payg_via_registry(aiohttp_client):
+async def test_update_allocations_spares_payg_via_registry(aiohttp_client, scheduler_auth):
     """A stream-paid registry record must be spared by the stop loop even when absent
     from the allocation (the restored-PAYG case).
     Status is read from supervisor.list_vms(); payment tier from the registry."""
@@ -1522,14 +1554,10 @@ async def test_update_allocations_spares_payg_via_registry(aiohttp_client):
     fake_supervisor = MagicMock(delete_vm=AsyncMock(), list_vms=AsyncMock(return_value=[vm_info]))
     app["supervisor"] = fake_supervisor
 
-    settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
     client = await aiohttp_client(app)
 
-    response = await client.post(
-        "/control/allocations",
-        json={"persistent_vms": []},
-        headers={"X-Auth-Signature": "test"},
-    )
+    body, headers = scheduler_auth({"persistent_vms": []})
+    response = await client.post("/control/allocations", data=body, headers=headers)
     assert response.status == 200
     resp_json = await response.json()
     assert vm_hash not in resp_json["stopped"]
@@ -1538,7 +1566,7 @@ async def test_update_allocations_spares_payg_via_registry(aiohttp_client):
 
 
 @pytest.mark.asyncio
-async def test_update_allocations_spares_unrecorded_execution(aiohttp_client):
+async def test_update_allocations_spares_unrecorded_execution(aiohttp_client, scheduler_auth):
     """A VM with no registry record is not scheduler-managed and must NOT be stopped
     by the stop-loop; it is left to the idle-expiry path instead.
     Status is read from supervisor.list_vms(); a missing record means skip entirely."""
@@ -1572,14 +1600,10 @@ async def test_update_allocations_spares_unrecorded_execution(aiohttp_client):
     fake_supervisor = MagicMock(delete_vm=AsyncMock(), list_vms=AsyncMock(return_value=[vm_info]))
     app["supervisor"] = fake_supervisor
 
-    settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"  # = "test"
     client = await aiohttp_client(app)
 
-    response = await client.post(
-        "/control/allocations",
-        json={"persistent_vms": []},
-        headers={"X-Auth-Signature": "test"},
-    )
+    body, headers = scheduler_auth({"persistent_vms": []})
+    response = await client.post("/control/allocations", data=body, headers=headers)
     assert response.status == 200
     resp_json = await response.json()
     # No registry record → not scheduler-managed → not stopped by this loop.
@@ -1628,7 +1652,6 @@ _CREDIT_INSTANCE_CONTENT = {
 
 def _make_app_with_supervisor(supervisor):
     """Create a minimal webapp whose supervisor is replaced with the given double."""
-    settings.ALLOCATION_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
     app = setup_webapp(supervisor=LocalSupervisor(_FakeVmPool()))
     app["pubsub"] = None
     app["supervisor"] = supervisor
@@ -1667,7 +1690,7 @@ def _running_vm_info(
 
 
 @pytest.mark.asyncio
-async def test_stop_loop_stops_eligible_vm(aiohttp_client, mocker):
+async def test_stop_loop_stops_eligible_vm(aiohttp_client, mocker, scheduler_auth):
     """A running, persistent, hold-tier VM not in the allocation must be stopped.
 
     Behavior 1: registry has record, persistent=True, status=RUNNING, no GPUs,
@@ -1685,11 +1708,8 @@ async def test_stop_loop_stops_eligible_vm(aiohttp_client, mocker):
     mock_delete_records = mocker.patch("aleph.vm.agent.views.delete_records_for_vm", new_callable=AsyncMock)
 
     client = await aiohttp_client(app)
-    response = await client.post(
-        "/control/allocations",
-        json={"persistent_vms": []},
-        headers={"X-Auth-Signature": "test"},
-    )
+    body, headers = scheduler_auth({"persistent_vms": []})
+    response = await client.post("/control/allocations", data=body, headers=headers)
     assert response.status == 200
     resp_json = await response.json()
 
@@ -1735,7 +1755,9 @@ async def test_stop_loop_stops_eligible_vm(aiohttp_client, mocker):
     ],
 )
 @pytest.mark.asyncio
-async def test_stop_loop_spares_ineligible_vms(aiohttp_client, description, vm_info_kwargs, registry_kwargs):
+async def test_stop_loop_spares_ineligible_vms(
+    aiohttp_client, description, vm_info_kwargs, registry_kwargs, scheduler_auth
+):
     """Behavior 2: GPU-bearing, confidential, stream/credit-paid, or unrecorded VMs
     must NOT be stopped by the stop-loop.
     """
@@ -1775,11 +1797,8 @@ async def test_stop_loop_spares_ineligible_vms(aiohttp_client, description, vm_i
         app["vm_registry"].record(VM_HASH, message=message, original=message, persistent=True)
 
     client = await aiohttp_client(app)
-    response = await client.post(
-        "/control/allocations",
-        json={"persistent_vms": []},
-        headers={"X-Auth-Signature": "test"},
-    )
+    body, headers = scheduler_auth({"persistent_vms": []})
+    response = await client.post("/control/allocations", data=body, headers=headers)
     assert response.status == 200, description
     resp_json = await response.json()
 

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -5,6 +5,8 @@ docs/plans/2026-07-11-vprogram-scheduler-support-design.md.
 """
 
 import json
+import time
+from hashlib import sha256
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -18,6 +20,8 @@ from aleph_message.models import (
     VerifiableProgramMessage,
     parse_message,
 )
+from eth_account import Account
+from eth_account.messages import encode_defunct
 
 from aleph.vm.agent.messages import update_message
 from aleph.vm.agent.resources import Allocation
@@ -40,8 +44,29 @@ from aleph.vm.supervisor_interface.types import (
 from aleph.vm.vm_type import VmType
 
 FIXTURE = Path(__file__).parent / "fixtures" / "vprogram_message.json"
-# SHA-256 of "test", used by the existing views tests as the allocation token
-TEST_TOKEN_HASH = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+
+
+def _signed_allocation(account, body_dict):
+    """Body bytes plus the Aleph-EIP191-V1 headers binding them, for /control/allocations."""
+    body = json.dumps(body_dict).encode()
+    payload = {
+        "method": "POST",
+        "path": "/control/allocations",
+        "body_sha256": sha256(body).hexdigest(),
+        "iat": int(time.time()),
+    }
+    payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    signed = account.sign_message(encode_defunct(payload_bytes))
+    header = f"Aleph-EIP191-V1 sig={signed.signature.hex()},payload={payload_bytes.hex()}"
+    return body, {"Authorization": header, "Content-Type": "application/json"}
+
+
+@pytest.fixture()
+def scheduler_auth(monkeypatch):
+    """Authorize a throwaway scheduler key and sign requests as it."""
+    account = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [account.address])
+    return lambda body_dict: _signed_allocation(account, body_dict)
 
 
 def load_vprogram_message() -> VerifiableProgramMessage:
@@ -107,7 +132,7 @@ def test_allocation_model_v_programs():
 
 
 @pytest.mark.asyncio
-async def test_update_allocations_starts_v_programs(aiohttp_client, mocker):
+async def test_update_allocations_starts_v_programs(aiohttp_client, mocker, scheduler_auth):
     """v_programs hashes go through the same start path as instances."""
     message = load_vprogram_message()
     vm_hash = str(message.item_hash)
@@ -117,14 +142,10 @@ async def test_update_allocations_starts_v_programs(aiohttp_client, mocker):
     app["supervisor"] = MagicMock(delete_vm=AsyncMock(), list_vms=AsyncMock(return_value=[]))
 
     mock_start = mocker.patch("aleph.vm.agent.views.start_persistent_vm", new_callable=AsyncMock)
-    settings.ALLOCATION_TOKEN_HASH = TEST_TOKEN_HASH
     client = await aiohttp_client(app)
 
-    response = await client.post(
-        "/control/allocations",
-        json={"v_programs": [vm_hash]},
-        headers={"X-Auth-Signature": "test"},
-    )
+    body, headers = scheduler_auth({"v_programs": [vm_hash]})
+    response = await client.post("/control/allocations", data=body, headers=headers)
     assert response.status == 200
     resp_json = await response.json()
     assert vm_hash in resp_json["successful"]
@@ -133,7 +154,7 @@ async def test_update_allocations_starts_v_programs(aiohttp_client, mocker):
 
 
 @pytest.mark.asyncio
-async def test_update_allocations_stops_descheduled_vprogram(aiohttp_client, mocker):
+async def test_update_allocations_stops_descheduled_vprogram(aiohttp_client, mocker, scheduler_auth):
     """The scheduler is the single source of truth for v-programs: absence from
     the allocation stops them, despite being credit-paid and confidential
     (both of which spare other VM types)."""
@@ -148,14 +169,10 @@ async def test_update_allocations_stops_descheduled_vprogram(aiohttp_client, moc
     app["supervisor"] = fake_supervisor
 
     mock_delete_records = mocker.patch("aleph.vm.agent.views.delete_records_for_vm", new_callable=AsyncMock)
-    settings.ALLOCATION_TOKEN_HASH = TEST_TOKEN_HASH
     client = await aiohttp_client(app)
 
-    response = await client.post(
-        "/control/allocations",
-        json={"persistent_vms": []},
-        headers={"X-Auth-Signature": "test"},
-    )
+    body, headers = scheduler_auth({"persistent_vms": []})
+    response = await client.post("/control/allocations", data=body, headers=headers)
     assert response.status == 200
     resp_json = await response.json()
     assert vm_hash in resp_json["stopped"]
@@ -165,7 +182,7 @@ async def test_update_allocations_stops_descheduled_vprogram(aiohttp_client, moc
 
 
 @pytest.mark.asyncio
-async def test_update_allocations_spares_scheduled_vprogram(aiohttp_client, mocker):
+async def test_update_allocations_spares_scheduled_vprogram(aiohttp_client, mocker, scheduler_auth):
     """A running v-program still listed in v_programs must not be stopped."""
     message = load_vprogram_message()
     vm_hash = str(message.item_hash)
@@ -178,14 +195,10 @@ async def test_update_allocations_spares_scheduled_vprogram(aiohttp_client, mock
     fake_supervisor = MagicMock(delete_vm=AsyncMock(), list_vms=AsyncMock(return_value=[_running_vm_info(vm_hash)]))
     app["supervisor"] = fake_supervisor
 
-    settings.ALLOCATION_TOKEN_HASH = TEST_TOKEN_HASH
     client = await aiohttp_client(app)
 
-    response = await client.post(
-        "/control/allocations",
-        json={"v_programs": [vm_hash]},
-        headers={"X-Auth-Signature": "test"},
-    )
+    body, headers = scheduler_auth({"v_programs": [vm_hash]})
+    response = await client.post("/control/allocations", data=body, headers=headers)
     assert response.status == 200
     resp_json = await response.json()
     assert vm_hash not in resp_json["stopped"]

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -373,38 +373,24 @@ async def test_dispatcher_routes_to_signature_path(mock_request, authorize_signe
 
 
 @pytest.mark.asyncio
-async def test_dispatcher_invalid_signature_does_not_fall_back(mock_request, mocker):
-    """Garbage Aleph-EIP191-V1 + valid X-Auth-Signature → reject. The signature
-    path is authoritative once chosen."""
+async def test_dispatcher_invalid_signature_rejected(mock_request):
+    """Garbage Aleph-EIP191-V1 → reject."""
     request = mock_request(
-        headers={
-            "Authorization": "Aleph-EIP191-V1 sig=0xdead,payload=0xbeef",
-            "X-Auth-Signature": "test",  # would be valid via the legacy path
-        },
+        headers={"Authorization": "Aleph-EIP191-V1 sig=0xdead,payload=0xbeef"},
         body=b"{}",
     )
-    spy_legacy = mocker.spy(allocation_auth, "_verify_legacy_token")
     assert await allocation_auth.authenticate_api_request(request) is False
-    spy_legacy.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_dispatcher_falls_back_to_legacy_silently(mock_request, caplog, monkeypatch):
-    """No Aleph-EIP191-V1, valid legacy token → accept WITHOUT per-request log.
+async def test_dispatcher_legacy_x_auth_signature_header_rejected(mock_request):
+    """`X-Auth-Signature` alone → reject, whatever its value.
 
-    The deprecation notice is emitted once at boot via
-    `log_allocation_auth_config`; logging on every request would flood logs.
+    The shared-bearer-token scheme it belonged to was removed; a request
+    carrying only that header must not authenticate under any configuration.
     """
-    monkeypatch.setattr(
-        settings,
-        "ALLOCATION_TOKEN_HASH",
-        sha256(b"test").hexdigest(),
-    )
     request = mock_request(headers={"X-Auth-Signature": "test"}, body=b"{}")
-
-    with caplog.at_level("WARNING"):
-        assert await allocation_auth.authenticate_api_request(request) is True
-    assert not any("legacy" in r.message.lower() for r in caplog.records)
+    assert await allocation_auth.authenticate_api_request(request) is False
 
 
 @pytest.mark.asyncio
@@ -414,62 +400,17 @@ async def test_dispatcher_no_auth_headers(mock_request):
 
 
 @pytest.mark.asyncio
-async def test_dispatcher_empty_legacy_token_returns_false(mock_request, monkeypatch):
-    """X-Auth-Signature: '' (header present but empty) → False, not a raise.
-
-    Otherwise the response message would differ from other rejections,
-    leaking dispatch-path info.
-    """
-    monkeypatch.setattr(
-        settings,
-        "ALLOCATION_TOKEN_HASH",
-        sha256(b"test").hexdigest(),
-    )
-    request = mock_request(headers={"X-Auth-Signature": ""}, body=b"{}")
+async def test_dispatcher_unknown_scheme_rejected(mock_request):
+    """Authorization with an unknown scheme → reject."""
+    request = mock_request(headers={"Authorization": "Bearer abc"}, body=b"{}")
     assert await allocation_auth.authenticate_api_request(request) is False
 
 
 @pytest.mark.asyncio
-async def test_dispatcher_unknown_scheme_does_not_fall_back(mock_request, mocker, monkeypatch):
-    """Authorization with an unknown scheme + valid legacy → reject. The
-    Authorization header's mere presence is authoritative."""
-    monkeypatch.setattr(
-        settings,
-        "ALLOCATION_TOKEN_HASH",
-        sha256(b"test").hexdigest(),
-    )
-    request = mock_request(
-        headers={
-            "Authorization": "Bearer abc",
-            "X-Auth-Signature": "test",  # would be valid via legacy
-        },
-        body=b"{}",
-    )
-    spy_legacy = mocker.spy(allocation_auth, "_verify_legacy_token")
+async def test_dispatcher_eip191_scheme_without_params_rejected(mock_request):
+    """Authorization: 'Aleph-EIP191-V1' (no trailing space, no params) → reject."""
+    request = mock_request(headers={"Authorization": "Aleph-EIP191-V1"}, body=b"{}")
     assert await allocation_auth.authenticate_api_request(request) is False
-    spy_legacy.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_dispatcher_eip191_scheme_without_params_does_not_fall_back(mock_request, mocker, monkeypatch):
-    """Authorization: 'Aleph-EIP191-V1' (no trailing space, no params)
-    + valid legacy → reject. Misconfigured client must not be rescued
-    by legacy fallback."""
-    monkeypatch.setattr(
-        settings,
-        "ALLOCATION_TOKEN_HASH",
-        sha256(b"test").hexdigest(),
-    )
-    request = mock_request(
-        headers={
-            "Authorization": "Aleph-EIP191-V1",  # missing the params
-            "X-Auth-Signature": "test",
-        },
-        body=b"{}",
-    )
-    spy_legacy = mocker.spy(allocation_auth, "_verify_legacy_token")
-    assert await allocation_auth.authenticate_api_request(request) is False
-    spy_legacy.assert_not_called()
 
 
 # --- C1: concurrent iat check+update must not race ---
@@ -648,48 +589,19 @@ async def test_verify_failure_logs_at_warning(mock_request, caplog):
 
 
 def test_log_allocation_auth_config_signature_path_only(caplog, monkeypatch):
-    """Signers configured, legacy hash cleared → INFO summary, no warning."""
+    """Signers configured → INFO summary, no warning."""
     monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", ["0xdAC17F958D2ee523a2206206994597C13D831ec7"])
-    monkeypatch.setattr(settings, "ALLOCATION_TOKEN_HASH", "")
 
     with caplog.at_level("INFO", logger="aleph.vm.agent.views.allocation_auth"):
         log_allocation_auth_config()
     assert any("Aleph-EIP191-V1 enabled" in r.message for r in caplog.records)
-    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
-    assert not any("legacy" in r.message.lower() for r in warnings)
-
-
-def test_log_allocation_auth_config_both_enabled_warns(caplog, monkeypatch):
-    """Signers + legacy hash → both messages, including a warning to remove legacy."""
-    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", ["0xdAC17F958D2ee523a2206206994597C13D831ec7"])
-    monkeypatch.setattr(settings, "ALLOCATION_TOKEN_HASH", sha256(b"test").hexdigest())
-
-    with caplog.at_level("INFO", logger="aleph.vm.agent.views.allocation_auth"):
-        log_allocation_auth_config()
-    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
-    assert any("legacy X-Auth-Signature path is still enabled" in m for m in warnings)
-
-
-def test_log_allocation_auth_config_legacy_still_enabled_warns(caplog, monkeypatch):
-    """No local override + legacy hash → warning to remove the legacy path.
-
-    The signature path is not "disabled" here: with no local override signers
-    are sourced from the settings aggregate, so the only thing worth warning
-    about is the still-enabled legacy token."""
-    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
-    monkeypatch.setattr(settings, "ALLOCATION_TOKEN_HASH", sha256(b"test").hexdigest())
-
-    with caplog.at_level("INFO", logger="aleph.vm.agent.views.allocation_auth"):
-        log_allocation_auth_config()
-    assert any("legacy X-Auth-Signature path is still enabled" in r.message for r in caplog.records)
+    assert not [r for r in caplog.records if r.levelname == "WARNING"]
 
 
 def test_log_allocation_auth_config_aggregate_sourced_when_local_empty(caplog, monkeypatch):
-    """No local override and no legacy hash → signers come from the settings
-    aggregate (the default for a stock CRN); this is not a misconfiguration, so
-    no warning is emitted."""
+    """No local override → signers come from the settings aggregate (the default
+    for a stock CRN); this is not a misconfiguration, so no warning is emitted."""
     monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [])
-    monkeypatch.setattr(settings, "ALLOCATION_TOKEN_HASH", "")
 
     with caplog.at_level("INFO", logger="aleph.vm.agent.views.allocation_auth"):
         log_allocation_auth_config()


### PR DESCRIPTION
Removes the shared-bearer-token scheme superseded by `Aleph-EIP191-V1`: `_verify_legacy_token`, the `X-Auth-Signature` dispatch branch, `settings.ALLOCATION_TOKEN_HASH`, and the boot-time deprecation warning.

### Why now, beyond dead code

The default `ALLOCATION_TOKEN_HASH` shipped in the repo, so any CRN that never overrode it trusted a token whose hash is public — on the endpoints that start, stop and migrate VMs.

### Upgrade impact: none

`ALEPH_VM_ALLOCATION_TOKEN_HASH` left behind in an operator's `supervisor.env` is harmless. pydantic-settings ignores `ALEPH_VM_*` vars with no matching field, so the supervisor still starts; the variable simply grants nothing. `test_legacy_allocation_token_env_var_grants_no_access` pins that, driving the setting through the environment rather than through a Python attribute that no longer exists.

### Callers moved to signed requests

The deletion was the small part — CI and two docs still authenticated with the old header.

- **`scripts/sign_allocation_request.py`** (new) builds the `Authorization` header for CI, docs and manual operator checks. `test_sign_allocation_request_helper_authenticates` runs its output through the real verifier so the two encodings cannot drift apart silently.
- **CI** signs each `/control/allocations` call with a throwaway key authorized via `AUTHORIZED_ALLOCATION_SIGNERS`. Note the retry change: `curl --retry` would have resent an identical signed payload, which the supervisor rejects as a replay, so retries now re-sign in a shell loop.
- **Docs** (`doc/confidential.md`, `QEMU.md`) become working `curl` invocations instead of `.http` snippets carrying a token that no longer authenticates.

Tests that used the legacy header merely to get past auth now sign via a `scheduler_auth` fixture; the ones that existed only to prove the fallback worked are gone.

### Verification

- `tests/supervisor`: 1117 passed. The 10 failures are pre-existing environment-only ones (pyroute2 needs root, journald, dbus) — confirmed as the identical set on unmodified `dev`.
- `mypy`, `ruff format`, `isort`, `yamlfix`, and pinned `shellcheck` 0.11.0 all clean.