### PR TITLE
fix(supervisor): report FAILED for a controller unit that died

### DIFF
--- a/src/aleph/vm/supervisor/local.py
+++ b/src/aleph/vm/supervisor/local.py
@@ -69,6 +69,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# systemd ActiveState values this module reasons about. The full vocabulary is
+# documented on SystemDManager.get_service_active_state.
+ACTIVE = "active"
+FAILED = "failed"
+
 
 def _backend_of(execution) -> Backend:
     """The VMM only; confidential computing is reported via confidential_mode."""
@@ -77,30 +82,46 @@ def _backend_of(execution) -> Backend:
     return Backend.QEMU
 
 
-def _is_running(execution, pool) -> bool:
+def _controller_state(execution, pool) -> str:
+    """The controller unit's systemd ActiveState.
+
+    Non-persistent executions have no unit, so their liveness (the timestamp
+    pair) is reduced to the same vocabulary: every caller then reasons about
+    one thing instead of a bool here and a string there.
+    """
     if execution.persistent and getattr(execution, "systemd_manager", None) and getattr(pool, "systemd_manager", None):
-        states = pool.systemd_manager.get_services_active_states([execution.controller_service])
-        return states.get(execution.controller_service, False)
+        states = pool.systemd_manager.get_services_states([execution.controller_service])
+        return states.get(execution.controller_service, "unknown")
     times = execution.times
-    return bool(times.starting_at and not times.stopping_at)
+    return ACTIVE if (times.starting_at and not times.stopping_at) else "inactive"
 
 
-def _status_of(execution, running: bool) -> VmStatus:
+def _is_running(execution, pool) -> bool:
+    return _controller_state(execution, pool) == ACTIVE
+
+
+def _status_of(execution, controller_state: str) -> VmStatus:
     times = execution.times
     if times.stopped_at:
         return VmStatus.STOPPED
     if times.stopping_at:
         return VmStatus.STOPPING
-    if running:
+    if controller_state == ACTIVE:
         return VmStatus.RUNNING
+    if controller_state == FAILED:
+        # systemd only reports "failed" once Restart=on-failure has given up,
+        # so the VM is not coming back on its own. Reporting BOOTING here (what
+        # the timestamps alone say) makes a crashed VM look like a starting one,
+        # and the caller waits for a VM that will never run.
+        return VmStatus.FAILED
     if times.starting_at:
         return VmStatus.BOOTING
     return VmStatus.DEFINED
 
 
-def _uptime_secs(execution, running: bool) -> int:
+def _uptime_secs(execution, controller_state: str) -> int:
     started = execution.times.started_at
-    if running and started:
+    if controller_state == ACTIVE and started:
         return int((datetime.now(tz=timezone.utc) - started).total_seconds())
     return 0
 
@@ -117,10 +138,10 @@ def _ns(dt: datetime | None) -> int:
     return int(dt.timestamp()) * 1_000_000_000 + dt.microsecond * 1_000
 
 
-def _running_states(pool) -> dict[str, bool]:
-    """Running flag for every execution with one batched systemd query.
+def _controller_states(pool) -> dict[str, str]:
+    """Controller ActiveState for every execution with one batched systemd query.
 
