### PR TITLE
fix(agent): land the V-PROGRAM agent fixes from the validation branch

### DIFF
--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -34,7 +34,11 @@ from aleph.vm.agent.translate import build_create_vm_spec, build_program_create_
 from aleph.vm.agent.update_watcher import UpdateWatcher
 from aleph.vm.agent.vm.program_client import ProgramGuestClient
 from aleph.vm.agent.vm_registry import AgentVmRegistry, persist_record
-from aleph.vm.agent.vprogram_launch import build_vprogram_spec, remove_vprogram_staging
+from aleph.vm.agent.vprogram_launch import (
+    build_vprogram_spec,
+    remove_vprogram_staging,
+    resolve_vprogram_attestation_port,
+)
 from aleph.vm.conf import settings
 from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.supervisor_interface import errors as supervisor_errors
@@ -102,13 +106,20 @@ def _is_spec_eligible(content) -> bool:
     return isinstance(content, InstanceContent)
 
 
-async def resolve_port_forwards(vm_id: VmId, content) -> list[PortForwardSpec]:
+async def resolve_port_forwards(vm_id: VmId, content, *, strict: bool = False) -> list[PortForwardSpec]:
     """Agent-side policy: translate the user's port-forwarding aggregate settings
     into the set of forwards the hypervisor should apply.
 
     This is the agent half of the old VmExecution.fetch_port_redirect_config_and_setup.
     Nothing here touches nftables; the caller applies each spec through
     supervisor.add_port_forward. host_port is left 0; the hypervisor assigns it.
+
+    ``strict=True`` turns an aggregate-fetch failure into an exception instead
+    of the SSH-only fallback. The fallback is right on create (worst case the
+    VM starts with SSH only), but a convergence caller reconciling an already
+    forwarded VM must not treat "could not fetch" as "the user removed every
+    port": converging on the fallback set would tear the user's forwards down
+    on a transient CCN error. Strict callers skip reconciling instead.
     """
     ports_requests: dict[int, dict[str, bool]] = {}
     try:
@@ -117,6 +128,8 @@ async def resolve_port_forwards(vm_id: VmId, content) -> list[PortForwardSpec]:
         fetched = vm_port_forwarding.get("ports", {})
         ports_requests = {int(port): flags for port, flags in fetched.items()}
     except Exception:
+        if strict:
+            raise
         logger.info("Could not fetch port redirect settings for %s", content.address, exc_info=True)
 
     # Always forward SSH.
@@ -137,14 +150,14 @@ async def resolve_port_forwards(vm_id: VmId, content) -> list[PortForwardSpec]:
     return forwards
 
 
