### PR TITLE
fix(agent): retry a failed SNP vCPU probe instead of caching it forever

### DIFF
--- a/src/aleph/vm/agent/resources.py
+++ b/src/aleph/vm/agent/resources.py
@@ -179,11 +179,16 @@ async def _get_tee_properties() -> TeeProperties | None:
 
 
 @async_cache
-async def get_machine_properties() -> MachineProperties:
-    """Fetch machine properties such as architecture, CPU vendor, ...
-    These should not change while the supervisor is running.
+async def _get_static_machine_properties() -> MachineProperties:
+    """The part of the machine properties that cannot change while the agent
+    runs: architecture, vendor and the SEV feature flags. Cached because
+    ``get_hardware_info`` shells out.
 
-    In the future, some properties may have to be fetched from within a VM.
+    ``tee`` is deliberately left ``None`` here and filled in per call by
+    ``get_machine_properties``: it depends on the QEMU probe, which can fail
+    transiently and then recover, and caching it alongside the static facts
+    would freeze a failed probe's empty advertisement for the life of the
+    process.
     """
     hw = await get_hardware_info()
     cpu_info = get_cpu_info(hw)
@@ -202,8 +207,22 @@ async def get_machine_properties() -> MachineProperties:
                 )
             ),
         ),
-        tee=await _get_tee_properties(),
+        tee=None,
     )
+
+
+async def get_machine_properties() -> MachineProperties:
+    """Fetch machine properties such as architecture, CPU vendor, ...
+
+    The static part is cached; the TEE block is re-evaluated on every call so
+    that a probe which failed once and has since recovered is advertised
+    again. Cheap once the probe has succeeded, since the probe keeps its own
+    result.
+
+    In the future, some properties may have to be fetched from within a VM.
+    """
+    static = await _get_static_machine_properties()
+    return static.model_copy(update={"tee": await _get_tee_properties()})
 
 
 @async_cache

--- a/src/aleph/vm/agent/resources.py
+++ b/src/aleph/vm/agent/resources.py
@@ -167,9 +167,6 @@ async def _gpus_from_host_info(host_info) -> GpuProperties:
     )
 
 
-machine_properties_cached = None
-
-
 async def _get_tee_properties() -> TeeProperties | None:
     """TEE launch capability, absent when there is nothing provable to advertise."""
     snp_vcpu_types = await get_supported_snp_vcpu_types()
@@ -226,7 +223,12 @@ async def get_machine_properties() -> MachineProperties:
 
 
 @async_cache
-async def get_machine_capability() -> MachineCapability:
+async def _get_static_machine_capability() -> MachineCapability:
+    """The part of the machine capability that cannot change while the agent
+    runs. Cached because ``get_hardware_info`` shells out. ``tee`` is left
+    ``None`` and filled in per call by ``get_machine_capability``, for the
+    same reason as ``_get_static_machine_properties``.
+    """
     hw = await get_hardware_info()
     cpu_info = get_cpu_info(hw)
     mem_info = get_memory_info(hw)
@@ -255,8 +257,15 @@ async def get_machine_capability() -> MachineCapability:
             type=mem_info["type"],
             clock=mem_info["clock"],
         ),
-        tee=await _get_tee_properties(),
+        tee=None,
     )
+
+
+async def get_machine_capability() -> MachineCapability:
+    """What ``/about/capability`` reports. Static part cached, TEE block
+    re-evaluated per call so a recovered probe is advertised again."""
+    static = await _get_static_machine_capability()
+    return static.model_copy(update={"tee": await _get_tee_properties()})
 
 
 def _disk_usage_from_pools(host_info) -> DiskUsage:

--- a/src/aleph/vm/agent/vcpu_probe.py
+++ b/src/aleph/vm/agent/vcpu_probe.py
@@ -8,12 +8,19 @@ exact QEMU build + host kernel + silicon), not a static CPUID table.
 import asyncio
 import json
 import logging
+import time
 
-from aleph.vm.utils import async_cache, check_amd_sev_snp_supported
+from aleph.vm.utils import check_amd_sev_snp_supported
 
 logger = logging.getLogger(__name__)
 
 PROBE_TIMEOUT_SECONDS = 15.0
+
+# How long a failed probe is remembered before it is retried. Long enough that
+# a host with no working qemu is not re-probed (and stalled for up to
+# PROBE_TIMEOUT_SECONDS) on every usage poll and every launch, short enough
+# that a transient failure at boot heals without anyone restarting the agent.
+PROBE_RETRY_SECONDS = 60.0
 
 
 async def _read_qmp_response(stdout: asyncio.StreamReader) -> dict:
@@ -82,15 +89,60 @@ def filter_snp_vcpu_types(definitions: list[dict]) -> list[str]:
     )
 
 
-@async_cache
+class _ProbeCache:
+    """Process-wide memory of the QEMU probe.
+
+    A successful probe is a fact about this QEMU build, kernel and silicon, so it
+    is kept for the life of the process. A failed one is not a fact about the
+    host, only about that attempt (a spawn that timed out during boot, say), so
+    it is kept only for PROBE_RETRY_SECONDS and then tried again. The generic
+    ``async_cache`` cannot tell the two apart: it would pin the empty list from
+    a failed attempt forever, and this list feeds both what the node advertises
+    and which models it will launch, so one bad probe at startup would take the
+    node out of the confidential pool until someone restarted the agent.
+
+    The lock keeps concurrent first callers (the usage endpoint and a launch
+    racing at startup) from each spawning a qemu.
+    """
+
+    def __init__(self) -> None:
+        self.supported: list[str] | None = None
+        self.failed_at: float | None = None
+        self.lock = asyncio.Lock()
+
+    def reset(self) -> None:
+        self.supported = None
+        self.failed_at = None
+
+
+_probe_cache = _ProbeCache()
+
+
+def reset_snp_vcpu_probe_cache() -> None:
+    """Forget the cached probe. For tests; production never needs it."""
+    _probe_cache.reset()
+
+
 async def get_supported_snp_vcpu_types() -> list[str]:
     """SNP guest CPU models this node can launch; [] when SNP is unsupported
     or the probe fails. We never advertise what we cannot prove."""
     if not check_amd_sev_snp_supported():
         return []
-    try:
-        definitions = await query_cpu_definitions()
-    except Exception:
-        logger.warning("QEMU vCPU probe failed, not advertising SNP guest models", exc_info=True)
-        return []
-    return filter_snp_vcpu_types(definitions)
+    async with _probe_cache.lock:
+        if _probe_cache.supported is not None:
+            return _probe_cache.supported
+        now = time.monotonic()
+        if _probe_cache.failed_at is not None and now - _probe_cache.failed_at < PROBE_RETRY_SECONDS:
+            return []
+        try:
+            definitions = await query_cpu_definitions()
+        except Exception:
+            _probe_cache.failed_at = now
+            logger.warning(
+                "QEMU vCPU probe failed, not advertising SNP guest models; retrying in %ss",
+                PROBE_RETRY_SECONDS,
+                exc_info=True,
+            )
+            return []
+        _probe_cache.supported = filter_snp_vcpu_types(definitions)
+        return _probe_cache.supported

--- a/tests/supervisor/test_vprogram_probe.py
+++ b/tests/supervisor/test_vprogram_probe.py
@@ -5,15 +5,28 @@ models advertised in /about/usage/system properties.tee, so the advertised
 list must reflect what this exact QEMU + kernel + silicon can launch.
 """
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
 
