### PR TITLE
chore: dead imports, dead locals, and a broken __all__

### DIFF
--- a/src/aleph/vm/agent/migration/helpers.py
+++ b/src/aleph/vm/agent/migration/helpers.py
@@ -4,7 +4,6 @@ import asyncio
 import hashlib
 import logging
 import shutil
-import time
 from pathlib import Path
 
 import aiohttp

--- a/src/aleph/vm/supervisor/controllers/qemu/__init__.py
+++ b/src/aleph/vm/supervisor/controllers/qemu/__init__.py
@@ -1,3 +1,3 @@
 from .instance import AlephQemuInstance
 
-__all__ = "AlephQemuInstance"
+__all__ = ["AlephQemuInstance"]

--- a/src/aleph/vm/testing/harness.py
+++ b/src/aleph/vm/testing/harness.py
@@ -72,7 +72,6 @@ async def benchmark(runs: int):
 
     bench: list[float] = []
 
-    loop = asyncio.get_event_loop()
     pool = VmPool()
     await pool.setup()
     bench_supervisor = LocalSupervisor(pool)
@@ -169,7 +168,6 @@ async def start_instance(item_hash: ItemHash, pubsub: PubSub | None, pool) -> No
 async def run_instances(instances: list[ItemHash]) -> None:
     """Run instances from a list of message identifiers."""
     logger.info(f"Instances to run: {instances}")
-    loop = asyncio.get_event_loop()
     pool = VmPool()
     # Bind the supervisor DB engine (port mappings) and set up the network;
     # the create path hits that DB on its first port-mapping lookup.

--- a/src/aleph/vm/utils/__init__.py
+++ b/src/aleph/vm/utils/__init__.py
@@ -11,7 +11,7 @@ from dataclasses import asdict as dataclass_as_dict
 from dataclasses import is_dataclass
 from pathlib import Path
 from shutil import disk_usage
-from typing import Any, Optional
+from typing import Any
 
 import aiodns
 import msgpack

--- a/tests/supervisor/test_firewall.py
+++ b/tests/supervisor/test_firewall.py
@@ -1743,6 +1743,8 @@ async def test_setup_nftables_for_vm_ipv6_disabled(mocker):
     setup_nftables_for_vm(1, mock_interface)
 
     # Only IPv4 calls - no ip6
+    mock_build_post.assert_called_once()
     mock_build_fwd.assert_called_once()
+    mock_build_masq.assert_called_once()
     mock_build_fwd_rule.assert_called_once()
     mock_exec.assert_called_once()

--- a/tests/supervisor/test_grpc_roundtrip.py
+++ b/tests/supervisor/test_grpc_roundtrip.py
@@ -16,7 +16,6 @@ mock with ``fake.<method>.return_value = ...`` before calling the client, then
 assert on ``fake.<method>`` (e.g. ``assert_awaited_once_with(...)``).
 """
 
-from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -29,9 +28,7 @@ from aleph.vm.supervisor_interface.client import GrpcSupervisor
 from aleph.vm.supervisor_interface.types import (
     Backend,
     DirectoryPath,
-    GpuSpec,
     IpAssignment,
-    PciAddress,
     VmId,
     VmInfo,
     VmStatus,

--- a/tests/supervisor/test_host_gpu_detail.py
+++ b/tests/supervisor/test_host_gpu_detail.py
@@ -1,6 +1,6 @@
 """HostGPU retains device_id + model so the supervisor can report full GpuDevices."""
 
-from aleph.vm.resources import GpuDevice, GpuDeviceClass, HostGPU
+from aleph.vm.resources import HostGPU
 
 
 def test_hostgpu_fields_default_for_spec_path():

--- a/tests/supervisor/test_proto_bindings.py
+++ b/tests/supervisor/test_proto_bindings.py
@@ -316,7 +316,7 @@ def test_log_source_has_stderr():
 
     assert supervisor_pb2.LogChunk.LOG_SOURCE_STDERR == 4
 
-    from aleph.vm.supervisor_interface.types import IpAssignment, LogSource
+    from aleph.vm.supervisor_interface.types import LogSource
 
     assert LogSource.STDERR.value == "stderr"
 

--- a/tests/supervisor/views/test_operator.py
+++ b/tests/supervisor/views/test_operator.py
@@ -539,7 +539,7 @@ async def test_websocket_logs_missing_auth(aiohttp_client, mocker):
     # Wait for message without sending an auth package.
     # Test with a timeout because we receive nothing
     with pytest.raises((TimeoutError, asyncio.exceptions.TimeoutError)):
-        response = await websocket.receive_json(timeout=1)
+        await websocket.receive_json(timeout=1)
         assert False
 
     # It's totally reachable with the pytest.raises


### PR DESCRIPTION
Cleanups surfaced by `ruff check --select F401,F811,F841`. The CI style step gates only `ruff format` and `isort`, so these lint rules never ran and had quietly accumulated.

### The one that was not cosmetic

`src/aleph/vm/supervisor/controllers/qemu/__init__.py` set `__all__` to a bare string rather than a list:

```python
__all__ = "AlephQemuInstance"
```

`import *` iterates `__all__`, so it walked the characters and raised `AttributeError: module 'aleph.vm.supervisor.controllers.qemu' has no attribute 'A'`. Nothing star-imports the package today, which is why it went unnoticed.

### A small test gap

`test_setup_nftables_for_vm_ipv6_disabled` patched `build_postrouting_chain_entities` and `build_masquerading_rule_entities` but asserted on neither, so half of what "only IPv4 calls - no ip6" claims to check went unverified. Asserting on them (rather than dropping the unused bindings) closes that; both do get called once, so the test passes as strengthened.

### The rest

An unused `time` import, an unused `Optional`, two dead `loop = asyncio.get_event_loop()` assignments in the test harness, four unused test imports, and a pointless assignment of a `receive_json` result on a line only ever reached by raising.

### Verification

- `tests/supervisor`: 1119 passed. The 10 failures are pre-existing environment-only ones (pyroute2 needs root, journald, dbus) — the identical set on unmodified `dev`.
- `ruff check --select F401,F811,F841` now clean across `src/`, `tests/`, `scripts/`; `mypy`, `ruff format`, `isort` clean.