### PR TITLE
chore(vprogram): adopt measurement registers from aleph-message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "aiosqlite==0.19",
   "alembic==1.13.1",
   # MERGE GATE: replace the git pin with a released aleph-message version (V-PROGRAM schema, PR #158)
-  "aleph-message @ git+https://github.com/aleph-im/aleph-message@bc9c0f86958a746faeecbd6c6f96cc6f5b4538de",
+  "aleph-message @ git+https://github.com/aleph-im/aleph-message@4ad261ff25f595a64589d49bf36f514c402e7c5e",
   "aleph-superfluid~=0.2.1",
   "dbus-python==1.3.2",
   "eth-account~=0.10",

--- a/src/aleph/vm/vprogram/measurement.py
+++ b/src/aleph/vm/vprogram/measurement.py
@@ -3,7 +3,8 @@
 TRANSIENT: wraps the sev-snp-measure pip package (0.0.12, matching the nix
 pin in nix/flake.nix). The intended home for measurement computation is
 aleph-rs (the Rust CLI); this module is the stopgap so the publisher can pin
-verification.measurements[].digest for a message-delivered workload.
+verification.measurements[].registers['launch'] for a message-delivered
+workload.
 
 The launch digest is a function of OVMF + kernel + initrd + cmdline + vcpu
 count + vcpu type: this wrapper takes exactly those inputs and nothing else,

--- a/tests/supervisor/fixtures/vprogram_message.json
+++ b/tests/supervisor/fixtures/vprogram_message.json
@@ -36,7 +36,9 @@
             "measurements": [
                 {
                     "platform": "sev_snp",
-                    "digest": "abababababababababababababababababababababababababababababababababababababababababababababababab",
+                    "registers": {
+                        "launch": "abababababababababababababababababababababababababababababababababababababababababababababababab"
+                    },
                     "vcpu_type": "EPYC-v4"
                 }
             ]
@@ -50,6 +52,6 @@
             }
         ]
     },
-    "item_content": "{\"address\":\"0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba\",\"time\":1719502000.0,\"allow_amend\":false,\"payment\":{\"type\":\"credit\"},\"environment\":{\"internet\":true},\"resources\":{\"vcpus\":2,\"memory\":2048,\"seconds\":30},\"runtime\":{\"ref\":\"cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe\",\"comment\":\"compose-runner snp bundle\"},\"workload\":{\"ref\":\"beefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef\",\"hash_tree\":\"feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed\",\"roothash\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd\"},\"verification\":{\"backend\":\"sev_snp\",\"policy\":196608,\"measurements\":[{\"platform\":\"sev_snp\",\"digest\":\"abababababababababababababababababababababababababababababababababababababababababababababababab\",\"vcpu_type\":\"EPYC-v4\"}]},\"volumes\":[{\"ref\":\"dadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadada\",\"hash_tree\":\"d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5\",\"roothash\":\"efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefef\",\"comment\":\"model weights\"}]}",
-    "item_hash": "4c319b6bdf98f1e90f2bf8c69da175679fa21ca27d4547bbfa32f77dd3b49fe6"
+    "item_content": "{\"address\":\"0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba\",\"time\":1719502000.0,\"allow_amend\":false,\"payment\":{\"type\":\"credit\"},\"environment\":{\"internet\":true},\"resources\":{\"vcpus\":2,\"memory\":2048,\"seconds\":30},\"runtime\":{\"ref\":\"cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe\",\"comment\":\"compose-runner snp bundle\"},\"workload\":{\"ref\":\"beefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef\",\"hash_tree\":\"feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed\",\"roothash\":\"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd\"},\"verification\":{\"backend\":\"sev_snp\",\"policy\":196608,\"measurements\":[{\"platform\":\"sev_snp\",\"registers\":{\"launch\":\"abababababababababababababababababababababababababababababababababababababababababababababababab\"},\"vcpu_type\":\"EPYC-v4\"}]},\"volumes\":[{\"ref\":\"dadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadada\",\"hash_tree\":\"d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5\",\"roothash\":\"efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefef\",\"comment\":\"model weights\"}]}",
+    "item_hash": "1f9df10846e37cfb1fee1bcf139309a449b7fdd005e633c3a38c663edc77a8c3"
 }


### PR DESCRIPTION
Adopts the register-map schema from aleph-im/aleph-message#159.

`LaunchMeasurement.digest` becomes a `registers` object, so a
multi-register TEE such as Intel TDX (MRTD plus RTMRs) fits later without a
breaking protocol change. SEV-SNP declares `{"launch": "<hex>"}`.

## Scope

Supervisor code is unaffected. Measurements are never sent to the
supervisor, and `compute_snp_measurement` returns a bare hex digest rather
than a `LaunchMeasurement`; only its docstring named the message field.

So this is the dependency pin, the fixture, and that docstring.

The fixture's `item_hash` is recomputed because `item_content` changes. The
new value matches the aleph-rs and pyaleph fixtures byte for byte, which
cross-checks that all three repos serialize the same canonical content.

## Merge gate

The pin points at aleph-im/aleph-message#159, which must merge and be
reachable on `od/vprogram-schema` before this installs.

## Test plan

`tests/supervisor`: **10 failed / 1129 passed**, an identical failure set to
`dev` on this machine (pyroute2 needs root, journald, dbus stubs). Baselined
against a clean `dev` checkout and diffed rather than eyeballed, so the
result is no regressions rather than "the failures look environmental".

Design: `docs/superpowers/specs/2026-08-20-intel-tdx-design.md` §3, §4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaLi3sSGWh8EtWcVn64yni
