### PR TITLE
fix(packaging): ship the registers-schema aleph-message in the deb

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -45,7 +45,7 @@ debian-package-code:
 	# MERGE GATE: aleph-message is git-pinned to the V-PROGRAM schema ref, swap for a release with pyproject.toml.
 	# protobuf is pinned to 5.29.6: 5.29.0 has a compilation issue; 6.x needs grpcio/tools 1.71+.
 	# legacy-cgi is packaging-only: it backfills the `cgi` module removed from the Python 3.13+ stdlib.
-	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message @ git+https://github.com/aleph-im/aleph-message@bc9c0f86958a746faeecbd6c6f96cc6f5b4538de' 'eth-account~=0.10' 'sentry-sdk==2.8' 'qmp==1.1' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2' 'aiosqlite==0.19' 'alembic==1.13.1' 'aiohttp-cors~=0.7.0' 'pydantic-settings~=2.6.1' 'pyroute2==0.7.12' 'python-cpuid==0.1.1' 'solathon==1.0.7' 'protobuf==5.29.6' 'grpcio>=1.70,<1.71' 'redis>=4.2' 'legacy-cgi>=1.0'
+	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message @ git+https://github.com/aleph-im/aleph-message@4ad261ff25f595a64589d49bf36f514c402e7c5e' 'eth-account~=0.10' 'sentry-sdk==2.8' 'qmp==1.1' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2' 'aiosqlite==0.19' 'alembic==1.13.1' 'aiohttp-cors~=0.7.0' 'pydantic-settings~=2.6.1' 'pyroute2==0.7.12' 'python-cpuid==0.1.1' 'solathon==1.0.7' 'protobuf==5.29.6' 'grpcio>=1.70,<1.71' 'redis>=4.2' 'legacy-cgi>=1.0'
 	build_venv/bin/python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux target/bin/sevctl


### PR DESCRIPTION
packaging/Makefile's pip install line must mirror pyproject.toml (its own comment says so), but #1143 moved the aleph-message git pin to 4ad261ff (measurement registers) only in pyproject. Debs built from dev since then bundle the old digest-schema models, so the CRN agent rejects any V-PROGRAM message published with the registers map:

```
2 validation errors for VerifiableProgramMessage
content.verification.measurements.0.digest: Field required
content.verification.measurements.0.registers: Extra inputs are not permitted
```

Observed live on the testnet validation run 32416035775 (aleph-cli 0.17.0-rc11 + pyaleph 0.10.3-rc9 publish/accept registers, the deb-installed agent refuses to start the VM).

One-line fix: move the Makefile pin to the same ref. Longer term the MERGE GATE comment already covers this: both pins disappear in favor of a released aleph-message.