-async def reconcile_port_forwards(supervisor: Supervisor, vm_id: VmId, content) -> None:
-    """Drive the hypervisor's forwards to match the aggregate settings.
-
-    Agent policy half of the old fetch_port_redirect_config_and_setup: compute
-    the desired set, diff against what the hypervisor reports, and issue
-    add/remove calls. The hypervisor owns application and persistence.
+async def _reconcile_forwards(supervisor: Supervisor, vm_id: VmId, desired_specs: list[PortForwardSpec]) -> None:
+    """Diff `desired_specs` against what the hypervisor currently reports for
+    `vm_id` and issue add/remove calls so the two converge. The hypervisor
+    owns application and persistence; this is pure agent policy, and it is
+    idempotent: calling it again with the same desired set (e.g. on
+    re-adoption) issues no calls at all.
     """
-    desired = {(int(spec.vm_port), spec.protocol): spec for spec in await resolve_port_forwards(vm_id, content)}
+    desired = {(int(spec.vm_port), spec.protocol): spec for spec in desired_specs}
     current = {(int(info.vm_port), info.protocol): info for info in await supervisor.list_port_forwards(vm_id)}
     for key, info in current.items():
         if key not in desired:
@@ -152,6 +165,82 @@ async def reconcile_port_forwards(supervisor: Supervisor, vm_id: VmId, content) 
     for key, spec in desired.items():
         if key not in current:
             await supervisor.add_port_forward(spec)
+
+
+async def reconcile_port_forwards(supervisor: Supervisor, vm_id: VmId, content) -> None:
+    """Drive the hypervisor's forwards to match the aggregate settings.
+
+    Agent policy half of the old fetch_port_redirect_config_and_setup: compute
+    the desired set, then converge through ``_reconcile_forwards``.
+    """
+    await _reconcile_forwards(supervisor, vm_id, await resolve_port_forwards(vm_id, content))
+
+
+def resolve_vprogram_port_forwards(vm_id: VmId, attest_port: int | None) -> list[PortForwardSpec]:
+    """The only forward a V-PROGRAM gets: the manifest's RA-TLS attestation
+    port (tcp), mapped to a host IPv4 port so an external client (the aleph
+    CLI) can reach the guest's RA-TLS endpoint. Host-only DNAT,
+    measurement-neutral: unlike instances, no user aggregate is consulted and
+    SSH is never force-added. `attest_port` is None when the manifest
+    declared no aleph.ra-tls tcp transport; that V-PROGRAM gets no mapping.
+    """
+    if attest_port is None:
+        return []
+    return [
+        PortForwardSpec(
+            vm_id=vm_id,
+            host_port=HostPort(0),
+            vm_port=GuestPort(int(attest_port)),
+            protocol=Protocol.TCP,
+        )
+    ]
+
+
+async def reconcile_vprogram_port_forwards(supervisor: Supervisor, vm_id: VmId, attest_port: int | None) -> None:
+    """Drive the hypervisor's forwards to match the V-PROGRAM's single
+    attestation-port mapping. Reuses ``_reconcile_forwards``, so it is
+    idempotent by construction: both the create path and the re-adoption
+    path (``reconcile_adopted_port_forwards``) call it safely.
+    """
+    await _reconcile_forwards(supervisor, vm_id, resolve_vprogram_port_forwards(vm_id, attest_port))
+
+
+async def reconcile_adopted_port_forwards(supervisor: Supervisor, registry: AgentVmRegistry, vm_hash: ItemHash) -> None:
+    """Best-effort port-forward healing for a VM adopted already-created.
+
+    The create path applies forwards right after the VM first reaches RUNNING;
+    a VM re-adopted on a later allocation (typically after an agent restart)
+    skipped that step in this agent's lifetime. If the previous life crashed
+    in the window between RUNNING and the forward setup, the VM is up but
+    unreachable (no SSH for an instance, no attestation endpoint for a
+    V-PROGRAM); for instances, the port-forwarding aggregate may also have
+    changed while the agent was down, past the live aggregate watcher.
+    Converge the hypervisor state here.
+
+    Best-effort by design, unlike the create path (which fails loudly and
+    tears the VM down): the adopted VM is already up and possibly serving, so
+    a healing failure must never fail the allocation and invite scheduler
+    churn. Skipping leaves exactly the state we found.
+    """
+    record = registry.get(vm_hash)
+    if record is None:
+        # Nothing to derive the desired forward set from (agent DB loss).
+        logger.warning("No agent record for adopted VM %s; port forwards left as found", vm_hash)
+        return
+    vm_id = VmId(str(vm_hash))
+    content = record.message
+    try:
+        if isinstance(content, VerifiableProgramContent):
+            attest_port = await resolve_vprogram_attestation_port(content)
+            await reconcile_vprogram_port_forwards(supervisor, vm_id, attest_port)
+        elif _is_spec_eligible(content):
+            # strict: a failed aggregate fetch must skip healing, not converge
+            # the VM onto the SSH-only fallback set (which would remove the
+            # user's aggregate-declared forwards on a transient CCN error).
+            await _reconcile_forwards(supervisor, vm_id, await resolve_port_forwards(vm_id, content, strict=True))
+        # Programs get no agent-side forwards: nothing to heal.
+    except Exception:
+        logger.warning("Could not reconcile port forwards for adopted VM %s; left as found", vm_hash, exc_info=True)
 
 
 class VmStartupError(Exception):
@@ -409,7 +498,7 @@ async def create_vm_execution(
         # set), so the plain readiness wait applies.
         record = registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
         try:
-            spec = await build_vprogram_spec(vm_hash, content)
+            spec, attest_port = await build_vprogram_spec(vm_hash, content)
             # Agent-side admission after the download, like the instance path:
             # a failed bundle fetch never consumes capacity.
             capacity.check_capacity(
@@ -428,6 +517,17 @@ async def create_vm_execution(
             raise
         try:
             await _wait_until_running(supervisor, info.vm_id)
+            # Host-only DNAT so an external client (the aleph CLI) can reach
+            # the guest's RA-TLS attestation endpoint; measurement-neutral
+            # (no guest image/cmdline change) and idempotent via the same
+            # reconcile machinery the instance path uses.
+            #
+            # A reconcile failure lands in the teardown branch below on
+            # purpose, mirroring the instance path: a V-PROGRAM whose
+            # attestation endpoint cannot be mapped is unreachable for its
+            # sole consumer, so failing the create loudly (and letting the
+            # scheduler retry) beats keeping an unusable VM alive.
+            await reconcile_vprogram_port_forwards(supervisor, info.vm_id, attest_port)
         except Exception:
             registry.forget(vm_hash)
             try:
@@ -873,6 +973,14 @@ async def start_persistent_vm(
             # them) so the recreated VM reloads the same host ports.
             await supervisor.delete_vm(vm_id, keep_port_mappings=True)
             info = None
+        if info is not None and not info.awaiting_confidential_init:
+            # Every branch that kept `info` ends with a RUNNING VM this agent
+            # did not create in its own lifetime. Only the create path applies
+            # forwards, so heal them here: a previous life crashing between
+            # RUNNING and the forward setup leaves the VM up but unreachable
+            # forever otherwise. Best-effort; never fails the allocation.
+            # The recreate branches (info = None) reconcile in the create path.
+            await reconcile_adopted_port_forwards(supervisor, registry, vm_hash)
 
     if info is None:
         logger.info(f"Starting persistent virtual machine with id: {vm_hash}")

--- a/src/aleph/vm/agent/update_watcher.py
+++ b/src/aleph/vm/agent/update_watcher.py
@@ -2,7 +2,12 @@ import asyncio
 import logging
 from collections.abc import Callable
 
-from aleph_message.models import ExecutableContent, InstanceContent, ItemHash
+from aleph_message.models import (
+    ExecutableContent,
+    InstanceContent,
+    ItemHash,
+    VerifiableProgramContent,
+)
 
 from aleph.vm.agent.pubsub import PubSub
 from aleph.vm.agent.vm_registry import AgentVmRegistry
@@ -19,6 +24,11 @@ def update_refs(original: ExecutableContent) -> list[str]:
     Adapted from VmExecution.watch_for_updates: instances watch their
     volume refs; programs also watch code / runtime / data.
     """
