### PR TITLE
fix(agent): admit VMs against disk before downloading their resources

### DIFF
--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -14,6 +14,7 @@ from aiohttp.web_exceptions import (
     HTTPServiceUnavailable,
 )
 from aleph_message.models import (
+    ExecutableContent,
     InstanceContent,
     ItemHash,
     ProgramContent,
@@ -23,7 +24,11 @@ from msgpack import UnpackValueError
 from multidict import CIMultiDict
 
 from aleph.vm.agent.aggregate import get_user_settings
-from aleph.vm.agent.capacity import CapacityManager, requested_gpu_ids
+from aleph.vm.agent.capacity import (
+    CapacityManager,
+    requested_gpu_ids,
+    requirements_from_message,
+)
 from aleph.vm.agent.expiry import ExpiryManager
 from aleph.vm.agent.snp_instance_launch import (
     build_snp_instance_spec,
@@ -329,6 +334,29 @@ async def _wait_until_gone(
         await asyncio.sleep(interval)
 
 
+def _admit(capacity: CapacityManager, content: ExecutableContent, vm_hash: ItemHash, *, is_instance: bool) -> None:
+    """Agent-side admission, ahead of any download.
+
+    Disk is judged here and only here: build_*_spec downloads the resources and
+    creates the volume files, so a disk check after it would measure space this
+    VM has already taken. Refusing here also means a host with no room never
+    pays for the download.
+
+    ``is_instance`` is passed explicitly rather than taken from the message:
+    a V-PROGRAM is an SNP VM and belongs in the instance memory bucket, but it
+    is not an InstanceContent, which is all requirements_from_message can see.
+    """
+    requirements = requirements_from_message(content)
+    capacity.check_capacity(
+        memory_mib=requirements.memory_mib,
+        vcpus=requirements.vcpus,
+        disk_mib=requirements.disk_mib,
+        max_volume_mib=requirements.max_volume_mib,
+        is_instance=is_instance,
+        exclude_vm_hash=vm_hash,
+    )
+
+
 async def create_vm_execution(
     vm_hash: ItemHash,
     *,
@@ -360,6 +388,7 @@ async def create_vm_execution(
         # on the first request through _ensure_program_vm. On-demand programs
         # are created and configured per request there too, so this branch only
         # does eager work for the persistent (scheduled) case.
+        _admit(capacity, content, vm_hash, is_instance=False)
         spec, _resources = await build_program_create_vm_spec(vm_hash, content)
         capacity.check_capacity(
             memory_mib=content.resources.memory,
@@ -400,6 +429,7 @@ async def create_vm_execution(
         snp_instance = is_snp_instance(content)
         attest_port: int | None = None
         try:
+            _admit(capacity, content, vm_hash, is_instance=True)
             if snp_instance:
                 # SEV-SNP confidential instances build through the dedicated
                 # LUKS-rootfs SNP launch path, not build_create_vm_spec (which
@@ -498,6 +528,7 @@ async def create_vm_execution(
         # set), so the plain readiness wait applies.
         record = registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
         try:
+            _admit(capacity, content, vm_hash, is_instance=True)
             spec, attest_port = await build_vprogram_spec(vm_hash, content)
             # Agent-side admission after the download, like the instance path:
             # a failed bundle fetch never consumes capacity.

--- a/tests/supervisor/test_create_path_disk_admission.py
+++ b/tests/supervisor/test_create_path_disk_admission.py
@@ -151,3 +151,30 @@ class TestVProgramPath:
             await _create(capacity)
 
         assert [c.kwargs["is_instance"] for c in capacity.check_capacity.call_args_list] == [True]
+
+
+class TestBothChecksOnTheHappyPath:
+    """The two checks are a contract, not a duplicate: the pre-build one owns
+    disk, the post-build one re-checks memory and vCPUs (and is where GPU holds
+    are resolved) without re-requiring space this VM has already taken."""
+
+    @pytest.mark.asyncio
+    async def test_disk_is_required_once_before_the_build_and_never_again(self, monkeypatch):
+        from test_supervisor_run_routing import _info, _spec
+
+        _patch_message(monkeypatch, _make_qemu_instance_message(hypervisor=HypervisorType.qemu))
+        monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(return_value=_spec()))
+        monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+        monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+        monkeypatch.setattr(run_module, "persist_record", AsyncMock())
+        capacity = _capacity()
+        supervisor = SimpleNamespace(
+            create_vm=AsyncMock(return_value=_info()),
+            get_vm=AsyncMock(return_value=_info()),
+            add_port_forward=AsyncMock(),
+            delete_vm=AsyncMock(),
+        )
+
+        await _create(capacity, supervisor)
+
+        assert _disk_args(capacity) == [(INSTANCE_ROOTFS_MIB, INSTANCE_ROOTFS_MIB), (0, 0)]

--- a/tests/supervisor/test_create_path_disk_admission.py
+++ b/tests/supervisor/test_create_path_disk_admission.py
@@ -1,0 +1,153 @@
+"""Capacity admission runs before the download, and it accounts for disk.
+
+Every create path called check_capacity with disk_mib=0, so neither the total
+disk requirement nor the largest-single-volume check ran: only the reserve
+endpoint ever judged disk. Filling the number in at the old call site would
+have been theatre, because that call sits *after* build_*_spec, which
+downloads the resources and creates the volume files: by then the space is
+already allocated and requiring it again would double-count it.
+
+So the admission gate moves ahead of the build, where refusing still saves the
+download, and the post-build call keeps disk_mib=0 as the memory/vCPU re-check
+and the GPU resolution point.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aleph_message.models import ItemHash
+from aleph_message.models.execution.environment import HypervisorType
+from test_supervisor_translate import _make_qemu_instance_message
+
+from aleph.vm.agent import run as run_module
+from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.resources import InsufficientResourcesError
+from aleph.vm.utils import get_message_executable_content
+
+_HASH = ItemHash("deadbeef" * 8)
+
+# _make_qemu_instance_message declares a single 10000 MiB rootfs and no extra
+# volumes, so both the total and the largest single volume are 10000.
+INSTANCE_ROOTFS_MIB = 10000
+
+
+def _program_content():
+    with open("examples/program_message_from_aleph.json") as fd:
+        return get_message_executable_content(json.load(fd)["content"])
+
+
+def _capacity(*, refuse: bool = False):
+    """Admission stub. `refuse` makes every check fail, standing in for a host
+    with no room left."""
+    error = InsufficientResourcesError("no room", required={}, available={})
+    return SimpleNamespace(
+        check_capacity=MagicMock(side_effect=error if refuse else None),
+        resolve_gpus=AsyncMock(return_value=[]),
+    )
+
+
+def _supervisor():
+    return SimpleNamespace(
+        create_vm=AsyncMock(side_effect=AssertionError("create_vm must not be reached")),
+        delete_vm=AsyncMock(),
+    )
+
+
+def _patch_message(monkeypatch, content):
+    message = MagicMock(content=content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
+    )
+
+
+async def _create(capacity, supervisor=None):
+    await run_module.create_vm_execution(
+        _HASH,
+        supervisor=supervisor or _supervisor(),
+        registry=AgentVmRegistry(),
+        capacity=capacity,
+        persistent=True,
+    )
+
+
+def _disk_args(capacity):
+    """(disk_mib, max_volume_mib) of every check_capacity call."""
+    return [
+        (c.kwargs.get("disk_mib"), c.kwargs.get("max_volume_mib", 0)) for c in capacity.check_capacity.call_args_list
+    ]
+
+
+class TestInstancePath:
+    @pytest.mark.asyncio
+    async def test_refused_before_the_download(self, monkeypatch):
+        _patch_message(monkeypatch, _make_qemu_instance_message(hypervisor=HypervisorType.qemu))
+        build = AsyncMock()
+        monkeypatch.setattr(run_module, "build_create_vm_spec", build)
+        capacity = _capacity(refuse=True)
+
+        with pytest.raises(InsufficientResourcesError):
+            await _create(capacity)
+
+        build.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_admission_carries_the_declared_disk(self, monkeypatch):
+        _patch_message(monkeypatch, _make_qemu_instance_message(hypervisor=HypervisorType.qemu))
+        monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock())
+        capacity = _capacity(refuse=True)
+
+        with pytest.raises(InsufficientResourcesError):
+            await _create(capacity)
+
+        assert _disk_args(capacity) == [(INSTANCE_ROOTFS_MIB, INSTANCE_ROOTFS_MIB)]
+
+
+class TestProgramPath:
+    @pytest.mark.asyncio
+    async def test_refused_before_the_download(self, monkeypatch):
+        _patch_message(monkeypatch, _program_content())
+        build = AsyncMock()
+        monkeypatch.setattr(run_module, "build_program_create_vm_spec", build)
+        capacity = _capacity(refuse=True)
+
+        with pytest.raises(InsufficientResourcesError):
+            await _create(capacity)
+
+        build.assert_not_awaited()
+
+
+class TestVProgramPath:
+    @pytest.mark.asyncio
+    async def test_refused_before_the_bundle_fetch(self, monkeypatch):
+        from test_vprogram import load_vprogram_message
+
+        _patch_message(monkeypatch, load_vprogram_message().content)
+        build = AsyncMock()
+        monkeypatch.setattr(run_module, "build_vprogram_spec", build)
+        capacity = _capacity(refuse=True)
+
+        with pytest.raises(InsufficientResourcesError):
+            await _create(capacity)
+
+        build.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_admission_uses_the_instance_memory_bucket(self, monkeypatch):
+        """A v-program is an SNP VM, not a Firecracker program: it is admitted
+        against the instance bucket, as the pre-existing post-build check
+        already did. requirements_from_message alone would say otherwise, since
+        VerifiableProgramContent is not an InstanceContent."""
+        from test_vprogram import load_vprogram_message
+
+        _patch_message(monkeypatch, load_vprogram_message().content)
+        monkeypatch.setattr(run_module, "build_vprogram_spec", AsyncMock())
+        capacity = _capacity(refuse=True)
+
+        with pytest.raises(InsufficientResourcesError):
+            await _create(capacity)
+
+        assert [c.kwargs["is_instance"] for c in capacity.check_capacity.call_args_list] == [True]


### PR DESCRIPTION
Every create path calls `check_capacity` with `disk_mib=0` (`agent/run.py`, three call sites), so nothing on the create side ever judges disk: only the reserve endpoint does, through `requirements_from_message`. A CRN with a full disk keeps accepting instances and fails later, on write. The per-pool "largest single volume" check (`max_volume_mib`) is skipped for the same reason.

Prerequisite for the async-allocations work (2.1), where the CRN answers "would you accept these VMs?" before downloading anything: an advisory answer that ignores disk would be strictly weaker than what the create path enforces, and a plan-time rejection could be followed by a `notify_allocation` acceptance for the same VM. Landing it separately because the gap exists today, independently of allocations.

## Changes

Filling the number in at the existing call site would have been theatre: that call sits **after** `build_*_spec`, which downloads the resources and creates the volume files (`qemu-img`, `fallocate`). By then the space is already allocated, so requiring it again would double-count it.

- New shared `_admit()` in `agent/run.py`, called **before** the spec build on all three create paths (program, instance including SNP, v-program). It is built on `requirements_from_message`, the same helper the reserve endpoint uses, so advisory and enforced admission now agree. Refusing there also means a host with no room never pays for the download.
- The existing post-build `check_capacity` calls stay as they are, at `disk_mib=0`: they re-check memory and vCPUs against anything that changed during the download, and they remain the point where GPU holds are resolved and consumed. That must stay after the build so a failed download never burns the owner's hold, which is what the current comment describes.
- `_admit` takes `is_instance` explicitly rather than reading it off the message. A V-PROGRAM belongs in the instance memory bucket (as its pre-existing post-build check already said), but it is not an `InstanceContent`, so `requirements_from_message` would have put it in the much smaller program bucket and refused it. There is a test pinning this.

Behaviour to expect: a create whose declared rootfs plus volumes exceed the free space, or whose largest single volume exceeds the roomiest pool, is refused up front with `InsufficientResourcesError` instead of proceeding and failing on write. Sizes stay best-effort for immutable volumes (they carry no `size_mib`), which the existing code already acknowledges.

## How to test

`pytest tests/supervisor/test_create_path_disk_admission.py`

5 new tests, written before the implementation: each path refuses before its build is awaited, the instance path passes the declared 10000 MiB rootfs as both total and largest-volume, and the v-program path is admitted against the instance bucket.

## Notes

- Deliberately does **not** move the memory/vCPU check or the GPU resolution: only the disk-bearing gate is added ahead of the download.
- The full `tests/supervisor` run has ~105 pre-existing failures in my environment (`PermissionError: /var/cache/aleph`). The FAILED set is byte-identical before and after this branch. No new mypy errors.
- Part 2 of 2 prerequisites for the async scheduler allocations design; the other is #1152. They are independent and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