-    Same semantics as _is_running, but a single D-Bus call covers all
+    Same semantics as _controller_state, but a single D-Bus call covers all
     persistent VMs instead of one call each.
     """
     persistent_services: dict[str, str] = {}
@@ -128,17 +149,17 @@ def _running_states(pool) -> dict[str, bool]:
         if execution.persistent and getattr(execution, "systemd_manager", None):
             persistent_services[execution.controller_service] = str(vm_id)
 
-    service_states: dict[str, bool] = {}
+    service_states: dict[str, str] = {}
     if persistent_services and getattr(pool, "systemd_manager", None):
-        service_states = pool.systemd_manager.get_services_active_states(list(persistent_services.keys()))
+        service_states = pool.systemd_manager.get_services_states(list(persistent_services.keys()))
 
-    states: dict[str, bool] = {}
+    states: dict[str, str] = {}
     for vm_id, execution in pool.executions.items():
         if execution.persistent and getattr(execution, "systemd_manager", None):
-            states[str(vm_id)] = service_states.get(execution.controller_service, False)
+            states[str(vm_id)] = service_states.get(execution.controller_service, "unknown")
         else:
             times = execution.times
-            states[str(vm_id)] = bool(times.starting_at and not times.stopping_at)
+            states[str(vm_id)] = ACTIVE if (times.starting_at and not times.stopping_at) else "inactive"
     return states
 
 
@@ -203,9 +224,17 @@ async def _run_code_over_channel(channel_path: str, scope: dict, *, timeout: flo
         await writer.wait_closed()
 
 
-def _to_vm_info(execution, running: bool) -> VmInfo:
+def _to_vm_info(execution, controller_state: str) -> VmInfo:
     tap = execution.vm.tap_interface if execution.vm else None
     times = execution.times
+    status = _status_of(execution, controller_state)
+    # Only FAILED carries a reason: every other status is self-explanatory, and
+    # a message on them would be noise the agent has to ignore.
+    status_message = (
+        f"controller unit {getattr(execution, 'controller_service', '')} is in failed state"
+        if status is VmStatus.FAILED
+        else ""
+    )
     ipv4 = IpAssignment(
         address=str(tap.guest_ip.ip) if tap else "",
         network_cidr=str(tap.ip_network) if tap else "",
@@ -218,13 +247,13 @@ def _to_vm_info(execution, running: bool) -> VmInfo:
     )
     return VmInfo(
         vm_id=VmId(str(execution.vm_id)),
-        status=_status_of(execution, running),
+        status=status,
         ipv4=ipv4,
         ipv6=ipv6,
-        uptime_secs=_uptime_secs(execution, running),
+        uptime_secs=_uptime_secs(execution, controller_state),
         backend=_backend_of(execution),
         numa_node=None,
-        status_message="",
+        status_message=status_message,
         defined_at_ns=_ns(times.defined_at),
         preparing_at_ns=_ns(times.preparing_at),
         prepared_at_ns=_ns(times.prepared_at),
@@ -316,7 +345,7 @@ class LocalSupervisor(Supervisor):
             self._event_queues.discard(queue)
 
     def _status_snapshot(self, execution) -> VmStatus:
-        return _status_of(execution, _is_running(execution, self.pool))
+        return _status_of(execution, _controller_state(execution, self.pool))
 
     # Host
     async def health(self) -> HealthInfo:
@@ -350,7 +379,7 @@ class LocalSupervisor(Supervisor):
     async def create_vm(self, spec: CreateVmSpec) -> VmInfo:
         with translating_errors():
             execution = await self.pool.create_vm_from_spec(spec)
-            info = _to_vm_info(execution, _is_running(execution, self.pool))
+            info = _to_vm_info(execution, _controller_state(execution, self.pool))
             self._emit_event(spec.vm_id, VmStatus.DEFINED, info.status)
             return info
 
@@ -365,8 +394,8 @@ class LocalSupervisor(Supervisor):
             # (start_persistent_vm), so keeping it on the loop stalls
             # every other request for the whole sweep on busy CRNs (the
             # in-process remnant of main's batched-lookup fix, #1084).
-            running = await asyncio.to_thread(_is_running, execution, self.pool)
-            return _to_vm_info(execution, running)
+            state = await asyncio.to_thread(_controller_state, execution, self.pool)
+            return _to_vm_info(execution, state)
 
     async def list_vms(self) -> list[VmInfo]:
         with translating_errors():
@@ -375,8 +404,8 @@ class LocalSupervisor(Supervisor):
             # (the payment sweep and every /about/executions/list request) for
             # the duration of that call. Mirrors main's monitor_payments fix
             # (aleph-vm#963), and applies it to the list endpoints too.
-            running = await asyncio.to_thread(_running_states, self.pool)
-            return [_to_vm_info(execution, running[str(vm_id)]) for vm_id, execution in self.pool.executions.items()]
+            states = await asyncio.to_thread(_controller_states, self.pool)
+            return [_to_vm_info(execution, states[str(vm_id)]) for vm_id, execution in self.pool.executions.items()]
 
     def _require(self, vm_id: VmId):
         execution = self.pool.executions.get(vm_id)
@@ -449,7 +478,7 @@ class LocalSupervisor(Supervisor):
             execution.stop_event = asyncio.Event()
             self.pool.executions[execution.vm_id] = execution
             self._emit_event(vm_id, old_status, VmStatus.STOPPED)
-            return _to_vm_info(execution, running=False)
+            return _to_vm_info(execution, "inactive")
 
     async def start_vm(self, vm_id: VmId) -> VmInfo:
         with translating_errors():
@@ -458,10 +487,10 @@ class LocalSupervisor(Supervisor):
                 msg = "Starting an ephemeral VM is not supported; the cycle is DeleteVm + CreateVm"
                 raise NotImplementedSupervisorError(msg)
             if _is_running(execution, self.pool):
-                return _to_vm_info(execution, running=True)
+                return _to_vm_info(execution, ACTIVE)
             old_status = self._status_snapshot(execution)
             await self.pool.restart_persistent_vm(execution)
-            info = _to_vm_info(execution, _is_running(execution, self.pool))
+            info = _to_vm_info(execution, _controller_state(execution, self.pool))
             self._emit_event(vm_id, old_status, info.status)
             return info
 
@@ -475,7 +504,7 @@ class LocalSupervisor(Supervisor):
                 # confirmed active so the reported status is truthful.
                 await execution.wait_for_controller_ready()
                 execution.times.started_at = datetime.now(tz=timezone.utc)
-                info = _to_vm_info(execution, _is_running(execution, self.pool))
+                info = _to_vm_info(execution, _controller_state(execution, self.pool))
                 # A reboot is a down-then-up pair; watchers that drop per-VM
                 # state on "down" must see the down.
                 self._emit_event(vm_id, old_status, VmStatus.STOPPED)
@@ -490,7 +519,7 @@ class LocalSupervisor(Supervisor):
             # recreate the VM itself instead of returning a stopped husk
             # and expecting the client to know it must re-create.
             new_execution = await self.pool.create_vm_from_spec(spec)
-            info = _to_vm_info(new_execution, _is_running(new_execution, self.pool))
+            info = _to_vm_info(new_execution, _controller_state(new_execution, self.pool))
             self._emit_event(vm_id, VmStatus.STOPPED, info.status)
             return info
 

--- a/src/aleph/vm/supervisor/local.py
+++ b/src/aleph/vm/supervisor/local.py
@@ -389,7 +389,7 @@ class LocalSupervisor(Supervisor):
             if execution is None:
                 raise VmNotFoundError(vm_id)
             # Off the event loop, like list_vms: for a persistent VM,
-            # _is_running is a synchronous D-Bus round-trip, and the
+            # _controller_state is a synchronous D-Bus round-trip, and the
             # allocation reconcile calls get_vm once per pushed hash
             # (start_persistent_vm), so keeping it on the loop stalls
             # every other request for the whole sweep on busy CRNs (the
@@ -399,7 +399,7 @@ class LocalSupervisor(Supervisor):
 
     async def list_vms(self) -> list[VmInfo]:
         with translating_errors():
-            # Off the event loop: _running_states issues a single batched D-Bus
+            # Off the event loop: _controller_states issues a single batched D-Bus
             # ListUnits() call. Keeping it on the loop would stall every caller
             # (the payment sweep and every /about/executions/list request) for
             # the duration of that call. Mirrors main's monitor_payments fix

--- a/src/aleph/vm/systemd.py
+++ b/src/aleph/vm/systemd.py
@@ -283,11 +283,51 @@ class SystemDManager:
             _log_dbus_lookup_error(service, error)
             return False
 
+    def get_services_states(self, services: list[str]) -> dict[str, str]:
+        """Get the ActiveState of multiple services in a single D-Bus call.
+
+        Much more efficient than calling get_service_active_state() per
+        service, as it uses ListUnits(), which returns all loaded units in one
+        call.
+
+        Values are the raw systemd strings ("active", "activating",
+        "deactivating", "inactive", "failed"), plus the same two synthetic ones
+        get_service_active_state uses: "not-loaded" for a unit systemd does not
+        list (never started, or garbage-collected after a clean stop) and
+        "unknown" when the call itself fails.
+
+        Args:
+            services: List of service names to check (e.g., ["aleph-vm-controller@hash.service"])
+
+        Returns:
+            Dictionary mapping service name to its ActiveState.
+        """
+        if not services:
+            return {}
+
+        try:
+            units = self._call_with_reconnect(lambda: self._get_manager().ListUnits())
+        except DBusException as error:
+            logger.error(f"Failed to get services active states: {error}")
+            return {service: "unknown" for service in services}
+
+        # ListUnits returns: (name, description, load_state, active_state, sub_state,
+        #                     following, unit_path, job_id, job_type, job_path)
+        service_set = set(services)
+        listed: dict[str, str] = {}
+        for unit in units:
+            name = str(unit[0])
+            if name in service_set:
+                listed[name] = str(unit[3])
+
+        return {service: listed.get(service, "not-loaded") for service in services}
+
     def get_services_active_states(self, services: list[str]) -> dict[str, bool]:
         """Get active state of multiple services in a single D-Bus call.
 