+from aleph.vm.agent import resources
 from aleph.vm.agent.resources import get_machine_properties
 from aleph.vm.agent.vcpu_probe import (
+    PROBE_RETRY_SECONDS,
     filter_snp_vcpu_types,
     get_supported_snp_vcpu_types,
+    reset_snp_vcpu_probe_cache,
 )
+from aleph.vm.utils import async_cache
+
+
+@pytest.fixture(autouse=True)
+def _fresh_probe_cache():
+    """Every test starts from an unprobed host and leaves one behind."""
+    reset_snp_vcpu_probe_cache()
+    yield
+    reset_snp_vcpu_probe_cache()
 
 
 def test_filter_snp_vcpu_types():
@@ -30,7 +43,7 @@ def test_filter_snp_vcpu_types():
 async def test_get_supported_snp_vcpu_types_no_snp(mocker):
     mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=False)
     probe = mocker.patch("aleph.vm.agent.vcpu_probe.query_cpu_definitions", new_callable=AsyncMock)
-    assert await get_supported_snp_vcpu_types.__wrapped__() == []
+    assert await get_supported_snp_vcpu_types() == []
     probe.assert_not_awaited()
 
 
@@ -43,7 +56,7 @@ async def test_get_supported_snp_vcpu_types_probe_failure(mocker):
         new_callable=AsyncMock,
         side_effect=OSError("qemu-system-x86_64 not found"),
     )