+    if isinstance(original, VerifiableProgramContent):
+        # V-PROGRAMs are immutable (allow_amend is schema-rejected) and every
+        # reference is pinned by exact hash: nothing can update, nothing to
+        # watch. Falling through would crash on the program-only attributes.
+        return []
     volume_refs = [volume.ref for volume in (original.volumes or []) if hasattr(volume, "ref")]
     if isinstance(original, InstanceContent):
         return volume_refs

--- a/src/aleph/vm/agent/vprogram_launch.py
+++ b/src/aleph/vm/agent/vprogram_launch.py
@@ -126,13 +126,33 @@ def _ensure_verity_sidecars(rootfs_path: Path, hash_tree_path: Path, platform_ro
             shutil.copyfile(hash_tree_path, verity_path)
 
 
-async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramContent) -> CreateVmSpec:
+def _select_attestation_port(manifest: RuntimeManifest) -> int | None:
+    """The RA-TLS attestation port a CRN maps to a host IPv4 port, so an
+    external client (the aleph CLI) can reach the guest's attestation
+    endpoint. Selects the ``aleph.ra-tls`` protocol's tcp transport port;
+    None when the manifest declares none (the caller skips port-forward
+    setup rather than failing closed on it, since attestation reachability
+    is not required for the VM itself to boot and run). First match wins:
+    the schema allows several ``aleph.ra-tls`` entries but a single RA-TLS
+    transport is the expected case, so extra entries are not mapped."""
+    for protocol in manifest.attestation:
+        if protocol.protocol == "aleph.ra-tls" and protocol.transport.type == "tcp":
+            return protocol.transport.port
+    return None
+
+
+async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramContent) -> tuple[CreateVmSpec, int | None]:
     """Fetch, verify and stage the runtime bundle, then build the SNP spec.
 
     Mirrors the on-host launch template (aleph-testnets test_vm_snp.py): QEMU
     backend, direct-kernel boot from the measured bundle members, and a disk
     order that IS the contract: the guest init reads the platform rootfs from
     /dev/vda and the dm-verity hash tree from /dev/vdb.
+
+    Also returns the manifest's RA-TLS attestation port (or None), so the
+    caller can map it to a host port after the VM reaches RUNNING. Nothing
+    here touches spec construction to surface it: the attestation port is a
+    host-only DNAT concern, entirely orthogonal to the measured launch.
     """
     manifest = await fetch_runtime_manifest(str(content.runtime.ref))
 
@@ -194,7 +214,7 @@ async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramConte
     # agent computes it upfront (empty under the dynamic policy).
     requested_ipv6, ipv6_prefix_len = compute_requested_ipv6(vm_hash, VmType.from_message_content(content))
 