-        This is much more efficient than calling is_service_active() for each service,
-        as it uses ListUnits() which returns all loaded units in one call.
+        The boolean reduction of get_services_states, for callers that only ask
+        "is it up". Callers that must tell a crashed unit from one that never
+        started need the state string instead.
 
         Args:
             services: List of service names to check (e.g., ["aleph-vm-controller@hash.service"])
@@ -295,34 +335,7 @@ class SystemDManager:
         Returns:
             Dictionary mapping service name to active state (True if active, False otherwise)
         """
-        if not services:
-            return {}
-
-        try:
-            units = self._call_with_reconnect(lambda: self._get_manager().ListUnits())
-
-            # Build lookup from ListUnits() result
-            # ListUnits returns: (name, description, load_state, active_state, sub_state,
-            #                     following, unit_path, job_id, job_type, job_path)
-            active_states: dict[str, bool] = {}
-            service_set = set(services)
-
-            for unit in units:
-                name = str(unit[0])
-                if name in service_set:
-                    active_state = str(unit[3])
-                    active_states[name] = active_state == "active"
-
-            # Services not in ListUnits() output are not loaded (treat as inactive)
-            for service in services:
-                if service not in active_states:
-                    active_states[service] = False
-
-            return active_states
-        except DBusException as error:
-            logger.error(f"Failed to get services active states: {error}")
-            # Return all as inactive on error
-            return {service: False for service in services}
+        return {service: state == "active" for service, state in self.get_services_states(services).items()}
 
     def get_services_enabled_states(self, services: list[str]) -> dict[str, bool]:
         """Get enabled state of multiple services via individual GetUnitFileState calls.