-    assert await get_supported_snp_vcpu_types.__wrapped__() == []
+    assert await get_supported_snp_vcpu_types() == []
 
 
 @pytest.mark.asyncio
@@ -57,11 +70,22 @@ async def test_get_supported_snp_vcpu_types_success(mocker):
             {"name": "EPYC-Genoa", "unavailable-features": ["flag"]},
         ],
     )
-    assert await get_supported_snp_vcpu_types.__wrapped__() == ["EPYC-Milan"]
+    assert await get_supported_snp_vcpu_types() == ["EPYC-Milan"]
 
 
 def _mock_cpu_info() -> dict:
     return {"architecture": "x86_64", "vendor": "AuthenticAMD", "model": "EPYC", "frequency": 2000, "count": 8}
+
+
+@pytest.fixture(autouse=True)
+def _fresh_static_properties(monkeypatch):
+    """The static half of the machine properties is process-cached; give each
+    test its own cache so a mock from one cannot leak into the next."""
+    monkeypatch.setattr(
+        resources,
+        "_get_static_machine_properties",
+        async_cache(resources._get_static_machine_properties.__wrapped__),
+    )
 
 
 @pytest.mark.asyncio
@@ -77,7 +101,7 @@ async def test_machine_properties_tee_block(mocker):
         return_value=["EPYC", "EPYC-v4"],
     )
 
-    properties = await get_machine_properties.__wrapped__()
+    properties = await get_machine_properties()
     assert properties.tee is not None
     assert properties.tee.sev_snp is not None
     assert properties.tee.sev_snp.supported_vcpu_types == ["EPYC", "EPYC-v4"]
@@ -98,7 +122,7 @@ async def test_machine_properties_no_tee_block_without_models(mocker):
         return_value=[],
     )
 
-    properties = await get_machine_properties.__wrapped__()
+    properties = await get_machine_properties()
     assert properties.tee is None
     # exclude_none keeps the usage-endpoint JSON free of a null tee key
     assert "tee" not in properties.model_dump(exclude_none=True)
@@ -115,3 +139,124 @@ def test_check_amd_sev_snp_requires_dev_sev(mocker):
     assert utils.check_amd_sev_snp_supported() is False
     path_cls.return_value.exists.return_value = True
     assert utils.check_amd_sev_snp_supported() is True
