### PR TITLE
fix(tests): build the SNP instance measurement with registers

### DIFF
--- a/tests/supervisor/test_snp_instance_launch.py
+++ b/tests/supervisor/test_snp_instance_launch.py
@@ -26,6 +26,7 @@ from aleph_message.models.execution.environment import (
     InstanceEnvironment,
     LaunchMeasurement,
     MachineResources,
+    SevSnpRegisters,
     TeePlatform,
     TrustedExecutionEnvironment,
 )
@@ -175,7 +176,11 @@ def snp_instance_content(
         "mode": "sev_snp",
         "policy": DEFAULT_SNP_POLICY,
         "runtime": ItemHash(MANIFEST_REF),
-        "measurements": [LaunchMeasurement(platform=TeePlatform.sev_snp, digest="a" * 96, vcpu_type="EPYC-v4")],
+        "measurements": [
+            LaunchMeasurement(
+                platform=TeePlatform.sev_snp, registers=SevSnpRegisters(launch="a" * 96), vcpu_type="EPYC-v4"
+            )
+        ],
     }
     trusted_execution_kwargs.update(trusted_execution_overrides or {})
     return InstanceContent(


### PR DESCRIPTION
`dev` is currently red on 18 tests, from a semantic conflict between two PRs that merged two hours apart today.

#1131 added `tests/supervisor/test_snp_instance_launch.py` with a helper that builds `LaunchMeasurement(platform=..., digest="a" * 96, vcpu_type=...)`. #1143 then replaced `LaunchMeasurement.digest` with a per-platform register map and carried the V-PROGRAM fixture to the new shape, but that helper did not exist on its branch. Both PRs were green on their own; the merged combination was never tested.

Result on `dev` today: every test that builds SNP-instance content dies at fixture construction.

```
E   pydantic_core._pydantic_core.ValidationError: 2 validation errors for LaunchMeasurement
E   registers
E     Field required
E   digest
E     Extra inputs are not permitted
```

That is 13 tests in `test_snp_instance_launch.py` and 5 in `test_snp_instance_run.py`.

## The fix

One line: the helper builds `registers=SevSnpRegisters(launch="a" * 96)`. The typed model rather than a bare `{"launch": ...}` dict, because `LaunchMeasurement.registers` is typed and mypy runs over `tests/` in CI (a dict passes pytest and fails mypy).

## Verification

Run locally against the exact `aleph-message` rev `pyproject.toml` pins (`4ad261ff`), installed side by side rather than into the shared venv:

| tree | `tests/supervisor/` |
| --- | --- |
| `dev` | 28 failed, 1138 passed |
| this branch | 10 failed, 1156 passed |

The remaining 10 are this machine's usual environment-only failures (pyroute2 needs root, journald, dbus stubs), identical on both trees. `ruff format`, `isort` and `mypy` clean on the touched file.

Same fix also rides in #1145, which needed it to show a green CI; that copy drops out when this lands and #1145 rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