--- a/tests/supervisor/test_inprocess_vm_info.py
+++ b/tests/supervisor/test_inprocess_vm_info.py
@@ -32,23 +32,23 @@ def _execution(*, confidential=False, policy=0, gpus=()):
 
 
 def test_non_confidential_reports_none():
-    info = _to_vm_info(_execution(confidential=False), running=True)
+    info = _to_vm_info(_execution(confidential=False), "active")
     assert info.confidential_mode is ConfidentialMode.NONE
 
 
 def test_sev_policy_reports_sev():
-    info = _to_vm_info(_execution(confidential=True, policy=0x1), running=True)  # NO_DBG, no ES bit
+    info = _to_vm_info(_execution(confidential=True, policy=0x1), "active")  # NO_DBG, no ES bit
     assert info.confidential_mode is ConfidentialMode.SEV
 
 
 def test_sev_es_policy_reports_sev_es():
-    info = _to_vm_info(_execution(confidential=True, policy=0x4), running=True)  # SEV_ES bit
+    info = _to_vm_info(_execution(confidential=True, policy=0x4), "active")  # SEV_ES bit
     assert info.confidential_mode is ConfidentialMode.SEV_ES
 
 
 def test_gpus_are_reported_as_devices():
     gpu = HostGPU(pci_host="0000:01:00.0", supports_x_vga=True, device_id="10de:2504", model="RTX 3090")
-    info = _to_vm_info(_execution(gpus=[gpu]), running=True)
+    info = _to_vm_info(_execution(gpus=[gpu]), "active")
     assert [(g.pci_host, g.device_id, g.model, g.supports_x_vga) for g in info.gpus] == [
         ("0000:01:00.0", "10de:2504", "RTX 3090", True)
     ]
@@ -56,11 +56,11 @@ def test_gpus_are_reported_as_devices():
 
 def test_gpu_model_none_becomes_empty_string():
     gpu = HostGPU(pci_host="0000:02:00.0", supports_x_vga=False, device_id="10de:1111", model=None)