+
+
+# ---------------------------------------------------------------------------
+# What the probe remembers, and for how long.
+#
+# The list it returns feeds both what the node advertises and which models it
+# will launch, so a failed attempt must not be mistaken for a fact about the
+# host: it is retried, while a successful one is kept.
+# ---------------------------------------------------------------------------
+
+
+def _snp_host(mocker, probe):
+    mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=True)
+    return mocker.patch("aleph.vm.agent.vcpu_probe.query_cpu_definitions", new_callable=AsyncMock, **probe)
+
+
+def _clock(mocker, start: float = 1000.0):
+    """A controllable time.monotonic for the probe module."""
+    now = {"t": start}
+    mocker.patch("aleph.vm.agent.vcpu_probe.time.monotonic", side_effect=lambda: now["t"])
+    return now
+
+
+@pytest.mark.asyncio
+async def test_a_successful_probe_is_not_repeated(mocker):
+    probe = _snp_host(mocker, {"return_value": [{"name": "EPYC-v4", "unavailable-features": []}]})
+    assert await get_supported_snp_vcpu_types() == ["EPYC-v4"]
+    assert await get_supported_snp_vcpu_types() == ["EPYC-v4"]
+    assert probe.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_failed_probe_is_not_repeated_within_the_retry_window(mocker):
+    # A host with no working qemu must not be re-probed, and stalled for up to
+    # the probe timeout, on every usage poll and every launch.
+    clock = _clock(mocker)
+    probe = _snp_host(mocker, {"side_effect": OSError("qemu-system-x86_64 not found")})
+    assert await get_supported_snp_vcpu_types() == []
+    clock["t"] += PROBE_RETRY_SECONDS / 2
+    assert await get_supported_snp_vcpu_types() == []
+    assert probe.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_failed_probe_is_retried_after_the_window_and_recovers(mocker):
+    # The case that used to need an agent restart: a transient failure at boot.
+    clock = _clock(mocker)
+    probe = _snp_host(mocker, {"side_effect": TimeoutError("probe timed out")})
+    assert await get_supported_snp_vcpu_types() == []
+
+    probe.side_effect = None
+    probe.return_value = [{"name": "EPYC-v4", "unavailable-features": []}]
+    clock["t"] += PROBE_RETRY_SECONDS
+    assert await get_supported_snp_vcpu_types() == ["EPYC-v4"]
+    assert probe.await_count == 2
+    # ...and once recovered it is a fact, kept for good.
+    clock["t"] += PROBE_RETRY_SECONDS * 10
+    assert await get_supported_snp_vcpu_types() == ["EPYC-v4"]
+    assert probe.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_callers_probe_once(mocker):
+    # The usage endpoint and a launch can race at startup; one qemu, not two.
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_probe():
+        started.set()
+        await release.wait()
+        return [{"name": "EPYC-v4", "unavailable-features": []}]
+
+    mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=True)
+    probe = mocker.patch("aleph.vm.agent.vcpu_probe.query_cpu_definitions", side_effect=slow_probe)
+
+    first = asyncio.create_task(get_supported_snp_vcpu_types())
+    await started.wait()
+    second = asyncio.create_task(get_supported_snp_vcpu_types())
+    await asyncio.sleep(0)
+    release.set()
+    assert await asyncio.gather(first, second) == [["EPYC-v4"], ["EPYC-v4"]]
+    assert probe.call_count == 1
+
+
+def _static_host(mocker):
+    hardware = mocker.patch("aleph.vm.agent.resources.get_hardware_info", new_callable=AsyncMock, return_value={})
+    mocker.patch("aleph.vm.agent.resources.get_cpu_info", return_value=_mock_cpu_info())
+    mocker.patch("aleph.vm.agent.resources.check_amd_sev_supported", return_value=True)
+    mocker.patch("aleph.vm.agent.resources.check_amd_sev_es_supported", return_value=True)
+    mocker.patch("aleph.vm.agent.resources.check_amd_sev_snp_supported", return_value=True)
+    return hardware
+
+
+@pytest.mark.asyncio
+async def test_advertisement_recovers_after_a_failed_first_probe(mocker):
+    # End to end through the usage endpoint's view: the tee block reappears
+    # once the probe recovers, without the process-cached static properties
+    # having pinned its absence.
+    _static_host(mocker)
+    clock = _clock(mocker)
+    probe = _snp_host(mocker, {"side_effect": OSError("qemu-system-x86_64 not found")})
+
+    assert (await get_machine_properties()).tee is None
+
+    probe.side_effect = None
+    probe.return_value = [{"name": "EPYC-v4", "unavailable-features": []}]
+    clock["t"] += PROBE_RETRY_SECONDS
+    properties = await get_machine_properties()
+    assert properties.tee is not None
+    assert properties.tee.sev_snp is not None
+    assert properties.tee.sev_snp.supported_vcpu_types == ["EPYC-v4"]
+
+
+@pytest.mark.asyncio
+async def test_static_properties_stay_cached_across_calls(mocker):
+    # Splitting the tee block out must not cost a hardware scan per poll.
+    hardware = _static_host(mocker)
+    _snp_host(mocker, {"return_value": [{"name": "EPYC-v4", "unavailable-features": []}]})
+    await get_machine_properties()
+    await get_machine_properties()
+    assert hardware.await_count == 1

--- a/tests/supervisor/test_vprogram_probe.py
+++ b/tests/supervisor/test_vprogram_probe.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from aleph.vm.agent import resources
-from aleph.vm.agent.resources import get_machine_properties
+from aleph.vm.agent.resources import get_machine_capability, get_machine_properties
 from aleph.vm.agent.vcpu_probe import (
     PROBE_RETRY_SECONDS,
     filter_snp_vcpu_types,
@@ -85,6 +85,11 @@ def _fresh_static_properties(monkeypatch):
         resources,
         "_get_static_machine_properties",
         async_cache(resources._get_static_machine_properties.__wrapped__),
+    )
+    monkeypatch.setattr(
+        resources,
+        "_get_static_machine_capability",
+        async_cache(resources._get_static_machine_capability.__wrapped__),
     )
 
 
@@ -250,6 +255,29 @@ async def test_advertisement_recovers_after_a_failed_first_probe(mocker):
     assert properties.tee is not None
     assert properties.tee.sev_snp is not None
     assert properties.tee.sev_snp.supported_vcpu_types == ["EPYC-v4"]