-    return CreateVmSpec(
+    spec = CreateVmSpec(
         vm_id=VmId(str(vm_hash)),
         backend=Backend.QEMU,
         kernel_path=kernel_path,
@@ -222,3 +242,4 @@ async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramConte
         persistent=True,
         hostname=get_hostname_from_hash(vm_hash),
     )
+    return spec, _select_attestation_port(manifest)

--- a/src/aleph/vm/agent/vprogram_launch.py
+++ b/src/aleph/vm/agent/vprogram_launch.py
@@ -141,6 +141,22 @@ def _select_attestation_port(manifest: RuntimeManifest) -> int | None:
     return None
 
 
+async def resolve_vprogram_attestation_port(content: VerifiableProgramContent) -> int | None:
+    """Re-derive the RA-TLS attestation port from the runtime manifest alone.
+
+    The re-adoption path (an agent picking an already-RUNNING V-PROGRAM back
+    up) needs the port to reconcile the host DNAT mapping, but must not pay
+    for ``build_vprogram_spec``: that stages the whole runtime bundle, which
+    the running VM already booted from. The manifest is a small STORE file:
+    one message-metadata lookup, with the file itself coming from the local
+    download cache after the first create. Raises VmSetupError when the
+    manifest cannot be fetched or parsed; the caller decides whether that is
+    fatal.
+    """
+    manifest = await fetch_runtime_manifest(str(content.runtime.ref))
+    return _select_attestation_port(manifest)
+
+
 async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramContent) -> tuple[CreateVmSpec, int | None]:
     """Fetch, verify and stage the runtime bundle, then build the SNP spec.
 

--- a/tests/supervisor/test_supervisor_run_helpers.py
+++ b/tests/supervisor/test_supervisor_run_helpers.py
@@ -59,6 +59,18 @@ async def test_resolve_port_forwards_tolerates_settings_error(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_resolve_port_forwards_strict_raises_on_settings_error(monkeypatch):
+    """strict=True is for convergence callers: a fetch failure must abort the
+    reconcile, not converge the VM onto the SSH-only fallback set (which would
+    remove the user's aggregate-declared forwards on a transient CCN error)."""
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(side_effect=RuntimeError("boom")))
+    content = SimpleNamespace(address="0xabc")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await run_module.resolve_port_forwards(_VM_ID, content, strict=True)
+
+
+@pytest.mark.asyncio
 async def test_wait_until_running_returns_on_running(monkeypatch):
     booting = SimpleNamespace(status=VmStatus.BOOTING)
     running = SimpleNamespace(status=VmStatus.RUNNING)

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -27,9 +27,14 @@ from aleph.vm.supervisor_interface.types import (
     DiskRole,
     DiskSpec,
     GpuSpec,
+    GuestPort,
+    HostPort,
     IpAssignment,
     NetworkConfig,
     PciAddress,
+    PortForwardInfo,
+    PortForwardSpec,
+    Protocol,
     VmId,
     VmInfo,
     VmStatus,
@@ -512,6 +517,113 @@ async def test_start_persistent_resumes_stopped(monkeypatch):
     sup.start_vm.assert_awaited_once()  # STOPPED -> resume in place
     sup.delete_vm.assert_not_awaited()  # not deleted
     created.assert_not_awaited()  # not recreated
+
+
+def _readopt_supervisor(*, get_status: VmStatus = VmStatus.RUNNING, current_forwards: list | None = None):
+    sup = _fake_supervisor(get_status=get_status)
+    sup.list_port_forwards = AsyncMock(return_value=current_forwards or [])
+    sup.remove_port_forward = AsyncMock()
+    return sup
+
+
+def _instance_registry() -> AgentVmRegistry:
+    content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
+    registry = AgentVmRegistry()
+    registry.record(_HASH, message=content, original=content, persistent=True)
+    return registry
+
+
+async def _start_persistent(sup, registry):
+    return await run_module.start_persistent_vm(
+        ItemHash(_HASH),
+        None,
+        supervisor=sup,
+        registry=registry,
+        capacity=_fake_capacity(),
+        expiry=MagicMock(),
+        update_watcher=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_readopt_instance_heals_with_strict_resolve(monkeypatch):
+    """An instance adopted already-RUNNING gets its forwards reconciled from
+    the aggregate, resolved strictly: on re-adoption "could not fetch" must
+    mean "skip", never "converge onto the SSH-only fallback"."""
+    sup = _readopt_supervisor()
+    monkeypatch.setattr(run_module, "create_vm_execution", AsyncMock())
+    ssh = PortForwardSpec(vm_id=VmId(str(_HASH)), host_port=HostPort(0), vm_port=GuestPort(22), protocol=Protocol.TCP)
+    resolve = AsyncMock(return_value=[ssh])
+    monkeypatch.setattr(run_module, "resolve_port_forwards", resolve)
+
+    await _start_persistent(sup, _instance_registry())
+
+    resolve.assert_awaited_once()
+    await_args = resolve.await_args
+    assert await_args is not None
+    assert await_args.kwargs.get("strict") is True
+    sup.add_port_forward.assert_awaited_once_with(ssh)
+    sup.remove_port_forward.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_readopt_instance_settings_error_removes_nothing(monkeypatch):
+    """A transient aggregate-fetch failure during re-adoption healing must
+    leave existing forwards exactly as found and never fail the allocation."""
+    existing = PortForwardInfo(
+        vm_id=VmId(str(_HASH)), host_port=HostPort(24080), vm_port=GuestPort(8080), protocol=Protocol.TCP
+    )
+    sup = _readopt_supervisor(current_forwards=[existing])
+    monkeypatch.setattr(run_module, "create_vm_execution", AsyncMock())
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(side_effect=RuntimeError("CCN down")))
+
+    await _start_persistent(sup, _instance_registry())
+
+    sup.remove_port_forward.assert_not_awaited()
+    sup.add_port_forward.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_readopt_awaiting_init_not_healed(monkeypatch):
+    """A confidential VM awaiting its owner's session is left untouched: it is
+    not RUNNING, so there is nothing to heal (the create path applies forwards
+    once it comes up)."""
+    sup = _fake_supervisor()
+    sup.get_vm = AsyncMock(return_value=replace(_info(VmStatus.DEFINED), awaiting_confidential_init=True))
+    heal = AsyncMock()
+    monkeypatch.setattr(run_module, "reconcile_adopted_port_forwards", heal)
+    monkeypatch.setattr(run_module, "create_vm_execution", AsyncMock())
+
+    await _start_persistent(sup, AgentVmRegistry())
+
+    heal.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_persistent_readopt_stopped_heals_after_resume(monkeypatch):
+    """The resume-in-place branch ends with a RUNNING VM this agent did not
+    create, so it heals forwards too (idempotent when nothing is missing)."""
+    sup = _fake_supervisor(get_status=VmStatus.STOPPED)
+    heal = AsyncMock()
+    monkeypatch.setattr(run_module, "reconcile_adopted_port_forwards", heal)
+    monkeypatch.setattr(run_module, "create_vm_execution", AsyncMock())
+    monkeypatch.setattr(run_module, "_wait_until_running", AsyncMock())
+
+    await _start_persistent(sup, AgentVmRegistry())
+
+    sup.start_vm.assert_awaited_once()
+    heal.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_adopted_program_content_is_a_noop():
+    """Programs get no agent-side forwards: adoption healing must not touch
+    the supervisor at all (a bare namespace would AttributeError if it did)."""
+    registry = AgentVmRegistry()
+    content = MagicMock(spec=ProgramContent)
+    registry.record(_HASH, message=content, original=content, persistent=True)
+
+    await run_module.reconcile_adopted_port_forwards(SimpleNamespace(), registry, _HASH)
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -394,3 +394,12 @@ def test_payment_sweep_excludes_vprograms():
 
     grouped = _group_executions_by_payment([_running_vm_info(vm_hash)], registry, PaymentType.credit)
     assert grouped == {}
+
+
+def test_update_refs_returns_nothing_for_a_v_program():
+    """V-PROGRAMs are immutable: the update watcher must not derive refs from
+    them (regression: the program arm crashed on the missing .data/.code)."""
+    from aleph.vm.agent.update_watcher import update_refs
+
+    message = load_vprogram_message()
+    assert update_refs(message.content) == []

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -215,7 +215,9 @@ async def test_create_vm_execution_vprogram_launches_snp(mocker):
     mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
 
     fake_spec = MagicMock()
-    mock_build = mocker.patch("aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=fake_spec)
+    mock_build = mocker.patch(
+        "aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=(fake_spec, 8443)
+    )
     mock_persist = mocker.patch("aleph.vm.agent.run.persist_record", new_callable=AsyncMock)
 
     info = _running_vm_info(str(vm_hash))
@@ -224,6 +226,8 @@ async def test_create_vm_execution_vprogram_launches_snp(mocker):
         create_vm=AsyncMock(return_value=info),
         get_vm=AsyncMock(return_value=info),
         delete_vm=AsyncMock(),
+        list_port_forwards=AsyncMock(return_value=[]),
+        add_port_forward=AsyncMock(),
     )
     registry = AgentVmRegistry()
 
@@ -238,6 +242,10 @@ async def test_create_vm_execution_vprogram_launches_snp(mocker):
     mock_build.assert_awaited_once_with(vm_hash, message.content)
     supervisor.create_vm.assert_awaited_once_with(fake_spec)
     supervisor.delete_vm.assert_not_awaited()
+    supervisor.add_port_forward.assert_awaited_once()
+    added_spec = supervisor.add_port_forward.await_args.args[0]
+    assert added_spec.vm_port == 8443
+    assert added_spec.protocol.value == "tcp"
     assert vm_hash in registry
     record = registry.get(vm_hash)
     assert record is not None and record.persistent
@@ -269,7 +277,7 @@ async def test_create_vm_execution_vprogram_wait_failure_tears_down(mocker):
     mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
 
     fake_spec = MagicMock()
-    mocker.patch("aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=fake_spec)
+    mocker.patch("aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=(fake_spec, 8443))
     mock_persist = mocker.patch("aleph.vm.agent.run.persist_record", new_callable=AsyncMock)
 
     info = _failed_vm_info(str(vm_hash))
@@ -331,7 +339,7 @@ async def test_create_vm_execution_vprogram_capacity_failure_forgets_record(mock
     create_vm (a distinct failure path from a build failure)."""
     message = load_vprogram_message()
     mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
-    mocker.patch("aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=MagicMock())
+    mocker.patch("aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=(MagicMock(), 8443))
 
     capacity = MagicMock()
     capacity.check_capacity.side_effect = InsufficientResourcesError("no room", required={}, available={})

--- a/tests/supervisor/test_vprogram_launch.py
+++ b/tests/supervisor/test_vprogram_launch.py
@@ -237,7 +237,8 @@ async def test_build_vprogram_spec(staged_bundle):
     persistent."""
     message = load_vprogram_message()
     content = message.content
-    spec = await build_vprogram_spec(message.item_hash, content)
+    spec, attest_port = await build_vprogram_spec(message.item_hash, content)
+    assert attest_port == 8443
 
     staging = vprogram_staging_dir(message.item_hash)
     assert spec.vm_id == str(message.item_hash)
@@ -285,12 +286,36 @@ async def test_build_vprogram_spec(staged_bundle):
 
 
 @pytest.mark.asyncio
+async def test_build_vprogram_spec_no_ra_tls_attestation_port(tmp_path, storage_files):
+    """A manifest whose attestation list has no aleph.ra-tls tcp entry
+    surfaces attest_port=None: the caller (run.py) skips port-forward setup
+    rather than failing the create path on it."""
+    tar_path = make_bundle(tmp_path)
+    manifest_path = make_manifest(
+        tar_path,
+        tmp_path,
+        **{
+            "attestation": [
+                {"protocol": "aleph.other-attest", "version": "1", "transport": {"type": "tcp", "port": 9000}}
+            ]
+        },
+    )
+    storage_files[MANIFEST_REF] = manifest_path
+    storage_files[BUNDLE_REF] = tar_path
+    stage_workload(storage_files, tmp_path)
+
+    message = load_vprogram_message()
+    _spec, attest_port = await build_vprogram_spec(message.item_hash, message.content)
+    assert attest_port is None
+
+
+@pytest.mark.asyncio
 async def test_roothash_sidecar_present_after_staging(staged_bundle):
     """The daemon derives the measured cmdline from <rootfs>.roothash and the
     hash tree from <rootfs>.verity next to the rootfs disk: both must be in
     place after staging, with the manifest's platform roothash."""
     message = load_vprogram_message()
-    spec = await build_vprogram_spec(message.item_hash, message.content)
+    spec, _attest_port = await build_vprogram_spec(message.item_hash, message.content)
 
     rootfs = spec.rootfs.path
     roothash_sidecar = rootfs.with_name(rootfs.name + ".roothash")
@@ -311,7 +336,7 @@ async def test_roothash_sidecar_written_when_bundle_lacks_it(tmp_path, storage_f
     stage_workload(storage_files, tmp_path)
 
     message = load_vprogram_message()
-    spec = await build_vprogram_spec(message.item_hash, message.content)
+    spec, _attest_port = await build_vprogram_spec(message.item_hash, message.content)
     rootfs = spec.rootfs.path
     assert rootfs.with_name(rootfs.name + ".roothash").read_text().strip() == PLATFORM_ROOTHASH
 
@@ -378,7 +403,7 @@ async def test_workload_attached_and_sidecar_written(staged_bundle):
     message = load_vprogram_message()
     content = message.content
     assert content.workload.roothash == WORKLOAD_ROOTHASH
-    spec = await build_vprogram_spec(message.item_hash, content)
+    spec, _attest_port = await build_vprogram_spec(message.item_hash, content)
 
     assert len(spec.disks) == 3
     assert [d.role for d in spec.disks] == [

--- a/tests/supervisor/test_vprogram_port_map.py
+++ b/tests/supervisor/test_vprogram_port_map.py
@@ -14,13 +14,21 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aleph_message.models import VerifiableProgramMessage, parse_message
 
-from aleph.vm.agent.run import create_vm_execution, reconcile_vprogram_port_forwards
+from aleph.vm.agent.run import (
+    create_vm_execution,
+    reconcile_vprogram_port_forwards,
+    start_persistent_vm,
+)
 from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor_interface.errors import VmSetupError
 from aleph.vm.supervisor_interface.types import (
     Backend,
     ConfidentialMode,
+    GuestPort,
+    HostPort,
     IpAssignment,
     PortForwardInfo,
+    PortForwardSpec,
     Protocol,
     VmId,
     VmInfo,
@@ -147,3 +155,96 @@ async def test_reconcile_vprogram_no_attestation_port_is_noop():
     await reconcile_vprogram_port_forwards(supervisor, VmId("deadbeef"), None)
     assert supervisor.add_port_forward_calls == []
     assert await supervisor.list_port_forwards(VmId("deadbeef")) == []
+
+
+async def _start_persistent(vm_hash, supervisor, registry):
+    return await start_persistent_vm(
+        vm_hash,
+        None,
+        supervisor=supervisor,
+        registry=registry,
+        capacity=MagicMock(),
+        expiry=MagicMock(),
+        update_watcher=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_readopted_running_vprogram_heals_missing_forward(mocker):
+    """A V-PROGRAM adopted already-RUNNING (agent restart) whose attestation
+    forward is missing (previous life crashed between RUNNING and the forward
+    setup) gets it healed from the manifest, without rebuilding the spec or
+    recreating the VM. A second adoption then no-ops (idempotent heal)."""
+    message = load_vprogram_message()
+    vm_hash = message.item_hash
+    mocker.patch(
+        "aleph.vm.agent.run.resolve_vprogram_attestation_port",
+        new_callable=AsyncMock,
+        return_value=ATTEST_PORT,
+    )
+    create = mocker.patch("aleph.vm.agent.run.create_vm_execution", new_callable=AsyncMock)
+
+    supervisor = FakeSupervisor(_running_vm_info(str(vm_hash)))
+    registry = AgentVmRegistry()
+    registry.record(vm_hash, message=message.content, original=message.content, persistent=True)
+
+    await _start_persistent(vm_hash, supervisor, registry)
+
+    create.assert_not_awaited()
+    assert len(supervisor.add_port_forward_calls) == 1
+    pf = supervisor.add_port_forward_calls[0]
+    assert pf.vm_port == ATTEST_PORT
+    assert pf.protocol is Protocol.TCP
+
+    await _start_persistent(vm_hash, supervisor, registry)
+    assert len(supervisor.add_port_forward_calls) == 1
+    assert len(await supervisor.list_port_forwards(VmId(str(vm_hash)))) == 1
+
+
+@pytest.mark.asyncio
+async def test_readopted_vprogram_manifest_failure_leaves_forwards_as_found(mocker):
+    """Healing is best-effort: when the manifest cannot be re-fetched on
+    re-adoption, the allocation still succeeds and the forwards that exist
+    stay exactly as found (no teardown, no removal)."""
+    message = load_vprogram_message()
+    vm_hash = message.item_hash
+    mocker.patch(
+        "aleph.vm.agent.run.resolve_vprogram_attestation_port",
+        new_callable=AsyncMock,
+        side_effect=VmSetupError("manifest unavailable"),
+    )
+    mocker.patch("aleph.vm.agent.run.create_vm_execution", new_callable=AsyncMock)
+
+    supervisor = FakeSupervisor(_running_vm_info(str(vm_hash)))
+    # An existing (possibly stale) forward that healing must not touch when
+    # it cannot compute the desired set.
+    await supervisor.add_port_forward(
+        PortForwardSpec(
+            vm_id=VmId(str(vm_hash)), host_port=HostPort(0), vm_port=GuestPort(ATTEST_PORT), protocol=Protocol.TCP
+        )
+    )
+    supervisor.add_port_forward_calls.clear()
+    registry = AgentVmRegistry()
+    registry.record(vm_hash, message=message.content, original=message.content, persistent=True)
+
+    await _start_persistent(vm_hash, supervisor, registry)
+
+    assert supervisor.add_port_forward_calls == []
+    assert len(await supervisor.list_port_forwards(VmId(str(vm_hash)))) == 1
+
+
+@pytest.mark.asyncio
+async def test_readopted_vprogram_without_record_leaves_supervisor_untouched(mocker):
+    """No agent record (DB loss): there is nothing to derive the desired set
+    from, so adoption must not touch the forwards at all."""
+    message = load_vprogram_message()
+    vm_hash = message.item_hash
+    resolve = mocker.patch("aleph.vm.agent.run.resolve_vprogram_attestation_port", new_callable=AsyncMock)
+    mocker.patch("aleph.vm.agent.run.create_vm_execution", new_callable=AsyncMock)
+
+    supervisor = FakeSupervisor(_running_vm_info(str(vm_hash)))
+
+    await _start_persistent(vm_hash, supervisor, AgentVmRegistry())
+
+    resolve.assert_not_awaited()
+    assert supervisor.add_port_forward_calls == []

--- a/tests/supervisor/test_vprogram_port_map.py
+++ b/tests/supervisor/test_vprogram_port_map.py
@@ -1,0 +1,149 @@
+"""Task 1: the CRN auto-maps a running V-PROGRAM's attestation port (from
+the runtime manifest's ``aleph.ra-tls`` entry) to a host IPv4 port, so an
+external client (the ``aleph`` CLI) can reach the guest's RA-TLS endpoint.
+Host-only DNAT, measurement-neutral (no guest image/cmdline change),
+idempotent on re-adoption.
+
+Uses the canonical cross-SDK fixture message shared with test_vprogram.py.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aleph_message.models import VerifiableProgramMessage, parse_message
+
+from aleph.vm.agent.run import create_vm_execution, reconcile_vprogram_port_forwards
+from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor_interface.types import (
+    Backend,
+    ConfidentialMode,
+    IpAssignment,
+    PortForwardInfo,
+    Protocol,
+    VmId,
+    VmInfo,
+    VmStatus,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "vprogram_message.json"
+ATTEST_PORT = 8443
+
+
+def load_vprogram_message() -> VerifiableProgramMessage:
+    message = parse_message(json.loads(FIXTURE.read_text()))
+    assert isinstance(message, VerifiableProgramMessage)
+    return message
+
+
+def _running_vm_info(vm_hash: str) -> VmInfo:
+    return VmInfo(
+        vm_id=VmId(vm_hash),
+        status=VmStatus.RUNNING,
+        ipv4=IpAssignment(),
+        ipv6=IpAssignment(),
+        uptime_secs=0,
+        backend=Backend.QEMU,
+        numa_node=None,
+        status_message="",
+        confidential_mode=ConfidentialMode.SEV_SNP,
+        gpus=[],
+    )
+
+
+class FakeSupervisor:
+    """Enough of the Supervisor surface to drive the V-PROGRAM create path
+    and its port-forward reconcile. Keeps a real in-memory mapping store (not
+    just a call recorder) so a second reconcile against the same desired set
+    genuinely no-ops, the way the real hypervisor's diff would.
+    """
+
+    def __init__(self, info: VmInfo):
+        self._info = info
+        self._forwards: dict[tuple[str, int, Protocol], int] = {}
+        self._next_host_port = 40000
+        self.add_port_forward_calls: list = []
+
+    async def create_vm(self, spec):
+        return self._info
+
+    async def get_vm(self, vm_id):
+        return self._info
+
+    async def delete_vm(self, vm_id, **kwargs):
+        pass
+
+    async def add_port_forward(self, spec):
+        self.add_port_forward_calls.append(spec)
+        key = (str(spec.vm_id), int(spec.vm_port), spec.protocol)
+        host_port = self._next_host_port
+        self._next_host_port += 1
+        self._forwards[key] = host_port
+        return PortForwardInfo(vm_id=spec.vm_id, host_port=host_port, vm_port=spec.vm_port, protocol=spec.protocol)
+
+    async def remove_port_forward(self, vm_id, host_port, protocol):
+        self._forwards = {
+            key: value
+            for key, value in self._forwards.items()
+            if not (key[0] == str(vm_id) and value == host_port and key[2] == protocol)
+        }
+
+    async def list_port_forwards(self, vm_id=None):
+        return [
+            PortForwardInfo(vm_id=VmId(key[0]), host_port=value, vm_port=key[1], protocol=key[2])
+            for key, value in self._forwards.items()
+            if vm_id is None or key[0] == str(vm_id)
+        ]
+
+
+@pytest.mark.asyncio
+async def test_vprogram_create_maps_attestation_port(mocker):
+    """After a V-PROGRAM reaches RUNNING, the create path calls
+    add_port_forward exactly once, for the manifest's RA-TLS attestation
+    port (tcp); a second reconcile (e.g. re-adoption) adds no duplicate."""
+    message = load_vprogram_message()
+    vm_hash = message.item_hash
+    mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
+
+    fake_spec = MagicMock()
+    mocker.patch(
+        "aleph.vm.agent.run.build_vprogram_spec",
+        new_callable=AsyncMock,
+        return_value=(fake_spec, ATTEST_PORT),
+    )
+    mocker.patch("aleph.vm.agent.run.persist_record", new_callable=AsyncMock)
+
+    info = _running_vm_info(str(vm_hash))
+    supervisor = FakeSupervisor(info)
+    registry = AgentVmRegistry()
+
+    await create_vm_execution(
+        vm_hash,
+        supervisor=supervisor,
+        registry=registry,
+        capacity=MagicMock(),
+        persistent=True,
+    )
+
+    assert len(supervisor.add_port_forward_calls) == 1
+    pf = supervisor.add_port_forward_calls[0]
+    assert pf.vm_port == ATTEST_PORT
+    assert pf.protocol is Protocol.TCP
+
+    # Idempotency: re-running the reconcile (e.g. daemon re-adopts the VM on
+    # restart) must not create a duplicate mapping.
+    await reconcile_vprogram_port_forwards(supervisor, VmId(str(vm_hash)), ATTEST_PORT)
+    assert len(supervisor.add_port_forward_calls) == 1
+    active = await supervisor.list_port_forwards(VmId(str(vm_hash)))
+    assert len(active) == 1
+
+
+@pytest.mark.asyncio
+async def test_reconcile_vprogram_no_attestation_port_is_noop():
+    """A manifest with no aleph.ra-tls tcp transport (attest_port=None, the
+    guard build_vprogram_spec applies) yields no forwards and no calls."""
+    supervisor = FakeSupervisor(_running_vm_info("deadbeef"))
+    await reconcile_vprogram_port_forwards(supervisor, VmId("deadbeef"), None)
+    assert supervisor.add_port_forward_calls == []
+    assert await supervisor.list_port_forwards(VmId("deadbeef")) == []


### PR DESCRIPTION
Lands the four commits that so far lived only on the `od/vprogram-integration-3` validation aggregation branch (#1142), folded into three:

1. **feat(vprogram): map the attestation port to a host IPv4 port** (originally reviewed as #1079): the agent allocates a host port forwarded to the guest's :8443 attest agent and reports it on the execution, so clients can resolve an attested endpoint. Without it, `vprogram create --wait` times out with no `attested_endpoint` (aleph-testnets run 32361553700). The agent run.py reconcile (`reconcile_vprogram_port_forwards`), dropped in an earlier bad conflict resolution and restored by a separate repair commit on the aggregation branch, is squashed back into this commit where it belongs.
2. **fix(agent): heal port forwards when re-adopting a running VM** (originally reviewed as #1085): re-creates missing forwards when the agent restarts while VMs are up.
3. **fix(agent): update_refs must not derive refs from a V-PROGRAM**: the update watcher treated any non-Instance content as a program and read `.code`/`.data`/`.runtime.ref`, crashing with `'VerifiableProgramContent' object has no attribute 'data'` after every V-PROGRAM boot. V-PROGRAMs are immutable with hash-pinned refs, so it returns no refs.

Context: #1079/#1085 were reviewed and merged into the staging branch `od/vprogram-portmap-base`, which stalled and never reached dev; the third commit was written during the first live testnet run. All three are cherry-picked from `od/vprogram-integration-3`, already conflict-resolved against current dev. The resulting tree is **byte-identical** to that branch's tip, which passed the full aleph-testnets validation (runs 32368297653 and 32426136992, 28/28: SNP boot, attested exec + compose V-PROGRAM calls, port-mapped attestation endpoints).

Once merged, #1142 can close and the testnets manifesto can point at plain dev.