-    info = _to_vm_info(_execution(gpus=[gpu]), running=True)
+    info = _to_vm_info(_execution(gpus=[gpu]), "active")
     assert info.gpus[0].model == ""
 
 
 def test_confidential_but_not_yet_launched_reports_sev():
     """is_confidential with no hypervisor object yet (vm=None) -> SEV (sub-mode refines once launched)."""
-    info = _to_vm_info(_execution(confidential=True, policy=0), running=True)
+    info = _to_vm_info(_execution(confidential=True, policy=0), "active")
     assert info.confidential_mode is ConfidentialMode.SEV

--- a/tests/supervisor/test_supervisor_inprocess_query.py
+++ b/tests/supervisor/test_supervisor_inprocess_query.py
@@ -59,11 +59,17 @@ def make_execution(
 
 
 class FakeSystemd:
-    def __init__(self, active: dict[str, bool] | None = None):
-        self._active = active or {}
+    """Mirrors the real manager: the state string is the source of truth and
+    the boolean helper is derived from it."""
+
+    def __init__(self, active: dict[str, bool] | None = None, states: dict[str, str] | None = None):
+        self._states = states or {service: "active" for service, up in (active or {}).items() if up}
+
+    def get_services_states(self, services):
+        return {s: self._states.get(s, "inactive") for s in services}
 
     def get_services_active_states(self, services):
-        return {s: self._active.get(s, False) for s in services}
+        return {s: state == "active" for s, state in self.get_services_states(services).items()}
 
 
 class FakePool:
@@ -192,9 +198,9 @@ async def test_list_vms_batches_the_systemd_query():
     calls: list[list[str]] = []
 
     class CountingSystemd(FakeSystemd):
-        def get_services_active_states(self, services):
+        def get_services_states(self, services):
             calls.append(list(services))
-            return super().get_services_active_states(services)
+            return super().get_services_states(services)
 
     pool = FakePool(
         executions={"hash-a": make_execution(vm_id="hash-a"), "hash-b": make_execution(vm_id="hash-b")},

--- a/tests/supervisor/test_supervisor_inprocess_stubs.py
+++ b/tests/supervisor/test_supervisor_inprocess_stubs.py
@@ -39,6 +39,9 @@ class FakeSystemd:
     def __init__(self):
         self.enable_and_start = AsyncMock()
 
+    def get_services_states(self, services):
+        return {service: "inactive" for service in services}
+
 
 class ConfidentialPool:
     def __init__(self, vm_id, execution):

--- a/tests/supervisor/test_systemd_states.py
+++ b/tests/supervisor/test_systemd_states.py
@@ -1,0 +1,70 @@
+"""Batched ActiveState lookup keeps the raw systemd string.
+
+get_services_active_states collapses ActiveState to `== "active"`, which
+throws away the distinction between a unit that never started and one that
+failed. get_services_states preserves it, with the boolean helper expressed
+on top so both come from a single ListUnits() call.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from aleph.vm.systemd import SystemDManager
+
+SERVICE = "aleph-vm-controller@decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca.service"
+OTHER = "aleph-vm-controller@beefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef.service"
+
+
+def _unit(name: str, active_state: str):
+    """One ListUnits() row: (name, description, load_state, active_state,
+    sub_state, following, unit_path, job_id, job_type, job_path)."""
+    return (name, "", "loaded", active_state, "", "", "/org/freedesktop/systemd1/unit/x", 0, "", "/job/x")
+
+
+@pytest.fixture
+def manager(mocker) -> SystemDManager:
+    mocker.patch.object(SystemDManager, "_connect")
+    return SystemDManager()
+
+
+def _with_units(manager: SystemDManager, *units) -> SystemDManager:
+    manager._get_manager = MagicMock(return_value=MagicMock(ListUnits=MagicMock(return_value=list(units))))
+    manager._call_with_reconnect = MagicMock(side_effect=lambda call: call())
+    return manager
+
+
+class TestGetServicesStates:
+    def test_reports_the_raw_active_state(self, manager):
+        _with_units(manager, _unit(SERVICE, "failed"))
+        assert manager.get_services_states([SERVICE]) == {SERVICE: "failed"}
+
+    def test_reports_not_loaded_for_a_unit_systemd_does_not_list(self, manager):
+        _with_units(manager, _unit(OTHER, "active"))
+        assert manager.get_services_states([SERVICE]) == {SERVICE: "not-loaded"}
+
+    def test_one_call_covers_every_service(self, manager):
+        _with_units(manager, _unit(SERVICE, "active"), _unit(OTHER, "failed"))
+        assert manager.get_services_states([SERVICE, OTHER]) == {SERVICE: "active", OTHER: "failed"}
+        assert manager._call_with_reconnect.call_count == 1
+
+    def test_no_services_needs_no_dbus_call(self, manager):
+        _with_units(manager)
+        assert manager.get_services_states([]) == {}
+        assert manager._call_with_reconnect.call_count == 0
+
+
+class TestActiveStatesStillBoolean:
+    """The existing boolean API keeps its exact semantics."""
+
+    def test_active_is_true(self, manager):
+        _with_units(manager, _unit(SERVICE, "active"))
+        assert manager.get_services_active_states([SERVICE]) == {SERVICE: True}
+
+    def test_failed_is_false(self, manager):
+        _with_units(manager, _unit(SERVICE, "failed"))
+        assert manager.get_services_active_states([SERVICE]) == {SERVICE: False}
+
+    def test_unlisted_is_false(self, manager):
+        _with_units(manager)
+        assert manager.get_services_active_states([SERVICE]) == {SERVICE: False}

--- a/tests/supervisor/test_vm_status_failed.py
+++ b/tests/supervisor/test_vm_status_failed.py
@@ -1,0 +1,105 @@
+"""A dead controller unit must report FAILED, not BOOTING.
+
+systemd sets ActiveState=failed only once Restart=on-failure has given up, so
+a unit in that state is not coming back on its own. Reporting it as BOOTING
+(what a bool "is it active" collapses to) makes a crashed VM indistinguishable
+from one still starting, and start_persistent_vm then waits for a VM that will
+never run instead of taking its recreate branch.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from aleph.vm.supervisor.local import LocalSupervisor, _to_vm_info
+from aleph.vm.supervisor_interface.types import VmStatus
+
+SERVICE = "aleph-vm-controller@decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca.service"
+NOW = datetime(2026, 8, 25, 12, 0, tzinfo=timezone.utc)
+
+
+def _execution(**times_kwargs):
+    times = SimpleNamespace(
+        defined_at=None,
+        preparing_at=None,
+        prepared_at=None,
+        starting_at=None,
+        started_at=None,
+        stopping_at=None,
+        stopped_at=None,
+    )
+    for key, value in times_kwargs.items():
+        setattr(times, key, value)
+    return SimpleNamespace(
+        vm_id="abc",
+        vm=None,
+        times=times,
+        is_program=False,
+        is_confidential=False,
+        is_awaiting_confidential_init=False,
+        hypervisor=None,
+        gpus=[],
+        persistent=True,
+        controller_service=SERVICE,
+    )
+
+
+class TestFailedControllerUnit:
+    def test_failed_unit_reports_failed(self):
+        execution = _execution(starting_at=NOW, started_at=NOW)
+        assert _to_vm_info(execution, "failed").status is VmStatus.FAILED
+
+    def test_failed_unit_names_the_unit_in_status_message(self):
+        execution = _execution(starting_at=NOW, started_at=NOW)
+        assert SERVICE in _to_vm_info(execution, "failed").status_message
+
+    def test_stopping_takes_precedence_over_a_failed_unit(self):
+        """A unit that fails while stopping is stopping, not crashed: the
+        operator asked for it to go away and it is going away."""
+        execution = _execution(starting_at=NOW, started_at=NOW, stopping_at=NOW)
+        assert _to_vm_info(execution, "failed").status is VmStatus.STOPPING
+
+
+class TestUnchangedStates:
+    def test_active_unit_reports_running(self):
+        execution = _execution(starting_at=NOW, started_at=NOW)
+        assert _to_vm_info(execution, "active").status is VmStatus.RUNNING
+
+    def test_inactive_unit_while_starting_still_reports_booting(self):
+        """The window between StartUnit and the unit going active must keep
+        reporting BOOTING; only "failed" is terminal."""
+        execution = _execution(starting_at=NOW)
+        assert _to_vm_info(execution, "inactive").status is VmStatus.BOOTING
+
+    def test_not_loaded_unit_before_start_reports_defined(self):
+        assert _to_vm_info(_execution(), "not-loaded").status is VmStatus.DEFINED
+
+    def test_running_state_carries_no_status_message(self):
+        execution = _execution(starting_at=NOW, started_at=NOW)
+        assert _to_vm_info(execution, "active").status_message == ""
+
+    def test_failed_unit_reports_no_uptime(self):
+        execution = _execution(starting_at=NOW, started_at=NOW)
+        assert _to_vm_info(execution, "failed").uptime_secs == 0
+
+
+class TestBatchedListing:
+    """list_vms takes the batched path (one ListUnits for every VM), which has
+    its own state lookup and could report the per-VM path's answer wrongly."""
+
+    @pytest.mark.asyncio
+    async def test_list_vms_reports_failed_for_a_dead_unit(self):
+        execution = _execution(starting_at=NOW, started_at=NOW)
+        execution.systemd_manager = SimpleNamespace()
+        # Both APIs, as the real manager has them: on the boolean one a failed
+        # unit is simply "not active", which is what used to lose the reason.
+        systemd = SimpleNamespace(
+            get_services_states=lambda services: {s: "failed" for s in services},
+            get_services_active_states=lambda services: {s: False for s in services},
+        )
+        pool = SimpleNamespace(executions={"abc": execution}, systemd_manager=systemd, network=None)
+
+        infos = await LocalSupervisor(pool=pool).list_vms()
+
+        assert [info.status for info in infos] == [VmStatus.FAILED]


### PR DESCRIPTION
`VmStatus.FAILED` is declared in the supervisor's status vocabulary but nothing ever produces it. `_status_of` derives the status from a bool ("is the controller unit active"), which collapses systemd's `ActiveState`: a unit that *failed* and one that *never started* are both "not active", so a crashed VM reports `BOOTING` forever.

This is not only a cosmetic status. `start_persistent_vm` treats `BOOTING` as "already starting" and waits in `_wait_until_running` for a VM that will never run, so its `FAILED` branch (delete + recreate, keeping the port mappings) is unreachable. The routing test covering that branch has been passing against a state production could not reach.

Prerequisite for the async-allocations work (2.1): once allocation is asynchronous, "my VM died" has to be answerable from the CRN's advertised status, not from an HTTP status code. Landing it separately because every consumer of `VmInfo` benefits, allocations or not.

## Changes

- `systemd.py`: `get_services_states()` returns the raw `ActiveState` per service from the same single `ListUnits()` call, with `"not-loaded"` for units systemd does not list. `get_services_active_states()` becomes its boolean reduction, semantics unchanged for its callers (`pool.load_persistent_executions` still uses it).
- `supervisor/local.py`: `_controller_state` / `_controller_states` replace `_is_running` / `_running_states` as the carrier. Non-persistent executions map their timestamp pair onto the same vocabulary, so there is one thing to reason about instead of a bool here and a string there. `_is_running` remains as the boolean helper for callers that only ask "is it up".
- `_status_of` maps `"failed"` to `VmStatus.FAILED`, ranked below RUNNING and above BOOTING. `stopped_at` and `stopping_at` keep precedence: a unit that fails while stopping is stopping, not crashed.
- `VmInfo.status_message`, hardcoded to `""` until now, names the failed unit. Only FAILED carries a message; on any other status it would be noise.
- Test doubles updated to mirror the real manager (state string is the source of truth, boolean derived).

Behaviour to expect: a persistent VM whose controller died after `Restart=on-failure` gave up now reports FAILED, and the next allocation push recreates it instead of waiting on it. systemd only reports `failed` once restarts are exhausted, so the state means the VM is not coming back on its own.

## How to test

`pytest tests/supervisor/test_vm_status_failed.py tests/supervisor/test_systemd_states.py`

16 new tests, written before the implementation. The batched-path test was verified to fail against `dev` with `assert [VmStatus.BOOTING] == [VmStatus.FAILED]`, which is the bug in one line.

On a real CRN: `systemctl kill --signal=SIGKILL aleph-vm-controller@<hash>.service` until systemd gives up, then `GET /v2/about/executions/list` and check the VM is no longer reported as running-but-booting.

## Notes

- The full `tests/supervisor` run has ~105 pre-existing failures in my environment (`PermissionError: /var/cache/aleph`). The FAILED set is byte-identical before and after this branch.
- No new mypy errors (the 5 in `agent/pubsub.py` are pre-existing).
- Part 1 of 2 prerequisites for the async scheduler allocations design; the other is #1153 (create-path disk admission). They are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)