+
+
+@pytest.mark.asyncio
+async def test_capability_advertisement_recovers_after_a_failed_first_probe(mocker):
+    # /about/capability had the same frozen tee block as /about/usage/system;
+    # the scheduler does not read it, but it is public and says the same thing.
+    _static_host(mocker)
+    mocker.patch(
+        "aleph.vm.agent.resources.get_memory_info",
+        return_value={"size": 64, "units": "GiB", "type": "DDR5", "clock": 4800},
+    )
+    clock = _clock(mocker)
+    probe = _snp_host(mocker, {"side_effect": OSError("qemu-system-x86_64 not found")})
+
+    assert (await get_machine_capability()).tee is None
+
+    probe.side_effect = None
+    probe.return_value = [{"name": "EPYC-v4", "unavailable-features": []}]
+    clock["t"] += PROBE_RETRY_SECONDS
+    capability = await get_machine_capability()
+    assert capability.tee is not None
+    assert capability.tee.sev_snp is not None
+    assert capability.tee.sev_snp.supported_vcpu_types == ["EPYC-v4"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Spotted while assessing #1145, and independent of it: this lands cleanly on either side, and #1145 is what turns it from "node quietly drops out of the confidential pool" into "node also refuses every SNP launch".

## The problem

Two pieces that are each fine on their own:

`get_supported_snp_vcpu_types` turns every probe failure into a normal return:

```python
try:
    definitions = await query_cpu_definitions()
except Exception:
    logger.warning("QEMU vCPU probe failed, not advertising SNP guest models", exc_info=True)
    return []
```

and `@async_cache` (`utils/__init__.py:273`) keeps whatever the function returns, forever. So `[]` from "this host has no SNP" (a hardware fact, fine to cache) and `[]` from "the qemu spawn timed out at 15s during boot" (transient) are indistinguishable to the cache, and both stick for the life of the process.

The list feeds two things. It is what `/about/usage/system` advertises in `properties.tee.sev_snp.supported_vcpu_types`, which the scheduler's v-program gate reads, so a stuck `[]` silently removes the node from the confidential pool. And once #1145 lands, `select_snp_vcpu_type` fails closed on an empty host list, so the same stuck `[]` also refuses every SNP launch. Both are the correct fail-closed outcome. The recovery is a manual agent restart, and the cause was logged once at startup.

**There was a second layer.** `get_machine_properties` is `@async_cache`d too, and built the tee block *inside* that cache. Fixing the probe alone would have restored launches while the advertisement stayed frozen, which is the side the scheduler sees. `test_advertisement_recovers_after_a_failed_first_probe` is the end-to-end check for that.

## The change

| outcome of a probe | remembered for |
|---|---|
| success | the life of the process (a fact about this QEMU + kernel + silicon) |
| failure | `PROBE_RETRY_SECONDS` (60s), then tried again |

So a transient failure heals within a minute with no operator action, and a host with no working qemu costs one 15s probe per minute rather than one per request. A lock closes a small pre-existing race where the usage endpoint and a launch could both spawn a qemu at startup.

`get_machine_properties` is split: `_get_static_machine_properties` keeps the cache (it calls `get_hardware_info`, which shells out), and the tee block is re-evaluated per call, which is cheap once the probe holds its own result. `test_static_properties_stay_cached_across_calls` pins that the split doesn't cost a hardware scan per poll.

The generic `async_cache` is left alone: "cache every return" is the right semantics for its other users. Only the probe has a return value that isn't a fact about the host.

`reset_snp_vcpu_probe_cache()` exists for tests, replacing the `.__wrapped__()` trick the old tests used to bypass the decorator.

## Tests

Six new in `test_vprogram_probe.py`, plus the existing seven updated to the new reset hook:

- a successful probe is not repeated
- a failed probe is not repeated within the retry window
- a failed probe is retried after the window and recovers (the case that used to need a restart)
- concurrent first callers probe once
- the advertisement recovers after a failed first probe (end to end via `get_machine_properties`)
- the static properties stay cached across calls

Verified these discriminate rather than pass vacuously: with the old semantics injected (failure pinned as `supported = []`, tee built inside the static cache), exactly the two recovery tests fail and the other eleven still pass.

Locally: 13 passed, `ruff format` clean, `isort --profile black` clean, `mypy` clean on the three files. The one remaining `ruff check` finding in the test file (`PLC0415` at line 134) is pre-existing on `dev`. I could not build the `hatch` testing env here (`dbus-python` fails to compile on this machine), so this ran in a venv with the same pins minus that package; CI is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
