### PR TITLE
feat(agent): disk reclamation, retire_vm and volume retention (2.1, PR A)

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -122,9 +122,13 @@ agent registered at startup (`storage_pools.set_room_maker`, wired to
 `reconciler.make_room`) so the retained directories on the target pool are
 evicted oldest-first until the create fits. See "Reclamation" below: a
 retained disk is a cache entry, not usage, so counting it as used would sell
-less capacity than the node actually has. `about_system_usage` is deliberately
-left on the raw `pools_disk_usage()` figures, since it reports what the
-filesystem currently holds, not what a create could get.
+less capacity than the node actually has. The rule holds for all three disk
+figures the agent produces, and they have to agree: the aggregate
+(`_available_disk_bytes`), the largest-single-volume check (`_check_max_volume`,
+which adds each pool's own `reclaimable_bytes(pool.path)` to that pool's free
+space) and the advertised capacity (`about_system_usage` /
+`_disk_usage_from_pools`). A node that advertises less than admission accepts
+is a node the scheduler stops sending work to.
 
 The Rust supervisor daemon does none of this pool selection or admission
 work. It parses `VOLUME_POOLS` (`config.rs`) with the same validation rules
@@ -345,11 +349,23 @@ keyed by a hash validated by `purge._checked_namespace`.
 
 Passes run at startup, every `VOLUME_RECONCILE_INTERVAL` (jittered, so a
 fleet of nodes does not sweep in lockstep), after every `GONE` under `keep`
-(`retire.set_after_gone_hook`), and on admission pressure
-(`make_room`, through `storage_pools.set_room_maker`). A pass runs in a
-worker thread, so the live-VM set is snapshotted on the event loop first
-(`live_hashes`) and handed over; `make_room` never evicts a hash in it, even
-if a stale marker says it could.
+(`retire.set_after_gone_hook`, best effort: a failing pass never breaks the
+sweep that retired the VM), and on admission pressure (`make_room`, through
+`storage_pools.set_room_maker`). A pass runs in a worker thread, so the
+live-VM set is snapshotted on the event loop first (`live_hashes`) and handed
+over; `make_room` never evicts a hash in it, even if a stale marker says it
+could. Loop-triggered passes serialize on a lock (`reconcile_now`), and
+placement runs `make_room` through `asyncio.to_thread`, so it can still
+overlap a pass: every removal therefore tolerates a directory that another
+pass took first, and counts only what it actually removed.
+
+The create guard covers more than the create paths in `run.py`: a migration
+import stages multi-GB disks into `{pool}/{vm_hash}/` for a namespace the
+registry knows nothing about yet, so `run_import` holds `creating()` across
+the whole transfer and records the imported VM in the registry (and the agent
+DB) once `CreateVm` returns. A namespace under the guard is skipped whole,
+`.part` files included: the directory mtime does not advance while a file
+inside it grows, so age is no evidence that a transfer has stopped.
 
 ### Settings
 
@@ -398,9 +414,11 @@ pass against an empty registry would call every running VM an orphan.
 - Disk admission checks aggregate free space and, separately, that the
   single largest requested volume fits the roomiest eligible pool, since no
   pool splits a volume across disks (`src/aleph/vm/agent/capacity.py`).
-- Reclaimable bytes are advertised as free, not as used, and a placement
-  that does not fit evicts them (oldest first) before it is refused
-  (`src/aleph/vm/agent/capacity.py`, `src/aleph/vm/storage_pools.py`).
+- Reclaimable bytes are advertised as free, not as used, in every disk figure
+  the agent reports (aggregate, largest single volume, advertised capacity),
+  and a placement that does not fit evicts them (oldest first) before it is
+  refused (`src/aleph/vm/agent/capacity.py`,
+  `src/aleph/vm/agent/resources.py`, `src/aleph/vm/storage_pools.py`).
 - Every agent-side deletion goes through `retire_vm` with an explicit
   reason; nothing else under `src/aleph/vm/agent/` calls
   `supervisor.delete_vm` (`src/aleph/vm/agent/vm/retire.py`).

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -320,18 +320,27 @@ the volumes are reused through the existing sticky placement in
 ### The reconciler
 
 `reconcile_storage()` (`src/aleph/vm/agent/vm/reconciler.py`) treats the
-filesystem as the truth and the agent's registry as the list of owners. One
-pass does, in order:
+filesystem as the truth and asks two sources who the owners are: the agent
+registry, and the VMs the supervisor lists. The union is the live set. The
+registry alone is not enough, because it is refilled at boot from the agent
+DB and that rehydration skips any record with an empty or unparseable
+message. One pass does, in order:
 
-1. Walk `{pool}/*/`. Each directory is live (a registry record exists),
-   reclaimable (a marker is present) or an orphan (neither). Orphans are
-   purged under `reap` and marked `reason: orphan` under `keep`.
+1. Walk `{pool}/*/`. Each directory is live (the registry or the supervisor
+   knows its hash), reclaimable (a marker is present) or an orphan
+   (neither). Orphans are purged under `reap` and marked `reason: orphan`
+   under `keep`. Liveness is asked again immediately before anything is
+   marked, purged or evicted, so a create that commits while the pass walks
+   is not mistaken for an orphan.
 2. Delete `*.part` files older than the guard, in the four download caches
    and in the pools (the downloader streams volumes in place).
 3. Sweep the side directories keyed by VM hash: the confidential session
    directory, the SNP and V-PROGRAM staging directories, and
    `/mnt/{namespace}_{volume}` mount points. A directory that is still a
-   mount point is logged and left alone.
+   mount point is logged and left alone, and under `/mnt` only empty
+   mount-point directories are removed (with `rmdir`, never `rmtree`): `/mnt`
+   is the operator's directory, and an unmounted agent mount point is empty
+   by construction.
 4. Enforce the retention budget per pool: sum the markers' `size_bytes` and
    evict oldest-first (by `reclaimable_since`) until under
    `VOLUME_RETENTION_BUDGET`. Under `reap` everything marked is given back,
@@ -347,6 +356,12 @@ somehow escaped the context manager is still protected by the second.
 Everything a pass touches is under a directory the agent created and is
 keyed by a hash validated by `purge._checked_namespace`.
 
+The startup pass is stricter than the rest: it refuses to purge anything
+(it runs dry and logs why) when the supervisor did not answer `list_vms`,
+or when rehydration left the registry empty while the supervisor still runs
+at least one VM. Both states mean the live set cannot be trusted, and the
+first pass on a node is the one acting on the biggest backlog.
+
 Passes run at startup, every `VOLUME_RECONCILE_INTERVAL` (jittered, so a
 fleet of nodes does not sweep in lockstep), after every `GONE` under `keep`
 (`retire.set_after_gone_hook`, best effort: a failing pass never breaks the
@@ -354,7 +369,9 @@ sweep that retired the VM), and on admission pressure (`make_room`, through
 `storage_pools.set_room_maker`). A pass runs in a worker thread, so the
 live-VM set is snapshotted on the event loop first (`live_hashes`) and handed
 over; `make_room` never evicts a hash in it, even if a stale marker says it
-could. Loop-triggered passes serialize on a lock (`reconcile_now`), and
+could. Loop-triggered passes serialize on a lock (`reconcile_now`); they are
+serialized, not coalesced, so a sweep that retires N VMs `GONE` queues N
+passes. And
 placement runs `make_room` through `asyncio.to_thread`, so it can still
 overlap a pass: every removal therefore tolerates a directory that another
 pass took first, and counts only what it actually removed.
@@ -422,8 +439,9 @@ pass against an empty registry would call every running VM an orphan.
 - Every agent-side deletion goes through `retire_vm` with an explicit
   reason; nothing else under `src/aleph/vm/agent/` calls
   `supervisor.delete_vm` (`src/aleph/vm/agent/vm/retire.py`).
-- The reconciler never removes a directory whose hash is live, is in the
-  in-process creating set, or whose mtime is inside `VOLUME_CREATE_GUARD`
+- The reconciler never removes a directory whose hash is live in the agent
+  registry or listed by the supervisor, is in the in-process creating set,
+  or whose mtime is inside `VOLUME_CREATE_GUARD`
   (`src/aleph/vm/agent/vm/reconciler.py`).
 - The Rust supervisor daemon never selects, adopts, or writes to a pool; it
   only re-validates `VOLUME_POOLS` and sums free bytes for host-info

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -115,6 +115,17 @@ happily admit, say, a 900 GiB volume onto two half-full 500 GiB disks and
 then fail at creation time. Either check failing raises
 `InsufficientResourcesError`.
 
+Admission counts retained (reclaimable) bytes as free:
+`_available_disk_bytes` adds `reclaimable_bytes()` to the pooled free sum,
+and `select_pool`, before refusing a placement, calls the room maker the
+agent registered at startup (`storage_pools.set_room_maker`, wired to
+`reconciler.make_room`) so the retained directories on the target pool are
+evicted oldest-first until the create fits. See "Reclamation" below: a
+retained disk is a cache entry, not usage, so counting it as used would sell
+less capacity than the node actually has. `about_system_usage` is deliberately
+left on the raw `pools_disk_usage()` figures, since it reports what the
+filesystem currently holds, not what a create could get.
+
 The Rust supervisor daemon does none of this pool selection or admission
 work. It parses `VOLUME_POOLS` (`config.rs`) with the same validation rules
 purely so a configuration the agent would refuse to boot on also fails
@@ -251,6 +262,122 @@ download) files, since that combination is unambiguous evidence of an
 aborted import; a namespace with only complete `.qcow2` files but no known
 VM is left alone and only logged, since a retried import can still adopt it.
 
+## Reclamation
+
+Every agent path that ends a VM goes through one function,
+`retire_vm(vm_hash, reason, ...)` (`src/aleph/vm/agent/vm/retire.py`), and
+the reason decides what happens to the disks. There is no default: a call
+site has to say what it means, which is exactly what was missing when disks
+leaked.
+
+| Reason | Volumes | Registry, ports | Session, staging, backups |
+|--------|---------|-----------------|---------------------------|
+| `RECREATE` | untouched | kept | untouched |
+| `GONE` | `reap`: purged; `keep`: marked reclaimable | dropped | removed |
+| `ERASE` | purged, whatever the policy | dropped | removed |
+| `FAILED_CREATE` | purged, whatever the policy | dropped | removed |
+
+`RECREATE` is the same VM coming straight back (message amend, crash
+recovery, idle program reap, reboot). `GONE` needs positive knowledge that
+it will not: a forgotten or removed message, a stopped payment, a scheduler
+deallocation, a completed migration hand-off. An API error or a timeout is
+not an answer and retires nothing. `ERASE` ignores `keep` on purpose:
+retention protects against administrative deletion, not against the owner's
+own request, and a `FAILED_CREATE` never ran, so it has nothing worth
+keeping. A create that fails on a VM whose volumes already existed retires
+`RECREATE` instead, since the create paths are also the re-create paths for
+a host-persistent VM.
+
+### The `.reclaimable` marker
+
+A namespace directory with no marker belongs to a live VM. Under
+`VOLUME_RETENTION=keep`, `GONE` drops the registry record and writes
+`{pool}/{vm_hash}/.reclaimable` in its place
+(`src/aleph/vm/agent/vm/reclaimable.py`):
+
+```json
+{
+  "version": 1,
+  "reclaimable_since": "<iso timestamp>",
+  "reason": "gone | orphan",
+  "size_bytes": 12345,
+  "depends_on": ["<parent image ref>", "..."]
+}
+```
+
+One marker per pool the VM spans, so each pool's budget is computed from its
+own tree. `depends_on` names the cache entries (parent images) the volumes
+still need, so the cache pass cannot evict a parent from under a retained
+overlay. Under `reap` no marker is ever written: the purge is immediate.
+A create for the same hash adopts the directory (the marker is unlinked and
+the volumes are reused through the existing sticky placement in
+`volume_path_for`), which is what `reconciler.creating()` does on entry.
+
+### The reconciler
+
+`reconcile_storage()` (`src/aleph/vm/agent/vm/reconciler.py`) treats the
+filesystem as the truth and the agent's registry as the list of owners. One
+pass does, in order:
+
+1. Walk `{pool}/*/`. Each directory is live (a registry record exists),
+   reclaimable (a marker is present) or an orphan (neither). Orphans are
+   purged under `reap` and marked `reason: orphan` under `keep`.
+2. Delete `*.part` files older than the guard, in the four download caches
+   and in the pools (the downloader streams volumes in place).
+3. Sweep the side directories keyed by VM hash: the confidential session
+   directory, the SNP and V-PROGRAM staging directories, and
+   `/mnt/{namespace}_{volume}` mount points. A directory that is still a
+   mount point is logged and left alone.
+4. Enforce the retention budget per pool: sum the markers' `size_bytes` and
+   evict oldest-first (by `reclaimable_since`) until under
+   `VOLUME_RETENTION_BUDGET`. Under `reap` everything marked is given back,
+   which is how a node switched from `keep` to `reap` drains.
+5. Sweep expired backups.
+
+Nothing a create is still building is touched. Two independent guards say
+so: a hash registered in the in-process "creating" set (every create path in
+`run.py` and `_ensure_program_vm` runs inside `reconciler.creating()`), and
+an mtime younger than `VOLUME_CREATE_GUARD`. Both matter, since a create
+that outlives the guard is only protected by the first, and a create that
+somehow escaped the context manager is still protected by the second.
+Everything a pass touches is under a directory the agent created and is
+keyed by a hash validated by `purge._checked_namespace`.
+
+Passes run at startup, every `VOLUME_RECONCILE_INTERVAL` (jittered, so a
+fleet of nodes does not sweep in lockstep), after every `GONE` under `keep`
+(`retire.set_after_gone_hook`), and on admission pressure
+(`make_room`, through `storage_pools.set_room_maker`). A pass runs in a
+worker thread, so the live-VM set is snapshotted on the event loop first
+(`live_hashes`) and handed over; `make_room` never evicts a hash in it, even
+if a stale marker says it could.
+
+### Settings
+
+| Setting | Default | What it does |
+|---------|---------|--------------|
+| `VOLUME_RETENTION` | `reap` | `reap` purges a `GONE` VM's volumes at once; `keep` retains them |
+| `VOLUME_RETENTION_BUDGET` | `10%` | Cap on reclaimable bytes per pool (percentage or absolute, e.g. `50G`) |
+| `VOLUME_RECONCILE_INTERVAL` | `3600` | Seconds between periodic passes |
+| `VOLUME_CREATE_GUARD` | `600` | Seconds a young directory or `.part` file is assumed to be an in-flight create |
+| `CACHE_BUDGET` | `20%` | Cap on each download cache (runtime, code, data, message) |
+
+`keep` is not a promise of "forever": reclaimable disks are unpaid storage,
+and an attacker does not need to stop paying to create them (create, forget,
+repeat). It means "kept as long as the budget and live demand allow, oldest
+goes first", which is the only promise a node can honestly sell.
+
+### First start on an existing node
+
+The first pass on an upgraded node finds every directory leaked by the bugs
+this machinery fixes, as an orphan. Under `reap` that is a one-shot cleanup
+of potentially a lot of data, so the startup hook runs a dry pass first and
+logs what it is about to remove, once as a total and once per pool
+(count and bytes), before the real pass runs. An operator reading the log
+can then explain why free space jumped. Under `keep` those directories
+become reclaimable with `reason: orphan` and fall under the budget instead.
+The startup hook is registered after registry rehydration on purpose: a
+pass against an empty registry would call every running VM an orphan.
+
 ## Key invariants
 
 - `PERSISTENT_VOLUMES_DIR` is always pool index 0 and is always VM-eligible
@@ -271,6 +398,15 @@ VM is left alone and only logged, since a retried import can still adopt it.
 - Disk admission checks aggregate free space and, separately, that the
   single largest requested volume fits the roomiest eligible pool, since no
   pool splits a volume across disks (`src/aleph/vm/agent/capacity.py`).
+- Reclaimable bytes are advertised as free, not as used, and a placement
+  that does not fit evicts them (oldest first) before it is refused
+  (`src/aleph/vm/agent/capacity.py`, `src/aleph/vm/storage_pools.py`).
+- Every agent-side deletion goes through `retire_vm` with an explicit
+  reason; nothing else under `src/aleph/vm/agent/` calls
+  `supervisor.delete_vm` (`src/aleph/vm/agent/vm/retire.py`).
+- The reconciler never removes a directory whose hash is live, is in the
+  in-process creating set, or whose mtime is inside `VOLUME_CREATE_GUARD`
+  (`src/aleph/vm/agent/vm/reconciler.py`).
 - The Rust supervisor daemon never selects, adopts, or writes to a pool; it
   only re-validates `VOLUME_POOLS` and sums free bytes for host-info
   reporting. All placement is agent-side
@@ -303,6 +439,13 @@ VM is left alone and only logged, since a retried import can still adopt it.
   (`_make_writable_volume`) and the `pool0_only` wiring for Firecracker.
 - `src/aleph/vm/agent/capacity.py`: `CapacityManager.check_capacity` and the
   disk-admission checks.
+- `src/aleph/vm/agent/vm/retire.py`: `retire_vm` and `RetireReason`, the one
+  way a VM's storage is released.
+- `src/aleph/vm/agent/vm/reclaimable.py`: the `.reclaimable` marker
+  (`mark_reclaimable`, `adopt`, `iter_reclaimable`, `reclaimable_bytes`).
+- `src/aleph/vm/agent/vm/reconciler.py`: `reconcile_storage`, the create
+  guard (`creating`), the evictor (`make_room`) and the startup/periodic
+  hooks the agent registers in `src/aleph/vm/agent/supervisor.py`.
 - `src/aleph/vm/agent/resources.py`: `about_system_usage`'s pooled disk
   figures.
 - `rust/crates/supervisor-daemon/src/config.rs`: `VOLUME_POOLS`/`MediaClass`

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -305,14 +305,21 @@ A namespace directory with no marker belongs to a live VM. Under
   "reclaimable_since": "<iso timestamp>",
   "reason": "gone | orphan",
   "size_bytes": 12345,
-  "depends_on": ["<parent image ref>", "..."]
+  "depends_on": ["<parent image ref>", "..."],
+  "owner": "<owner address>"
 }
 ```
 
 One marker per pool the VM spans, so each pool's budget is computed from its
 own tree. `depends_on` names the cache entries (parent images) the volumes
 still need, so the cache pass cannot evict a parent from under a retained
-overlay. Under `reap` no marker is ever written: the purge is immediate.
+overlay. `owner` is the address from the VM's message, copied in at `GONE`
+because the marker outlives every other record of it (the registry record is
+forgotten and the DB rows are deleted), and it is what lets the node
+authorize the owner's own erase of retained data; it is optional, so markers
+written before the field and orphan markers for a VM whose message the node
+never held simply have none. Under `reap` no marker is ever written: the
+purge is immediate.
 A create for the same hash adopts the directory (the marker is unlinked and
 the volumes are reused through the existing sticky placement in
 `volume_path_for`), which is what `reconciler.creating()` does on entry.

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -292,6 +292,15 @@ keeping. A create that fails on a VM whose volumes already existed retires
 `RECREATE` instead, since the create paths are also the re-create paths for
 a host-persistent VM.
 
+A payment shortfall is a stopped payment: when the held balance, the credit
+balance or the stream no longer covers the VMs it pays for, the payment
+monitor retires them `GONE`, so under the default `reap` their volumes are
+purged at once. This is a change from 1.x, which stopped such a VM but kept
+its record and disks for a later top-up, and then never reclaimed them. A
+node that wants to give a re-paying owner a grace period runs
+`VOLUME_RETENTION=keep`: the marker carries the owner, and a re-created VM
+adopts its retained directory untouched.
+
 ### The `.reclaimable` marker
 
 A namespace directory with no marker belongs to a live VM. Under

--- a/docs/architecture/vm-lifecycle.md
+++ b/docs/architecture/vm-lifecycle.md
@@ -355,13 +355,40 @@ shared by every program on that runtime), and a spec-only view misses the
 namespace directory itself, volumes on other pools and the staging
 directories. `DeleteVm` therefore takes no erase flag at all.
 
-Deletion lives in `src/aleph/vm/agent/vm/purge.py`, keyed by `vm_hash` and
-scoped to directories the agent created, so a shared cache entry is not
-merely spared by a check but unreachable: `purge_vm_volumes` deletes the
-files under `{pool}/{vm_hash}/` on every pool (the reinstall path);
-`purge_vm_storage` removes those directories, the confidential session
-directory and the SNP/V-PROGRAM staging directory (`operate_erase`, the
-owner's "delete all my data", which erases the rootfs too). A `.btrfs`
+Every agent path that ends a VM goes through one function,
+`retire_vm(vm_hash, reason, ...)` (`src/aleph/vm/agent/vm/retire.py`): it
+quiesces the VM through `DeleteVm`, then applies the reason to everything
+the agent holds for it (registry record, DB records, volumes, session and
+staging directories, backups). Nothing else under `src/aleph/vm/agent/`
+calls `supervisor.delete_vm`, and the reason has no default, since a call
+site that does not say what it means is how disks leaked in the first place.
+
+| Reason | Volumes | Registry, ports | Session, staging, backups |
+|--------|---------|-----------------|---------------------------|
+| `RECREATE` | untouched | kept | untouched |
+| `GONE` | `reap`: purged; `keep`: marked reclaimable | dropped | removed |
+| `ERASE` | purged, whatever the policy | dropped | removed |
+| `FAILED_CREATE` | purged, whatever the policy | dropped | removed |
+
+`RECREATE` is the same VM coming straight back (message amend, crash
+recovery, idle program reap, reboot) and stops after the quiesce. `GONE`
+requires positive knowledge that it will not come back: a forgotten or
+removed message, a stopped payment, a scheduler deallocation, a completed
+migration hand-off; an API error or timeout is not an answer and retires
+nothing. `ERASE` is the owner's own "delete all my data" and ignores the
+retention policy, as does `FAILED_CREATE`, a create that never committed. A
+create that fails on a VM whose volumes already existed retires `RECREATE`
+instead, so a transient failure never wipes a host-persistent owner's disks.
+See "Reclamation" in `docs/architecture/storage.md` for the retention
+policy, the `.reclaimable` marker and the reconciler that enforces the
+budget.
+
+The deletion primitives live in `src/aleph/vm/agent/vm/purge.py`, keyed by
+`vm_hash` and scoped to directories the agent created, so a shared cache
+entry is not merely spared by a check but unreachable: `purge_vm_volumes`
+deletes the files under `{pool}/{vm_hash}/` on every pool (the reinstall
+path); `purge_vm_storage` removes those directories, the confidential
+session directory and the SNP/V-PROGRAM staging directory. A `.btrfs`
 volume whose device-mapper target is still present is refused with an
 error rather than unlinked (the loop device would pin the inode and
 `create_devmapper` would skip the rebuild), until dm teardown on stop

--- a/docs/architecture/vm-lifecycle.md
+++ b/docs/architecture/vm-lifecycle.md
@@ -381,7 +381,17 @@ create that fails on a VM whose volumes already existed retires `RECREATE`
 instead, so a transient failure never wipes a host-persistent owner's disks.
 See "Reclamation" in `docs/architecture/storage.md` for the retention
 policy, the `.reclaimable` marker and the reconciler that enforces the
-budget.
+budget. The reconciler never removes a directory whose hash is live in the
+agent registry or listed by the supervisor; under `/mnt` it removes empty
+mount-point directories only; and its startup pass refuses to purge
+anything at all when the supervisor cannot be listed, or when the registry
+rehydrated empty while the supervisor still runs VMs.
+
+`ERASE` is answered whenever the node still holds something for the hash:
+a registry record, or a retained directory left by a `GONE` under `keep`.
+The supervisor's own knowledge of the VM is not a precondition (it forgets
+a VM on restart, while the disks stay), so `operate_erase` 404s only when
+neither the registry nor a marker knows the hash.
 
 The deletion primitives live in `src/aleph/vm/agent/vm/purge.py`, keyed by
 `vm_hash` and scoped to directories the agent created, so a shared cache

--- a/docs/architecture/vm-lifecycle.md
+++ b/docs/architecture/vm-lifecycle.md
@@ -391,7 +391,11 @@ rehydrated empty while the supervisor still runs VMs.
 a registry record, or a retained directory left by a `GONE` under `keep`.
 The supervisor's own knowledge of the VM is not a precondition (it forgets
 a VM on restart, while the disks stay), so `operate_erase` 404s only when
-neither the registry nor a marker knows the hash.
+neither the registry nor a marker knows the hash. Ownership is always
+proven: against the message when the registry or the agent DB still holds
+one, and otherwise against the `owner` address in the marker, which is why
+`GONE` writes it there. A marker with no owner is refused (403), never
+wiped on request.
 
 The deletion primitives live in `src/aleph/vm/agent/vm/purge.py`, keyed by
 `vm_hash` and scoped to directories the agent created, so a shared cache

--- a/docs/architecture/vm-lifecycle.md
+++ b/docs/architecture/vm-lifecycle.md
@@ -387,6 +387,15 @@ mount-point directories only; and its startup pass refuses to purge
 anything at all when the supervisor cannot be listed, or when the registry
 rehydrated empty while the supervisor still runs VMs.
 
+A payment shortfall is a stopped payment: when the held balance, the credit
+balance or the stream no longer covers the VMs it pays for, the payment
+monitor retires them `GONE`, so under the default `reap` their volumes are
+purged at once. This is a change from 1.x, which stopped such a VM but kept
+its record and disks for a later top-up, and then never reclaimed them. A
+node that wants to give a re-paying owner a grace period runs
+`VOLUME_RETENTION=keep`: the marker carries the owner, and a re-created VM
+adopts its retained directory untouched.
+
 `ERASE` is answered whenever the node still holds something for the hash:
 a registry record, or a retained directory left by a `GONE` under `keep`.
 The supervisor's own knowledge of the VM is not a precondition (it forgets

--- a/src/aleph/vm/agent/allocation/teardown.py
+++ b/src/aleph/vm/agent/allocation/teardown.py
@@ -6,24 +6,18 @@ is not the authority on those. A v-program inverts that, because the scheduler
 IS its single source of truth, and it is credit-paid and confidential by
 construction.
 
-Tearing down is a composite: the supervisor owns the VM, the agent owns the
-registry record, the DB rows and the staging directories, so all of them have
-to go.
+Stopping means retiring as GONE: the scheduler said this VM should not exist,
+so the record and side state go, and the disks follow VOLUME_RETENTION. The
+named seam exists because the legacy endpoint and the v2 reconciler share this
+exact behaviour.
 """
-
-import logging
 
 from aleph_message.models import ItemHash
 
-from aleph.vm.agent.metrics import delete_records_for_vm
-from aleph.vm.agent.snp_instance_launch import remove_snp_instance_staging
+from aleph.vm.agent.vm.retire import RetireReason, retire_vm
 from aleph.vm.agent.vm_registry import AgentVmRecord, AgentVmRegistry
-from aleph.vm.agent.vprogram_launch import remove_vprogram_staging
 from aleph.vm.supervisor_interface.abc import Supervisor
-from aleph.vm.supervisor_interface.errors import VmNotFoundError
-from aleph.vm.supervisor_interface.types import ConfidentialMode, VmId, VmInfo
-
-logger = logging.getLogger(__name__)
+from aleph.vm.supervisor_interface.types import ConfidentialMode, VmInfo
 
 
 def is_removable_by_allocation(record: AgentVmRecord, info: VmInfo) -> bool:
@@ -41,16 +35,11 @@ def is_removable_by_allocation(record: AgentVmRecord, info: VmInfo) -> bool:
 
 
 async def teardown_vm(vm_hash: ItemHash, *, supervisor: Supervisor, registry: AgentVmRegistry) -> None:
-    """Delete the VM and every piece of agent-side state that belongs to it.
+    """Retire the VM as GONE, the allocation plane's one way to stop a VM.
 
-    Idempotent: a VM the supervisor has already forgotten still has its agent
-    state cleaned, since that state is ours and would otherwise leak.
+    Everything this used to do by hand (supervisor delete, registry forget,
+    DB rows, staging directories) is what GONE does, plus device teardown and
+    the retention policy for the disks; a VM the supervisor has already
+    forgotten is still cleaned, since the rest of that state is ours.
     """
-    try:
-        await supervisor.delete_vm(VmId(str(vm_hash)))
-    except VmNotFoundError:
-        logger.info("Supervisor no longer knows %s; cleaning agent state anyway", vm_hash)
-    registry.forget(vm_hash)
-    await delete_records_for_vm(str(vm_hash))
-    remove_vprogram_staging(vm_hash)
-    remove_snp_instance_staging(vm_hash)
+    await retire_vm(vm_hash, RetireReason.GONE, supervisor=supervisor, registry=registry)

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -459,10 +459,19 @@ class CapacityManager:
         """None when ``max_volume_mib`` fits the roomiest eligible pool, else
         an error string describing the shortfall. No pool holds a volume
         split across disks, so this catches a request the aggregate free
-        figure alone would wrongly admit."""
+        figure alone would wrongly admit.
+
+        A pool's room is its free bytes plus the reclaimable bytes it holds,
+        for the same reason the aggregate figure counts them: placement
+        evicts that pool's retained directories before it refuses the volume.
+        """
         if max_volume_mib <= 0:
             return None
-        roomiest_mib = storage_pools.roomiest_pool_free_bytes() // (1024 * 1024)
+        roomiest_bytes = max(
+            (free + reclaimable_bytes(pool.path) for pool, free in storage_pools.eligible_pool_free_bytes()),
+            default=0,
+        )
+        roomiest_mib = roomiest_bytes // (1024 * 1024)
         if max_volume_mib <= roomiest_mib:
             return None
         return f"Disk (largest single volume): required {max_volume_mib} MiB, roomiest pool has {roomiest_mib} MiB"

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -24,6 +24,7 @@ from aleph_message.models import ExecutableContent, ItemHash, VerifiableProgramC
 from aleph_message.models.execution.instance import InstanceContent
 
 from aleph.vm import storage_pools
+from aleph.vm.agent.vm.reclaimable import reclaimable_bytes
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 from aleph.vm.resources import GpuDevice, InsufficientResourcesError
@@ -475,8 +476,11 @@ class CapacityManager:
         reserved-but-unused delta it adds per execution is 0 for every
         spec-built VM (spec disks carry no size). Unreachable pools (missing
         dir, dead disk) contribute 0 rather than failing admission outright.
+
+        Reclaimable (retained) bytes count as free: the reconciler evicts them
+        on demand when a placement needs the room.
         """
-        return max(storage_pools.pools_disk_usage()[1], 0)
+        return max(storage_pools.pools_disk_usage()[1], 0) + reclaimable_bytes()
 
     async def _available_gpus(self) -> list[GpuDevice]:
         """Host cards not attached to any VM, per the supervisor's HostInfo."""

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -435,7 +435,15 @@ class CapacityManager:
     def _committed_resources(self, excluded: Collection[ItemHash]) -> tuple[int, int, int]:
         """(committed_instance_memory_mib, committed_program_memory_mib,
         committed_vcpus) summed over the registry, skipping the records of
-        ``excluded`` (see ``check_capacity`` and ``simulate``)."""
+        ``excluded`` (see ``check_capacity`` and ``simulate``).
+
+        A record is not proof that a VM runs. A create that fails against
+        volumes that already existed retires RECREATE and deliberately keeps
+        its record (``run._retire_after_create_failure``), so the sums here
+        can include a VM that never started, until the next allocation cycle
+        replaces or retires it. That is conservative (it under-admits, never
+        over-admits) and it never blocks the retry of that VM's own create,
+        which excludes its own hash."""
         committed_instance_memory_mib = 0
         committed_program_memory_mib = 0
         committed_vcpus = 0

--- a/src/aleph/vm/agent/expiry.py
+++ b/src/aleph/vm/agent/expiry.py
@@ -2,8 +2,8 @@ import asyncio
 import logging
 from collections.abc import Callable
 
+from aleph.vm.agent.vm.retire import RetireReason, retire_vm
 from aleph.vm.supervisor_interface.abc import Supervisor
-from aleph.vm.supervisor_interface.errors import VmNotFoundError
 from aleph.vm.supervisor_interface.types import VmId
 
 logger = logging.getLogger(__name__)
@@ -49,10 +49,9 @@ class ExpiryManager:
         try:
             await asyncio.sleep(timeout)
             logger.info("Idle timeout reached for %s, reaping", vm_id)
-            await self.supervisor.delete_vm(vm_id)
-            reaped = True
-        except VmNotFoundError:
-            logger.debug("Expiry: VM %s already gone", vm_id)
+            # An idle on-demand program is recreated on the next request:
+            # RECREATE keeps its host-port forwards and disks.
+            await retire_vm(str(vm_id), RetireReason.RECREATE, supervisor=self.supervisor)
             reaped = True
         except asyncio.CancelledError:
             raise

--- a/src/aleph/vm/agent/expiry.py
+++ b/src/aleph/vm/agent/expiry.py
@@ -50,7 +50,11 @@ class ExpiryManager:
             await asyncio.sleep(timeout)
             logger.info("Idle timeout reached for %s, reaping", vm_id)
             # An idle on-demand program is recreated on the next request:
-            # RECREATE keeps its host-port forwards and disks.
+            # RECREATE keeps its host-port forwards and disks so the program
+            # comes back on the same ports. That reservation is deliberate
+            # and lasts as long as the program does: when it is forgotten
+            # (GONE from the scheduler) or erased by its owner, retire_vm
+            # deletes the records, port forwards included.
             await retire_vm(str(vm_id), RetireReason.RECREATE, supervisor=self.supervisor)
             reaped = True
         except asyncio.CancelledError:

--- a/src/aleph/vm/agent/migration/runner.py
+++ b/src/aleph/vm/agent/migration/runner.py
@@ -34,6 +34,8 @@ from aleph.vm.agent.migration.jobs import (
 )
 from aleph.vm.agent.run import finish_instance_create
 from aleph.vm.agent.translate import build_create_vm_spec
+from aleph.vm.agent.vm.reconciler import creating
+from aleph.vm.agent.vm_registry import AgentVmRegistry, persist_record
 from aleph.vm.conf import settings
 from aleph.vm.storage import get_rootfs_base_path
 from aleph.vm.storage_pools import iter_namespace_dirs, select_pool
@@ -221,6 +223,7 @@ async def run_import(
     supervisor: "Supervisor",
     *,
     capacity: CapacityManager,
+    registry: AgentVmRegistry,
     disk_files: list[DiskFileInfo],
     export_token: str,
     prior_task: asyncio.Task | None = None,
@@ -248,114 +251,136 @@ async def run_import(
     start = time.monotonic()
     async with sem:
         try:
-            job.current_step = "fetching_message"
-            message, _original_message = await load_updated_message(job.vm_hash)
+            # The whole import runs under the create guard. Nothing here is in
+            # the agent registry yet, the namespace directory's own mtime does
+            # not advance while a multi-GB disk is streamed into it, and a
+            # transfer easily outlives VOLUME_CREATE_GUARD: without this the
+            # reconciler would classify the staging directory as an orphan and
+            # reap it (and its .part files) mid-transfer.
+            with creating(str(job.vm_hash)):
+                job.current_step = "fetching_message"
+                message, original_message = await load_updated_message(job.vm_hash)
 
-            if message.type != MessageType.instance:
-                msg = "Message is not an instance"
-                raise RuntimeError(msg)
-            # Resolve the hypervisor exactly as the create path does
-            # (translate.build_create_vm_spec): an instance message that omits
-            # the field (the CLI never sets it) falls back to
-            # INSTANCE_DEFAULT_HYPERVISOR, which is QEMU. A hardcoded Firecracker
-            # fallback here rejected every default instance before create_vm,
-            # so migrated VMs never booted on the destination.
-            hypervisor = message.content.environment.hypervisor or settings.INSTANCE_DEFAULT_HYPERVISOR
-            if hypervisor != HypervisorType.qemu:
-                msg = "Migration only supported for QEMU instances"
-                raise RuntimeError(msg)
-            if message.content.environment.trusted_execution is not None:
-                msg = "Migration not supported for confidential VMs"
-                raise RuntimeError(msg)
-
-            job.current_step = "downloading_parent"
-            parent_ref = message.content.rootfs.parent.ref
-            parent_path = await get_rootfs_base_path(parent_ref)
-            parent_format = await detect_parent_format(parent_path)
-
-            # Stage onto the pool with the most room for the whole transfer;
-            # build_create_vm_spec later adopts the staged overlay wherever it
-            # is (the downloader's volume lookup scans every pool).
-            incoming_mib = sum(df.size_bytes for df in disk_files) // (1024 * 1024)
-            dest_dir = select_pool(incoming_mib).path / str(job.vm_hash)
-            dest_dir.mkdir(parents=True, exist_ok=True)
-            job.dest_dir = dest_dir
-            job.total_bytes_expected = sum(df.size_bytes for df in disk_files)
-
-            job.current_step = "downloading_disks"
-            scheme = "https" if job.source_port == 443 else "http"
-            base_url = f"{scheme}://{job.source_host}:{job.source_port}"
-
-            # No total cap (transfers can be large), but require steady progress —
-            # without this a hung peer leaves the import task running forever and
-            # holding the migration semaphore slot.
-            timeout = aiohttp.ClientTimeout(total=None, sock_connect=30, sock_read=300)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                for disk_file in disk_files:
-                    url = f"{base_url}{disk_file.download_path}"
-                    dest_path = dest_dir / disk_file.name
-                    job.downloaded_files.append(dest_path)
-                    base_so_far = job.bytes_downloaded
-
-                    def _progress(file_total: int, _b=base_so_far) -> None:
-                        job.bytes_downloaded = _b + file_total
-
-                    await download_disk_from_source(
-                        session,
-                        url,
-                        dest_path,
-                        export_token,
-                        expected_sha256=disk_file.sha256,
-                        on_chunk=_progress,
-                    )
-
-            job.current_step = "rebasing"
-            for disk_file in disk_files:
-                overlay_path = dest_dir / disk_file.name
-                if not overlay_path.exists():
-                    msg = f"Expected overlay {overlay_path} missing after download"
+                if message.type != MessageType.instance:
+                    msg = "Message is not an instance"
                     raise RuntimeError(msg)
-                await rebase_overlay(overlay_path, parent_path, parent_format)
+                # Resolve the hypervisor exactly as the create path does
+                # (translate.build_create_vm_spec): an instance message that omits
+                # the field (the CLI never sets it) falls back to
+                # INSTANCE_DEFAULT_HYPERVISOR, which is QEMU. A hardcoded Firecracker
+                # fallback here rejected every default instance before create_vm,
+                # so migrated VMs never booted on the destination.
+                hypervisor = message.content.environment.hypervisor or settings.INSTANCE_DEFAULT_HYPERVISOR
+                if hypervisor != HypervisorType.qemu:
+                    msg = "Migration only supported for QEMU instances"
+                    raise RuntimeError(msg)
+                if message.content.environment.trusted_execution is not None:
+                    msg = "Migration not supported for confidential VMs"
+                    raise RuntimeError(msg)
 
-            job.current_step = "creating_vm"
-            # The standard instance-create path: build the same spec a normal
-            # persistent-instance create uses (run.create_vm_execution ->
-            # build_create_vm_spec). The spec's rootfs path resolves through
-            # the pool-aware volume lookup, which finds the overlay exactly
-            # where the download+rebase staged it, and build_create_vm_spec
-            # adopts an already-present host-persistence overlay rather than
-            # recreating it, so create_vm reuses the staged disk (no
-            # re-download).
-            spec = await build_create_vm_spec(job.vm_hash, message.content)
-            # Same agent-side admission as the normal create: bucket from the
-            # message type, GPU requests resolved to concrete host cards on
-            # this destination (owner = message.address).
-            capacity.check_capacity(
-                memory_mib=message.content.resources.memory,
-                vcpus=message.content.resources.vcpus,
-                disk_mib=0,
-                is_instance=True,
-                exclude_vm_hash=job.vm_hash,
-            )
-            requested_gpus = requested_gpu_ids(message.content)
-            if requested_gpus:
-                resolved_gpus = await capacity.resolve_gpus(requested_gpus, owner=message.content.address)
-                spec = replace(spec, gpus=resolved_gpus)
-            await supervisor.create_vm(spec)
+                job.current_step = "downloading_parent"
+                parent_ref = message.content.rootfs.parent.ref
+                parent_path = await get_rootfs_base_path(parent_ref)
+                parent_format = await detect_parent_format(parent_path)
 
-            # A fresh destination has no persisted port mappings, and
-            # create_vm_from_spec only reloads those - it never applies the
-            # agent's port-forwarding policy. Run the same post-create tail the
-            # normal create path runs so the migrated instance gets its SSH (and
-            # any aggregate) host port forwards; without this mapped_ports stays
-            # empty and the VM is unreachable on the new CRN.
-            job.current_step = "port_forwards"
-            await finish_instance_create(supervisor, spec.vm_id, message.content)
+                # Stage onto the pool with the most room for the whole transfer;
+                # build_create_vm_spec later adopts the staged overlay wherever it
+                # is (the downloader's volume lookup scans every pool).
+                incoming_mib = sum(df.size_bytes for df in disk_files) // (1024 * 1024)
+                # Off the loop: placement reads every pool's free space and can
+                # call the reclaimer's evictor (storage_pools.set_room_maker),
+                # which walks pools and removes directories.
+                pool = await asyncio.to_thread(select_pool, incoming_mib)
+                dest_dir = pool.path / str(job.vm_hash)
+                dest_dir.mkdir(parents=True, exist_ok=True)
+                job.dest_dir = dest_dir
+                job.total_bytes_expected = sum(df.size_bytes for df in disk_files)
 
-            job.transfer_time_ms = int((time.monotonic() - start) * 1000)
-            job.finished_at = datetime.now(timezone.utc)
-            job.state = MigrationState.IMPORTED
-            schedule_import_ttl(job, IMPORT_TTL_SECONDS)
+                job.current_step = "downloading_disks"
+                scheme = "https" if job.source_port == 443 else "http"
+                base_url = f"{scheme}://{job.source_host}:{job.source_port}"
+
+                # No total cap (transfers can be large), but require steady progress:
+                # without this a hung peer leaves the import task running forever and
+                # holding the migration semaphore slot.
+                timeout = aiohttp.ClientTimeout(total=None, sock_connect=30, sock_read=300)
+                async with aiohttp.ClientSession(timeout=timeout) as session:
+                    for disk_file in disk_files:
+                        url = f"{base_url}{disk_file.download_path}"
+                        dest_path = dest_dir / disk_file.name
+                        job.downloaded_files.append(dest_path)
+                        base_so_far = job.bytes_downloaded
+
+                        def _progress(file_total: int, _b=base_so_far) -> None:
+                            job.bytes_downloaded = _b + file_total
+
+                        await download_disk_from_source(
+                            session,
+                            url,
+                            dest_path,
+                            export_token,
+                            expected_sha256=disk_file.sha256,
+                            on_chunk=_progress,
+                        )
+
+                job.current_step = "rebasing"
+                for disk_file in disk_files:
+                    overlay_path = dest_dir / disk_file.name
+                    if not overlay_path.exists():
+                        msg = f"Expected overlay {overlay_path} missing after download"
+                        raise RuntimeError(msg)
+                    await rebase_overlay(overlay_path, parent_path, parent_format)
+
+                job.current_step = "creating_vm"
+                # The standard instance-create path: build the same spec a normal
+                # persistent-instance create uses (run.create_vm_execution ->
+                # build_create_vm_spec). The spec's rootfs path resolves through
+                # the pool-aware volume lookup, which finds the overlay exactly
+                # where the download+rebase staged it, and build_create_vm_spec
+                # adopts an already-present host-persistence overlay rather than
+                # recreating it, so create_vm reuses the staged disk (no
+                # re-download).
+                spec = await build_create_vm_spec(job.vm_hash, message.content)
+                # Same agent-side admission as the normal create: bucket from the
+                # message type, GPU requests resolved to concrete host cards on
+                # this destination (owner = message.address).
+                capacity.check_capacity(
+                    memory_mib=message.content.resources.memory,
+                    vcpus=message.content.resources.vcpus,
+                    disk_mib=0,
+                    is_instance=True,
+                    exclude_vm_hash=job.vm_hash,
+                )
+                requested_gpus = requested_gpu_ids(message.content)
+                if requested_gpus:
+                    resolved_gpus = await capacity.resolve_gpus(requested_gpus, owner=message.content.address)
+                    spec = replace(spec, gpus=resolved_gpus)
+                await supervisor.create_vm(spec)
+
+                # The agent records its own knowledge of the VM, exactly as
+                # create_vm_execution does. The registry is what the storage
+                # reconciler reads to tell a live VM's volumes from an orphan's,
+                # and persisting it is what makes the record survive a restart
+                # (rehydrate_registry): without this the imported VM's disks
+                # would be unowned the moment the create guard is released.
+                record = registry.record(
+                    job.vm_hash, message=message.content, original=original_message.content, persistent=True
+                )
+                await persist_record(job.vm_hash, record)
+
+                # A fresh destination has no persisted port mappings, and
+                # create_vm_from_spec only reloads those - it never applies the
+                # agent's port-forwarding policy. Run the same post-create tail the
+                # normal create path runs so the migrated instance gets its SSH (and
+                # any aggregate) host port forwards; without this mapped_ports stays
+                # empty and the VM is unreachable on the new CRN.
+                job.current_step = "port_forwards"
+                await finish_instance_create(supervisor, spec.vm_id, message.content)
+
+                job.transfer_time_ms = int((time.monotonic() - start) * 1000)
+                job.finished_at = datetime.now(timezone.utc)
+                job.state = MigrationState.IMPORTED
+                schedule_import_ttl(job, IMPORT_TTL_SECONDS)
 
         except Exception as error:
             logger.exception("Import failed for %s: %s", job.vm_hash, error)

--- a/src/aleph/vm/agent/migration/runner.py
+++ b/src/aleph/vm/agent/migration/runner.py
@@ -35,6 +35,7 @@ from aleph.vm.agent.migration.jobs import (
 from aleph.vm.agent.run import finish_instance_create
 from aleph.vm.agent.translate import build_create_vm_spec
 from aleph.vm.agent.vm.reconciler import creating
+from aleph.vm.agent.vm.retire import RetireReason, retire_vm
 from aleph.vm.agent.vm_registry import AgentVmRegistry, persist_record
 from aleph.vm.conf import settings
 from aleph.vm.storage import get_rootfs_base_path
@@ -249,6 +250,7 @@ async def run_import(
             logger.debug("Prior import task for %s ended with error: %s", job.vm_hash, e)
     sem = get_migration_semaphore()
     start = time.monotonic()
+    vm_created = False
     async with sem:
         try:
             # The whole import runs under the create guard. Nothing here is in
@@ -356,6 +358,7 @@ async def run_import(
                     resolved_gpus = await capacity.resolve_gpus(requested_gpus, owner=message.content.address)
                     spec = replace(spec, gpus=resolved_gpus)
                 await supervisor.create_vm(spec)
+                vm_created = True
 
                 # The agent records its own knowledge of the VM, exactly as
                 # create_vm_execution does. The registry is what the storage
@@ -387,6 +390,20 @@ async def run_import(
             job.error = str(error)
             job.finished_at = datetime.now(timezone.utc)
             job.state = MigrationState.IMPORT_FAILED
+
+            if vm_created:
+                # The same teardown a fresh create gets when it fails after
+                # create_vm (run._retire_after_create_failure): a VM that is
+                # up but never got its port forwards is unreachable and holds
+                # memory, vCPUs and disks for nothing. A failed import already
+                # discards the staged disks (the rmtree below), so this is a
+                # FAILED_CREATE, not a RECREATE: the record it would keep would
+                # describe disks that are gone. The device teardown and the
+                # purge inside retire_vm make the rmtree a no-op.
+                try:
+                    await retire_vm(job.vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
+                except Exception:
+                    logger.exception("Teardown of the half-imported %s failed", job.vm_hash)
 
             if job.dest_dir is not None and not await _vm_exists(supervisor, job.vm_hash):
                 shutil.rmtree(job.dest_dir, ignore_errors=True)

--- a/src/aleph/vm/agent/resources.py
+++ b/src/aleph/vm/agent/resources.py
@@ -14,6 +14,7 @@ from aleph.vm.agent.vcpu_probe import (
     get_snp_launch_capability,
     get_supported_snp_vcpu_types,
 )
+from aleph.vm.agent.vm.reclaimable import reclaimable_bytes
 from aleph.vm.conf import settings
 from aleph.vm.resources import GpuDevice
 from aleph.vm.sevclient import SevClient
@@ -319,11 +320,18 @@ def hugepages_free_bytes(sysfs_path: Path = HUGEPAGES_SYSFS_PATH) -> int:
 def _disk_usage_from_pools(host_info) -> DiskUsage:
     """Aggregate capacity across every volume pool (same-filesystem pools
     counted once). Usage-aware available disk comes from the supervisor's
-    HostInfo; a gRPC supervisor that has not implemented it yet reports 0."""
+    HostInfo; a gRPC supervisor that has not implemented it yet reports 0.
+
+    Reclaimable (retained) bytes are added to whichever free figure is used:
+    what the node advertises has to match what admission accepts, and
+    admission counts them (a placement evicts them before it refuses). A node
+    advertising less than it will take is a node the scheduler stops feeding.
+    """
     total_bytes, free_bytes = pools_disk_usage()
+    available_bytes = host_info.available_disk_bytes or free_bytes
     return DiskUsage(
         total_kB=total_bytes // 1000,
-        available_kB=(host_info.available_disk_bytes // 1000 if host_info.available_disk_bytes else free_bytes // 1000),
+        available_kB=(available_bytes + reclaimable_bytes()) // 1000,
     )
 
 

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -40,6 +40,7 @@ from aleph.vm.agent.translate import build_create_vm_spec, build_program_create_
 from aleph.vm.agent.update_watcher import UpdateWatcher
 from aleph.vm.agent.vm.program_client import ProgramGuestClient
 from aleph.vm.agent.vm.purge import vm_has_volumes
+from aleph.vm.agent.vm.reconciler import creating
 from aleph.vm.agent.vm.retire import RetireReason, retire_vm
 from aleph.vm.agent.vm_registry import AgentVmRegistry, persist_record
 from aleph.vm.agent.vprogram_launch import (
@@ -509,33 +510,37 @@ async def create_vm_execution(
         # on the first request through _ensure_program_vm. On-demand programs
         # are created and configured per request there too, so this branch only
         # does eager work for the persistent (scheduled) case.
-        _admit(capacity, content, vm_hash)
-        # Snapshot before any allocation: a persistent program's volumes may
-        # already exist (host persistence), and a failed create must not
-        # wipe them (see _retire_after_create_failure).
-        had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
-        spec, _resources = await build_program_create_vm_spec(vm_hash, content)
-        capacity.check_capacity(
-            memory_mib=content.resources.memory,
-            vcpus=content.resources.vcpus,
-            disk_mib=0,
-            is_instance=is_instance_bucket(content),
-            exclude_vm_hash=vm_hash,
-        )
-        info = await supervisor.create_vm(spec)
-        record = registry.record(
-            vm_hash, message=content, original=original_message.content, persistent=bool(content.on.persistent)
-        )
-        try:
-            await _wait_until_running(supervisor, info.vm_id)
-        except Exception:
-            # Readiness failed: retire the half-started VM, but never let a
-            # teardown error mask the original failure.
-            await _retire_after_create_failure(
-                vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="program VM"
+        # Everything from admission to the registry commit runs under the
+        # create guard: it adopts any retained volumes for this hash and keeps
+        # the storage reconciler off a VM that is still being built.
+        with creating(str(vm_hash)):
+            _admit(capacity, content, vm_hash)
+            # Snapshot before any allocation: a persistent program's volumes may
+            # already exist (host persistence), and a failed create must not
+            # wipe them (see _retire_after_create_failure).
+            had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
+            spec, _resources = await build_program_create_vm_spec(vm_hash, content)
+            capacity.check_capacity(
+                memory_mib=content.resources.memory,
+                vcpus=content.resources.vcpus,
+                disk_mib=0,
+                is_instance=is_instance_bucket(content),
+                exclude_vm_hash=vm_hash,
             )
-            raise
-        await persist_record(vm_hash, record)
+            info = await supervisor.create_vm(spec)
+            record = registry.record(
+                vm_hash, message=content, original=original_message.content, persistent=bool(content.on.persistent)
+            )
+            try:
+                await _wait_until_running(supervisor, info.vm_id)
+            except Exception:
+                # Readiness failed: retire the half-started VM, but never let a
+                # teardown error mask the original failure.
+                await _retire_after_create_failure(
+                    vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="program VM"
+                )
+                raise
+            await persist_record(vm_hash, record)
         return None
 
     if _is_spec_eligible(content):
@@ -551,89 +556,93 @@ async def create_vm_execution(
         # state before initializing it; the supervisor machinery never reads this
         # record. Spec-eligible VMs are QEMU instances, always persistent.
         record = registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
-        snp_instance = is_snp_instance(content)
-        attest_port: int | None = None
-        # Snapshot before any allocation: a persistent instance's volumes may
-        # already exist (host persistence, e.g. a crash-recovery re-create),
-        # and a failed create must not wipe them (see
-        # _retire_after_create_failure). Reused by both except blocks below:
-        # they cover the same create attempt.
-        had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
-        try:
-            _admit(capacity, content, vm_hash)
-            if snp_instance:
-                # SEV-SNP confidential instances build through the dedicated
-                # LUKS-rootfs SNP launch path, not build_create_vm_spec (which
-                # would build a SEV spec with no firmware, since these
-                # messages carry no trusted_execution.firmware). GPU
-                # passthrough is not supported yet on this path: reject
-                # before any staging I/O runs.
-                if requested_gpu_ids(content):
-                    msg = "GPU passthrough is not supported on SEV-SNP instances yet"
-                    raise VmSetupError(msg)
-                spec, attest_port = await build_snp_instance_spec(vm_hash, content, str(message.sender))
-            else:
-                spec = await build_create_vm_spec(vm_hash, content)
-            # Agent-side admission, after the download so a failed download
-            # never consumes a GPU hold: bucket from the message type, then
-            # resolve the requested device_ids to concrete host cards (owner =
-            # message.address, consuming this owner's own holds). This VM's
-            # own registry record (the early owner record above) is excluded
-            # from the committed sums.
-            capacity.check_capacity(
-                memory_mib=content.resources.memory,
-                vcpus=content.resources.vcpus,
-                disk_mib=0,
-                is_instance=is_instance_bucket(content),
-                exclude_vm_hash=vm_hash,
-            )
-            if not snp_instance:
-                # GPU resolution only applies to the legacy spec path: SNP
-                # instances are rejected above before reaching here.
-                requested_gpus = requested_gpu_ids(content)
-                if requested_gpus:
-                    resolved_gpus = await capacity.resolve_gpus(requested_gpus, owner=content.address)
-                    spec = replace(spec, gpus=resolved_gpus)
-            info = await supervisor.create_vm(spec)
-        except Exception:
-            # build or create failed: retire the early record so a failed
-            # create never leaves a dangling owner-identity entry behind (a
-            # record with no VM the supervisor knows about), and drop any
-            # runtime bundle build_snp_instance_spec may have already
-            # extracted before the failure.
-            await _retire_after_create_failure(
-                vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="instance"
-            )
-            raise
-        if info.awaiting_confidential_init:
-            # A confidential VM is created but not started: only the owner can
-            # start it, by uploading the session certificates via
-            # /confidential/initialize. Waiting for RUNNING would block forever,
-            # and there are no port forwards to apply on a VM that is not up.
-            # This mirrors the message path, which never waits on a confidential
-            # VM either. SNP instances never set this: the daemon boots them
-            # immediately, so this branch is SEV-only.
+        # Everything from admission to the registry commit runs under the
+        # create guard: it adopts any retained volumes for this hash and keeps
+        # the storage reconciler off a VM that is still being built.
+        with creating(str(vm_hash)):
+            snp_instance = is_snp_instance(content)
+            attest_port: int | None = None
+            # Snapshot before any allocation: a persistent instance's volumes may
+            # already exist (host persistence, e.g. a crash-recovery re-create),
+            # and a failed create must not wipe them (see
+            # _retire_after_create_failure). Reused by both except blocks below:
+            # they cover the same create attempt.
+            had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
+            try:
+                _admit(capacity, content, vm_hash)
+                if snp_instance:
+                    # SEV-SNP confidential instances build through the dedicated
+                    # LUKS-rootfs SNP launch path, not build_create_vm_spec (which
+                    # would build a SEV spec with no firmware, since these
+                    # messages carry no trusted_execution.firmware). GPU
+                    # passthrough is not supported yet on this path: reject
+                    # before any staging I/O runs.
+                    if requested_gpu_ids(content):
+                        msg = "GPU passthrough is not supported on SEV-SNP instances yet"
+                        raise VmSetupError(msg)
+                    spec, attest_port = await build_snp_instance_spec(vm_hash, content, str(message.sender))
+                else:
+                    spec = await build_create_vm_spec(vm_hash, content)
+                # Agent-side admission, after the download so a failed download
+                # never consumes a GPU hold: bucket from the message type, then
+                # resolve the requested device_ids to concrete host cards (owner =
+                # message.address, consuming this owner's own holds). This VM's
+                # own registry record (the early owner record above) is excluded
+                # from the committed sums.
+                capacity.check_capacity(
+                    memory_mib=content.resources.memory,
+                    vcpus=content.resources.vcpus,
+                    disk_mib=0,
+                    is_instance=is_instance_bucket(content),
+                    exclude_vm_hash=vm_hash,
+                )
+                if not snp_instance:
+                    # GPU resolution only applies to the legacy spec path: SNP
+                    # instances are rejected above before reaching here.
+                    requested_gpus = requested_gpu_ids(content)
+                    if requested_gpus:
+                        resolved_gpus = await capacity.resolve_gpus(requested_gpus, owner=content.address)
+                        spec = replace(spec, gpus=resolved_gpus)
+                info = await supervisor.create_vm(spec)
+            except Exception:
+                # build or create failed: retire the early record so a failed
+                # create never leaves a dangling owner-identity entry behind (a
+                # record with no VM the supervisor knows about), and drop any
+                # runtime bundle build_snp_instance_spec may have already
+                # extracted before the failure.
+                await _retire_after_create_failure(
+                    vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="instance"
+                )
+                raise
+            if info.awaiting_confidential_init:
+                # A confidential VM is created but not started: only the owner can
+                # start it, by uploading the session certificates via
+                # /confidential/initialize. Waiting for RUNNING would block forever,
+                # and there are no port forwards to apply on a VM that is not up.
+                # This mirrors the message path, which never waits on a confidential
+                # VM either. SNP instances never set this: the daemon boots them
+                # immediately, so this branch is SEV-only.
+                await persist_record(vm_hash, record)
+                return None
+            try:
+                await finish_instance_create(supervisor, info.vm_id, content)
+                if attest_port is not None:
+                    # finish_instance_create mapped the attestation port already
+                    # (it is part of the instance's desired forward set); wait
+                    # until the guest service (aleph.ra-tls) behind it listens
+                    # before declaring the create done.
+                    await _wait_until_attest_endpoint_listens(supervisor, info.vm_id, attest_port)
+            except Exception:
+                # Readiness or port-forward setup failed: retire the half-started
+                # VM, but never let a teardown error mask the original failure.
+                await _retire_after_create_failure(
+                    vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="VM"
+                )
+                raise
+            # Agent persists its own knowledge; the hypervisor object is not
+            # touched. Registry rehydration and past-logs owner-auth read the
+            # message back from the agent DB.
             await persist_record(vm_hash, record)
-            return None
-        try:
-            await finish_instance_create(supervisor, info.vm_id, content)
-            if attest_port is not None:
-                # finish_instance_create mapped the attestation port already
-                # (it is part of the instance's desired forward set); wait
-                # until the guest service (aleph.ra-tls) behind it listens
-                # before declaring the create done.
-                await _wait_until_attest_endpoint_listens(supervisor, info.vm_id, attest_port)
-        except Exception:
-            # Readiness or port-forward setup failed: retire the half-started
-            # VM, but never let a teardown error mask the original failure.
-            await _retire_after_create_failure(
-                vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="VM"
-            )
-            raise
-        # Agent persists its own knowledge; the hypervisor object is not
-        # touched. Registry rehydration and past-logs owner-auth read the
-        # message back from the agent DB.
-        await persist_record(vm_hash, record)
         return None
 
     if isinstance(content, VerifiableProgramContent):
@@ -646,55 +655,59 @@ async def create_vm_execution(
         # boots an SNP VM immediately (awaiting_confidential_init is never
         # set), so the plain readiness wait applies.
         record = registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
-        # Snapshot before any allocation, same reasoning as the instance path
-        # above; reused by both except blocks below, which cover the same
-        # create attempt.
-        had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
-        try:
-            _admit(capacity, content, vm_hash)
-            spec, attest_port = await build_vprogram_spec(vm_hash, content)
-            # Agent-side admission after the download, like the instance path:
-            # a failed bundle fetch never consumes capacity.
-            capacity.check_capacity(
-                memory_mib=content.resources.memory,
-                vcpus=content.resources.vcpus,
-                disk_mib=0,
-                is_instance=is_instance_bucket(content),
-                exclude_vm_hash=vm_hash,
-            )
-            info = await supervisor.create_vm(spec)
-        except Exception:
-            # build or create failed: retire the early record, and drop any
-            # bundle build_vprogram_spec may have already extracted before
-            # the failure (e.g. capacity admission fails after staging).
-            await _retire_after_create_failure(
-                vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="V-PROGRAM"
-            )
-            raise
-        try:
-            await _wait_until_running(supervisor, info.vm_id)
-            # Host-only DNAT so an external client (the aleph CLI) can reach
-            # the guest's RA-TLS attestation endpoint; measurement-neutral
-            # (no guest image/cmdline change) and idempotent via the same
-            # reconcile machinery the instance path uses.
-            #
-            # A reconcile failure lands in the teardown branch below on
-            # purpose, mirroring the instance path: a V-PROGRAM whose
-            # attestation endpoint cannot be mapped is unreachable for its
-            # sole consumer, so failing the create loudly (and letting the
-            # scheduler retry) beats keeping an unusable VM alive.
-            await reconcile_vprogram_port_forwards(supervisor, info.vm_id, attest_port)
-            if attest_port is not None:
-                await _wait_until_attest_endpoint_listens(supervisor, info.vm_id, attest_port)
-        except Exception:
-            # Readiness or port-forward setup failed: retire the half-started
-            # V-PROGRAM, but never let a teardown error mask the original
-            # failure.
-            await _retire_after_create_failure(
-                vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="V-PROGRAM"
-            )
-            raise
-        await persist_record(vm_hash, record)
+        # Everything from admission to the registry commit runs under the
+        # create guard: it adopts any retained volumes for this hash and keeps
+        # the storage reconciler off a VM that is still being built.
+        with creating(str(vm_hash)):
+            # Snapshot before any allocation, same reasoning as the instance path
+            # above; reused by both except blocks below, which cover the same
+            # create attempt.
+            had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
+            try:
+                _admit(capacity, content, vm_hash)
+                spec, attest_port = await build_vprogram_spec(vm_hash, content)
+                # Agent-side admission after the download, like the instance path:
+                # a failed bundle fetch never consumes capacity.
+                capacity.check_capacity(
+                    memory_mib=content.resources.memory,
+                    vcpus=content.resources.vcpus,
+                    disk_mib=0,
+                    is_instance=is_instance_bucket(content),
+                    exclude_vm_hash=vm_hash,
+                )
+                info = await supervisor.create_vm(spec)
+            except Exception:
+                # build or create failed: retire the early record, and drop any
+                # bundle build_vprogram_spec may have already extracted before
+                # the failure (e.g. capacity admission fails after staging).
+                await _retire_after_create_failure(
+                    vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="V-PROGRAM"
+                )
+                raise
+            try:
+                await _wait_until_running(supervisor, info.vm_id)
+                # Host-only DNAT so an external client (the aleph CLI) can reach
+                # the guest's RA-TLS attestation endpoint; measurement-neutral
+                # (no guest image/cmdline change) and idempotent via the same
+                # reconcile machinery the instance path uses.
+                #
+                # A reconcile failure lands in the teardown branch below on
+                # purpose, mirroring the instance path: a V-PROGRAM whose
+                # attestation endpoint cannot be mapped is unreachable for its
+                # sole consumer, so failing the create loudly (and letting the
+                # scheduler retry) beats keeping an unusable VM alive.
+                await reconcile_vprogram_port_forwards(supervisor, info.vm_id, attest_port)
+                if attest_port is not None:
+                    await _wait_until_attest_endpoint_listens(supervisor, info.vm_id, attest_port)
+            except Exception:
+                # Readiness or port-forward setup failed: retire the half-started
+                # V-PROGRAM, but never let a teardown error mask the original
+                # failure.
+                await _retire_after_create_failure(
+                    vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="V-PROGRAM"
+                )
+                raise
+            await persist_record(vm_hash, record)
         return None
 
     # Every supported content type is handled above: programs through the spec
@@ -844,32 +857,36 @@ async def _ensure_program_vm(
             await _wait_until_gone(supervisor, vm_id)
 
         try:
-            # Snapshot before any allocation: a persistent program's volumes
-            # may already exist (host persistence, or the recreate just
-            # above), and a failed create must not wipe them.
-            had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
-            spec, resources = await build_program_create_vm_spec(vm_hash, content)
-            capacity.check_capacity(
-                memory_mib=content.resources.memory,
-                vcpus=content.resources.vcpus,
-                disk_mib=0,
-                is_instance=is_instance_bucket(content),
-                exclude_vm_hash=vm_hash,
-            )
-            await supervisor.create_vm(spec)
-            record = registry.record(
-                vm_hash, message=content, original=original, persistent=bool(content.on.persistent)
-            )
-            try:
-                info = await _wait_until_running(supervisor, vm_id)
-                await program_client.setup_program(info, content, resources)
-            except Exception:
-                await program_client.forget(vm_id)
-                await _retire_after_create_failure(
-                    vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="program VM"
+            # Everything from the snapshot to the registry commit runs under
+            # the create guard: it adopts any retained volumes for this hash
+            # and keeps the storage reconciler off a VM still being built.
+            with creating(str(vm_hash)):
+                # Snapshot before any allocation: a persistent program's volumes
+                # may already exist (host persistence, or the recreate just
+                # above), and a failed create must not wipe them.
+                had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
+                spec, resources = await build_program_create_vm_spec(vm_hash, content)
+                capacity.check_capacity(
+                    memory_mib=content.resources.memory,
+                    vcpus=content.resources.vcpus,
+                    disk_mib=0,
+                    is_instance=is_instance_bucket(content),
+                    exclude_vm_hash=vm_hash,
                 )
-                raise
-            await persist_record(vm_hash, record)
+                await supervisor.create_vm(spec)
+                record = registry.record(
+                    vm_hash, message=content, original=original, persistent=bool(content.on.persistent)
+                )
+                try:
+                    info = await _wait_until_running(supervisor, vm_id)
+                    await program_client.setup_program(info, content, resources)
+                except Exception:
+                    await program_client.forget(vm_id)
+                    await _retire_after_create_failure(
+                        vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="program VM"
+                    )
+                    raise
+                await persist_record(vm_hash, record)
             return info
         except web.HTTPException:
             raise

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -469,6 +469,15 @@ async def _retire_after_create_failure(
     directory as an orphan and purge it after VOLUME_CREATE_GUARD, which is
     why this is RECREATE and not a records-only teardown.
 
+    The kept record is a known phantom: it describes a VM that is not
+    running, and it counts in CapacityManager's committed memory and vCPU
+    sums (see ``_committed_resources``) until the next allocation cycle
+    replaces or retires it. It never blocks the retry of its own create,
+    which admits through ``_admit`` with ``exclude_vm_hash`` set, but it does
+    hold capacity against other VMs in the meantime. Straightening that out
+    means a record lifecycle that separates "allocated" from "running",
+    which is not this work.
+
     Never lets a teardown error mask the original failure: logs and
     swallows.
     """

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -34,12 +34,12 @@ from aleph.vm.agent.expiry import ExpiryManager
 from aleph.vm.agent.snp_instance_launch import (
     build_snp_instance_spec,
     is_snp_instance,
-    remove_snp_instance_staging,
     resolve_instance_attestation_port,
 )
 from aleph.vm.agent.translate import build_create_vm_spec, build_program_create_vm_spec
 from aleph.vm.agent.update_watcher import UpdateWatcher
 from aleph.vm.agent.vm.program_client import ProgramGuestClient
+from aleph.vm.agent.vm.purge import vm_has_volumes
 from aleph.vm.agent.vm.retire import RetireReason, retire_vm
 from aleph.vm.agent.vm_registry import AgentVmRegistry, persist_record
 from aleph.vm.agent.vprogram_launch import (
@@ -446,6 +446,38 @@ def _admit(capacity: CapacityManager, content: ExecutableContent, vm_hash: ItemH
     )
 
 
+async def _retire_after_create_failure(
+    vm_hash: ItemHash,
+    *,
+    supervisor: Supervisor,
+    registry: AgentVmRegistry,
+    had_volumes: bool,
+    what: str,
+) -> None:
+    """Retire a VM whose create attempt failed.
+
+    The reason depends on whether its volumes already existed before this
+    attempt started (``had_volumes``, snapshotted before any allocation, e.g.
+    before build_*_spec runs). A create that allocated fresh disks retires
+    FAILED_CREATE: nothing worth keeping, purge everything. A create that
+    failed against volumes that already existed is the re-create path for a
+    host-persistent VM (downloader._make_writable_volume returns early when
+    the destination already exists), and must not wipe them: it retires
+    RECREATE instead, which keeps the record and the disks. Dropping the
+    record while keeping the disks would make the reconciler treat the
+    directory as an orphan and purge it after VOLUME_CREATE_GUARD, which is
+    why this is RECREATE and not a records-only teardown.
+
+    Never lets a teardown error mask the original failure: logs and
+    swallows.
+    """
+    reason = RetireReason.RECREATE if had_volumes else RetireReason.FAILED_CREATE
+    try:
+        await retire_vm(vm_hash, reason, supervisor=supervisor, registry=registry)
+    except Exception:
+        logger.exception("Teardown of half-started %s %s failed", what, vm_hash)
+
+
 async def create_vm_execution(
     vm_hash: ItemHash,
     *,
@@ -478,6 +510,10 @@ async def create_vm_execution(
         # are created and configured per request there too, so this branch only
         # does eager work for the persistent (scheduled) case.
         _admit(capacity, content, vm_hash)
+        # Snapshot before any allocation: a persistent program's volumes may
+        # already exist (host persistence), and a failed create must not
+        # wipe them (see _retire_after_create_failure).
+        had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
         spec, _resources = await build_program_create_vm_spec(vm_hash, content)
         capacity.check_capacity(
             memory_mib=content.resources.memory,
@@ -493,13 +529,11 @@ async def create_vm_execution(
         try:
             await _wait_until_running(supervisor, info.vm_id)
         except Exception:
-            # Readiness failed: retire the half-started VM (nothing worth
-            # keeping from a VM that never ran), but never let a teardown
-            # error mask the original failure.
-            try:
-                await retire_vm(vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
-            except Exception:
-                logger.exception("Teardown of half-started program VM %s failed", vm_hash)
+            # Readiness failed: retire the half-started VM, but never let a
+            # teardown error mask the original failure.
+            await _retire_after_create_failure(
+                vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="program VM"
+            )
             raise
         await persist_record(vm_hash, record)
         return None
@@ -519,6 +553,12 @@ async def create_vm_execution(
         record = registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
         snp_instance = is_snp_instance(content)
         attest_port: int | None = None
+        # Snapshot before any allocation: a persistent instance's volumes may
+        # already exist (host persistence, e.g. a crash-recovery re-create),
+        # and a failed create must not wipe them (see
+        # _retire_after_create_failure). Reused by both except blocks below:
+        # they cover the same create attempt.
+        had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
         try:
             _admit(capacity, content, vm_hash)
             if snp_instance:
@@ -560,9 +600,10 @@ async def create_vm_execution(
             # create never leaves a dangling owner-identity entry behind (a
             # record with no VM the supervisor knows about), and drop any
             # runtime bundle build_snp_instance_spec may have already
-            # extracted before the failure. Nothing is persisted yet, so
-            # this only touches in-memory and staging state.
-            await retire_vm(vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
+            # extracted before the failure.
+            await _retire_after_create_failure(
+                vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="instance"
+            )
             raise
         if info.awaiting_confidential_init:
             # A confidential VM is created but not started: only the owner can
@@ -584,13 +625,10 @@ async def create_vm_execution(
                 await _wait_until_attest_endpoint_listens(supervisor, info.vm_id, attest_port)
         except Exception:
             # Readiness or port-forward setup failed: retire the half-started
-            # VM (records, staging and volumes go: nothing worth keeping from
-            # a VM that never ran), but never let a teardown error mask the
-            # original failure.
-            try:
-                await retire_vm(vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
-            except Exception:
-                logger.exception("Teardown of half-started VM %s failed", vm_hash)
+            # VM, but never let a teardown error mask the original failure.
+            await _retire_after_create_failure(
+                vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="VM"
+            )
             raise
         # Agent persists its own knowledge; the hypervisor object is not
         # touched. Registry rehydration and past-logs owner-auth read the
@@ -608,6 +646,10 @@ async def create_vm_execution(
         # boots an SNP VM immediately (awaiting_confidential_init is never
         # set), so the plain readiness wait applies.
         record = registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
+        # Snapshot before any allocation, same reasoning as the instance path
+        # above; reused by both except blocks below, which cover the same
+        # create attempt.
+        had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
         try:
             _admit(capacity, content, vm_hash)
             spec, attest_port = await build_vprogram_spec(vm_hash, content)
@@ -625,7 +667,9 @@ async def create_vm_execution(
             # build or create failed: retire the early record, and drop any
             # bundle build_vprogram_spec may have already extracted before
             # the failure (e.g. capacity admission fails after staging).
-            await retire_vm(vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
+            await _retire_after_create_failure(
+                vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="V-PROGRAM"
+            )
             raise
         try:
             await _wait_until_running(supervisor, info.vm_id)
@@ -644,12 +688,11 @@ async def create_vm_execution(
                 await _wait_until_attest_endpoint_listens(supervisor, info.vm_id, attest_port)
         except Exception:
             # Readiness or port-forward setup failed: retire the half-started
-            # V-PROGRAM (records, staging and volumes go), but never let a
-            # teardown error mask the original failure.
-            try:
-                await retire_vm(vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
-            except Exception:
-                logger.exception("Teardown of half-started V-PROGRAM %s failed", vm_hash)
+            # V-PROGRAM, but never let a teardown error mask the original
+            # failure.
+            await _retire_after_create_failure(
+                vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="V-PROGRAM"
+            )
             raise
         await persist_record(vm_hash, record)
         return None
@@ -801,6 +844,10 @@ async def _ensure_program_vm(
             await _wait_until_gone(supervisor, vm_id)
 
         try:
+            # Snapshot before any allocation: a persistent program's volumes
+            # may already exist (host persistence, or the recreate just
+            # above), and a failed create must not wipe them.
+            had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
             spec, resources = await build_program_create_vm_spec(vm_hash, content)
             capacity.check_capacity(
                 memory_mib=content.resources.memory,
@@ -818,10 +865,9 @@ async def _ensure_program_vm(
                 await program_client.setup_program(info, content, resources)
             except Exception:
                 await program_client.forget(vm_id)
-                try:
-                    await retire_vm(vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
-                except Exception:
-                    logger.exception("Teardown of half-started program VM %s failed", vm_hash)
+                await _retire_after_create_failure(
+                    vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="program VM"
+                )
                 raise
             await persist_record(vm_hash, record)
             return info

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -40,10 +40,10 @@ from aleph.vm.agent.snp_instance_launch import (
 from aleph.vm.agent.translate import build_create_vm_spec, build_program_create_vm_spec
 from aleph.vm.agent.update_watcher import UpdateWatcher
 from aleph.vm.agent.vm.program_client import ProgramGuestClient
+from aleph.vm.agent.vm.retire import RetireReason, retire_vm
 from aleph.vm.agent.vm_registry import AgentVmRegistry, persist_record
 from aleph.vm.agent.vprogram_launch import (
     build_vprogram_spec,
-    remove_vprogram_staging,
     resolve_vprogram_attestation_port,
 )
 from aleph.vm.conf import settings
@@ -493,9 +493,11 @@ async def create_vm_execution(
         try:
             await _wait_until_running(supervisor, info.vm_id)
         except Exception:
-            registry.forget(vm_hash)
+            # Readiness failed: retire the half-started VM (nothing worth
+            # keeping from a VM that never ran), but never let a teardown
+            # error mask the original failure.
             try:
-                await supervisor.delete_vm(info.vm_id)
+                await retire_vm(vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
             except Exception:
                 logger.exception("Teardown of half-started program VM %s failed", vm_hash)
             raise
@@ -554,16 +556,13 @@ async def create_vm_execution(
                     spec = replace(spec, gpus=resolved_gpus)
             info = await supervisor.create_vm(spec)
         except Exception:
-            # build or create failed: drop the early record so a failed create
-            # never leaves a dangling owner-identity entry behind (a record with no
-            # VM the supervisor knows about). Nothing is persisted yet, so
-            # forgetting the in-memory entry is sufficient.
-            registry.forget(vm_hash)
-            if snp_instance:
-                # build_snp_instance_spec may have already extracted the
-                # runtime bundle (e.g. capacity admission fails after
-                # staging): do not leak it.
-                remove_snp_instance_staging(vm_hash)
+            # build or create failed: retire the early record so a failed
+            # create never leaves a dangling owner-identity entry behind (a
+            # record with no VM the supervisor knows about), and drop any
+            # runtime bundle build_snp_instance_spec may have already
+            # extracted before the failure. Nothing is persisted yet, so
+            # this only touches in-memory and staging state.
+            await retire_vm(vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
             raise
         if info.awaiting_confidential_init:
             # A confidential VM is created but not started: only the owner can
@@ -584,15 +583,14 @@ async def create_vm_execution(
                 # before declaring the create done.
                 await _wait_until_attest_endpoint_listens(supervisor, info.vm_id, attest_port)
         except Exception:
-            # Readiness or port-forward setup failed: tear the half-started VM
-            # down, but never let a teardown error mask the original failure.
-            registry.forget(vm_hash)
+            # Readiness or port-forward setup failed: retire the half-started
+            # VM (records, staging and volumes go: nothing worth keeping from
+            # a VM that never ran), but never let a teardown error mask the
+            # original failure.
             try:
-                await supervisor.delete_vm(info.vm_id)
+                await retire_vm(vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
             except Exception:
                 logger.exception("Teardown of half-started VM %s failed", vm_hash)
-            if snp_instance:
-                remove_snp_instance_staging(vm_hash)
             raise
         # Agent persists its own knowledge; the hypervisor object is not
         # touched. Registry rehydration and past-logs owner-auth read the
@@ -624,10 +622,10 @@ async def create_vm_execution(
             )
             info = await supervisor.create_vm(spec)
         except Exception:
-            registry.forget(vm_hash)
-            # build_vprogram_spec may have already extracted the bundle (e.g.
-            # capacity admission fails after staging): do not leak it.
-            remove_vprogram_staging(vm_hash)
+            # build or create failed: retire the early record, and drop any
+            # bundle build_vprogram_spec may have already extracted before
+            # the failure (e.g. capacity admission fails after staging).
+            await retire_vm(vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
             raise
         try:
             await _wait_until_running(supervisor, info.vm_id)
@@ -645,12 +643,13 @@ async def create_vm_execution(
             if attest_port is not None:
                 await _wait_until_attest_endpoint_listens(supervisor, info.vm_id, attest_port)
         except Exception:
-            registry.forget(vm_hash)
+            # Readiness or port-forward setup failed: retire the half-started
+            # V-PROGRAM (records, staging and volumes go), but never let a
+            # teardown error mask the original failure.
             try:
-                await supervisor.delete_vm(info.vm_id)
+                await retire_vm(vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
             except Exception:
                 logger.exception("Teardown of half-started V-PROGRAM %s failed", vm_hash)
-            remove_vprogram_staging(vm_hash)
             raise
         await persist_record(vm_hash, record)
         return None
@@ -672,10 +671,9 @@ async def create_vm_execution_or_raise_http_error(
     capacity: CapacityManager,
     persistent: bool = False,
 ) -> None:
-    # The spec path tears down and forgets a half-started VM inside
-    # create_vm_execution (registry.forget + supervisor.delete_vm), so this
-    # wrapper only translates failures to HTTP responses. The agent holds no
-    # pool to clean up.
+    # The spec path retires a half-started VM as FAILED_CREATE inside
+    # create_vm_execution, so this wrapper only translates failures to HTTP
+    # responses. The agent holds no pool to clean up.
     try:
         return await create_vm_execution(
             vm_hash=vm_hash, supervisor=supervisor, registry=registry, capacity=capacity, persistent=persistent
@@ -799,10 +797,7 @@ async def _ensure_program_vm(
                 return info
             logger.info("Program VM %s is %s/unconfigured; recreating", vm_hash, info.status.value)
             await program_client.forget(vm_id)
-            try:
-                await supervisor.delete_vm(vm_id)
-            except VmNotFoundError:
-                pass
+            await retire_vm(vm_hash, RetireReason.RECREATE, supervisor=supervisor)
             await _wait_until_gone(supervisor, vm_id)
 
         try:
@@ -822,10 +817,9 @@ async def _ensure_program_vm(
                 info = await _wait_until_running(supervisor, vm_id)
                 await program_client.setup_program(info, content, resources)
             except Exception:
-                registry.forget(vm_hash)
                 await program_client.forget(vm_id)
                 try:
-                    await supervisor.delete_vm(vm_id)
+                    await retire_vm(vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
                 except Exception:
                     logger.exception("Teardown of half-started program VM %s failed", vm_hash)
                 raise
@@ -936,7 +930,9 @@ async def run_code_on_request(vm_hash: ItemHash, path: str, request: web.Request
             # on-demand VM down (it is recreated on a future request); a
             # persistent VM is left for the scheduler to restart.
             if not persistent:
-                await supervisor.delete_vm(vm_id)
+                # An on-demand VM comes back on the next request: RECREATE
+                # keeps its host-port forwards and disks.
+                await retire_vm(vm_hash, RetireReason.RECREATE, supervisor=supervisor)
                 await program_client.forget(vm_id)
 
             return web.Response(
@@ -961,7 +957,10 @@ async def run_code_on_request(vm_hash: ItemHash, path: str, request: web.Request
                 expiry.schedule(vm_id, settings.REUSE_TIMEOUT)
         elif not persistent:
             update_watcher.cancel(vm_id)
-            await supervisor.delete_vm(vm_id)
+            # REUSE_TIMEOUT == 0: tear down after every request, but the same
+            # VM comes back on the next one, so RECREATE keeps its forwards
+            # and disks.
+            await retire_vm(vm_hash, RetireReason.RECREATE, supervisor=supervisor)
             await program_client.forget(vm_id)
 
 
@@ -1040,7 +1039,10 @@ async def run_code_on_event(
                 expiry.schedule(vm_id, settings.REUSE_TIMEOUT)
         elif not persistent:
             update_watcher.cancel(vm_id)
-            await supervisor.delete_vm(vm_id)
+            # REUSE_TIMEOUT == 0: tear down after every event, but the same
+            # VM comes back on the next one, so RECREATE keeps its forwards
+            # and disks.
+            await retire_vm(vm_hash, RetireReason.RECREATE, supervisor=supervisor)
             await program_client.forget(vm_id)
 
 
@@ -1084,10 +1086,10 @@ async def start_persistent_vm(
             await _wait_until_running(supervisor, vm_id)
         else:  # FAILED
             logger.info(f"{vm_hash} in terminal state {info.status}, recreating")
-            # Crash recovery is a delete+recreate cycle, not a dealloc: keep
-            # the persisted host-port forwards (the owner's SSH forward among
-            # them) so the recreated VM reloads the same host ports.
-            await supervisor.delete_vm(vm_id, keep_port_mappings=True)
+            # Crash recovery is a delete+recreate cycle, not a dealloc:
+            # RECREATE keeps the persisted host-port forwards (the owner's
+            # SSH forward among them) and the disks.
+            await retire_vm(vm_hash, RetireReason.RECREATE, supervisor=supervisor)
             info = None
         if info is not None and not info.awaiting_confidential_init:
             # Every branch that kept `info` ends with a RUNNING VM this agent

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -501,9 +501,11 @@ def run():
     app.on_startup.append(_run_migration_reaper)
     app.on_startup.append(_rehydrate_vm_registry)
     app.on_startup.append(log_snp_launch_capability)
-    # After _rehydrate_vm_registry, which fills the live set the reconciler
-    # judges orphans against (on_startup hooks run in append order): a pass on
-    # an empty registry would treat every running VM's volumes as unowned.
+    # After _rehydrate_vm_registry, which fills half of the live set the
+    # reconciler judges orphans against (on_startup hooks run in append
+    # order); the other half is what the supervisor lists, so a VM whose DB
+    # record was lost or is unparseable is still live. The startup pass
+    # refuses to purge at all when neither half can be trusted.
     app.on_startup.append(reconcile_at_startup)
     app.on_startup.append(start_storage_reconcile_task)
     app.on_cleanup.append(stop_storage_reconcile_task)

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -15,6 +15,7 @@ from aiohttp import hdrs, web
 from aiohttp.web_exceptions import HTTPException
 from aiohttp_cors import ResourceOptions, setup
 
+from aleph.vm import storage_pools
 from aleph.vm.agent.capacity import CapacityManager
 from aleph.vm.agent.expiry import ExpiryManager
 from aleph.vm.agent.migration.reaper import reap_orphan_migration_files
@@ -22,6 +23,15 @@ from aleph.vm.agent.update_watcher import UpdateWatcher
 from aleph.vm.agent.vcpu_probe import get_snp_launch_capability
 from aleph.vm.agent.vm.backup import BackupManager
 from aleph.vm.agent.vm.program_client import ProgramGuestClient
+from aleph.vm.agent.vm.reconciler import (
+    live_hashes,
+    make_room,
+    reconcile_at_startup,
+    reconcile_now,
+    start_storage_reconcile_task,
+    stop_storage_reconcile_task,
+)
+from aleph.vm.agent.vm.retire import set_after_gone_hook
 from aleph.vm.agent.vm_registry import AgentVmRegistry, rehydrate_registry
 from aleph.vm.conf import settings
 from aleph.vm.sevclient import SevClient
@@ -491,6 +501,21 @@ def run():
     app.on_startup.append(_run_migration_reaper)
     app.on_startup.append(_rehydrate_vm_registry)
     app.on_startup.append(log_snp_launch_capability)
+    # After _rehydrate_vm_registry, which fills the live set the reconciler
+    # judges orphans against (on_startup hooks run in append order): a pass on
+    # an empty registry would treat every running VM's volumes as unowned.
+    app.on_startup.append(reconcile_at_startup)
+    app.on_startup.append(start_storage_reconcile_task)
+    app.on_cleanup.append(stop_storage_reconcile_task)
+    # Placement asks the reconciler to evict retained volumes when a create
+    # does not fit, and a GONE under keep enforces the retention budget right
+    # away instead of waiting for the next periodic pass. Both are module
+    # hooks: aleph.vm.storage_pools and retire.py cannot import the
+    # reconciler, so the app is what wires them together.
+    storage_pools.set_room_maker(
+        lambda pool, needed: make_room(pool, needed, live=live_hashes(app["vm_registry"])),
+    )
+    set_after_gone_hook(lambda: reconcile_now(app))
     app.on_startup.append(start_node_hash_discovery)
     app.on_cleanup.append(stop_node_hash_discovery)
 

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -24,7 +24,7 @@ from aleph.vm.agent.vcpu_probe import get_snp_launch_capability
 from aleph.vm.agent.vm.backup import BackupManager
 from aleph.vm.agent.vm.program_client import ProgramGuestClient
 from aleph.vm.agent.vm.reconciler import (
-    live_hashes,
+    known_live_hashes,
     make_room,
     reconcile_at_startup,
     reconcile_now,
@@ -515,7 +515,7 @@ def run():
     # hooks: aleph.vm.storage_pools and retire.py cannot import the
     # reconciler, so the app is what wires them together.
     storage_pools.set_room_maker(
-        lambda pool, needed: make_room(pool, needed, live=live_hashes(app["vm_registry"])),
+        lambda pool, needed: make_room(pool, needed, live=known_live_hashes(app["vm_registry"])),
     )
     set_after_gone_hook(lambda: reconcile_now(app))
     app.on_startup.append(start_node_hash_discovery)

--- a/src/aleph/vm/agent/tasks.py
+++ b/src/aleph/vm/agent/tasks.py
@@ -27,16 +27,14 @@ from aleph_message.status import MessageStatus
 from yarl import URL
 
 from aleph.vm.agent.haproxy_sync import sync_domain_mappings
-from aleph.vm.agent.metrics import delete_records_for_vm
 from aleph.vm.agent.run import reconcile_port_forwards
-from aleph.vm.agent.snp_instance_launch import remove_snp_instance_staging
 from aleph.vm.agent.utils import (
     format_cost,
     get_community_wallet_address,
     is_after_community_wallet_start,
 )
+from aleph.vm.agent.vm.retire import RetireReason, retire_vm
 from aleph.vm.agent.vm_registry import AgentVmRegistry
-from aleph.vm.agent.vprogram_launch import remove_vprogram_staging
 from aleph.vm.conf import settings
 from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.supervisor_interface.errors import VmNotFoundError
@@ -363,6 +361,9 @@ async def check_payment(supervisor: Supervisor, registry: AgentVmRegistry):
     funds in the wallet or inadequate payment stream coverage. Handles forgotten VMs
     balance checks for the "hold" tier, and stream flow validation for the "superfluid" tier
     stopping executions as needed to maintain compliance.
+
+    Stopping a VM here means retiring it as GONE: the record is dropped and the
+    disks follow VOLUME_RETENTION.
     """
     # Take a single snapshot of all running VMs from the supervisor.
     infos = await supervisor.list_vms()
@@ -401,11 +402,7 @@ async def check_payment(supervisor: Supervisor, registry: AgentVmRegistry):
                 message_status,
             )
             del _terminal_strike_count[key]
-            await supervisor.delete_vm(VmId(str(vm_hash)))
-            registry.forget(vm_hash)
-            await delete_records_for_vm(str(vm_hash))
-            remove_vprogram_staging(vm_hash)
-            remove_snp_instance_staging(vm_hash)
+            await retire_vm(vm_hash, RetireReason.GONE, supervisor=supervisor, registry=registry)
         else:
             # Status is healthy — reset any previous strikes
             _terminal_strike_count.pop(str(vm_hash), None)
@@ -425,10 +422,7 @@ async def check_payment(supervisor: Supervisor, registry: AgentVmRegistry):
             while vm_infos and balance < (required_balance + settings.PAYMENT_BUFFER):
                 last_info = vm_infos.pop(-1)
                 logger.debug(f"Stopping {last_info.vm_id} due to insufficient balance")
-                try:
-                    await supervisor.delete_vm(last_info.vm_id)
-                except VmNotFoundError:
-                    pass
+                await retire_vm(ItemHash(last_info.vm_id), RetireReason.GONE, supervisor=supervisor, registry=registry)
                 required_balance = await compute_required_balance([ItemHash(i.vm_id) for i in vm_infos])
 
     community_wallet = await get_community_wallet_address()
@@ -452,10 +446,7 @@ async def check_payment(supervisor: Supervisor, registry: AgentVmRegistry):
             while vm_infos and balance < (required_credits + settings.PAYMENT_BUFFER):
                 last_info = vm_infos.pop(-1)
                 logger.debug(f"Stopping {last_info.vm_id} due to insufficient credit balance")
-                try:
-                    await supervisor.delete_vm(last_info.vm_id)
-                except VmNotFoundError:
-                    pass
+                await retire_vm(ItemHash(last_info.vm_id), RetireReason.GONE, supervisor=supervisor, registry=registry)
                 required_credits = await compute_required_credit_balance([ItemHash(i.vm_id) for i in vm_infos])
 
     # Check if the balance held in the wallet is sufficient stream tier resources
@@ -513,10 +504,7 @@ async def check_payment(supervisor: Supervisor, registry: AgentVmRegistry):
                 # Stop executions until the required stream is reached
                 last_info = vm_infos.pop(-1)
                 logger.info(f"Stopping {last_info.vm_id} of {execution_address} due to insufficient stream")
-                try:
-                    await supervisor.delete_vm(last_info.vm_id)
-                except VmNotFoundError:
-                    pass
+                await retire_vm(ItemHash(last_info.vm_id), RetireReason.GONE, supervisor=supervisor, registry=registry)
 
 
 async def start_payment_monitoring_task(app: web.Application):

--- a/src/aleph/vm/agent/tasks.py
+++ b/src/aleph/vm/agent/tasks.py
@@ -12,6 +12,7 @@ from typing import TypeVar
 import aiohttp
 import pydantic
 from aiohttp import web
+from aleph_message.exceptions import UnknownHashError
 from aleph_message.models import (
     AggregateMessage,
     AlephMessage,
@@ -365,8 +366,18 @@ async def check_payment(supervisor: Supervisor, registry: AgentVmRegistry):
     Stopping a VM here means retiring it as GONE: the record is dropped and the
     disks follow VOLUME_RETENTION.
     """
-    # Take a single snapshot of all running VMs from the supervisor.
-    infos = await supervisor.list_vms()
+    # Take a single snapshot of all running VMs from the supervisor, dropping
+    # ids that are not item hashes the way the reconciler's supervisor_hashes
+    # does: one unparseable id must not take the whole payment sweep down,
+    # and it cannot name a payment-checked VM anyway.
+    infos = []
+    for info in await supervisor.list_vms():
+        try:
+            ItemHash(str(info.vm_id))
+        except (UnknownHashError, ValueError):
+            logger.warning("Skipping payment checks for %r: its id is not an item hash", info.vm_id)
+            continue
+        infos.append(info)
 
     # Check if the executions continues existing or are forgotten before checking the payment
     # this is actually the main workflow for properly stopping PAYG instances, a user agent would stop the payment stream

--- a/src/aleph/vm/agent/update_watcher.py
+++ b/src/aleph/vm/agent/update_watcher.py
@@ -10,9 +10,9 @@ from aleph_message.models import (
 )
 
 from aleph.vm.agent.pubsub import PubSub
+from aleph.vm.agent.vm.retire import RetireReason, retire_vm
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.supervisor_interface.abc import Supervisor
-from aleph.vm.supervisor_interface.errors import VmNotFoundError
 from aleph.vm.supervisor_interface.types import VmId
 
 logger = logging.getLogger(__name__)
@@ -88,12 +88,9 @@ class UpdateWatcher:
             await pubsub.msubscribe(*refs)
             logger.info("Update received for %s, reaping", vm_id)
             # An update reap is a delete+recreate cycle, not a dealloc: the VM
-            # is redeployed with the updated message, so keep the persisted
-            # host-port forwards for the recreated VM to reload.
-            await self.supervisor.delete_vm(vm_id, keep_port_mappings=True)
-            reaped = True
-        except VmNotFoundError:
-            logger.debug("Update-watch: VM %s already gone", vm_id)
+            # is redeployed with the updated message, so RECREATE keeps the
+            # persisted host-port forwards for the recreated VM to reload.
+            await retire_vm(str(vm_id), RetireReason.RECREATE, supervisor=self.supervisor)
             reaped = True
         except asyncio.CancelledError:
             raise

--- a/src/aleph/vm/agent/views/migration.py
+++ b/src/aleph/vm/agent/views/migration.py
@@ -292,6 +292,7 @@ async def migration_import(request: web.Request) -> web.Response:
             job,
             supervisor,
             capacity=request.app["capacity"],
+            registry=request.app["vm_registry"],
             disk_files=params.disk_files,
             export_token=params.export_token,
             prior_task=prior_task,

--- a/src/aleph/vm/agent/views/migration.py
+++ b/src/aleph/vm/agent/views/migration.py
@@ -31,6 +31,7 @@ from aleph.vm.agent.migration.jobs import (
     import_jobs,
 )
 from aleph.vm.agent.migration.runner import run_export, run_import
+from aleph.vm.agent.vm.retire import RetireReason, retire_vm
 from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.supervisor_interface.errors import VmNotFoundError
 from aleph.vm.supervisor_interface.types import (
@@ -386,13 +387,11 @@ async def migration_cleanup(request: web.Request) -> web.Response:
     try:
         if job.ttl_task is not None and not job.ttl_task.done():
             job.ttl_task.cancel()
-        # The source VM has migrated away: drop it from the pool through the
-        # standard lifecycle RPC, which stops it, forgets the definition and
-        # removes the controller config. The disks are deliberately left in
-        # place: the destination owns the data now, and DeleteVm never touches
-        # storage anyway (the agent owns it). They are the operator's to
-        # reclaim once the migration is confirmed good.
-        await supervisor.delete_vm(VmId(str(vm_hash)))
+        # The source VM has migrated away: the destination owns the data now.
+        # Retire it as GONE: the supervisor stops it and forgets the
+        # definition, the agent drops the record and applies
+        # VOLUME_RETENTION to the disks it left behind.
+        await retire_vm(vm_hash, RetireReason.GONE, supervisor=supervisor, registry=request.app["vm_registry"])
         for path in job.export_paths:
             try:
                 Path(path).unlink(missing_ok=True)

--- a/src/aleph/vm/agent/views/operator.py
+++ b/src/aleph/vm/agent/views/operator.py
@@ -29,7 +29,7 @@ from aleph.vm.agent.views.authentication import (
 from aleph.vm.agent.vm.backup import BackupManager
 from aleph.vm.agent.vm.downloader import recreate_vm_volumes
 from aleph.vm.agent.vm.purge import purge_vm_staging, purge_vm_volumes
-from aleph.vm.agent.vm.reclaimable import is_reclaimable
+from aleph.vm.agent.vm.reclaimable import retained_marker
 from aleph.vm.agent.vm.retire import RetireReason, retire_vm
 from aleph.vm.agent.vm_registry import AgentVmRecord
 from aleph.vm.backup.archive import InsufficientDiskSpaceError
@@ -225,6 +225,18 @@ async def check_owner_permissions(authenticated_sender: str, message: BaseExecut
     return False
 
 
+def is_owner_address(authenticated_sender: str, address: str) -> bool:
+    """The owner half of ``is_sender_authorized``: does the address the
+    signature resolved to (``require_jwk_authentication`` did the
+    cryptography) match the VM's owner address?
+
+    Split out so the erase endpoint can apply the same rule to the owner
+    address carried by a ``.reclaimable`` marker, where there is no message
+    left to check (and therefore no delegation aggregate to consult either).
+    """
+    return bool(address) and authenticated_sender.lower() == address.lower()
+
+
 async def is_sender_authorized(authenticated_sender: str, message: BaseExecutableContent) -> bool:
     """
     Check if the authenticated sender is authorized to access the message resources.
@@ -241,7 +253,7 @@ async def is_sender_authorized(authenticated_sender: str, message: BaseExecutabl
         True if authorized, False otherwise
     """
     # Check if sender is the owner
-    if authenticated_sender.lower() == message.address.lower():
+    if is_owner_address(authenticated_sender, message.address):
         return True
 
     # Check if sender has delegation permissions
@@ -670,18 +682,27 @@ async def operate_erase(request: web.Request, authenticated_sender: str) -> web.
     vm_hash = get_itemhash_or_400(request.match_info)
     with set_vm_for_logging(vm_hash=vm_hash):
         record = request.app["vm_registry"].get(vm_hash)
-        retained = record is None and await asyncio.to_thread(is_reclaimable, str(vm_hash))
-        if record is None and not retained:
+        marker = None if record is not None else await asyncio.to_thread(retained_marker, str(vm_hash))
+        if record is None and marker is None:
             raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_hash}")
         message = record.message if record is not None else await _owner_auth_message(request, vm_hash)
-        if message is None:
-            # Retained disks, but nothing left that says who owns them:
-            # ownership is proven against the message, and this endpoint will
-            # not wipe on anybody's word. The node operator reclaims those
-            # through the agent's own storage CLI.
-            raise web.HTTPForbidden(body=f"No owner record for {vm_hash}: its retained data cannot be erased here")
-        if not await is_sender_authorized(authenticated_sender, message):
-            return web.Response(status=403, body="Unauthorized sender")
+        if message is not None:
+            if not await is_sender_authorized(authenticated_sender, message):
+                return web.Response(status=403, body="Unauthorized sender")
+        elif marker is not None and marker.owner:
+            # Retained disks and no message anywhere: GONE forgot the registry
+            # record and deleted the DB rows, which is the normal state of a
+            # retained VM. The marker's owner address is what is left, and the
+            # signature has already been resolved to an address by
+            # require_jwk_authentication, so the same owner rule applies.
+            if not is_owner_address(authenticated_sender, marker.owner):
+                return web.Response(status=403, body="Unauthorized sender")
+        else:
+            # A marker with no owner (written before the field existed, or an
+            # orphan directory for a VM whose message this node never held):
+            # nothing can prove ownership, so nothing is wiped on request. The
+            # operator reclaims those through the agent's own storage CLI.
+            raise web.HTTPForbidden(body=f"No owner recorded for {vm_hash}: its retained data cannot be erased here")
 
         logger.info(f"Erasing {vm_hash}")
         supervisor: Supervisor = request.app["supervisor"]

--- a/src/aleph/vm/agent/views/operator.py
+++ b/src/aleph/vm/agent/views/operator.py
@@ -28,7 +28,8 @@ from aleph.vm.agent.views.authentication import (
 )
 from aleph.vm.agent.vm.backup import BackupManager
 from aleph.vm.agent.vm.downloader import recreate_vm_volumes
-from aleph.vm.agent.vm.purge import purge_vm_staging, purge_vm_storage, purge_vm_volumes
+from aleph.vm.agent.vm.purge import purge_vm_staging, purge_vm_volumes
+from aleph.vm.agent.vm.retire import RetireReason, retire_vm
 from aleph.vm.agent.vm_registry import AgentVmRecord
 from aleph.vm.backup.archive import InsufficientDiskSpaceError
 from aleph.vm.backup.staging import download_volume_by_ref, get_backup_directory
@@ -504,7 +505,10 @@ async def operate_stop(request: web.Request, authenticated_sender: str) -> web.R
                 if record.persistent:
                     await supervisor.stop_vm(vm_id)
                 else:
-                    await supervisor.delete_vm(vm_id)
+                    # Ephemeral VMs have no stop state: the stop cycle is a
+                    # delete + recreate, so RECREATE keeps its port forwards
+                    # and disks for the VM that comes back.
+                    await retire_vm(vm_hash, RetireReason.RECREATE, supervisor=supervisor)
                 request.app["expiry"].cancel(vm_id)
                 request.app["update_watcher"].cancel(vm_id)
                 return web.Response(status=200, body=f"Stopped VM with ref {vm_hash}")
@@ -534,7 +538,9 @@ async def operate_reboot(request: web.Request, authenticated_sender: str) -> web
                 if record.persistent:
                     await supervisor.reboot_vm(vm_id)
                 else:
-                    await supervisor.delete_vm(vm_id)
+                    # Ephemeral reboot is also a delete + recreate cycle:
+                    # RECREATE keeps its port forwards and disks.
+                    await retire_vm(vm_hash, RetireReason.RECREATE, supervisor=supervisor)
                     request.app["expiry"].cancel(vm_id)
                     request.app["update_watcher"].cancel(vm_id)
                     await create_vm_execution_or_raise_http_error(
@@ -657,19 +663,15 @@ async def operate_erase(request: web.Request, authenticated_sender: str) -> web.
 
         logger.info(f"Erasing {vm_hash}")
         supervisor: Supervisor = request.app["supervisor"]
+        vm_id = VmId(str(vm_hash))
         try:
-            await supervisor.delete_vm(VmId(str(vm_hash)))
-            request.app["expiry"].cancel(VmId(str(vm_hash)))
-            request.app["update_watcher"].cancel(VmId(str(vm_hash)))
+            await supervisor.get_vm(vm_id)
         except VmNotFoundError:
             raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_hash}") from None
-        request.app["vm_registry"].forget(vm_hash)
-        await metrics.delete_records_for_vm(str(vm_hash))
-        # DeleteVm has released the supervisor's handles on the disks; the
-        # bytes are the agent's to delete, since the agent allocated them.
-        # This erases the rootfs too: an owner asking to erase their VM's data
-        # means all of it, and the rootfs is where most of it lives.
-        await asyncio.to_thread(purge_vm_storage, vm_hash)
+        request.app["expiry"].cancel(vm_id)
+        request.app["update_watcher"].cancel(vm_id)
+        # The owner asked for a wipe: ERASE purges regardless of VOLUME_RETENTION.
+        await retire_vm(vm_hash, RetireReason.ERASE, supervisor=supervisor, registry=request.app["vm_registry"])
         request.app["backups"].forget(str(vm_hash))
         return web.Response(status=200, body=f"Erased VM with ref {vm_hash}")
 
@@ -749,9 +751,11 @@ async def operate_reinstall(request: web.Request, authenticated_sender: str) -> 
                 # Ephemeral and confidential VMs are rebuilt from scratch: a
                 # confidential rootfs is measured and staged, so its bundle
                 # must be re-staged and its owner must re-attest anyway. This
-                # is a delete+recreate cycle, so the persisted host ports are
-                # kept for the recreated VM to reload.
-                await supervisor.delete_vm(vm_id, keep_port_mappings=True)
+                # is a delete+recreate cycle: RECREATE keeps the persisted
+                # host ports for the recreated VM to reload. The volume and
+                # staging purge below is a deliberate partial purge on top,
+                # with the registry record kept for the rebuild.
+                await retire_vm(vm_hash, RetireReason.RECREATE, supervisor=supervisor)
                 await asyncio.to_thread(purge_vm_volumes, vm_hash, include_data_volumes=include_data_volumes)
                 purge_vm_staging(vm_hash)
                 # The registry record is deliberately left in place: the create

--- a/src/aleph/vm/agent/views/operator.py
+++ b/src/aleph/vm/agent/views/operator.py
@@ -29,6 +29,7 @@ from aleph.vm.agent.views.authentication import (
 from aleph.vm.agent.vm.backup import BackupManager
 from aleph.vm.agent.vm.downloader import recreate_vm_volumes
 from aleph.vm.agent.vm.purge import purge_vm_staging, purge_vm_volumes
+from aleph.vm.agent.vm.reclaimable import is_reclaimable
 from aleph.vm.agent.vm.retire import RetireReason, retire_vm
 from aleph.vm.agent.vm_registry import AgentVmRecord
 from aleph.vm.backup.archive import InsufficientDiskSpaceError
@@ -251,10 +252,14 @@ async def is_sender_authorized(authenticated_sender: str, message: BaseExecutabl
     return False
 
 
-async def _logs_auth_message(request: web.Request, vm_hash: ItemHash):
-    """Message for owner-auth on the logs endpoints: registry first, then the
-    agent DB. Past executions keep their DB record: nothing deletes it today
-    (a follow-up adds explicit deletion on permanent dealloc)."""
+async def _owner_auth_message(request: web.Request, vm_hash: ItemHash):
+    """The message owner-auth is checked against: the agent registry first,
+    then the agent DB.
+
+    Used by the logs endpoints, whose past executions keep their DB record,
+    and by the erase endpoint, which must still answer for a VM the registry
+    has already dropped. Returns None when the node holds no message for the
+    hash, which is not the same as "no data on disk" (see operate_erase)."""
     record = request.app["vm_registry"].get(vm_hash)
     if record is not None:
         return record.message
@@ -276,7 +281,7 @@ async def stream_logs(request: web.Request) -> web.StreamResponse:
     """
     vm_hash = get_itemhash_or_400(request.match_info)
     with set_vm_for_logging(vm_hash=vm_hash):
-        message = await _logs_auth_message(request, vm_hash)
+        message = await _owner_auth_message(request, vm_hash)
         if message is None:
             raise web.HTTPNotFound(body=f"No execution found for VM {vm_hash}")
 
@@ -344,7 +349,7 @@ async def operate_logs_json(request: web.Request, authenticated_sender: str) -> 
     """Logs of a VM (not streaming) as json"""
     vm_hash = get_itemhash_or_400(request.match_info)
     with set_vm_for_logging(vm_hash=vm_hash):
-        message = await _logs_auth_message(request, vm_hash)
+        message = await _owner_auth_message(request, vm_hash)
         if message is None:
             raise aiohttp.web_exceptions.HTTPNotFound(body="No execution found for this VM")
         if not await is_sender_authorized(authenticated_sender, message):
@@ -654,20 +659,33 @@ async def operate_confidential_inject_secret(request: web.Request, authenticated
 async def operate_erase(request: web.Request, authenticated_sender: str) -> web.Response:
     """Delete all data stored by a virtual machine.
     Stop the virtual machine first if needed.
+
+    An erase is answered as long as the node still holds something for the
+    hash: a registry record, or a retained (``.reclaimable``) directory the
+    owner is entitled to wipe. The supervisor is not asked whether it knows
+    the VM: it forgets a VM on restart or after a delete, while the disks
+    stay, and a 404 there would leave the owner's data on the node with no
+    way to remove it (retire_vm swallows the supervisor's VmNotFoundError).
     """
     vm_hash = get_itemhash_or_400(request.match_info)
     with set_vm_for_logging(vm_hash=vm_hash):
-        record = get_agent_record_or_404(request, vm_hash)
-        if not await is_sender_authorized(authenticated_sender, record.message):
+        record = request.app["vm_registry"].get(vm_hash)
+        retained = record is None and await asyncio.to_thread(is_reclaimable, str(vm_hash))
+        if record is None and not retained:
+            raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_hash}")
+        message = record.message if record is not None else await _owner_auth_message(request, vm_hash)
+        if message is None:
+            # Retained disks, but nothing left that says who owns them:
+            # ownership is proven against the message, and this endpoint will
+            # not wipe on anybody's word. The node operator reclaims those
+            # through the agent's own storage CLI.
+            raise web.HTTPForbidden(body=f"No owner record for {vm_hash}: its retained data cannot be erased here")
+        if not await is_sender_authorized(authenticated_sender, message):
             return web.Response(status=403, body="Unauthorized sender")
 
         logger.info(f"Erasing {vm_hash}")
         supervisor: Supervisor = request.app["supervisor"]
         vm_id = VmId(str(vm_hash))
-        try:
-            await supervisor.get_vm(vm_id)
-        except VmNotFoundError:
-            raise web.HTTPNotFound(body=f"No virtual machine with ref {vm_hash}") from None
         request.app["expiry"].cancel(vm_id)
         request.app["update_watcher"].cancel(vm_id)
         # The owner asked for a wipe: ERASE purges regardless of VOLUME_RETENTION.

--- a/src/aleph/vm/agent/views/operator.py
+++ b/src/aleph/vm/agent/views/operator.py
@@ -30,6 +30,7 @@ from aleph.vm.agent.vm.backup import BackupManager
 from aleph.vm.agent.vm.downloader import recreate_vm_volumes
 from aleph.vm.agent.vm.purge import purge_vm_staging, purge_vm_volumes
 from aleph.vm.agent.vm.reclaimable import retained_marker
+from aleph.vm.agent.vm.reconciler import creating
 from aleph.vm.agent.vm.retire import RetireReason, retire_vm
 from aleph.vm.agent.vm_registry import AgentVmRecord
 from aleph.vm.backup.archive import InsufficientDiskSpaceError
@@ -769,8 +770,12 @@ async def operate_reinstall(request: web.Request, authenticated_sender: str) -> 
                 deleted = await asyncio.to_thread(purge_vm_volumes, vm_hash, include_data_volumes=include_data_volumes)
                 try:
                     # Rebuild each volume on the pool it was deleted from: the
-                    # running VM's spec still names those paths.
-                    with pin_layout(str(vm_hash), deleted):
+                    # running VM's spec still names those paths. This rebuild
+                    # is a create path, so it runs under creating(): the part
+                    # sweep spares only namespaces inside the guard (the
+                    # registry record this reinstall keeps does not shield its
+                    # downloads), and the adopt() on entry is a no-op here.
+                    with creating(str(vm_hash)), pin_layout(str(vm_hash), deleted):
                         await recreate_vm_volumes(record.message, str(vm_hash))
                     await supervisor.start_vm(vm_id)
                 except VmNotFoundError:

--- a/src/aleph/vm/agent/vm/backup.py
+++ b/src/aleph/vm/agent/vm/backup.py
@@ -30,9 +30,8 @@ from typing import BinaryIO
 
 from aleph_message.models import ItemHash
 
-from aleph.vm.agent.vm.purge import ROOTFS_STEM, iter_volume_files
+from aleph.vm.agent.vm.purge import ROOTFS_STEM, _checked_namespace, iter_volume_files
 from aleph.vm.backup.archive import (
-    BACKUP_TTL_HOURS,
     backup_metadata,
     check_disk_space_for_multiple,
     cleanup_expired_backups,
@@ -81,10 +80,15 @@ def purge_vm_backups(vm_hash: ItemHash | str) -> int:
 
     Called by retire_vm for every reason but RECREATE: a VM that is gone,
     erased or never committed has no owner left to hold its backups.
+
+    The hash goes through the same validation as every other delete
+    primitive: it is interpolated into a glob pattern here, and a delete path
+    never builds a pattern or a path out of an unchecked name.
     """
+    namespace = _checked_namespace(vm_hash)
     backup_dir = get_backup_directory()
     removed = 0
-    for archive in backup_dir.glob(f"{vm_hash}-*.tar"):
+    for archive in backup_dir.glob(f"{namespace}-*.tar"):
         archive.with_suffix(".tar.sha256").unlink(missing_ok=True)
         archive.with_suffix(".tar.meta.json").unlink(missing_ok=True)
         archive.unlink(missing_ok=True)
@@ -96,26 +100,11 @@ def sweep_expired_backups(now: datetime) -> int:
     """Remove every archive (of any VM) past the backup TTL, evaluated at
     ``now``.
 
-    Same TTL as ``cleanup_expired_backups``, but driven by an explicit
-    timestamp instead of the wall clock: the reconcile pass threads one
-    ``now`` through every sweep it runs, so a run is deterministic and does
-    not drift between the archives it looks at.
+    The reconciler's backup pass: the same sweep ``start_backup`` runs, on
+    the same TTL and through the same helper, but driven by the ``now`` the
+    pass threads through its other sweeps instead of by the wall clock.
     """
-    backup_dir = get_backup_directory()
-    cutoff = now.timestamp() - BACKUP_TTL_HOURS * 3600
-    removed = 0
-    for partial in backup_dir.glob("*.tar.partial"):
-        if partial.stat().st_mtime < cutoff:
-            partial.unlink()
-            logger.info("Deleted stale partial backup %s", partial.name)
-    for tar_file in backup_dir.glob("*.tar"):
-        if tar_file.stat().st_mtime < cutoff:
-            tar_file.with_suffix(".tar.sha256").unlink(missing_ok=True)
-            tar_file.with_suffix(".tar.meta.json").unlink(missing_ok=True)
-            tar_file.unlink()
-            logger.info("Deleted expired backup %s", tar_file.name)
-            removed += 1
-    return removed
+    return cleanup_expired_backups(get_backup_directory(), now=now.timestamp())
 
 
 @dataclass(frozen=True)

--- a/src/aleph/vm/agent/vm/backup.py
+++ b/src/aleph/vm/agent/vm/backup.py
@@ -28,8 +28,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import BinaryIO
 
+from aleph_message.models import ItemHash
+
 from aleph.vm.agent.vm.purge import ROOTFS_STEM, iter_volume_files
 from aleph.vm.backup.archive import (
+    BACKUP_TTL_HOURS,
     backup_metadata,
     check_disk_space_for_multiple,
     cleanup_expired_backups,
@@ -71,6 +74,48 @@ def validate_backup_id(vm_hash: str, backup_id: str) -> None:
     malformed = not backup_id or "/" in backup_id or "\\" in backup_id or ".." in backup_id
     if malformed or not backup_id.startswith(f"{vm_hash}-"):
         raise BackupNotFoundError(backup_id)
+
+
+def purge_vm_backups(vm_hash: ItemHash | str) -> int:
+    """Delete every backup archive of a VM (the .tar and its sidecars).
+
+    Called by retire_vm for every reason but RECREATE: a VM that is gone,
+    erased or never committed has no owner left to hold its backups.
+    """
+    backup_dir = get_backup_directory()
+    removed = 0
+    for archive in backup_dir.glob(f"{vm_hash}-*.tar"):
+        archive.with_suffix(".tar.sha256").unlink(missing_ok=True)
+        archive.with_suffix(".tar.meta.json").unlink(missing_ok=True)
+        archive.unlink(missing_ok=True)
+        removed += 1
+    return removed
+
+
+def sweep_expired_backups(now: datetime) -> int:
+    """Remove every archive (of any VM) past the backup TTL, evaluated at
+    ``now``.
+
+    Same TTL as ``cleanup_expired_backups``, but driven by an explicit
+    timestamp instead of the wall clock: the reconcile pass threads one
+    ``now`` through every sweep it runs, so a run is deterministic and does
+    not drift between the archives it looks at.
+    """
+    backup_dir = get_backup_directory()
+    cutoff = now.timestamp() - BACKUP_TTL_HOURS * 3600
+    removed = 0
+    for partial in backup_dir.glob("*.tar.partial"):
+        if partial.stat().st_mtime < cutoff:
+            partial.unlink()
+            logger.info("Deleted stale partial backup %s", partial.name)
+    for tar_file in backup_dir.glob("*.tar"):
+        if tar_file.stat().st_mtime < cutoff:
+            tar_file.with_suffix(".tar.sha256").unlink(missing_ok=True)
+            tar_file.with_suffix(".tar.meta.json").unlink(missing_ok=True)
+            tar_file.unlink()
+            logger.info("Deleted expired backup %s", tar_file.name)
+            removed += 1
+    return removed
 
 
 @dataclass(frozen=True)

--- a/src/aleph/vm/agent/vm/downloader.py
+++ b/src/aleph/vm/agent/vm/downloader.py
@@ -67,7 +67,10 @@ async def _make_writable_volume(
         msg = f"Format {parent_format} for {volume} unhandled by QEMU hypervisor"
         raise VmSetupError(msg)
 
-    dest_path = volume_path_for(namespace, f"{volume_name}.qcow2", volume.size_mib)
+    # Off the loop: placement reads every pool's free space and can call the
+    # reclaimer's evictor (storage_pools.set_room_maker), which walks pools and
+    # removes directories.
+    dest_path = await asyncio.to_thread(volume_path_for, namespace, f"{volume_name}.qcow2", volume.size_mib)
     # Do not override if user asked for host persistence.
     if dest_path.exists() and volume.persistence == VolumePersistence.host:
         return dest_path

--- a/src/aleph/vm/agent/vm/purge.py
+++ b/src/aleph/vm/agent/vm/purge.py
@@ -86,6 +86,17 @@ def iter_volume_files(
             yield entry
 
 
+def vm_has_volumes(vm_hash: ItemHash | str) -> bool:
+    """True when the VM already owns at least one volume file on disk.
+
+    Used by the create paths to tell a re-create (the VM's volumes already
+    exist, e.g. host-persistent storage that a failed create must not wipe)
+    apart from a fresh create (nothing allocated yet, safe to purge on
+    failure).
+    """
+    return any(iter_volume_files(vm_hash))
+
+
 def _held_by_device_mapper(namespace: str, volume: Path) -> bool:
     """True when ``volume`` is the backing file of a live dm target."""
     if volume.suffix != ".btrfs":

--- a/src/aleph/vm/agent/vm/purge.py
+++ b/src/aleph/vm/agent/vm/purge.py
@@ -184,6 +184,16 @@ def purge_vm_storage(vm_hash: ItemHash | str) -> int:
         except OSError:
             logger.warning("Failed to remove volume directory %s", volumes_dir, exc_info=True)
 
+    purge_vm_side_dirs(namespace)
+
+    return deleted
+
+
+def purge_vm_side_dirs(vm_hash: ItemHash | str) -> None:
+    """Delete the per-VM directories that are not volumes: the confidential
+    session directory and the staging directories. Rebuilt by the next
+    create, so a retained (reclaimable) VM keeps only its volumes."""
+    namespace = _checked_namespace(vm_hash)
     if settings.CONFIDENTIAL_SESSION_DIRECTORY:
         session_dir = Path(settings.CONFIDENTIAL_SESSION_DIRECTORY) / namespace
         if session_dir.exists():
@@ -192,7 +202,4 @@ def purge_vm_storage(vm_hash: ItemHash | str) -> int:
                 logger.info("Removed the confidential session directory of %s", namespace)
             except OSError:
                 logger.warning("Failed to remove the session directory of %s", namespace, exc_info=True)
-
     purge_vm_staging(namespace)
-
-    return deleted

--- a/src/aleph/vm/agent/vm/purge.py
+++ b/src/aleph/vm/agent/vm/purge.py
@@ -86,6 +86,9 @@ def iter_volume_files(
             yield entry
 
 
+_PARTIAL_SUFFIXES = frozenset({".part", ".tmp"})
+
+
 def vm_has_volumes(vm_hash: ItemHash | str) -> bool:
     """True when the VM already owns at least one volume file on disk.
 
@@ -93,8 +96,13 @@ def vm_has_volumes(vm_hash: ItemHash | str) -> bool:
     exist, e.g. host-persistent storage that a failed create must not wipe)
     apart from a fresh create (nothing allocated yet, safe to purge on
     failure).
+
+    A half-written file (``.part``, ``.tmp``) from an earlier attempt is not
+    a volume: the downloader only renames it into place once complete, and
+    counting it would make a fresh create look like a re-create, keeping a
+    record and a directory that hold nothing bootable.
     """
-    return any(iter_volume_files(vm_hash))
+    return any(volume.suffix not in _PARTIAL_SUFFIXES for volume in iter_volume_files(vm_hash))
 
 
 def _held_by_device_mapper(namespace: str, volume: Path) -> bool:

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -1,0 +1,173 @@
+"""The ``.reclaimable`` marker: a VM directory nobody owns any more.
+
+A ``{pool}/{vm_hash}/`` directory without a marker belongs to a live VM. When
+the registry record drops at GONE under VOLUME_RETENTION=keep, the marker
+records what the registry no longer will: that the directory is unowned (so
+the reconciler may evict it and does not mistake it for a crashed create),
+since when (eviction order), how big it is (budget), and which cache entries
+its volumes depend on (so the cache pass does not evict a parent image from
+under a retained disk). The filesystem is the source of truth: there is no
+ledger, and restoring is deleting the marker.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import Iterator
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+from aleph_message.models import ExecutableContent, InstanceContent
+
+from aleph.vm.agent.vm.purge import _checked_namespace
+from aleph.vm.storage_pools import iter_namespace_dirs
+
+logger = logging.getLogger(__name__)
+
+MARKER_NAME = ".reclaimable"
+MARKER_VERSION = 1
+
+ReclaimReason = Literal["gone", "orphan"]
+
+
+@dataclass(frozen=True)
+class ReclaimableMarker:
+    reclaimable_since: datetime
+    reason: ReclaimReason
+    size_bytes: int
+    depends_on: tuple[str, ...] = ()
+    version: int = MARKER_VERSION
+
+    def to_json(self) -> str:
+        data = asdict(self)
+        data["reclaimable_since"] = self.reclaimable_since.isoformat()
+        data["depends_on"] = list(self.depends_on)
+        return json.dumps(data, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, text: str) -> ReclaimableMarker:
+        data = json.loads(text)
+        return cls(
+            reclaimable_since=datetime.fromisoformat(data["reclaimable_since"]),
+            reason=data["reason"],
+            size_bytes=int(data["size_bytes"]),
+            depends_on=tuple(data.get("depends_on", ())),
+            version=int(data.get("version", MARKER_VERSION)),
+        )
+
+
+def directory_size_bytes(directory: Path) -> int:
+    """Allocated bytes of the regular files directly inside ``directory``.
+
+    Uses st_blocks so a sparse qcow2 counts what it really occupies. The
+    marker itself is excluded, so the recorded size_bytes does not shift
+    depending on whether the marker already exists when this runs."""
+    total = 0
+    try:
+        entries = list(directory.iterdir())
+    except OSError:
+        return 0
+    for entry in entries:
+        if entry.name == MARKER_NAME:
+            continue
+        try:
+            st = entry.lstat()
+        except OSError:
+            continue
+        if not entry.is_file() or entry.is_symlink():
+            continue
+        total += st.st_blocks * 512
+    return total
+
+
+def read_marker(namespace_dir: Path) -> ReclaimableMarker | None:
+    path = namespace_dir / MARKER_NAME
+    if not path.is_file():
+        return None
+    try:
+        return ReclaimableMarker.from_json(path.read_text())
+    except (OSError, ValueError, KeyError, TypeError):
+        logger.warning("Corrupt reclaimable marker at %s, ignoring it", path)
+        return None
+
+
+def write_marker(namespace_dir: Path, marker: ReclaimableMarker) -> None:
+    path = namespace_dir / MARKER_NAME
+    tmp = path.with_name(MARKER_NAME + ".tmp")
+    tmp.write_text(marker.to_json())
+    os.replace(tmp, path)
+
+
+def clear_marker(namespace_dir: Path) -> bool:
+    path = namespace_dir / MARKER_NAME
+    if not path.exists():
+        return False
+    path.unlink()
+    return True
+
+
+def depends_on_from_content(content: ExecutableContent) -> tuple[str, ...]:
+    """The cache entries (parent images) a VM's per-VM volumes are built on."""
+    refs: list[str] = []
+    if isinstance(content, InstanceContent) and content.rootfs and content.rootfs.parent:
+        refs.append(str(content.rootfs.parent.ref))
+    for vol in content.volumes or []:
+        parent = getattr(vol, "parent", None)
+        if parent is not None:
+            refs.append(str(parent.ref))
+    return tuple(dict.fromkeys(refs))
+
+
+def mark_reclaimable(
+    namespace: str,
+    reason: ReclaimReason,
+    depends_on: tuple[str, ...] = (),
+    *,
+    now: datetime | None = None,
+) -> list[Path]:
+    """Write one marker per namespace directory (one per pool the VM spans)."""
+    namespace = _checked_namespace(namespace)
+    since = now or datetime.now(tz=timezone.utc)
+    written: list[Path] = []
+    for directory in iter_namespace_dirs(namespace):
+        marker = ReclaimableMarker(
+            reclaimable_since=since,
+            reason=reason,
+            size_bytes=directory_size_bytes(directory),
+            depends_on=depends_on,
+        )
+        write_marker(directory, marker)
+        written.append(directory / MARKER_NAME)
+        logger.info("Marked %s reclaimable (%s, %d bytes)", directory, reason, marker.size_bytes)
+    return written
+
+
+def adopt(namespace: str) -> int:
+    """A create for this hash takes its retained directories back."""
+    namespace = _checked_namespace(namespace)
+    cleared = 0
+    for directory in iter_namespace_dirs(namespace):
+        if clear_marker(directory):
+            logger.info("Adopted retained volumes in %s", directory)
+            cleared += 1
+    return cleared
+
+
+def iter_reclaimable() -> Iterator[tuple[Path, ReclaimableMarker]]:
+    for directory in iter_namespace_dirs():
+        marker = read_marker(directory)
+        if marker is not None:
+            yield directory, marker
+
+
+def reclaimable_bytes(pool_path: Path | None = None) -> int:
+    """Sum of marker size_bytes, across every pool or for one pool."""
+    return sum(
+        marker.size_bytes
+        for directory, marker in iter_reclaimable()
+        if pool_path is None or directory.parent == pool_path
+    )

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -157,6 +157,17 @@ def adopt(namespace: str) -> int:
     return cleared
 
 
+def is_reclaimable(namespace: str) -> bool:
+    """True when at least one of the VM's directories carries a marker.
+
+    The only record a retained VM has left: its registry record and its DB
+    records were dropped at GONE, so this is how a caller asks whether the
+    node still holds anything for a hash it otherwise knows nothing about.
+    """
+    namespace = _checked_namespace(namespace)
+    return any(read_marker(directory) is not None for directory in iter_namespace_dirs(namespace))
+
+
 def iter_reclaimable() -> Iterator[tuple[Path, ReclaimableMarker]]:
     for directory in iter_namespace_dirs():
         marker = read_marker(directory)

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -40,6 +40,13 @@ class ReclaimableMarker:
     reason: ReclaimReason
     size_bytes: int
     depends_on: tuple[str, ...] = ()
+    # The owner address from the VM's message, copied here because the marker
+    # outlives every other record of it: GONE forgets the registry record and
+    # deletes the DB rows. It is the only thing that lets the node answer
+    # "these are your disks" for a retained VM (see views.operator.operate_erase).
+    # Optional: markers written before this field, and orphan markers for a VM
+    # whose message the node never held, have no owner.
+    owner: str | None = None
     version: int = MARKER_VERSION
 
     def to_json(self) -> str:
@@ -51,11 +58,13 @@ class ReclaimableMarker:
     @classmethod
     def from_json(cls, text: str) -> ReclaimableMarker:
         data = json.loads(text)
+        owner = data.get("owner")
         return cls(
             reclaimable_since=datetime.fromisoformat(data["reclaimable_since"]),
             reason=data["reason"],
             size_bytes=int(data["size_bytes"]),
             depends_on=tuple(data.get("depends_on", ())),
+            owner=str(owner) if owner else None,
             version=int(data.get("version", MARKER_VERSION)),
         )
 
@@ -128,6 +137,7 @@ def mark_reclaimable(
     depends_on: tuple[str, ...] = (),
     *,
     now: datetime | None = None,
+    owner: str | None = None,
 ) -> list[Path]:
     """Write one marker per namespace directory (one per pool the VM spans)."""
     namespace = _checked_namespace(namespace)
@@ -139,6 +149,7 @@ def mark_reclaimable(
             reason=reason,
             size_bytes=directory_size_bytes(directory),
             depends_on=depends_on,
+            owner=owner,
         )
         write_marker(directory, marker)
         written.append(directory / MARKER_NAME)
@@ -157,15 +168,21 @@ def adopt(namespace: str) -> int:
     return cleared
 
 
-def is_reclaimable(namespace: str) -> bool:
-    """True when at least one of the VM's directories carries a marker.
+def retained_marker(namespace: str) -> ReclaimableMarker | None:
+    """The marker of a retained VM, from the first of its directories that
+    carries one, or None.
 
     The only record a retained VM has left: its registry record and its DB
-    records were dropped at GONE, so this is how a caller asks whether the
-    node still holds anything for a hash it otherwise knows nothing about.
+    rows were dropped at GONE, so this is how a caller asks whether the node
+    still holds anything for a hash it otherwise knows nothing about, and
+    who it belongs to.
     """
     namespace = _checked_namespace(namespace)
-    return any(read_marker(directory) is not None for directory in iter_namespace_dirs(namespace))
+    for directory in iter_namespace_dirs(namespace):
+        marker = read_marker(directory)
+        if marker is not None:
+            return marker
+    return None
 
 
 def iter_reclaimable() -> Iterator[tuple[Path, ReclaimableMarker]]:

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -135,24 +135,26 @@ def write_marker(namespace_dir: Path, marker: ReclaimableMarker, *, exclusive: b
     invalidate_reclaimable_cache()
     try:
         tmp.write_text(marker.to_json())
-        if not exclusive:
-            os.replace(tmp, path)
-            return True
-        try:
+        if exclusive:
             os.link(tmp, path)
-        except FileExistsError:
-            return False
-        except OSError:
-            # No hardlinks on this filesystem, or no space: the directory
-            # simply stays unmarked and the next pass tries again. Raising
-            # here would abort the whole reconcile pass for one directory.
-            logger.warning("Could not write the reclaimable marker at %s", path, exc_info=True)
-            return False
-        return True
+        else:
+            os.replace(tmp, path)
+    except FileExistsError:
+        # Exclusive only: another writer claimed the directory first.
+        return False
+    except OSError:
+        # No space, no permission, no hardlinks on this filesystem: the
+        # directory simply stays unmarked and the next pass tries again.
+        # Raising would abort the whole reconcile pass for one directory,
+        # and at startup the agent's boot, on a full pool: the one condition
+        # the reconciler exists to relieve.
+        logger.warning("Could not write the reclaimable marker at %s", path, exc_info=True)
+        return False
     finally:
-        # On success the replace consumed the temp file; on any failure
+        # On success the publish consumed the temp file; on any failure
         # (ENOSPC, EACCES, a failed write) nothing else would ever collect it.
         tmp.unlink(missing_ok=True)
+    return True
 
 
 def clear_marker(namespace_dir: Path) -> bool:

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -132,6 +132,9 @@ def write_marker(namespace_dir: Path, marker: ReclaimableMarker, *, exclusive: b
     """
     path = namespace_dir / MARKER_NAME
     tmp = path.with_name(MARKER_NAME + (".x.tmp" if exclusive else ".tmp"))
+    # Invalidated on both sides of the publish: a reader between the two
+    # would otherwise cache the pre-change sum, and a marker write does not
+    # touch the pool directory's mtime, so the fingerprint would not notice.
     invalidate_reclaimable_cache()
     try:
         tmp.write_text(marker.to_json())
@@ -154,6 +157,7 @@ def write_marker(namespace_dir: Path, marker: ReclaimableMarker, *, exclusive: b
         # On success the publish consumed the temp file; on any failure
         # (ENOSPC, EACCES, a failed write) nothing else would ever collect it.
         tmp.unlink(missing_ok=True)
+        invalidate_reclaimable_cache()
     return True
 
 
@@ -166,6 +170,8 @@ def clear_marker(namespace_dir: Path) -> bool:
         path.unlink()
     except FileNotFoundError:
         return False
+    finally:
+        invalidate_reclaimable_cache()
     return True
 
 

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -58,6 +58,9 @@ class ReclaimableMarker:
     @classmethod
     def from_json(cls, text: str) -> ReclaimableMarker:
         data = json.loads(text)
+        if not isinstance(data, dict):
+            msg = f"marker is not a JSON object: {type(data).__name__}"
+            raise ValueError(msg)
         owner = data.get("owner")
         return cls(
             reclaimable_since=datetime.fromisoformat(data["reclaimable_since"]),
@@ -94,13 +97,25 @@ def directory_size_bytes(directory: Path) -> int:
 
 
 def read_marker(namespace_dir: Path) -> ReclaimableMarker | None:
+    """The directory's marker, or None when it has none.
+
+    A marker that does not parse is removed, not just ignored: writes are
+    atomic, so a corrupt marker is never a write in progress, and left in
+    place it would wedge the directory (the exclusive orphan write backs off
+    from any existing file, so nothing could ever re-mark or evict it). Gone,
+    the directory re-enters the orphan flow on the next pass.
+    """
     path = namespace_dir / MARKER_NAME
     if not path.is_file():
         return None
     try:
         return ReclaimableMarker.from_json(path.read_text())
-    except (OSError, ValueError, KeyError, TypeError):
-        logger.warning("Corrupt reclaimable marker at %s, ignoring it", path)
+    except OSError:
+        logger.warning("Unreadable reclaimable marker at %s, ignoring it", path)
+        return None
+    except (ValueError, KeyError, TypeError, AttributeError):
+        logger.warning("Corrupt reclaimable marker at %s, removing it", path)
+        path.unlink(missing_ok=True)
         return None
 
 

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -104,11 +104,28 @@ def read_marker(namespace_dir: Path) -> ReclaimableMarker | None:
         return None
 
 
-def write_marker(namespace_dir: Path, marker: ReclaimableMarker) -> None:
+def write_marker(namespace_dir: Path, marker: ReclaimableMarker, *, exclusive: bool = False) -> bool:
+    """Publish the marker atomically (a reader sees the whole file or none).
+
+    With ``exclusive`` the write claims the directory only if no marker
+    exists yet, and reports whether it did: os.link publishes the finished
+    temp file if and only if nothing sits at the path. The two modes use
+    distinct temp names so an exclusive writer can never hand its content to
+    a concurrent replacing writer.
+    """
     path = namespace_dir / MARKER_NAME
-    tmp = path.with_name(MARKER_NAME + ".tmp")
+    tmp = path.with_name(MARKER_NAME + (".x.tmp" if exclusive else ".tmp"))
     tmp.write_text(marker.to_json())
-    os.replace(tmp, path)
+    if not exclusive:
+        os.replace(tmp, path)
+        return True
+    try:
+        os.link(tmp, path)
+    except FileExistsError:
+        return False
+    finally:
+        tmp.unlink(missing_ok=True)
+    return True
 
 
 def clear_marker(namespace_dir: Path) -> bool:
@@ -151,7 +168,14 @@ def mark_reclaimable(
             depends_on=depends_on,
             owner=owner,
         )
-        write_marker(directory, marker)
+        # An orphan marker only ever claims an unmarked directory: the
+        # periodic pass can decide "orphan" in the window where a GONE
+        # retire is writing the real marker, and replacing that marker
+        # would drop the owner (erase authorization) and the parent-image
+        # pins it carries.
+        if not write_marker(directory, marker, exclusive=reason == "orphan"):
+            logger.info("Not marking %s: another marker landed first", directory)
+            continue
         written.append(directory / MARKER_NAME)
         logger.info("Marked %s reclaimable (%s, %d bytes)", directory, reason, marker.size_bytes)
     return written

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -117,7 +117,12 @@ def write_marker(namespace_dir: Path, marker: ReclaimableMarker, *, exclusive: b
     tmp = path.with_name(MARKER_NAME + (".x.tmp" if exclusive else ".tmp"))
     tmp.write_text(marker.to_json())
     if not exclusive:
-        os.replace(tmp, path)
+        try:
+            os.replace(tmp, path)
+        finally:
+            # On success the replace consumed the temp file; on failure
+            # (ENOSPC, EACCES) nothing else would ever collect it.
+            tmp.unlink(missing_ok=True)
         return True
     try:
         os.link(tmp, path)

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -130,29 +130,36 @@ def write_marker(namespace_dir: Path, marker: ReclaimableMarker, *, exclusive: b
     """
     path = namespace_dir / MARKER_NAME
     tmp = path.with_name(MARKER_NAME + (".x.tmp" if exclusive else ".tmp"))
-    tmp.write_text(marker.to_json())
-    if not exclusive:
-        try:
-            os.replace(tmp, path)
-        finally:
-            # On success the replace consumed the temp file; on failure
-            # (ENOSPC, EACCES) nothing else would ever collect it.
-            tmp.unlink(missing_ok=True)
-        return True
     try:
-        os.link(tmp, path)
-    except FileExistsError:
-        return False
+        tmp.write_text(marker.to_json())
+        if not exclusive:
+            os.replace(tmp, path)
+            return True
+        try:
+            os.link(tmp, path)
+        except FileExistsError:
+            return False
+        except OSError:
+            # No hardlinks on this filesystem, or no space: the directory
+            # simply stays unmarked and the next pass tries again. Raising
+            # here would abort the whole reconcile pass for one directory.
+            logger.warning("Could not write the reclaimable marker at %s", path, exc_info=True)
+            return False
+        return True
     finally:
+        # On success the replace consumed the temp file; on any failure
+        # (ENOSPC, EACCES, a failed write) nothing else would ever collect it.
         tmp.unlink(missing_ok=True)
-    return True
 
 
 def clear_marker(namespace_dir: Path) -> bool:
+    """Remove the marker; whether there was one. A marker another adopter or
+    pass removed first is not an error, like every removal in the reclaimer."""
     path = namespace_dir / MARKER_NAME
-    if not path.exists():
+    try:
+        path.unlink()
+    except FileNotFoundError:
         return False
-    path.unlink()
     return True
 
 

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 from collections.abc import Iterator
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -24,7 +25,7 @@ from typing import Literal
 from aleph_message.models import ExecutableContent, InstanceContent
 
 from aleph.vm.agent.vm.purge import _checked_namespace
-from aleph.vm.storage_pools import iter_namespace_dirs
+from aleph.vm.storage_pools import get_pools, iter_namespace_dirs
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +116,7 @@ def read_marker(namespace_dir: Path) -> ReclaimableMarker | None:
         return None
     except (ValueError, KeyError, TypeError, AttributeError):
         logger.warning("Corrupt reclaimable marker at %s, removing it", path)
+        invalidate_reclaimable_cache()
         path.unlink(missing_ok=True)
         return None
 
@@ -130,6 +132,7 @@ def write_marker(namespace_dir: Path, marker: ReclaimableMarker, *, exclusive: b
     """
     path = namespace_dir / MARKER_NAME
     tmp = path.with_name(MARKER_NAME + (".x.tmp" if exclusive else ".tmp"))
+    invalidate_reclaimable_cache()
     try:
         tmp.write_text(marker.to_json())
         if not exclusive:
@@ -156,6 +159,7 @@ def clear_marker(namespace_dir: Path) -> bool:
     """Remove the marker; whether there was one. A marker another adopter or
     pass removed first is not an error, like every removal in the reclaimer."""
     path = namespace_dir / MARKER_NAME
+    invalidate_reclaimable_cache()
     try:
         path.unlink()
     except FileNotFoundError:
@@ -243,10 +247,44 @@ def iter_reclaimable() -> Iterator[tuple[Path, ReclaimableMarker]]:
             yield directory, marker
 
 
+# reclaimable_bytes runs on every admission check and every capacity report,
+# and adds the markers up by walking every namespace directory. The sum is
+# cached, keyed on the pools' own directory mtimes (a namespace directory
+# appearing or going changes them) and dropped whenever this process writes
+# or removes a marker, so the common case costs one stat per pool and an
+# in-process change is never stale. A marker written by another process (the
+# storage CLI) shows up within the TTL; until then the figure errs towards
+# counting space as reclaimable, which placement's own free-space check then
+# corrects.
+_RECLAIMABLE_CACHE_TTL = 5.0
+_reclaimable_cache: dict[Path | None, tuple[float, tuple, int]] = {}
+
+
+def invalidate_reclaimable_cache() -> None:
+    _reclaimable_cache.clear()
+
+
+def _pools_fingerprint() -> tuple:
+    stamps = []
+    for pool in get_pools():
+        try:
+            stamps.append((str(pool.path), pool.path.stat().st_mtime_ns))
+        except OSError:
+            stamps.append((str(pool.path), None))
+    return tuple(stamps)
+
+
 def reclaimable_bytes(pool_path: Path | None = None) -> int:
     """Sum of marker size_bytes, across every pool or for one pool."""
-    return sum(
+    now = time.monotonic()
+    fingerprint = _pools_fingerprint()
+    cached = _reclaimable_cache.get(pool_path)
+    if cached is not None and cached[1] == fingerprint and now - cached[0] < _RECLAIMABLE_CACHE_TTL:
+        return cached[2]
+    total = sum(
         marker.size_bytes
         for directory, marker in iter_reclaimable()
         if pool_path is None or directory.parent == pool_path
     )
+    _reclaimable_cache[pool_path] = (now, fingerprint, total)
+    return total

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -607,35 +607,32 @@ def _pass_lock(app: web.Application) -> asyncio.Lock:
     return cached[1]
 
 
-async def reconcile_now(app: web.Application, *, dry_run: bool = False, strict: bool = False) -> ReconcileReport:
+async def reconcile_now(app: web.Application, *, dry_run: bool = False) -> ReconcileReport:
     """One pass, off the event loop, serialized against the other passes.
 
     A GONE fires a pass while the periodic one may still be running: two
     threads walking the same pools would evict the same directories twice,
     double-counting the bytes freed and logging each removal twice. The
     waiting pass is not redundant, it re-reads the filesystem when it starts.
-
-    ``strict`` is for the startup pass: it downgrades the pass to a dry run
-    when the live set cannot be trusted (``_startup_refusal``).
     """
     registry = app["vm_registry"]
     async with _pass_lock(app):
-        live, running = await _live_set(app)
-        if strict and not dry_run:
-            refusal = _startup_refusal(registry, running)
-            if refusal is not None:
-                logger.warning("Startup storage reconcile is running dry and will purge nothing: %s", refusal)
-                dry_run = True
-        return await asyncio.to_thread(
-            reconcile_storage,
-            registry,
-            dry_run=dry_run,
-            live=live,
-            is_live=registry_is_live(registry, live),
-        )
+        live, _running = await _live_set(app)
+        return await _pass(registry, live, dry_run=dry_run)
 
 
-def _log_startup_preview(preview: ReconcileReport) -> None:
+async def _pass(registry: AgentVmRegistry, live: set[str], *, dry_run: bool) -> ReconcileReport:
+    """One walk in a worker thread, against a live set already established."""
+    return await asyncio.to_thread(
+        reconcile_storage,
+        registry,
+        dry_run=dry_run,
+        live=live,
+        is_live=registry_is_live(registry, live),
+    )
+
+
+def _log_startup_preview(preview: ReconcileReport, *, refusal: str | None = None) -> None:
     """Announce what the first pass is about to remove, per pool.
 
     On an upgraded node the first pass finds every directory leaked by the
@@ -643,8 +640,24 @@ def _log_startup_preview(preview: ReconcileReport) -> None:
     potentially a lot of data (spec section 6). The per-pool breakdown is
     what lets an operator match the log against the disk whose free space
     jumped.
+
+    ``refusal`` turns the announcement into its opposite: the same figures,
+    said as what a trusted pass *would* have reclaimed, so the log never
+    reads "will purge N" immediately above "purging nothing".
     """
     namespaces = [*preview.purged_orphans, *preview.marked_orphans, *preview.evicted]
+    if refusal is not None:
+        logger.warning(
+            "Startup storage reconcile is running dry and will purge nothing: %s. A trusted pass would have "
+            "purged %d orphan(s), marked %d, evicted %d, about %d bytes (VOLUME_RETENTION=%s)",
+            refusal,
+            len(preview.purged_orphans),
+            len(preview.marked_orphans),
+            len(preview.evicted),
+            preview.bytes_freed,
+            settings.VOLUME_RETENTION,
+        )
+        return
     if not namespaces:
         return
     logger.warning(
@@ -674,13 +687,19 @@ async def reconcile_at_startup(app: web.Application) -> None:
     remove, so an operator reading the log knows why free space jumped after
     an upgrade.
 
-    The pass is strict: it refuses to purge anything when the supervisor
-    cannot be listed, or when rehydration left the registry empty while the
-    supervisor still runs VMs.
+    The live set is established once and both passes share it: one
+    ``list_vms`` call, one refusal decision, and a preview that cannot
+    promise what the pass behind it then refuses to do. The pass is strict:
+    it purges nothing when the supervisor cannot be listed, or when
+    rehydration left the registry empty while the supervisor still runs VMs.
     """
-    preview = await reconcile_now(app, dry_run=True)
-    _log_startup_preview(preview)
-    await reconcile_now(app, strict=True)
+    registry = app["vm_registry"]
+    async with _pass_lock(app):
+        live, running = await _live_set(app)
+        refusal = _startup_refusal(registry, running)
+        _log_startup_preview(await _pass(registry, live, dry_run=True), refusal=refusal)
+        if refusal is None:
+            await _pass(registry, live, dry_run=False)
 
 
 async def periodic_reconcile(app: web.Application) -> None:

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -520,10 +520,17 @@ def _evict(
         logger.debug("Not evicting %s: its directories are already gone", namespace)
         return 0
     size = _dir_bytes(namespace)
-    report.evicted.append(namespace)
-    report.bytes_freed += size
     if not dry_run:
         purge_vm_storage(namespace)
+        if _still_on_disk(namespace):
+            # Same rule as the namespace pass: a directory the purge refuses
+            # (a device-mapper target still holds its volumes) is not space
+            # anyone got back, so make_room must not count it towards the
+            # create it is trying to fit.
+            logger.warning("Eviction of %s left directories behind; not counting them as reclaimed", namespace)
+            return 0
+    report.evicted.append(namespace)
+    report.bytes_freed += size
     return size
 
 

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -111,14 +111,25 @@ def _dir_bytes(namespace: str) -> int:
     return sum(directory_size_bytes(directory) for directory in iter_namespace_dirs(namespace))
 
 
+def _still_on_disk(namespace: str) -> bool:
+    """False when the namespace's directories vanished between being listed
+    and being acted on.
+
+    Passes can overlap (a GONE fires one while the periodic pass runs, and
+    ``make_room`` evicts from the create path), so losing a race is normal.
+    It is not an error, and it is not space this pass may claim to have
+    freed.
+    """
+    return any(True for _ in iter_namespace_dirs(namespace))
+
+
 def live_hashes(registry: AgentVmRegistry) -> set[str]:
     """Snapshot of the VMs the registry knows are alive.
 
     A pass runs in a worker thread while the event loop keeps creating and
-    retiring VMs, so the set is taken once and handed over rather than read
-    repeatedly mid-mutation. ``list()`` first: the snapshot is then a single
-    atomic step, which matters for the one caller that does run off the loop
-    (the room maker, called from placement inside a worker thread).
+    retiring VMs, so the set is taken once, on the loop, and handed over;
+    iterating the registry from the thread would read it mid-mutation.
+    ``list()`` first, so the snapshot itself is one atomic step.
     """
     return {str(vm_hash) for vm_hash, _ in list(registry.items())}
 
@@ -194,6 +205,9 @@ def _reconcile_namespaces(
         if namespace in seen or not _is_orphan(directory, live, now, guard, dry_run=dry_run):
             continue
         seen.add(namespace)
+        if not dry_run and not _still_on_disk(namespace):
+            logger.debug("Skipping %s: another pass got there first", namespace)
+            continue
         if settings.VOLUME_RETENTION == "keep":
             report.marked_orphans.append(namespace)
             if not dry_run:
@@ -207,11 +221,18 @@ def _reconcile_namespaces(
 
 def _part_roots() -> Iterator[Path]:
     """Where a half-downloaded file can sit: the four caches, and every
-    per-VM volume directory (the downloader streams volumes in place)."""
+    per-VM volume directory (the downloader streams volumes in place).
+
+    A namespace a create holds is skipped whole: a migration import streams
+    multi-GB disks into it for far longer than VOLUME_CREATE_GUARD, and its
+    ``.part`` files belong to that transfer however old they look.
+    """
     for cache in (settings.RUNTIME_CACHE, settings.CODE_CACHE, settings.DATA_CACHE, settings.MESSAGE_CACHE):
         if cache:
             yield Path(cache)
-    yield from iter_namespace_dirs()
+    for directory in iter_namespace_dirs():
+        if not is_creating(directory.name):
+            yield directory
 
 
 def _sweep_parts(now: datetime, guard: timedelta, report: ReconcileReport, *, dry_run: bool) -> None:
@@ -325,6 +346,9 @@ def _reclaimable_on(pool: StoragePool) -> list[tuple[Path, ReclaimableMarker]]:
 
 
 def _evict(namespace: str, report: ReconcileReport, *, dry_run: bool) -> int:
+    if not _still_on_disk(namespace):
+        logger.debug("Not evicting %s: its directories are already gone", namespace)
+        return 0
     size = _dir_bytes(namespace)
     report.evicted.append(namespace)
     report.bytes_freed += size
@@ -367,6 +391,11 @@ def make_room(pool: StoragePool, needed_bytes: int, *, live: Collection[str] | N
     those on every pass), but this runs on its own, off the create path, so
     callers should pass ``live`` (see ``live_hashes``) or have reconciled
     first; a hash in ``live`` is never evicted.
+
+    Synchronous, and called from placement: its callers wrap it in
+    ``asyncio.to_thread`` so the walk and the removals stay off the event
+    loop. It can therefore overlap a pass running in another thread, which is
+    why every removal here tolerates a directory that vanished first.
     """
     protected = set(live or ())
     freed = 0
@@ -376,6 +405,9 @@ def make_room(pool: StoragePool, needed_bytes: int, *, live: Collection[str] | N
             break
         if directory.name in protected:
             logger.warning("Not evicting %s: a live VM owns it despite its reclaimable marker", directory)
+            continue
+        if not directory.is_dir():
+            # A concurrent pass took it between the listing and now.
             continue
         # Only what this pool gets back: _evict purges the VM on every pool
         # it spans, and the other pools' bytes do not help this create.
@@ -387,10 +419,33 @@ def make_room(pool: StoragePool, needed_bytes: int, *, live: Collection[str] | N
     return freed
 
 
+def _pass_lock(app: web.Application) -> asyncio.Lock:
+    """The lock that serializes loop-triggered passes, one per event loop.
+
+    Stored on the app rather than at module level: the app outlives (and in
+    the tests, precedes) the loop, and an asyncio.Lock binds to the first
+    loop that awaits it.
+    """
+    loop = asyncio.get_running_loop()
+    cached = app.get("storage_reconcile_lock")
+    if cached is None or cached[0] is not loop:
+        cached = (loop, asyncio.Lock())
+        app["storage_reconcile_lock"] = cached
+    return cached[1]
+
+
 async def reconcile_now(app: web.Application, *, dry_run: bool = False) -> ReconcileReport:
+    """One pass, off the event loop, serialized against the other passes.
+
+    A GONE fires a pass while the periodic one may still be running: two
+    threads walking the same pools would evict the same directories twice,
+    double-counting the bytes freed and logging each removal twice. The
+    waiting pass is not redundant, it re-reads the filesystem when it starts.
+    """
     registry = app["vm_registry"]
-    live = live_hashes(registry)
-    return await asyncio.to_thread(reconcile_storage, registry, dry_run=dry_run, live=live)
+    async with _pass_lock(app):
+        live = live_hashes(registry)
+        return await asyncio.to_thread(reconcile_storage, registry, dry_run=dry_run, live=live)
 
 
 def _log_startup_preview(preview: ReconcileReport) -> None:

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -115,10 +115,12 @@ def live_hashes(registry: AgentVmRegistry) -> set[str]:
     """Snapshot of the VMs the registry knows are alive.
 
     A pass runs in a worker thread while the event loop keeps creating and
-    retiring VMs, so the set is taken once, on the loop, and handed over;
-    iterating the registry from the thread would read it mid-mutation.
+    retiring VMs, so the set is taken once and handed over rather than read
+    repeatedly mid-mutation. ``list()`` first: the snapshot is then a single
+    atomic step, which matters for the one caller that does run off the loop
+    (the room maker, called from placement inside a worker thread).
     """
-    return {str(vm_hash) for vm_hash, _ in registry.items()}
+    return {str(vm_hash) for vm_hash, _ in list(registry.items())}
 
 
 def reconcile_storage(
@@ -391,21 +393,46 @@ async def reconcile_now(app: web.Application, *, dry_run: bool = False) -> Recon
     return await asyncio.to_thread(reconcile_storage, registry, dry_run=dry_run, live=live)
 
 
+def _log_startup_preview(preview: ReconcileReport) -> None:
+    """Announce what the first pass is about to remove, per pool.
+
+    On an upgraded node the first pass finds every directory leaked by the
+    bugs this work fixes, which under ``reap`` is a one-shot cleanup of
+    potentially a lot of data (spec section 6). The per-pool breakdown is
+    what lets an operator match the log against the disk whose free space
+    jumped.
+    """
+    namespaces = [*preview.purged_orphans, *preview.marked_orphans, *preview.evicted]
+    if not namespaces:
+        return
+    logger.warning(
+        "Startup storage reconcile will purge %d orphan(s), mark %d, evict %d, freeing about %d bytes "
+        "(VOLUME_RETENTION=%s)",
+        len(preview.purged_orphans),
+        len(preview.marked_orphans),
+        len(preview.evicted),
+        preview.bytes_freed,
+        settings.VOLUME_RETENTION,
+    )
+    for pool in get_pools():
+        on_pool = [pool.path / namespace for namespace in namespaces if (pool.path / namespace).is_dir()]
+        if not on_pool:
+            continue
+        logger.warning(
+            "Startup storage reconcile: pool %d (%s) gives back %d directory(ies), %d bytes",
+            pool.index,
+            pool.path,
+            len(on_pool),
+            sum(directory_size_bytes(directory) for directory in on_pool),
+        )
+
+
 async def reconcile_at_startup(app: web.Application) -> None:
     """on_startup hook: one pass, preceded by a summary of what the pass will
     remove, so an operator reading the log knows why free space jumped after
     an upgrade."""
     preview = await reconcile_now(app, dry_run=True)
-    if preview.purged_orphans or preview.marked_orphans or preview.evicted:
-        logger.warning(
-            "Startup storage reconcile will purge %d orphan(s), mark %d, evict %d, freeing about %d bytes "
-            "(VOLUME_RETENTION=%s)",
-            len(preview.purged_orphans),
-            len(preview.marked_orphans),
-            len(preview.evicted),
-            preview.bytes_freed,
-            settings.VOLUME_RETENTION,
-        )
+    _log_startup_preview(preview)
     await reconcile_now(app)
 
 

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -290,6 +290,10 @@ def _is_orphan(
     namespace = directory.name
     if is_live(namespace) or is_creating(namespace):
         if read_marker(directory) is not None and not dry_run:
+            # Not routine housekeeping: a live VM's disks were one budget pass
+            # away from being evicted under it, so say so loudly enough to be
+            # noticed in a log.
+            logger.warning("Clearing the reclaimable marker on %s: a live VM owns it", directory)
             clear_marker(directory)
         return False
     if read_marker(directory) is not None:
@@ -333,10 +337,20 @@ def _reconcile_namespaces(
             if not dry_run:
                 mark_reclaimable(namespace, "orphan", now=now)
         else:
+            freed = _dir_bytes(namespace)
+            if dry_run:
+                report.purged_orphans.append(namespace)
+                report.bytes_freed += freed
+                continue
+            purge_vm_storage(namespace)
+            if _still_on_disk(namespace):
+                # purge_vm_storage refuses a directory a device-mapper target
+                # still holds. Nothing was freed, so nothing may be reported
+                # as freed; the next pass tries again.
+                logger.warning("Purge of %s left directories behind; not counting them as reclaimed", namespace)
+                continue
             report.purged_orphans.append(namespace)
-            report.bytes_freed += _dir_bytes(namespace)
-            if not dry_run:
-                purge_vm_storage(namespace)
+            report.bytes_freed += freed
 
 
 def _part_roots() -> Iterator[Path]:

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -282,10 +282,31 @@ def _is_stale_side_dir(child: Path, mode: str, live: Collection[str], now: datet
             return False
     except OSError:
         return False
+    return _side_dir_is_removable(child, mode)
+
+
+def _side_dir_is_removable(child: Path, mode: str) -> bool:
+    """The last two questions, about the directory rather than its owner."""
     if os.path.ismount(child):
         logger.warning("Not removing %s: it is a mount point", child)
         return False
+    if mode == "prefix" and not _is_empty(child):
+        # /mnt belongs to the operator, not to the agent: the only thing the
+        # agent puts there is a mount point (storage.create_devmapper mkdirs
+        # it and unmounts after the resize), which is empty by construction
+        # once unmounted. A name that merely looks like one but holds data
+        # (/mnt/externalstoragedisk_1) is the operator's, and an rmtree of it
+        # would be a disaster.
+        logger.debug("Not removing %s: it is not an empty mount point", child)
+        return False
     return True
+
+
+def _is_empty(directory: Path) -> bool:
+    try:
+        return not any(directory.iterdir())
+    except OSError:
+        return False
 
 
 def _sweep_side_dirs(
@@ -304,7 +325,11 @@ def _sweep_side_dirs(
                 continue
             if not dry_run:
                 try:
-                    shutil.rmtree(child)
+                    if mode == "exact":
+                        shutil.rmtree(child)
+                    else:
+                        # Never an rmtree here: see _is_stale_side_dir.
+                        os.rmdir(child)
                 except OSError:
                     logger.warning("Failed to remove %s", child, exc_info=True)
                     continue

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -4,8 +4,15 @@ Runs at startup, every VOLUME_RECONCILE_INTERVAL, after every GONE retire,
 and on admission pressure (make_room). Each pass walks the pools and the
 per-VM side directories and applies VOLUME_RETENTION to anything no live VM
 owns. It only ever touches directories the agent created, keyed by a
-plausible item hash; a create in flight (``creating``) or younger than
-VOLUME_CREATE_GUARD is left alone.
+plausible item hash.
+
+Nothing a create is still building is touched: every pass (namespaces and
+side directories alike) skips a hash registered through ``creating`` and
+anything whose mtime is younger than VOLUME_CREATE_GUARD. The two are
+belt and braces, and both matter: a create that outlives the guard is only
+protected by ``creating``, which is why wrapping every create path in it is
+mandatory, and a create that somehow escaped ``creating`` still has the
+guard.
 """
 
 from __future__ import annotations
@@ -15,7 +22,7 @@ import logging
 import os
 import random
 import shutil
-from collections.abc import Iterator
+from collections.abc import Collection, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -70,7 +77,15 @@ class ReconcileReport:
 
 @contextmanager
 def creating(namespace: str) -> Iterator[None]:
-    """Mark a create as in flight; adopt retained directories on entry."""
+    """Mark a create as in flight; adopt retained directories on entry.
+
+    Every create path must be wrapped in this: it is the only thing that
+    keeps a reconcile pass off a half-built VM once the create outlives
+    VOLUME_CREATE_GUARD, and the only place a retained directory is adopted
+    (spec section 3). A create that stages files, allocates volumes or
+    writes a session directory outside this context can have them removed
+    from under it by the next pass.
+    """
     adopt(namespace)
     _creating.add(namespace)
     try:
@@ -96,21 +111,37 @@ def _dir_bytes(namespace: str) -> int:
     return sum(directory_size_bytes(directory) for directory in iter_namespace_dirs(namespace))
 
 
+def live_hashes(registry: AgentVmRegistry) -> set[str]:
+    """Snapshot of the VMs the registry knows are alive.
+
+    A pass runs in a worker thread while the event loop keeps creating and
+    retiring VMs, so the set is taken once, on the loop, and handed over;
+    iterating the registry from the thread would read it mid-mutation.
+    """
+    return {str(vm_hash) for vm_hash, _ in registry.items()}
+
+
 def reconcile_storage(
     registry: AgentVmRegistry,
     *,
     now: datetime | None = None,
     dry_run: bool = False,
+    live: Collection[str] | None = None,
 ) -> ReconcileReport:
     """One reconciliation pass: namespaces, .part files, side directories,
-    the retention budget, then the backups."""
+    the retention budget, then the backups.
+
+    ``live`` is the set of hashes a live VM owns. Pass it when the caller
+    runs this off the event loop (see ``live_hashes``); it defaults to
+    reading ``registry`` directly, which is only safe on the loop itself.
+    """
     now = now or datetime.now(tz=timezone.utc)
     guard = timedelta(seconds=settings.VOLUME_CREATE_GUARD)
-    live = {str(vm_hash) for vm_hash, _ in registry.items()}
+    live = set(live) if live is not None else live_hashes(registry)
     report = ReconcileReport()
     _reconcile_namespaces(live, now, guard, report, dry_run=dry_run)
     _sweep_parts(now, guard, report, dry_run=dry_run)
-    _sweep_side_dirs(live, report, dry_run=dry_run)
+    _sweep_side_dirs(live, now, guard, report, dry_run=dry_run)
     _enforce_retention_budget(report, dry_run=dry_run)
     if not dry_run:
         report.backups_removed = sweep_expired_backups(now)
@@ -118,7 +149,7 @@ def reconcile_storage(
     return report
 
 
-def _is_orphan(directory: Path, live: set[str], now: datetime, guard: timedelta, *, dry_run: bool) -> bool:
+def _is_orphan(directory: Path, live: Collection[str], now: datetime, guard: timedelta, *, dry_run: bool) -> bool:
     """True when nothing owns ``directory`` and the reconciler may act on it.
 
     A live VM's directory is owned; a stale marker on one (a VM re-created
@@ -141,7 +172,7 @@ def _is_orphan(directory: Path, live: set[str], now: datetime, guard: timedelta,
 
 
 def _reconcile_namespaces(
-    live: set[str],
+    live: Collection[str],
     now: datetime,
     guard: timedelta,
     report: ReconcileReport,
@@ -210,18 +241,43 @@ def _side_dir_roots() -> Iterator[tuple[Path, str]]:
     yield MOUNT_ROOT, "prefix"  # /mnt/{namespace}_{volume name}
 
 
-def _sweep_side_dirs(live: set[str], report: ReconcileReport, *, dry_run: bool) -> None:
+def _is_stale_side_dir(child: Path, mode: str, live: Collection[str], now: datetime, guard: timedelta) -> bool:
+    """True when this side directory belongs to a VM that is not here any more.
+
+    Same three questions as the namespace pass, in the same order: is the
+    name a VM hash at all, does a live VM (or a create in flight) own it,
+    and is it old enough that no create can still be building it. A mount
+    point is left alone: unmounting is not this pass's job.
+    """
+    if not child.is_dir():
+        return False
+    namespace = child.name if mode == "exact" else child.name.split("_", 1)[0]
+    if not _plausible(namespace) or namespace in live or is_creating(namespace):
+        return False
+    try:
+        if now - _mtime(child) < guard:
+            return False
+    except OSError:
+        return False
+    if os.path.ismount(child):
+        logger.warning("Not removing %s: it is a mount point", child)
+        return False
+    return True
+
+
+def _sweep_side_dirs(
+    live: Collection[str],
+    now: datetime,
+    guard: timedelta,
+    report: ReconcileReport,
+    *,
+    dry_run: bool,
+) -> None:
     for root, mode in _side_dir_roots():
         if not root.is_dir():
             continue
         for child in list(root.iterdir()):
-            if not child.is_dir():
-                continue
-            namespace = child.name if mode == "exact" else child.name.split("_", 1)[0]
-            if not _plausible(namespace) or namespace in live or is_creating(namespace):
-                continue
-            if os.path.ismount(child):
-                logger.warning("Not removing %s: it is a mount point", child)
+            if not _is_stale_side_dir(child, mode, live, now, guard):
                 continue
             if not dry_run:
                 try:
@@ -237,6 +293,16 @@ def _pool_total(pool: StoragePool) -> int:
     try:
         return shutil.disk_usage(str(pool.path)).total
     except OSError:
+        return 0
+
+
+def _pool_free(pool: StoragePool) -> int:
+    try:
+        return shutil.disk_usage(str(pool.path)).free
+    except OSError:
+        # Unknown free space: report none, so make_room falls back to its
+        # "stop once needed_bytes have been freed" bound instead of looping.
+        logger.warning("Volume pool %s not accessible; freeing on the evicted bytes alone", pool.path)
         return 0
 
 
@@ -285,31 +351,51 @@ def _enforce_retention_budget(report: ReconcileReport, *, dry_run: bool) -> None
             _evict(directory.name, report, dry_run=dry_run)
 
 
-def make_room(pool: StoragePool, needed_bytes: int) -> int:
-    """Evict reclaimable directories on ``pool``, oldest first, until
-    ``needed_bytes`` have been freed or nothing reclaimable is left. Returns
-    the bytes freed."""
+def make_room(pool: StoragePool, needed_bytes: int, *, live: Collection[str] | None = None) -> int:
+    """Evict reclaimable directories on ``pool``, oldest first, until a
+    ``needed_bytes`` create fits on it. Returns the bytes freed on ``pool``.
+
+    Admission pressure, not a quota: the pool's own free space is what has
+    to reach ``needed_bytes``, so a pool that already fits the create loses
+    nothing. The second bound (``freed >= needed_bytes``) only exists so an
+    unreadable or lying filesystem cannot turn this into a loop over every
+    retained VM on the pool.
+
+    A marker on a directory a live VM owns is a bug (``_is_orphan`` clears
+    those on every pass), but this runs on its own, off the create path, so
+    callers should pass ``live`` (see ``live_hashes``) or have reconciled
+    first; a hash in ``live`` is never evicted.
+    """
+    protected = set(live or ())
     freed = 0
     report = ReconcileReport()
     for directory, _marker in _reclaimable_on(pool):
-        if freed >= needed_bytes:
+        if _pool_free(pool) >= needed_bytes or freed >= needed_bytes:
             break
-        freed += _evict(directory.name, report, dry_run=False)
+        if directory.name in protected:
+            logger.warning("Not evicting %s: a live VM owns it despite its reclaimable marker", directory)
+            continue
+        # Only what this pool gets back: _evict purges the VM on every pool
+        # it spans, and the other pools' bytes do not help this create.
+        on_this_pool = directory_size_bytes(directory)
+        _evict(directory.name, report, dry_run=False)
+        freed += on_this_pool
     if freed:
         logger.info("Made room on %s: evicted %s (%d bytes)", pool.path, ", ".join(report.evicted), freed)
     return freed
 
 
-async def reconcile_now(app: web.Application) -> ReconcileReport:
-    return await asyncio.to_thread(reconcile_storage, app["vm_registry"])
+async def reconcile_now(app: web.Application, *, dry_run: bool = False) -> ReconcileReport:
+    registry = app["vm_registry"]
+    live = live_hashes(registry)
+    return await asyncio.to_thread(reconcile_storage, registry, dry_run=dry_run, live=live)
 
 
 async def reconcile_at_startup(app: web.Application) -> None:
     """on_startup hook: one pass, preceded by a summary of what the pass will
     remove, so an operator reading the log knows why free space jumped after
     an upgrade."""
-    registry = app["vm_registry"]
-    preview = await asyncio.to_thread(reconcile_storage, registry, dry_run=True)
+    preview = await reconcile_now(app, dry_run=True)
     if preview.purged_orphans or preview.marked_orphans or preview.evicted:
         logger.warning(
             "Startup storage reconcile will purge %d orphan(s), mark %d, evict %d, freeing about %d bytes "

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -6,6 +6,16 @@ per-VM side directories and applies VOLUME_RETENTION to anything no live VM
 owns. It only ever touches directories the agent created, keyed by a
 plausible item hash.
 
+"Alive" is the union of the agent registry and the VMs the supervisor lists:
+the registry is refilled at boot from the agent DB alone, so it can be empty
+or incomplete while VMs are running, and the startup pass refuses to purge
+anything when that union cannot be established (see ``_startup_refusal``).
+
+Loop-triggered passes are serialized, not coalesced: a sweep that retires N
+VMs GONE under ``keep`` queues N passes behind the lock, each re-reading the
+filesystem when it starts. That is correctness at the cost of work; a
+coalescing pass is a later optimisation, not a bug fix.
+
 Nothing a create is still building is touched: every pass (namespaces and
 side directories alike) skips a hash registered through ``creating`` and
 anything whose mtime is younger than VOLUME_CREATE_GUARD. The two are
@@ -22,13 +32,15 @@ import logging
 import os
 import random
 import shutil
-from collections.abc import Collection, Iterator
+from collections.abc import Callable, Collection, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from aiohttp import web
+from aleph_message.exceptions import UnknownHashError
+from aleph_message.models import ItemHash
 
 from aleph.vm.agent.vm.backup import sweep_expired_backups
 from aleph.vm.agent.vm.purge import _ITEM_HASH_PATTERN, purge_vm_storage
@@ -45,6 +57,7 @@ from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 from aleph.vm.storage_budget import parse_budget
 from aleph.vm.storage_pools import StoragePool, get_pools, iter_namespace_dirs
+from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.utils import create_task_log_exceptions
 
 logger = logging.getLogger(__name__)
@@ -85,6 +98,13 @@ def creating(namespace: str) -> Iterator[None]:
     (spec section 3). A create that stages files, allocates volumes or
     writes a session directory outside this context can have them removed
     from under it by the next pass.
+
+    Adoption happens on entry, before the create is known to succeed, so a
+    create that is then refused leaves the directory unmarked: the next pass
+    re-marks it as an orphan with a fresh ``reclaimable_since``, which moves
+    it to the back of the eviction queue. Retention is a budgeted cache, not
+    a promise, so a reset order is acceptable; adopting later would mean a
+    create racing the eviction of the very disks it is about to reuse.
     """
     adopt(namespace)
     _creating.add(namespace)
@@ -126,12 +146,98 @@ def _still_on_disk(namespace: str) -> bool:
 def live_hashes(registry: AgentVmRegistry) -> set[str]:
     """Snapshot of the VMs the registry knows are alive.
 
-    A pass runs in a worker thread while the event loop keeps creating and
-    retiring VMs, so the set is taken once, on the loop, and handed over;
-    iterating the registry from the thread would read it mid-mutation.
-    ``list()`` first, so the snapshot itself is one atomic step.
+    Thread-safe by construction, and it has to be: the room maker wired in
+    ``supervisor.py`` calls this from inside ``asyncio.to_thread`` (through
+    ``volume_path_for``), while the event loop keeps creating and retiring
+    VMs. ``list()`` on the underlying dict's items is a single step under the
+    GIL, so the snapshot can never be a half-read of a mutating dict; without
+    it the comprehension would iterate the live dict and could raise.
     """
     return {str(vm_hash) for vm_hash, _ in list(registry.items())}
+
+
+async def supervisor_hashes(supervisor: Supervisor) -> set[str]:
+    """The item hashes of the VMs the supervisor is running.
+
+    A supervisor VM id is the VM's item hash, mapped the same way
+    ``update_allocations`` maps it (``views/__init__.py``). An id that is not
+    a plausible hash is dropped rather than raised on: it cannot name a
+    directory this pass would touch anyway.
+    """
+    hashes: set[str] = set()
+    for info in await supervisor.list_vms():
+        try:
+            hashes.add(str(ItemHash(str(info.vm_id))))
+        except (UnknownHashError, ValueError):
+            logger.warning("The supervisor lists a VM whose id is not an item hash: %r", info.vm_id)
+    return hashes
+
+
+async def _live_set(app: web.Application) -> tuple[set[str], int | None]:
+    """The hashes no pass may touch, and how many VMs the supervisor listed.
+
+    The registry alone is not a safe live set. It is refilled at boot from the
+    agent DB (``rehydrate_registry``), which skips any record with an empty or
+    unparseable message, so a fresh, lost or partly damaged DB would leave a
+    running VM's directory looking like an orphan. The supervisor is the
+    second opinion: what it runs is live, what the registry remembers is live,
+    and a pass acts on the union of the two.
+
+    The returned count is ``None`` when the supervisor could not be asked,
+    which is not the same answer as "it runs nothing" (see
+    ``_startup_refusal``).
+    """
+    registry_live = live_hashes(app["vm_registry"])
+    supervisor = app.get("supervisor")
+    if supervisor is None:
+        logger.warning("No supervisor handle on the app; the live set is the agent registry alone")
+        return registry_live, None
+    try:
+        running = await supervisor_hashes(supervisor)
+    except Exception as error:
+        logger.warning("Could not list the supervisor's VMs (%s); the live set is the agent registry alone", error)
+        return registry_live, None
+    return registry_live | running, len(running)
+
+
+def _startup_refusal(registry: AgentVmRegistry, running: int | None) -> str | None:
+    """Why the startup pass must not purge anything, or None.
+
+    The first pass on a node is the one that acts on the biggest backlog (an
+    upgraded node's leaked directories) and the one running when the agent
+    knows the least. Two states mean its live set cannot be trusted, and a
+    wrong answer there deletes the disks of VMs that are still running.
+    """
+    if running is None:
+        return "the supervisor did not answer list_vms, so the VMs it runs are unknown"
+    if running and not len(registry):
+        return (
+            f"the agent registry is empty while the supervisor runs {running} VM(s), "
+            "so the agent DB was lost or could not be read"
+        )
+    return None
+
+
+def _snapshot_is_live(live: Collection[str]) -> Callable[[str], bool]:
+    return frozenset(live).__contains__
+
+
+def registry_is_live(registry: AgentVmRegistry, snapshot: Collection[str]) -> Callable[[str], bool]:
+    """Liveness as of the removal, not as of the start of the pass.
+
+    ``live`` is snapshotted on the event loop and the walk that follows can
+    take minutes; a create that commits in between would look like an orphan,
+    since a directory's mtime only moves when an entry is added or renamed and
+    not when a file inside it grows. Asking the registry again just before
+    acting closes that window. The registry is a plain dict and ``in`` on one
+    is a single lookup under the GIL, so a worker thread may ask it.
+    """
+    frozen = frozenset(snapshot)
+
+    def is_live(namespace: str) -> bool:
+        return namespace in frozen or namespace in registry
+
+    return is_live
 
 
 def reconcile_storage(
@@ -140,6 +246,7 @@ def reconcile_storage(
     now: datetime | None = None,
     dry_run: bool = False,
     live: Collection[str] | None = None,
+    is_live: Callable[[str], bool] | None = None,
 ) -> ReconcileReport:
     """One reconciliation pass: namespaces, .part files, side directories,
     the retention budget, then the backups.
@@ -147,22 +254,31 @@ def reconcile_storage(
     ``live`` is the set of hashes a live VM owns. Pass it when the caller
     runs this off the event loop (see ``live_hashes``); it defaults to
     reading ``registry`` directly, which is only safe on the loop itself.
+
+    ``is_live`` is asked again immediately before anything is marked or
+    removed, so a create that commits while this pass walks is not treated as
+    an orphan (see ``registry_is_live``). It defaults to the ``live``
+    snapshot alone, which is what a caller holding no loop reference can
+    offer.
     """
     now = now or datetime.now(tz=timezone.utc)
     guard = timedelta(seconds=settings.VOLUME_CREATE_GUARD)
     live = set(live) if live is not None else live_hashes(registry)
+    is_live = is_live or _snapshot_is_live(live)
     report = ReconcileReport()
-    _reconcile_namespaces(live, now, guard, report, dry_run=dry_run)
+    _reconcile_namespaces(now, guard, report, dry_run=dry_run, is_live=is_live)
     _sweep_parts(now, guard, report, dry_run=dry_run)
     _sweep_side_dirs(live, now, guard, report, dry_run=dry_run)
-    _enforce_retention_budget(report, dry_run=dry_run)
+    _enforce_retention_budget(report, dry_run=dry_run, is_live=is_live)
     if not dry_run:
         report.backups_removed = sweep_expired_backups(now)
     logger.info("Storage reconcile%s: %s", " (dry run)" if dry_run else "", report.summary())
     return report
 
 
-def _is_orphan(directory: Path, live: Collection[str], now: datetime, guard: timedelta, *, dry_run: bool) -> bool:
+def _is_orphan(
+    directory: Path, is_live: Callable[[str], bool], now: datetime, guard: timedelta, *, dry_run: bool
+) -> bool:
     """True when nothing owns ``directory`` and the reconciler may act on it.
 
     A live VM's directory is owned; a stale marker on one (a VM re-created
@@ -172,7 +288,7 @@ def _is_orphan(directory: Path, live: Collection[str], now: datetime, guard: tim
     left is unowned, unless it is young enough to be a create in flight.
     """
     namespace = directory.name
-    if namespace in live or is_creating(namespace):
+    if is_live(namespace) or is_creating(namespace):
         if read_marker(directory) is not None and not dry_run:
             clear_marker(directory)
         return False
@@ -185,12 +301,12 @@ def _is_orphan(directory: Path, live: Collection[str], now: datetime, guard: tim
 
 
 def _reconcile_namespaces(
-    live: Collection[str],
     now: datetime,
     guard: timedelta,
     report: ReconcileReport,
     *,
     dry_run: bool,
+    is_live: Callable[[str], bool],
 ) -> None:
     seen: set[str] = set()
     for directory in list(iter_namespace_dirs()):
@@ -202,9 +318,13 @@ def _reconcile_namespaces(
             continue
         # A VM spanning two pools is handled once: purging or marking covers
         # every pool it is on.
-        if namespace in seen or not _is_orphan(directory, live, now, guard, dry_run=dry_run):
+        if namespace in seen or not _is_orphan(directory, is_live, now, guard, dry_run=dry_run):
             continue
         seen.add(namespace)
+        if is_live(namespace):
+            # A create that committed between the live snapshot and this walk.
+            logger.info("Skipping %s: a VM claimed it while this pass was walking", namespace)
+            continue
         if not dry_run and not _still_on_disk(namespace):
             logger.debug("Skipping %s: another pass got there first", namespace)
             continue
@@ -370,7 +490,18 @@ def _reclaimable_on(pool: StoragePool) -> list[tuple[Path, ReclaimableMarker]]:
     return entries
 
 
-def _evict(namespace: str, report: ReconcileReport, *, dry_run: bool) -> int:
+def _evict(
+    namespace: str,
+    report: ReconcileReport,
+    *,
+    dry_run: bool,
+    is_live: Callable[[str], bool] | None = None,
+) -> int:
+    if is_live is not None and is_live(namespace):
+        # A stale marker on a live VM, or a create that adopted the directory
+        # since this pass started listing it.
+        logger.warning("Not evicting %s: a live VM owns it despite its reclaimable marker", namespace)
+        return 0
     if not _still_on_disk(namespace):
         logger.debug("Not evicting %s: its directories are already gone", namespace)
         return 0
@@ -382,7 +513,12 @@ def _evict(namespace: str, report: ReconcileReport, *, dry_run: bool) -> int:
     return size
 
 
-def _enforce_retention_budget(report: ReconcileReport, *, dry_run: bool) -> None:
+def _enforce_retention_budget(
+    report: ReconcileReport,
+    *,
+    dry_run: bool,
+    is_live: Callable[[str], bool] | None = None,
+) -> None:
     reap = settings.VOLUME_RETENTION == "reap"
     for pool in get_pools():
         entries = _reclaimable_on(pool)
@@ -399,7 +535,7 @@ def _enforce_retention_budget(report: ReconcileReport, *, dry_run: bool) -> None
             if directory.name in report.evicted:
                 # A VM spanning two pools is purged whole on the first one.
                 continue
-            _evict(directory.name, report, dry_run=dry_run)
+            _evict(directory.name, report, dry_run=dry_run, is_live=is_live)
 
 
 def make_room(pool: StoragePool, needed_bytes: int, *, live: Collection[str] | None = None) -> int:
@@ -422,22 +558,20 @@ def make_room(pool: StoragePool, needed_bytes: int, *, live: Collection[str] | N
     loop. It can therefore overlap a pass running in another thread, which is
     why every removal here tolerates a directory that vanished first.
     """
-    protected = set(live or ())
+    protected = _snapshot_is_live(live or ())
     freed = 0
     report = ReconcileReport()
     for directory, _marker in _reclaimable_on(pool):
         if _pool_free(pool) >= needed_bytes or freed >= needed_bytes:
             break
-        if directory.name in protected:
-            logger.warning("Not evicting %s: a live VM owns it despite its reclaimable marker", directory)
-            continue
         if not directory.is_dir():
             # A concurrent pass took it between the listing and now.
             continue
         # Only what this pool gets back: _evict purges the VM on every pool
         # it spans, and the other pools' bytes do not help this create.
         on_this_pool = directory_size_bytes(directory)
-        _evict(directory.name, report, dry_run=False)
+        if not _evict(directory.name, report, dry_run=False, is_live=protected):
+            continue
         freed += on_this_pool
     if freed:
         logger.info("Made room on %s: evicted %s (%d bytes)", pool.path, ", ".join(report.evicted), freed)
@@ -459,18 +593,32 @@ def _pass_lock(app: web.Application) -> asyncio.Lock:
     return cached[1]
 
 
-async def reconcile_now(app: web.Application, *, dry_run: bool = False) -> ReconcileReport:
+async def reconcile_now(app: web.Application, *, dry_run: bool = False, strict: bool = False) -> ReconcileReport:
     """One pass, off the event loop, serialized against the other passes.
 
     A GONE fires a pass while the periodic one may still be running: two
     threads walking the same pools would evict the same directories twice,
     double-counting the bytes freed and logging each removal twice. The
     waiting pass is not redundant, it re-reads the filesystem when it starts.
+
+    ``strict`` is for the startup pass: it downgrades the pass to a dry run
+    when the live set cannot be trusted (``_startup_refusal``).
     """
     registry = app["vm_registry"]
     async with _pass_lock(app):
-        live = live_hashes(registry)
-        return await asyncio.to_thread(reconcile_storage, registry, dry_run=dry_run, live=live)
+        live, running = await _live_set(app)
+        if strict and not dry_run:
+            refusal = _startup_refusal(registry, running)
+            if refusal is not None:
+                logger.warning("Startup storage reconcile is running dry and will purge nothing: %s", refusal)
+                dry_run = True
+        return await asyncio.to_thread(
+            reconcile_storage,
+            registry,
+            dry_run=dry_run,
+            live=live,
+            is_live=registry_is_live(registry, live),
+        )
 
 
 def _log_startup_preview(preview: ReconcileReport) -> None:
@@ -510,10 +658,15 @@ def _log_startup_preview(preview: ReconcileReport) -> None:
 async def reconcile_at_startup(app: web.Application) -> None:
     """on_startup hook: one pass, preceded by a summary of what the pass will
     remove, so an operator reading the log knows why free space jumped after
-    an upgrade."""
+    an upgrade.
+
+    The pass is strict: it refuses to purge anything when the supervisor
+    cannot be listed, or when rehydration left the registry empty while the
+    supervisor still runs VMs.
+    """
     preview = await reconcile_now(app, dry_run=True)
     _log_startup_preview(preview)
-    await reconcile_now(app)
+    await reconcile_now(app, strict=True)
 
 
 async def periodic_reconcile(app: web.Application) -> None:

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -1,0 +1,352 @@
+"""Storage reconciler: the filesystem is the truth, the registry says who is alive.
+
+Runs at startup, every VOLUME_RECONCILE_INTERVAL, after every GONE retire,
+and on admission pressure (make_room). Each pass walks the pools and the
+per-VM side directories and applies VOLUME_RETENTION to anything no live VM
+owns. It only ever touches directories the agent created, keyed by a
+plausible item hash; a create in flight (``creating``) or younger than
+VOLUME_CREATE_GUARD is left alone.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import random
+import shutil
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from aiohttp import web
+
+from aleph.vm.agent.vm.backup import sweep_expired_backups
+from aleph.vm.agent.vm.purge import _ITEM_HASH_PATTERN, purge_vm_storage
+from aleph.vm.agent.vm.reclaimable import (
+    ReclaimableMarker,
+    adopt,
+    clear_marker,
+    directory_size_bytes,
+    iter_reclaimable,
+    mark_reclaimable,
+    read_marker,
+)
+from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.conf import settings
+from aleph.vm.storage_budget import parse_budget
+from aleph.vm.storage_pools import StoragePool, get_pools, iter_namespace_dirs
+from aleph.vm.utils import create_task_log_exceptions
+
+logger = logging.getLogger(__name__)
+
+# Where create_devmapper mounts a volume while resizing it (storage.py mounts
+# /mnt/{namespace}_{volume name}).
+MOUNT_ROOT = Path("/mnt")
+STAGING_KINDS = ("vprogram", "snp-instance")
+
+_creating: set[str] = set()
+
+
+@dataclass
+class ReconcileReport:
+    purged_orphans: list[str] = field(default_factory=list)
+    marked_orphans: list[str] = field(default_factory=list)
+    evicted: list[str] = field(default_factory=list)
+    parts_removed: int = 0
+    side_dirs_removed: int = 0
+    backups_removed: int = 0
+    bytes_freed: int = 0
+
+    def summary(self) -> str:
+        return (
+            f"orphans purged={len(self.purged_orphans)} marked={len(self.marked_orphans)}, "
+            f"evicted={len(self.evicted)}, parts={self.parts_removed}, side dirs={self.side_dirs_removed}, "
+            f"backups={self.backups_removed}, freed={self.bytes_freed} bytes"
+        )
+
+
+@contextmanager
+def creating(namespace: str) -> Iterator[None]:
+    """Mark a create as in flight; adopt retained directories on entry."""
+    adopt(namespace)
+    _creating.add(namespace)
+    try:
+        yield
+    finally:
+        _creating.discard(namespace)
+
+
+def is_creating(namespace: str) -> bool:
+    return namespace in _creating
+
+
+def _plausible(name: str) -> bool:
+    return bool(_ITEM_HASH_PATTERN.match(name))
+
+
+def _mtime(path: Path) -> datetime:
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+
+
+def _dir_bytes(namespace: str) -> int:
+    """Allocated bytes of a VM's volumes, on every pool it spans."""
+    return sum(directory_size_bytes(directory) for directory in iter_namespace_dirs(namespace))
+
+
+def reconcile_storage(
+    registry: AgentVmRegistry,
+    *,
+    now: datetime | None = None,
+    dry_run: bool = False,
+) -> ReconcileReport:
+    """One reconciliation pass: namespaces, .part files, side directories,
+    the retention budget, then the backups."""
+    now = now or datetime.now(tz=timezone.utc)
+    guard = timedelta(seconds=settings.VOLUME_CREATE_GUARD)
+    live = {str(vm_hash) for vm_hash, _ in registry.items()}
+    report = ReconcileReport()
+    _reconcile_namespaces(live, now, guard, report, dry_run=dry_run)
+    _sweep_parts(now, guard, report, dry_run=dry_run)
+    _sweep_side_dirs(live, report, dry_run=dry_run)
+    _enforce_retention_budget(report, dry_run=dry_run)
+    if not dry_run:
+        report.backups_removed = sweep_expired_backups(now)
+    logger.info("Storage reconcile%s: %s", " (dry run)" if dry_run else "", report.summary())
+    return report
+
+
+def _is_orphan(directory: Path, live: set[str], now: datetime, guard: timedelta, *, dry_run: bool) -> bool:
+    """True when nothing owns ``directory`` and the reconciler may act on it.
+
+    A live VM's directory is owned; a stale marker on one (a VM re-created
+    without going through ``creating()``) is cleared here so the budget pass
+    cannot evict a running VM's disks. A directory that already carries a
+    marker is reclaimable, not an orphan: the budget pass owns it. What is
+    left is unowned, unless it is young enough to be a create in flight.
+    """
+    namespace = directory.name
+    if namespace in live or is_creating(namespace):
+        if read_marker(directory) is not None and not dry_run:
+            clear_marker(directory)
+        return False
+    if read_marker(directory) is not None:
+        return False
+    try:
+        return now - _mtime(directory) >= guard
+    except OSError:
+        return False
+
+
+def _reconcile_namespaces(
+    live: set[str],
+    now: datetime,
+    guard: timedelta,
+    report: ReconcileReport,
+    *,
+    dry_run: bool,
+) -> None:
+    seen: set[str] = set()
+    for directory in list(iter_namespace_dirs()):
+        namespace = directory.name
+        if not _plausible(namespace):
+            # A pool is usually a mountpoint, so lost+found is expected here:
+            # debug, not a warning repeated every VOLUME_RECONCILE_INTERVAL.
+            logger.debug("Ignoring %s: not a VM directory", directory)
+            continue
+        # A VM spanning two pools is handled once: purging or marking covers
+        # every pool it is on.
+        if namespace in seen or not _is_orphan(directory, live, now, guard, dry_run=dry_run):
+            continue
+        seen.add(namespace)
+        if settings.VOLUME_RETENTION == "keep":
+            report.marked_orphans.append(namespace)
+            if not dry_run:
+                mark_reclaimable(namespace, "orphan", now=now)
+        else:
+            report.purged_orphans.append(namespace)
+            report.bytes_freed += _dir_bytes(namespace)
+            if not dry_run:
+                purge_vm_storage(namespace)
+
+
+def _part_roots() -> Iterator[Path]:
+    """Where a half-downloaded file can sit: the four caches, and every
+    per-VM volume directory (the downloader streams volumes in place)."""
+    for cache in (settings.RUNTIME_CACHE, settings.CODE_CACHE, settings.DATA_CACHE, settings.MESSAGE_CACHE):
+        if cache:
+            yield Path(cache)
+    yield from iter_namespace_dirs()
+
+
+def _sweep_parts(now: datetime, guard: timedelta, report: ReconcileReport, *, dry_run: bool) -> None:
+    for root in _part_roots():
+        try:
+            parts = list(root.glob("*.part"))
+        except OSError:
+            continue
+        for part in parts:
+            try:
+                stat = part.stat()
+                if now - datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc) < guard:
+                    continue
+                if not dry_run:
+                    part.unlink()
+                    logger.info("Removed stale partial download %s", part)
+                report.parts_removed += 1
+                report.bytes_freed += stat.st_blocks * 512
+            except OSError:
+                logger.warning("Failed to remove %s", part, exc_info=True)
+
+
+def _side_dir_roots() -> Iterator[tuple[Path, str]]:
+    """(root, how the hash is derived from the child name)."""
+    if settings.CONFIDENTIAL_SESSION_DIRECTORY:
+        yield Path(settings.CONFIDENTIAL_SESSION_DIRECTORY), "exact"
+    for kind in STAGING_KINDS:
+        yield Path(settings.EXECUTION_ROOT) / kind, "exact"
+    yield MOUNT_ROOT, "prefix"  # /mnt/{namespace}_{volume name}
+
+
+def _sweep_side_dirs(live: set[str], report: ReconcileReport, *, dry_run: bool) -> None:
+    for root, mode in _side_dir_roots():
+        if not root.is_dir():
+            continue
+        for child in list(root.iterdir()):
+            if not child.is_dir():
+                continue
+            namespace = child.name if mode == "exact" else child.name.split("_", 1)[0]
+            if not _plausible(namespace) or namespace in live or is_creating(namespace):
+                continue
+            if os.path.ismount(child):
+                logger.warning("Not removing %s: it is a mount point", child)
+                continue
+            if not dry_run:
+                try:
+                    shutil.rmtree(child)
+                except OSError:
+                    logger.warning("Failed to remove %s", child, exc_info=True)
+                    continue
+                logger.info("Removed the stale side directory %s", child)
+            report.side_dirs_removed += 1
+
+
+def _pool_total(pool: StoragePool) -> int:
+    try:
+        return shutil.disk_usage(str(pool.path)).total
+    except OSError:
+        return 0
+
+
+def _reclaimable_on(pool: StoragePool) -> list[tuple[Path, ReclaimableMarker]]:
+    """The pool's reclaimable directories, oldest marker first.
+
+    Implausibly named directories are dropped here rather than left to fail
+    the ``_checked_namespace`` guard mid-pass: a hand-made marker under a
+    directory nobody named after a VM must not abort a reconcile.
+    """
+    entries = [
+        (directory, marker)
+        for directory, marker in iter_reclaimable()
+        if directory.parent == pool.path and _plausible(directory.name)
+    ]
+    entries.sort(key=lambda item: item[1].reclaimable_since)
+    return entries
+
+
+def _evict(namespace: str, report: ReconcileReport, *, dry_run: bool) -> int:
+    size = _dir_bytes(namespace)
+    report.evicted.append(namespace)
+    report.bytes_freed += size
+    if not dry_run:
+        purge_vm_storage(namespace)
+    return size
+
+
+def _enforce_retention_budget(report: ReconcileReport, *, dry_run: bool) -> None:
+    reap = settings.VOLUME_RETENTION == "reap"
+    for pool in get_pools():
+        entries = _reclaimable_on(pool)
+        if not entries:
+            continue
+        # Under reap nothing is retained: a node switched from keep to reap
+        # gives back everything marked, whatever the budget says.
+        budget = 0 if reap else parse_budget(settings.VOLUME_RETENTION_BUDGET, _pool_total(pool))
+        total = sum(marker.size_bytes for _, marker in entries)
+        for directory, marker in entries:
+            if not reap and total <= budget:
+                break
+            total -= marker.size_bytes
+            if directory.name in report.evicted:
+                # A VM spanning two pools is purged whole on the first one.
+                continue
+            _evict(directory.name, report, dry_run=dry_run)
+
+
+def make_room(pool: StoragePool, needed_bytes: int) -> int:
+    """Evict reclaimable directories on ``pool``, oldest first, until
+    ``needed_bytes`` have been freed or nothing reclaimable is left. Returns
+    the bytes freed."""
+    freed = 0
+    report = ReconcileReport()
+    for directory, _marker in _reclaimable_on(pool):
+        if freed >= needed_bytes:
+            break
+        freed += _evict(directory.name, report, dry_run=False)
+    if freed:
+        logger.info("Made room on %s: evicted %s (%d bytes)", pool.path, ", ".join(report.evicted), freed)
+    return freed
+
+
+async def reconcile_now(app: web.Application) -> ReconcileReport:
+    return await asyncio.to_thread(reconcile_storage, app["vm_registry"])
+
+
+async def reconcile_at_startup(app: web.Application) -> None:
+    """on_startup hook: one pass, preceded by a summary of what the pass will
+    remove, so an operator reading the log knows why free space jumped after
+    an upgrade."""
+    registry = app["vm_registry"]
+    preview = await asyncio.to_thread(reconcile_storage, registry, dry_run=True)
+    if preview.purged_orphans or preview.marked_orphans or preview.evicted:
+        logger.warning(
+            "Startup storage reconcile will purge %d orphan(s), mark %d, evict %d, freeing about %d bytes "
+            "(VOLUME_RETENTION=%s)",
+            len(preview.purged_orphans),
+            len(preview.marked_orphans),
+            len(preview.evicted),
+            preview.bytes_freed,
+            settings.VOLUME_RETENTION,
+        )
+    await reconcile_now(app)
+
+
+async def periodic_reconcile(app: web.Application) -> None:
+    interval = settings.VOLUME_RECONCILE_INTERVAL
+    # Jitter, not cryptography: spread the passes of a fleet of nodes.
+    await asyncio.sleep(random.uniform(0, interval))  # noqa: S311
+    while True:
+        try:
+            await reconcile_now(app)
+        except Exception as error:
+            if isinstance(error, RuntimeError) and "Event loop is closed" in str(error):
+                return
+            logger.warning("Storage reconcile failed: %s", error, exc_info=True)
+        await asyncio.sleep(interval * random.uniform(0.85, 1.15))  # noqa: S311
+
+
+async def start_storage_reconcile_task(app: web.Application) -> None:
+    app["storage_reconcile"] = create_task_log_exceptions(periodic_reconcile(app), name="storage_reconcile")
+
+
+async def stop_storage_reconcile_task(app: web.Application) -> None:
+    task = app.get("storage_reconcile")
+    if task is None:
+        return
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        logger.debug("Task storage_reconcile is cancelled now")

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -117,8 +117,11 @@ def creating(namespace: str) -> Iterator[None]:
     # is_creating as False must have read it before this line, and then
     # still sees the marker adopt() has yet to clear.
     _creating[namespace] = _creating.get(namespace, 0) + 1
-    adopt(namespace)
     try:
+        # Inside the try: an adopt that raises (a marker that cannot be
+        # unlinked) must not leave the guard up for good, which would exempt
+        # the namespace from every future pass.
+        adopt(namespace)
         yield
     finally:
         remaining = _creating[namespace] - 1

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -516,6 +516,12 @@ def _evict(
         # since this pass started listing it.
         logger.warning("Not evicting %s: a live VM owns it despite its reclaimable marker", namespace)
         return 0
+    if is_creating(namespace):
+        # The owner re-created this VM after the pass listed it: creating()
+        # adopted the directory (clearing the marker), but the registry record
+        # only lands when the create commits, so is_live cannot catch this yet.
+        logger.warning("Not evicting %s: a create in flight owns it", namespace)
+        return 0
     if not _still_on_disk(namespace):
         logger.debug("Not evicting %s: its directories are already gone", namespace)
         return 0

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -106,8 +106,14 @@ def creating(namespace: str) -> Iterator[None]:
     a promise, so a reset order is acceptable; adopting later would mean a
     create racing the eviction of the very disks it is about to reuse.
     """
-    adopt(namespace)
+    # Register before adopting: between clear_marker and the add there would
+    # otherwise be an instant where the directory is protected by neither
+    # the marker nor the creating set, and a concurrent pass would see an
+    # unmarked, not-creating orphan. Registered first, a pass that read
+    # is_creating as False must have read it before this line, and then
+    # still sees the marker adopt() has yet to clear.
     _creating.add(namespace)
+    adopt(namespace)
     try:
         yield
     finally:
@@ -268,7 +274,7 @@ def reconcile_storage(
     report = ReconcileReport()
     _reconcile_namespaces(now, guard, report, dry_run=dry_run, is_live=is_live)
     _sweep_parts(now, guard, report, dry_run=dry_run)
-    _sweep_side_dirs(live, now, guard, report, dry_run=dry_run)
+    _sweep_side_dirs(live, now, guard, report, dry_run=dry_run, is_live=is_live)
     _enforce_retention_budget(report, dry_run=dry_run, is_live=is_live)
     if not dry_run:
         report.backups_removed = sweep_expired_backups(now)
@@ -325,8 +331,9 @@ def _reconcile_namespaces(
         if namespace in seen or not _is_orphan(directory, is_live, now, guard, dry_run=dry_run):
             continue
         seen.add(namespace)
-        if is_live(namespace):
-            # A create that committed between the live snapshot and this walk.
+        if is_live(namespace) or is_creating(namespace):
+            # A create that committed, or entered creating(), between the
+            # live snapshot and this walk.
             logger.info("Skipping %s: a VM claimed it while this pass was walking", namespace)
             continue
         if not dry_run and not _still_on_disk(namespace):
@@ -450,12 +457,18 @@ def _sweep_side_dirs(
     report: ReconcileReport,
     *,
     dry_run: bool,
+    is_live: Callable[[str], bool],
 ) -> None:
     for root, mode in _side_dir_roots():
         if not root.is_dir():
             continue
         for child in list(root.iterdir()):
             if not _is_stale_side_dir(child, mode, live, now, guard):
+                continue
+            namespace = child.name if mode == "exact" else child.name.split("_", 1)[0]
+            if is_live(namespace) or is_creating(namespace):
+                # Claimed since the listing: the same re-check the namespace
+                # pass and the evictor make immediately before removing.
                 continue
             if not dry_run:
                 try:

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -558,11 +558,19 @@ def _enforce_retention_budget(
         for directory, marker in entries:
             if not reap and total <= budget:
                 break
-            total -= marker.size_bytes
             if directory.name in report.evicted:
                 # A VM spanning two pools is purged whole on the first one.
+                total -= marker.size_bytes
                 continue
-            _evict(directory.name, report, dry_run=dry_run, is_live=is_live)
+            evicted = _evict(directory.name, report, dry_run=dry_run, is_live=is_live)
+            if evicted or not _still_on_disk(directory.name):
+                # Only bytes that actually left the disk count against the
+                # excess. A declined eviction (a live or in-flight re-create,
+                # a dm-held purge refusal) keeps its bytes: spending them
+                # anyway would stop every pass early at the same entry, a
+                # stable under-enforcement, since the marker survives and the
+                # next pass recomputes the same total.
+                total -= marker.size_bytes
 
 
 def make_room(pool: StoragePool, needed_bytes: int, *, live: Collection[str] | None = None) -> int:

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -198,12 +198,30 @@ async def _live_set(app: web.Application) -> tuple[set[str], int | None]:
     if supervisor is None:
         logger.warning("No supervisor handle on the app; the live set is the agent registry alone")
         return registry_live, None
+    global _last_supervisor_hashes  # noqa: PLW0603
     try:
         running = await supervisor_hashes(supervisor)
     except Exception as error:
         logger.warning("Could not list the supervisor's VMs (%s); the live set is the agent registry alone", error)
         return registry_live, None
+    _last_supervisor_hashes = running
     return registry_live | running, len(running)
+
+
+# What the supervisor listed at the last pass, for the one caller that cannot
+# ask it: the room maker runs synchronously on the placement path.
+_last_supervisor_hashes: set[str] = set()
+
+
+def known_live_hashes(registry: AgentVmRegistry) -> set[str]:
+    """``live_hashes`` plus the supervisor's VMs as of the last pass.
+
+    The reconciler judges against registry union supervisor because the
+    registry alone can lose a running VM's record; placement-pressure
+    eviction should protect the same set, and a listing a few minutes old
+    can only add names to it, never drop a live one that a pass would keep.
+    """
+    return live_hashes(registry) | _last_supervisor_hashes
 
 
 def _startup_refusal(registry: AgentVmRegistry, running: int | None) -> str | None:

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -67,7 +67,11 @@ logger = logging.getLogger(__name__)
 MOUNT_ROOT = Path("/mnt")
 STAGING_KINDS = ("vprogram", "snp-instance")
 
-_creating: set[str] = set()
+# Namespace to the number of creates in flight for it. A count rather than
+# a set: a scheduler push and an operator reinstall take no common per-hash
+# lock, so two creating() spans for one hash can overlap, and the first to
+# exit must not unguard the second.
+_creating: dict[str, int] = {}
 
 
 @dataclass
@@ -112,12 +116,16 @@ def creating(namespace: str) -> Iterator[None]:
     # unmarked, not-creating orphan. Registered first, a pass that read
     # is_creating as False must have read it before this line, and then
     # still sees the marker adopt() has yet to clear.
-    _creating.add(namespace)
+    _creating[namespace] = _creating.get(namespace, 0) + 1
     adopt(namespace)
     try:
         yield
     finally:
-        _creating.discard(namespace)
+        remaining = _creating[namespace] - 1
+        if remaining:
+            _creating[namespace] = remaining
+        else:
+            del _creating[namespace]
 
 
 def is_creating(namespace: str) -> bool:

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -561,6 +561,14 @@ def _evict(
         # only lands when the create commits, so is_live cannot catch this yet.
         logger.warning("Not evicting %s: a create in flight owns it", namespace)
         return 0
+    # A residual window remains on the periodic pass, which runs in a worker
+    # thread: a create can enter creating() on the event loop between this
+    # check and the purge below and adopt a directory that is about to go.
+    # Closing it would take a lock shared with creating() and held across the
+    # rmtree, stalling every create for the length of a purge, so it is left
+    # open; the window is a few instructions wide and needs the pool to be
+    # over budget at that instant. The room maker's evictions run on the
+    # event loop itself, where creating() cannot interleave at all.
     if not _still_on_disk(namespace):
         logger.debug("Not evicting %s: its directories are already gone", namespace)
         return 0

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -393,6 +393,14 @@ def _part_roots() -> Iterator[Path]:
     A namespace a create holds is skipped whole: a migration import streams
     multi-GB disks into it for far longer than VOLUME_CREATE_GUARD, and its
     ``.part`` files belong to that transfer however old they look.
+
+    Only the creating set is consulted, not the live set: a running VM's
+    directory is walked. That is sound only because every path that
+    downloads into a namespace (the create paths, a reinstall's volume
+    rebuild, a migration import) runs under ``creating()``. A new download
+    path that streams into the directory of a running VM outside the guard
+    would have its ``.part`` files removed from under it once they outlive
+    the guard.
     """
     for cache in (settings.RUNTIME_CACHE, settings.CODE_CACHE, settings.DATA_CACHE, settings.MESSAGE_CACHE):
         if cache:

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -98,8 +98,8 @@ def creating(namespace: str) -> Iterator[None]:
 
     Every create path must be wrapped in this: it is the only thing that
     keeps a reconcile pass off a half-built VM once the create outlives
-    VOLUME_CREATE_GUARD, and the only place a retained directory is adopted
-    (spec section 3). A create that stages files, allocates volumes or
+    VOLUME_CREATE_GUARD, and the only place a retained directory is adopted.
+    A create that stages files, allocates volumes or
     writes a session directory outside this context can have them removed
     from under it by the next pass.
 
@@ -757,7 +757,7 @@ def _log_startup_preview(preview: ReconcileReport, *, refusal: str | None = None
 
     On an upgraded node the first pass finds every directory leaked by the
     bugs this work fixes, which under ``reap`` is a one-shot cleanup of
-    potentially a lot of data (spec section 6). The per-pool breakdown is
+    potentially a lot of data. The per-pool breakdown is
     what lets an operator match the log against the disk whose free space
     jumped.
 

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -660,9 +660,13 @@ def make_room(pool: StoragePool, needed_bytes: int, *, live: Collection[str] | N
 
     Admission pressure, not a quota: the pool's own free space is what has
     to reach ``needed_bytes``, so a pool that already fits the create loses
-    nothing. The second bound (``freed >= needed_bytes``) only exists so an
-    unreadable or lying filesystem cannot turn this into a loop over every
-    retained VM on the pool.
+    nothing, and a pool that could not fit it even with every retained
+    directory gone loses nothing either (placement then fails, but without
+    having wiped retained data for it, on this pool or the next one it
+    tries). The third bound (``freed >= needed_bytes``) only exists so a
+    lying filesystem cannot turn this into a loop over every retained VM on
+    the pool; a pool whose free space cannot be read at all is never evicted
+    from.
 
     A marker on a directory a live VM owns is a bug (``_is_orphan`` clears
     those on every pass), but this runs on its own, off the create path, so
@@ -675,9 +679,23 @@ def make_room(pool: StoragePool, needed_bytes: int, *, live: Collection[str] | N
     why every removal here tolerates a directory that vanished first.
     """
     protected = _snapshot_is_live(live or ())
+    free = _pool_free(pool)
+    if free >= needed_bytes:
+        return 0
+    entries = _reclaimable_on(pool)
+    reclaimable = sum(directory_size_bytes(directory) for directory, _marker in entries)
+    if free + reclaimable < needed_bytes:
+        logger.info(
+            "Not making room on %s: %d bytes free plus %d retained cannot fit %d bytes",
+            pool.path,
+            free,
+            reclaimable,
+            needed_bytes,
+        )
+        return 0
     freed = 0
     report = ReconcileReport()
-    for directory, _marker in _reclaimable_on(pool):
+    for directory, _marker in entries:
         if _pool_free(pool) >= needed_bytes or freed >= needed_bytes:
             break
         if not directory.is_dir():

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -354,36 +354,62 @@ def _reconcile_namespaces(
             continue
         # A VM spanning two pools is handled once: purging or marking covers
         # every pool it is on.
-        if namespace in seen or not _is_orphan(directory, is_live, now, guard, dry_run=dry_run):
+        if namespace in seen:
             continue
-        seen.add(namespace)
-        if is_live(namespace) or is_creating(namespace):
-            # A create that committed, or entered creating(), between the
-            # live snapshot and this walk.
-            logger.info("Skipping %s: a VM claimed it while this pass was walking", namespace)
-            continue
-        if not dry_run and not _still_on_disk(namespace):
-            logger.debug("Skipping %s: another pass got there first", namespace)
-            continue
-        if settings.VOLUME_RETENTION == "keep":
-            report.marked_orphans.append(namespace)
-            if not dry_run:
-                mark_reclaimable(namespace, "orphan", now=now)
-        else:
-            freed = _dir_bytes(namespace)
-            if dry_run:
-                report.purged_orphans.append(namespace)
-                report.bytes_freed += freed
-                continue
-            purge_vm_storage(namespace)
-            if _still_on_disk(namespace):
-                # purge_vm_storage refuses a directory a device-mapper target
-                # still holds. Nothing was freed, so nothing may be reported
-                # as freed; the next pass tries again.
-                logger.warning("Purge of %s left directories behind; not counting them as reclaimed", namespace)
-                continue
-            report.purged_orphans.append(namespace)
-            report.bytes_freed += freed
+        try:
+            if _reconcile_namespace(directory, now, guard, report, dry_run=dry_run, is_live=is_live):
+                seen.add(namespace)
+        except Exception:
+            # One directory must not take the pass down with it, nor the
+            # agent's boot when this is the startup pass: the parts and
+            # side-directory sweeps skip a failing item the same way, and the
+            # next pass retries this one.
+            logger.exception("Reconcile of %s failed; leaving it for the next pass", namespace)
+            seen.add(namespace)
+
+
+def _reconcile_namespace(
+    directory: Path,
+    now: datetime,
+    guard: timedelta,
+    report: ReconcileReport,
+    *,
+    dry_run: bool,
+    is_live: Callable[[str], bool],
+) -> bool:
+    """Apply the retention policy to one directory. True when it was judged
+    an orphan, so the namespace pass covers a VM spanning two pools once."""
+    namespace = directory.name
+    if not _is_orphan(directory, is_live, now, guard, dry_run=dry_run):
+        return False
+    if is_live(namespace) or is_creating(namespace):
+        # A create that committed, or entered creating(), between the
+        # live snapshot and this walk.
+        logger.info("Skipping %s: a VM claimed it while this pass was walking", namespace)
+        return True
+    if not dry_run and not _still_on_disk(namespace):
+        logger.debug("Skipping %s: another pass got there first", namespace)
+        return True
+    if settings.VOLUME_RETENTION == "keep":
+        if not dry_run:
+            mark_reclaimable(namespace, "orphan", now=now)
+        report.marked_orphans.append(namespace)
+        return True
+    freed = _dir_bytes(namespace)
+    if dry_run:
+        report.purged_orphans.append(namespace)
+        report.bytes_freed += freed
+        return True
+    purge_vm_storage(namespace)
+    if _still_on_disk(namespace):
+        # purge_vm_storage refuses a directory a device-mapper target
+        # still holds. Nothing was freed, so nothing may be reported
+        # as freed; the next pass tries again.
+        logger.warning("Purge of %s left directories behind; not counting them as reclaimed", namespace)
+        return True
+    report.purged_orphans.append(namespace)
+    report.bytes_freed += freed
+    return True
 
 
 def _part_roots() -> Iterator[Path]:
@@ -770,12 +796,19 @@ async def reconcile_at_startup(app: web.Application) -> None:
     rehydration left the registry empty while the supervisor still runs VMs.
     """
     registry = app["vm_registry"]
-    async with _pass_lock(app):
-        live, running = await _live_set(app)
-        refusal = _startup_refusal(registry, running)
-        _log_startup_preview(await _pass(registry, live, dry_run=True), refusal=refusal)
-        if refusal is None:
-            await _pass(registry, live, dry_run=False)
+    try:
+        async with _pass_lock(app):
+            live, running = await _live_set(app)
+            refusal = _startup_refusal(registry, running)
+            _log_startup_preview(await _pass(registry, live, dry_run=True), refusal=refusal)
+            if refusal is None:
+                await _pass(registry, live, dry_run=False)
+    except Exception:
+        # Housekeeping never blocks the boot: an on_startup hook that raises
+        # stops the agent, and a full or read-only pool is exactly what this
+        # pass is meant to relieve, not a reason to loop the operator into
+        # fixing it by hand. The periodic pass retries.
+        logger.exception("Startup storage reconcile failed; the periodic pass will retry")
 
 
 async def periodic_reconcile(app: web.Application) -> None:

--- a/src/aleph/vm/agent/vm/retire.py
+++ b/src/aleph/vm/agent/vm/retire.py
@@ -1,0 +1,83 @@
+"""The one way the agent ends a VM.
+
+Every path that used to call ``supervisor.delete_vm`` and then some subset
+of ``registry.forget``, ``delete_records_for_vm`` and ``remove_*_staging``
+goes through ``retire_vm`` with a reason. The reason has no default: a call
+site must say what it means, which is what was missing when disks leaked
+(spec S1). The supervisor's DeleteVm is quiescence only; storage policy is
+decided here, agent-side, and never crosses the wire.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from enum import Enum
+
+from aleph_message.models import ItemHash
+
+from aleph.vm.agent.metrics import delete_records_for_vm
+from aleph.vm.agent.vm.backup import purge_vm_backups
+from aleph.vm.agent.vm.purge import purge_vm_side_dirs, purge_vm_storage
+from aleph.vm.agent.vm.reclaimable import depends_on_from_content, mark_reclaimable
+from aleph.vm.agent.vm_registry import AgentVmRecord, AgentVmRegistry
+from aleph.vm.conf import settings
+from aleph.vm.supervisor_interface.abc import Supervisor
+from aleph.vm.supervisor_interface.errors import VmNotFoundError
+from aleph.vm.supervisor_interface.types import VmId
+
+logger = logging.getLogger(__name__)
+
+
+class RetireReason(Enum):
+    RECREATE = "recreate"  # the same VM comes back immediately: amend, crash recovery, idle reap, reboot
+    GONE = "gone"  # positive knowledge it will not return: forgotten, unpaid, deallocated, migrated away
+    ERASE = "erase"  # the owner asked for a wipe
+    FAILED_CREATE = "failed_create"  # a create that never committed
+
+
+async def retire_vm(
+    vm_hash: ItemHash | str,
+    reason: RetireReason,
+    *,
+    supervisor: Supervisor,
+    registry: AgentVmRegistry | None = None,
+) -> None:
+    """Quiesce the VM through the supervisor, then apply ``reason`` to
+    everything the agent holds for it: registry record, DB records, volumes,
+    session and staging directories, backups.
+
+    RECREATE stops after the quiesce (port mappings kept, storage untouched).
+    Every other reason drops the records and the side directories; GONE
+    applies VOLUME_RETENTION to the volumes, ERASE and FAILED_CREATE purge
+    them regardless (retention protects against administrative deletion,
+    not against the owner's own request, and a VM that never ran has nothing
+    worth keeping).
+    """
+    vm_id = VmId(str(vm_hash))
+    try:
+        await supervisor.delete_vm(vm_id, keep_port_mappings=reason is RetireReason.RECREATE)
+    except VmNotFoundError:
+        logger.debug("Retire %s (%s): the supervisor does not know it", vm_hash, reason.value)
+    if reason is RetireReason.RECREATE:
+        return
+    if registry is None:
+        msg = f"retire_vm({reason.value}) needs the registry to drop the VM's record"
+        raise ValueError(msg)
+
+    item_hash = vm_hash if isinstance(vm_hash, ItemHash) else ItemHash(str(vm_hash))
+    record = registry.get(item_hash)
+    registry.forget(item_hash)
+    await delete_records_for_vm(str(vm_hash))
+    await asyncio.to_thread(_release_storage, str(vm_hash), reason, record)
+    await asyncio.to_thread(purge_vm_backups, str(vm_hash))
+    logger.info("Retired %s (%s)", vm_hash, reason.value)
+
+
+def _release_storage(namespace: str, reason: RetireReason, record: AgentVmRecord | None) -> None:
+    if reason is RetireReason.GONE and settings.VOLUME_RETENTION == "keep":
+        depends_on = depends_on_from_content(record.message) if record is not None else ()
+        mark_reclaimable(namespace, "gone", depends_on)
+        purge_vm_side_dirs(namespace)
+        return
+    purge_vm_storage(namespace)

--- a/src/aleph/vm/agent/vm/retire.py
+++ b/src/aleph/vm/agent/vm/retire.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from enum import Enum
 
 from aleph_message.models import ItemHash
@@ -45,6 +46,23 @@ class RetireReason(Enum):
     GONE = "gone"  # positive knowledge it will not return: forgotten, unpaid, deallocated, migrated away
     ERASE = "erase"  # the owner asked for a wipe
     FAILED_CREATE = "failed_create"  # a create that never committed and allocated nothing pre-existing
+
+
+AfterGoneHook = Callable[[], Awaitable[None]]
+_after_gone: AfterGoneHook | None = None
+
+
+def set_after_gone_hook(hook: AfterGoneHook | None) -> None:
+    """The app registers a reconcile pass here; it runs after every GONE
+    under VOLUME_RETENTION=keep so the budget is enforced right away.
+
+    This module cannot import the reconciler (the reconciler purges through
+    the same helpers and the agent wires both at startup), and a retention
+    budget that is only enforced once an hour is a budget an attacker can
+    burst through: create, forget, repeat.
+    """
+    global _after_gone  # noqa: PLW0603
+    _after_gone = hook
 
 
 async def retire_vm(
@@ -83,6 +101,10 @@ async def retire_vm(
     await asyncio.to_thread(_release_storage, str(vm_hash), reason, record)
     await asyncio.to_thread(purge_vm_backups, str(vm_hash))
     logger.info("Retired %s (%s)", vm_hash, reason.value)
+    if reason is RetireReason.GONE and settings.VOLUME_RETENTION == "keep" and _after_gone is not None:
+        # This VM's volumes just became reclaimable: bring the pool back under
+        # its retention budget now rather than at the next periodic pass.
+        await _after_gone()
 
 
 def _release_storage(namespace: str, reason: RetireReason, record: AgentVmRecord | None) -> None:

--- a/src/aleph/vm/agent/vm/retire.py
+++ b/src/aleph/vm/agent/vm/retire.py
@@ -6,6 +6,17 @@ goes through ``retire_vm`` with a reason. The reason has no default: a call
 site must say what it means, which is what was missing when disks leaked
 (spec S1). The supervisor's DeleteVm is quiescence only; storage policy is
 decided here, agent-side, and never crosses the wire.
+
+FAILED_CREATE is only for a create that allocated nothing pre-existing: the
+create paths in ``run.py`` are also the re-create paths for a
+host-persistent VM whose volumes already exist (``downloader``'s
+``_make_writable_volume`` returns early when the destination is already
+there), so a transient failure there (a boot timeout, an admission refusal
+on node restart, a base-image download error) must not retire FAILED_CREATE
+and purge the owner's disks. Those call sites snapshot whether the VM's
+volumes existed before the attempt and retire RECREATE instead when they
+did, keeping the record and the disks so the next create attempt lands on
+the same storage.
 """
 
 from __future__ import annotations
@@ -33,7 +44,7 @@ class RetireReason(Enum):
     RECREATE = "recreate"  # the same VM comes back immediately: amend, crash recovery, idle reap, reboot
     GONE = "gone"  # positive knowledge it will not return: forgotten, unpaid, deallocated, migrated away
     ERASE = "erase"  # the owner asked for a wipe
-    FAILED_CREATE = "failed_create"  # a create that never committed
+    FAILED_CREATE = "failed_create"  # a create that never committed and allocated nothing pre-existing
 
 
 async def retire_vm(

--- a/src/aleph/vm/agent/vm/retire.py
+++ b/src/aleph/vm/agent/vm/retire.py
@@ -117,7 +117,11 @@ async def retire_vm(
 def _release_storage(namespace: str, reason: RetireReason, record: AgentVmRecord | None) -> None:
     if reason is RetireReason.GONE and settings.VOLUME_RETENTION == "keep":
         depends_on = depends_on_from_content(record.message) if record is not None else ()
-        mark_reclaimable(namespace, "gone", depends_on)
+        # The record is about to be the last thing that knew who owns these
+        # disks (this runs after registry.forget and delete_records_for_vm),
+        # so the owner address goes into the marker with it.
+        owner = str(record.message.address) if record is not None and record.message.address else None
+        mark_reclaimable(namespace, "gone", depends_on, owner=owner)
         purge_vm_side_dirs(namespace)
         return
     purge_vm_storage(namespace)

--- a/src/aleph/vm/agent/vm/retire.py
+++ b/src/aleph/vm/agent/vm/retire.py
@@ -104,7 +104,14 @@ async def retire_vm(
     if reason is RetireReason.GONE and settings.VOLUME_RETENTION == "keep" and _after_gone is not None:
         # This VM's volumes just became reclaimable: bring the pool back under
         # its retention budget now rather than at the next periodic pass.
-        await _after_gone()
+        # Best effort: the GONE call sites sweep in a loop (terminal messages,
+        # unpaid VMs) with no local try, and this VM is already retired, so a
+        # failing pass must not take the rest of the sweep down with it. The
+        # periodic pass will retry.
+        try:
+            await _after_gone()
+        except Exception:
+            logger.exception("Storage reconcile after retiring %s failed", vm_hash)
 
 
 def _release_storage(namespace: str, reason: RetireReason, record: AgentVmRecord | None) -> None:

--- a/src/aleph/vm/agent/vm/retire.py
+++ b/src/aleph/vm/agent/vm/retire.py
@@ -3,8 +3,8 @@
 Every path that used to call ``supervisor.delete_vm`` and then some subset
 of ``registry.forget``, ``delete_records_for_vm`` and ``remove_*_staging``
 goes through ``retire_vm`` with a reason. The reason has no default: a call
-site must say what it means, which is what was missing when disks leaked
-(spec S1). The supervisor's DeleteVm is quiescence only; storage policy is
+site must say what it means, which is what was missing when disks leaked.
+The supervisor's DeleteVm is quiescence only; storage policy is
 decided here, agent-side, and never crosses the wire.
 
 FAILED_CREATE is only for a create that allocated nothing pre-existing: the

--- a/src/aleph/vm/agent/vm/retire.py
+++ b/src/aleph/vm/agent/vm/retire.py
@@ -98,7 +98,15 @@ async def retire_vm(
     record = registry.get(item_hash)
     registry.forget(item_hash)
     await delete_records_for_vm(str(vm_hash))
-    await asyncio.to_thread(_release_storage, str(vm_hash), reason, record)
+    try:
+        await asyncio.to_thread(_release_storage, str(vm_hash), reason, record)
+    except Exception:
+        # The VM is gone from the supervisor and its records are dropped; a
+        # marker or purge that failed (ENOSPC, EACCES) leaves an unmarked
+        # directory the next reconcile pass picks up as an orphan. Raising
+        # here would abort the caller's sweep (check_payment, an allocation
+        # push) with this VM half-retired and the others untouched.
+        logger.exception("Storage release of %s (%s) failed; the reconciler will retry", vm_hash, reason.value)
     await asyncio.to_thread(purge_vm_backups, str(vm_hash))
     logger.info("Retired %s (%s)", vm_hash, reason.value)
     if reason is RetireReason.GONE and settings.VOLUME_RETENTION == "keep" and _after_gone is not None:

--- a/src/aleph/vm/backup/archive.py
+++ b/src/aleph/vm/backup/archive.py
@@ -208,31 +208,51 @@ async def create_backup_archive(
 def cleanup_expired_backups(
     backup_dir: Path,
     ttl_hours: int = BACKUP_TTL_HOURS,
+    *,
+    now: float | None = None,
 ) -> int:
     """Remove backup archives older than ``ttl_hours``.
 
-    Also removes the companion .sha256 sidecar files.
+    Also removes the companion .sha256 and .tar.meta.json sidecar files.
+
+    ``now`` is the timestamp the TTL is evaluated against, defaulting to the
+    wall clock. The reconciler passes the one ``now`` it threads through a
+    whole pass, so a run is deterministic and does not drift between the
+    archives it looks at.
+
+    Every file is handled on its own: another sweep, or ``purge_vm_backups``
+    for a VM being retired, can remove an archive between the listing and the
+    unlink. Losing that race is normal, and it must not abort the rest of the
+    pass.
 
     Returns:
         Number of expired archives deleted.
     """
-    cutoff = time.time() - (ttl_hours * 3600)
+    cutoff = (now if now is not None else time.time()) - (ttl_hours * 3600)
     deleted = 0
 
     # A .tar.partial older than the TTL is an archive whose writer died
     # mid-backup (live ones are renamed to .tar within minutes).
     for partial in backup_dir.glob("*.tar.partial"):
-        if partial.stat().st_mtime < cutoff:
-            partial.unlink()
-            logger.info("Deleted stale partial backup %s", partial.name)
+        try:
+            if partial.stat().st_mtime < cutoff:
+                partial.unlink()
+                logger.info("Deleted stale partial backup %s", partial.name)
+        except OSError:
+            logger.debug("Skipping %s: it went away or is not readable", partial, exc_info=True)
 
     for tar_file in backup_dir.glob("*.tar"):
-        if tar_file.stat().st_mtime < cutoff:
+        try:
+            if tar_file.stat().st_mtime >= cutoff:
+                continue
             tar_file.unlink()
             tar_file.with_suffix(".tar.sha256").unlink(missing_ok=True)
             tar_file.with_suffix(".tar.meta.json").unlink(missing_ok=True)
-            logger.info("Deleted expired backup %s", tar_file.name)
-            deleted += 1
+        except OSError:
+            logger.debug("Skipping %s: it went away or is not readable", tar_file, exc_info=True)
+            continue
+        logger.info("Deleted expired backup %s", tar_file.name)
+        deleted += 1
 
     return deleted
 

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -19,6 +19,7 @@ from pydantic import Field, HttpUrl, ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from aleph.vm.chains import STREAM_CHAINS
+from aleph.vm.storage_budget import parse_budget
 from aleph.vm.utils import (
     check_amd_sev_es_supported,
     check_amd_sev_supported,
@@ -289,6 +290,33 @@ class Settings(BaseSettings):
 
     MAX_PROGRAM_ARCHIVE_SIZE: int = 10_000_000  # 10 MB
     MAX_DATA_ARCHIVE_SIZE: int = 10_000_000  # 10 MB
+    MAX_RUNTIME_ARCHIVE_SIZE: int = Field(
+        default=100 * 1024**3,
+        description="Maximum size in bytes of a runtime or instance base image download (default 100 GiB)",
+    )
+
+    VOLUME_RETENTION: Literal["reap", "keep"] = Field(
+        default="reap",
+        description="What happens to a VM's volumes when the VM is gone for good: "
+        "'reap' deletes them immediately, 'keep' retains them (within VOLUME_RETENTION_BUDGET, "
+        "oldest evicted first) so the same VM can be re-created with its data.",
+    )
+    VOLUME_RETENTION_BUDGET: str = Field(
+        default="10%",
+        description="Cap on retained (reclaimable) bytes per volume pool: a percentage of the pool "
+        "or an absolute size such as '50G'.",
+    )
+    VOLUME_RECONCILE_INTERVAL: int = Field(default=3600, description="Seconds between storage reconciler passes.")
+    VOLUME_CREATE_GUARD: int = Field(
+        default=600,
+        description="Seconds a directory or .part file is considered part of an in-flight create "
+        "and left alone by the reconciler.",
+    )
+    CACHE_BUDGET: str = Field(
+        default="20%",
+        description="Cap on each download cache (runtime, code, data, message): a percentage of the "
+        "filesystem the cache sits on or an absolute size.",
+    )
 
     HOST_MEMORY_RESERVED_MIB: int = Field(
         default=2048,
@@ -570,6 +598,12 @@ class Settings(BaseSettings):
             "enable it setting the env variable `ENABLE_QEMU_SUPPORT=True` in configuration"
         if self.ENABLE_GPU_SUPPORT:
             assert self.ENABLE_QEMU_SUPPORT, "Qemu Support is needed for GPU support and it's disabled, "
+
+        for setting_name in ("VOLUME_RETENTION_BUDGET", "CACHE_BUDGET"):
+            try:
+                parse_budget(getattr(self, setting_name), 0)
+            except ValueError as error:
+                raise ValueError(f"Invalid {setting_name}: {error}") from error
 
     def setup(self):
         """Setup the environment defined by the settings. Call this method after loading the settings."""

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -333,7 +333,12 @@ async def create_volume_file(
 ) -> Path:
     volume_name = volume.name if isinstance(volume, PersistentVolume) else "rootfs"
     # Assume that the main filesystem format is BTRFS
-    path = volume_path_for(namespace, f"{volume_name}.btrfs", volume.size_mib, pool0_only=pool0_only)
+    # Off the loop: placement reads every pool's free space and can call the
+    # reclaimer's evictor (storage_pools.set_room_maker), which walks pools and
+    # removes directories.
+    path = await asyncio.to_thread(
+        volume_path_for, namespace, f"{volume_name}.btrfs", volume.size_mib, pool0_only=pool0_only
+    )
     if not path.is_file():
         logger.debug(f"Creating {volume.size_mib}MB volume")
         # Create an empty file the right size
@@ -496,7 +501,10 @@ async def get_volume_path(volume: MachineVolume, namespace: str, *, pool0_only: 
             # pool 0 (jailer hardlink-copy would lose guest writes).
             return await create_devmapper(volume, namespace, pool0_only=pool0_only)
         else:
-            volume_path = volume_path_for(namespace, f"{volume_name}.ext4", volume.size_mib, pool0_only=pool0_only)
+            # Off the loop, same reason as create_volume_file above.
+            volume_path = await asyncio.to_thread(
+                volume_path_for, namespace, f"{volume_name}.ext4", volume.size_mib, pool0_only=pool0_only
+            )
             await create_ext4(volume_path, volume.size_mib)
             return volume_path
     else:

--- a/src/aleph/vm/storage_budget.py
+++ b/src/aleph/vm/storage_budget.py
@@ -1,0 +1,29 @@
+"""Budget strings for on-disk classes ("10%" of a filesystem, or "50G")."""
+
+from __future__ import annotations
+
+import re
+
+_UNITS = {"": 1, "K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4}
+_ABSOLUTE = re.compile(r"^(\d+)\s*([KMGT]?)$")
+_PERCENT = re.compile(r"^(\d+(?:\.\d+)?)\s*%$")
+
+
+def parse_budget(value: str | int, total_bytes: int) -> int:
+    """A budget as bytes: a percentage of ``total_bytes`` or an absolute size.
+
+    Accepts "10%", "512M", "50G", "2T", or a plain byte count (str or int).
+    """
+    if isinstance(value, int):
+        if value < 0:
+            raise ValueError(f"Negative budget: {value}")
+        return value
+    text = value.strip().upper()
+    if match := _PERCENT.match(text):
+        percent = float(match.group(1))
+        if percent > 100:
+            raise ValueError(f"Budget above 100%: {value!r}")
+        return int(total_bytes * percent / 100)
+    if match := _ABSOLUTE.match(text):
+        return int(match.group(1)) * _UNITS[match.group(2)]
+    raise ValueError(f"Unparseable budget: {value!r} (expected e.g. '10%', '50G' or a byte count)")

--- a/src/aleph/vm/storage_budget.py
+++ b/src/aleph/vm/storage_budget.py
@@ -7,6 +7,7 @@ import re
 _UNITS = {"": 1, "K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4}
 _ABSOLUTE = re.compile(r"^(\d+)\s*([KMGT]?)$")
 _PERCENT = re.compile(r"^(\d+(?:\.\d+)?)\s*%$")
+_MAX_PERCENT = 100.0
 
 
 def parse_budget(value: str | int, total_bytes: int) -> int:
@@ -16,14 +17,17 @@ def parse_budget(value: str | int, total_bytes: int) -> int:
     """
     if isinstance(value, int):
         if value < 0:
-            raise ValueError(f"Negative budget: {value}")
+            msg = f"Negative budget: {value}"
+            raise ValueError(msg)
         return value
     text = value.strip().upper()
     if match := _PERCENT.match(text):
         percent = float(match.group(1))
-        if percent > 100:
-            raise ValueError(f"Budget above 100%: {value!r}")
-        return int(total_bytes * percent / 100)
+        if percent > _MAX_PERCENT:
+            msg = f"Budget above 100%: {value!r}"
+            raise ValueError(msg)
+        return int(total_bytes * percent / _MAX_PERCENT)
     if match := _ABSOLUTE.match(text):
         return int(match.group(1)) * _UNITS[match.group(2)]
-    raise ValueError(f"Unparseable budget: {value!r} (expected e.g. '10%', '50G' or a byte count)")
+    msg = f"Unparseable budget: {value!r} (expected e.g. '10%', '50G' or a byte count)"
+    raise ValueError(msg)

--- a/src/aleph/vm/storage_pools.py
+++ b/src/aleph/vm/storage_pools.py
@@ -467,8 +467,18 @@ def pools_disk_usage() -> tuple[int, int]:
     return total, free
 
 
+def eligible_pool_free_bytes() -> list[tuple[StoragePool, int]]:
+    """``(pool, free bytes)`` for every reachable VM-eligible pool.
+
+    The per-pool breakdown admission needs: a volume never spans pools, and
+    what a pool can still take is its free space plus what it holds for the
+    reclaimer, which only the agent side can add up (this module cannot
+    import the reclaimable marker, which imports it).
+    """
+    return [(pool, free) for pool in get_pools() if pool.vm_eligible and (free := _pool_free_bytes(pool)) is not None]
+
+
 def roomiest_pool_free_bytes() -> int:
     """Free bytes on the emptiest eligible pool (the largest single volume
     that could still be placed); 0 when no pool is reachable."""
-    frees = [free for pool in get_pools() if pool.vm_eligible and (free := _pool_free_bytes(pool)) is not None]
-    return max(frees, default=0)
+    return max((free for _, free in eligible_pool_free_bytes()), default=0)

--- a/src/aleph/vm/storage_pools.py
+++ b/src/aleph/vm/storage_pools.py
@@ -18,7 +18,7 @@ import json
 import logging
 import os
 import shutil
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -286,12 +286,32 @@ def _pool_free_bytes(pool: StoragePool) -> int | None:
         return None
 
 
+RoomMaker = Callable[["StoragePool", int], int]
+_room_maker: RoomMaker | None = None
+
+
+def set_room_maker(fn: RoomMaker | None) -> None:
+    """Register the agent's evictor: called with (pool, needed_bytes) when no
+    pool fits a placement, before the placement is refused.
+
+    Retained volumes are advertised as free capacity (spec section 1), so a
+    placement that does not fit has to be given the chance to take that space
+    back before it fails. This module cannot import the reconciler (it is
+    agent-side and imports this one), so the agent registers the hook at
+    startup; a node that never registers one keeps the old behaviour.
+    """
+    global _room_maker  # noqa: PLW0603
+    _room_maker = fn
+
+
 def _select_from(candidates: list[StoragePool], size_mib: int) -> StoragePool:
     """The eligible candidate with the most free bytes that fits ``size_mib``.
 
     Ties break on the lowest pool index (candidates are scanned in index
     order, so the first max wins). Unreachable pools are skipped: a dead disk
-    stops receiving placements without failing the agent.
+    stops receiving placements without failing the agent. When nothing fits,
+    the registered room maker (if any) gets one chance to evict reclaimable
+    volumes off the best target before the placement is refused.
     """
     required_bytes = size_mib * 1024 * 1024
     best: StoragePool | None = None
@@ -304,6 +324,14 @@ def _select_from(candidates: list[StoragePool], size_mib: int) -> StoragePool:
             continue
         if free > best_free:
             best, best_free = pool, free
+    if (best is None or best_free < required_bytes) and _room_maker is not None:
+        # No pool reported free space at all: fall back to the first eligible
+        # candidate, which is still where this placement would land.
+        target = best or next((pool for pool in candidates if pool.vm_eligible), None)
+        if target is not None and _room_maker(target, required_bytes) > 0:
+            free = _pool_free_bytes(target)
+            if free is not None and free >= required_bytes:
+                return target
     if best is None or best_free < required_bytes:
         msg = f"No volume pool has {size_mib} MiB free"
         raise InsufficientResourcesError(

--- a/src/aleph/vm/storage_pools.py
+++ b/src/aleph/vm/storage_pools.py
@@ -310,8 +310,11 @@ def _select_from(candidates: list[StoragePool], size_mib: int) -> StoragePool:
     Ties break on the lowest pool index (candidates are scanned in index
     order, so the first max wins). Unreachable pools are skipped: a dead disk
     stops receiving placements without failing the agent. When nothing fits,
-    the registered room maker (if any) gets one chance to evict reclaimable
-    volumes off the best target before the placement is refused.
+    the registered room maker (if any) is offered every eligible candidate,
+    most free bytes first, before the placement is refused: admission counts
+    every pool's reclaimable bytes as free, so the volume may only fit on a
+    pool that is not the free-max one once its retained directories are
+    evicted.
     """
     required_bytes = size_mib * 1024 * 1024
     best: StoragePool | None = None
@@ -325,10 +328,17 @@ def _select_from(candidates: list[StoragePool], size_mib: int) -> StoragePool:
         if free > best_free:
             best, best_free = pool, free
     if (best is None or best_free < required_bytes) and _room_maker is not None:
-        # No pool reported free space at all: fall back to the first eligible
-        # candidate, which is still where this placement would land.
-        target = best or next((pool for pool in candidates if pool.vm_eligible), None)
-        if target is not None and _room_maker(target, required_bytes) > 0:
+        # Free-descending order asks the pool that needs the least eviction
+        # first; a pool that reports no free space at all (dead disk,
+        # unmounted) still gets a turn last, since it is where this placement
+        # would land if the evictor brings it back.
+        def known_free(pool: StoragePool) -> int:
+            free = _pool_free_bytes(pool)
+            return -1 if free is None else free
+
+        for target in sorted((pool for pool in candidates if pool.vm_eligible), key=known_free, reverse=True):
+            if _room_maker(target, required_bytes) <= 0:
+                continue
             free = _pool_free_bytes(target)
             if free is not None and free >= required_bytes:
                 return target

--- a/src/aleph/vm/storage_pools.py
+++ b/src/aleph/vm/storage_pools.py
@@ -294,7 +294,7 @@ def set_room_maker(fn: RoomMaker | None) -> None:
     """Register the agent's evictor: called with (pool, needed_bytes) when no
     pool fits a placement, before the placement is refused.
 
-    Retained volumes are advertised as free capacity (spec section 1), so a
+    Retained volumes are advertised as free capacity, so a
     placement that does not fit has to be given the chance to take that space
     back before it fails. This module cannot import the reconciler (it is
     agent-side and imports this one), so the agent registers the hook at

--- a/tests/migration/test_runner.py
+++ b/tests/migration/test_runner.py
@@ -16,6 +16,7 @@ from aleph.vm.agent.migration.jobs import (
     _reset_migration_semaphore_for_tests,
 )
 from aleph.vm.agent.migration.runner import run_export
+from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 from aleph.vm.supervisor_interface.errors import VmNotFoundError
 
@@ -25,6 +26,14 @@ def _fake_capacity():
     from types import SimpleNamespace
 
     return SimpleNamespace(check_capacity=MagicMock(), resolve_gpus=AsyncMock(return_value=[]))
+
+
+@pytest.fixture(autouse=True)
+def _stub_persist_record(monkeypatch):
+    """The import now records the migrated VM in the agent registry and its
+    DB; the DB write needs an app-level session these unit tests do not set
+    up."""
+    monkeypatch.setattr("aleph.vm.agent.migration.runner.persist_record", AsyncMock())
 
 
 @pytest.fixture(autouse=True)
@@ -220,7 +229,14 @@ async def testrun_import_success(tmp_path, monkeypatch, stub_finish_instance_cre
         )
     ]
 
-    await run_import(job, supervisor, capacity=_fake_capacity(), disk_files=disk_files, export_token="t0k3n")
+    await run_import(
+        job,
+        supervisor,
+        capacity=_fake_capacity(),
+        registry=AgentVmRegistry(),
+        disk_files=disk_files,
+        export_token="t0k3n",
+    )
 
     assert job.state == MigrationState.IMPORTED
     assert job.error is None
@@ -311,7 +327,14 @@ async def testrun_import_accepts_message_without_explicit_hypervisor(tmp_path, m
         )
     ]
 
-    await run_import(job, supervisor, capacity=_fake_capacity(), disk_files=disk_files, export_token="t0k3n")
+    await run_import(
+        job,
+        supervisor,
+        capacity=_fake_capacity(),
+        registry=AgentVmRegistry(),
+        disk_files=disk_files,
+        export_token="t0k3n",
+    )
 
     assert job.state == MigrationState.IMPORTED
     assert job.error is None
@@ -348,6 +371,7 @@ async def testrun_import_aborts_when_message_not_instance(tmp_path, monkeypatch)
         job,
         supervisor,
         capacity=_fake_capacity(),
+        registry=AgentVmRegistry(),
         disk_files=[DiskFileInfo(name="rootfs.qcow2", size_bytes=1, sha256="0" * 64, download_path="/x")],
         export_token="t",
     )
@@ -402,6 +426,7 @@ async def testrun_import_cleans_dest_dir_on_download_failure(tmp_path, monkeypat
         job,
         supervisor,
         capacity=_fake_capacity(),
+        registry=AgentVmRegistry(),
         disk_files=[DiskFileInfo(name="rootfs.qcow2", size_bytes=1, sha256="0" * 64, download_path="/x")],
         export_token="t",
     )
@@ -466,6 +491,7 @@ async def testrun_import_cleans_dest_dir_on_create_vm_failure(tmp_path, monkeypa
         job,
         supervisor,
         capacity=_fake_capacity(),
+        registry=AgentVmRegistry(),
         disk_files=[DiskFileInfo(name="rootfs.qcow2", size_bytes=1, sha256="0" * 64, download_path="/x")],
         export_token="t",
     )
@@ -529,6 +555,7 @@ async def testrun_import_keeps_dest_dir_when_supervisor_already_has_vm(tmp_path,
         job,
         supervisor,
         capacity=_fake_capacity(),
+        registry=AgentVmRegistry(),
         disk_files=[DiskFileInfo(name="rootfs.qcow2", size_bytes=1, sha256="0" * 64, download_path="/x")],
         export_token="t",
     )
@@ -725,3 +752,75 @@ async def test_import_spec_build_reuses_staged_overlay(tmp_path, monkeypatch):
     assert result == staged
     assert result.read_bytes() == b"staged-overlay"  # untouched
     assert create_calls == []  # no qemu-img create: the staged overlay was adopted
+
+
+@pytest.mark.asyncio
+async def test_import_holds_the_create_guard_and_records_the_vm(tmp_path, monkeypatch, stub_finish_instance_create):
+    """The import stages disks into a namespace nothing owns yet.
+
+    Until the registry record exists, only the create guard stands between a
+    multi-GB transfer and the storage reconciler, which would otherwise see an
+    unowned directory older than VOLUME_CREATE_GUARD and reap it. And once the
+    guard is released, the record is what keeps the disks: a migrated VM with
+    no registry entry is an orphan on the next pass.
+    """
+    from aleph.vm.agent.migration.jobs import DiskFileInfo, ImportJob
+    from aleph.vm.agent.migration.runner import run_import
+    from aleph.vm.agent.vm.reconciler import is_creating
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    monkeypatch.setattr(settings, "PERSISTENT_VOLUMES_DIR", tmp_path)
+    monkeypatch.setattr(settings, "INSTANCE_DEFAULT_HYPERVISOR", HypervisorType.qemu)
+
+    parent_path = tmp_path / "parent.qcow2"
+    parent_path.write_bytes(b"parent")
+
+    fake_message = MagicMock()
+    fake_message.type = MessageType.instance
+    fake_message.content.environment.hypervisor = HypervisorType.qemu
+    fake_message.content.environment.trusted_execution = None
+    fake_message.content.rootfs.parent.ref = "parentref"
+    fake_message.content.requirements = None
+
+    guard_while_downloading = []
+
+    async def fake_download(session, url, dest_path, token, *, expected_sha256, on_chunk=None):
+        guard_while_downloading.append(is_creating(str(vm_hash)))
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.write_bytes(b"downloaded")
+        return 10
+
+    monkeypatch.setattr(
+        "aleph.vm.agent.migration.runner.load_updated_message",
+        AsyncMock(return_value=(fake_message, fake_message)),
+    )
+    monkeypatch.setattr("aleph.vm.agent.migration.runner.get_rootfs_base_path", AsyncMock(return_value=parent_path))
+    monkeypatch.setattr("aleph.vm.agent.migration.runner.detect_parent_format", AsyncMock(return_value="qcow2"))
+    monkeypatch.setattr("aleph.vm.agent.migration.runner.download_disk_from_source", fake_download)
+    monkeypatch.setattr("aleph.vm.agent.migration.runner.rebase_overlay", AsyncMock())
+    monkeypatch.setattr(
+        "aleph.vm.agent.migration.runner.build_create_vm_spec",
+        AsyncMock(return_value=MagicMock(vm_id=vm_hash)),
+    )
+
+    registry = AgentVmRegistry()
+    job = ImportJob(
+        vm_hash=vm_hash,
+        state=MigrationState.IMPORTING,
+        started_at=datetime.now(timezone.utc),
+        source_host="src",
+        source_port=443,
+    )
+    await run_import(
+        job,
+        _import_supervisor(),
+        capacity=_fake_capacity(),
+        registry=registry,
+        disk_files=[DiskFileInfo(name="rootfs.qcow2", size_bytes=10, sha256="0" * 64, download_path="/x")],
+        export_token="t",
+    )
+
+    assert job.state == MigrationState.IMPORTED
+    assert guard_while_downloading == [True]
+    assert registry.get(vm_hash) is not None
+    assert not is_creating(str(vm_hash))

--- a/tests/migration/test_runner.py
+++ b/tests/migration/test_runner.py
@@ -824,3 +824,73 @@ async def test_import_holds_the_create_guard_and_records_the_vm(tmp_path, monkey
     assert guard_while_downloading == [True]
     assert registry.get(vm_hash) is not None
     assert not is_creating(str(vm_hash))
+
+
+@pytest.mark.asyncio
+async def test_a_failure_after_create_vm_retires_the_half_imported_vm(
+    tmp_path, monkeypatch, stub_finish_instance_create
+):
+    """finish_instance_create failing leaves a VM that is up, registered and
+    unreachable (no port forwards). The import tears it down the way a fresh
+    create does when it fails after create_vm: FAILED_CREATE, since a failed
+    import discards its staged disks anyway, so a kept record would describe
+    disks that are gone."""
+    from aleph.vm.agent.migration.jobs import DiskFileInfo, ImportJob
+    from aleph.vm.agent.migration.runner import run_import
+    from aleph.vm.agent.vm.retire import RetireReason
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    monkeypatch.setattr(settings, "PERSISTENT_VOLUMES_DIR", tmp_path)
+    monkeypatch.setattr(settings, "INSTANCE_DEFAULT_HYPERVISOR", HypervisorType.qemu)
+
+    parent_path = tmp_path / "parent.qcow2"
+    parent_path.write_bytes(b"parent")
+
+    fake_message = MagicMock()
+    fake_message.type = MessageType.instance
+    fake_message.content.environment.hypervisor = HypervisorType.qemu
+    fake_message.content.environment.trusted_execution = None
+    fake_message.content.rootfs.parent.ref = "parentref"
+    fake_message.content.requirements = None
+
+    async def fake_download(session, url, dest_path, token, *, expected_sha256, on_chunk=None):
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.write_bytes(b"downloaded")
+        return 10
+
+    monkeypatch.setattr(
+        "aleph.vm.agent.migration.runner.load_updated_message",
+        AsyncMock(return_value=(fake_message, fake_message)),
+    )
+    monkeypatch.setattr("aleph.vm.agent.migration.runner.get_rootfs_base_path", AsyncMock(return_value=parent_path))
+    monkeypatch.setattr("aleph.vm.agent.migration.runner.detect_parent_format", AsyncMock(return_value="qcow2"))
+    monkeypatch.setattr("aleph.vm.agent.migration.runner.download_disk_from_source", fake_download)
+    monkeypatch.setattr("aleph.vm.agent.migration.runner.rebase_overlay", AsyncMock())
+    monkeypatch.setattr(
+        "aleph.vm.agent.migration.runner.build_create_vm_spec",
+        AsyncMock(return_value=MagicMock(vm_id=vm_hash)),
+    )
+    retire = AsyncMock()
+    monkeypatch.setattr("aleph.vm.agent.migration.runner.retire_vm", retire)
+    stub_finish_instance_create.side_effect = RuntimeError("port forwards failed")
+
+    registry = AgentVmRegistry()
+    supervisor = _import_supervisor()
+    job = ImportJob(
+        vm_hash=vm_hash,
+        state=MigrationState.IMPORTING,
+        started_at=datetime.now(timezone.utc),
+        source_host="src",
+        source_port=443,
+    )
+    await run_import(
+        job,
+        supervisor,
+        capacity=_fake_capacity(),
+        registry=registry,
+        disk_files=[DiskFileInfo(name="rootfs.qcow2", size_bytes=10, sha256="0" * 64, download_path="/x")],
+        export_token="t",
+    )
+
+    assert job.state == MigrationState.IMPORT_FAILED
+    retire.assert_awaited_once_with(vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)

--- a/tests/supervisor/reclaim_fixtures.py
+++ b/tests/supervisor/reclaim_fixtures.py
@@ -1,0 +1,53 @@
+"""Shared temp-directory fixture for the reclamation tests: two volume pools,
+a session directory, and the four download caches."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import aleph.vm.storage_pools as storage_pools_module
+from aleph.vm.conf import settings
+from aleph.vm.storage_pools import MediaClass, StoragePool, reset_pools
+
+VM_HASH = "cafe" * 16
+OTHER_HASH = "beef" * 16
+
+
+@pytest.fixture
+def pools(tmp_path, monkeypatch):
+    execution_root = tmp_path / "execution"
+    pool0 = execution_root / "volumes" / "persistent"
+    pool1 = tmp_path / "mnt" / "nvme1"
+    sessions = execution_root / "sessions"
+    caches = {name: tmp_path / "cache" / name for name in ("runtime", "code", "data", "message")}
+    for directory in (pool0, pool1, sessions, *caches.values()):
+        directory.mkdir(parents=True)
+    monkeypatch.setattr(settings, "EXECUTION_ROOT", execution_root)
+    monkeypatch.setattr(settings, "PERSISTENT_VOLUMES_DIR", pool0)
+    monkeypatch.setattr(settings, "CONFIDENTIAL_SESSION_DIRECTORY", sessions)
+    monkeypatch.setattr(settings, "RUNTIME_CACHE", caches["runtime"])
+    monkeypatch.setattr(settings, "CODE_CACHE", caches["code"])
+    monkeypatch.setattr(settings, "DATA_CACHE", caches["data"])
+    monkeypatch.setattr(settings, "MESSAGE_CACHE", caches["message"])
+    monkeypatch.setattr(settings, "BACKUP_DIRECTORY", execution_root / "backups")
+    (execution_root / "backups").mkdir()
+    monkeypatch.setattr(
+        storage_pools_module,
+        "_pools",
+        [
+            StoragePool(path=pool0, media_class=MediaClass.SSD, index=0),
+            StoragePool(path=pool1, media_class=MediaClass.NVME, index=1),
+        ],
+    )
+    yield {"pool0": pool0, "pool1": pool1, "sessions": sessions, "execution_root": execution_root, **caches}
+    reset_pools()
+
+
+def volume(pool: Path, namespace: str, filename: str, size: int = 1) -> Path:
+    directory = pool / namespace
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / filename
+    path.write_bytes(b"x" * size)
+    return path

--- a/tests/supervisor/test_agent_backups.py
+++ b/tests/supervisor/test_agent_backups.py
@@ -5,8 +5,11 @@ and the supervisor reduced to quiescence (freeze/thaw) plus stop/start."""
 from __future__ import annotations
 
 import asyncio
+import os
 import subprocess
 import tarfile
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -14,7 +17,12 @@ import pytest
 
 import aleph.vm.storage_pools as storage_pools_module
 from aleph.vm.agent.vm import backup as backup_module
-from aleph.vm.agent.vm.backup import BackupManager, vm_disks
+from aleph.vm.agent.vm.backup import (
+    BackupManager,
+    purge_vm_backups,
+    sweep_expired_backups,
+    vm_disks,
+)
 from aleph.vm.backup import staging as staging_module
 from aleph.vm.backup.types import (
     BackupId,
@@ -662,3 +670,66 @@ async def test_restore_from_image_of_an_unknown_vm_propagates_not_found(pools, b
 
     with pytest.raises(VmNotFoundError):
         await manager.restore_from_image(VM_HASH, staged)
+
+
+# --- Sweeps ---
+
+
+def test_purge_vm_backups_removes_the_archive_and_its_sidecars(backup_dir):
+    """A VM that is gone leaves no archive behind, and no other VM's archive
+    is touched: the glob is scoped to the hash."""
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    archive = backup_dir / f"{VM_HASH}-20260824T120000Z.tar"
+    archive.write_bytes(b"tar")
+    sidecar = archive.with_suffix(".tar.sha256")
+    sidecar.write_text("abc\n")
+    meta = archive.with_suffix(".tar.meta.json")
+    meta.write_text("{}")
+    other = backup_dir / f"{OTHER_HASH}-20260824T120000Z.tar"
+    other.write_bytes(b"tar")
+
+    removed = purge_vm_backups(VM_HASH)
+
+    assert removed == 1
+    assert not archive.exists() and not sidecar.exists() and not meta.exists()
+    assert other.exists()
+
+
+def test_purge_vm_backups_refuses_an_implausible_hash(backup_dir):
+    """Every delete primitive is keyed by a validated hash; a glob is no
+    exception."""
+    with pytest.raises(ValueError, match="implausible"):
+        purge_vm_backups("../../etc")
+
+    # It refuses before it so much as resolves the backup directory.
+    assert not backup_dir.exists()
+
+
+def test_sweep_survives_a_backup_that_vanishes_mid_pass(backup_dir, monkeypatch):
+    """Another sweep, or purge_vm_backups for a retired VM, can remove a file
+    between the listing and the unlink. That is a race, not an error, and it
+    must not abort the rest of the pass."""
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    expired = []
+    for index in range(2):
+        archive = backup_dir / f"{VM_HASH}-2026010{index}T000000Z.tar"
+        archive.write_bytes(b"tar")
+        old = time.time() - 25 * 3600
+        os.utime(archive, (old, old))
+        expired.append(archive)
+    vanishing, survivor = sorted(expired)
+    real_stat = Path.stat
+
+    def stat_then_vanish(self, *args, **kwargs):
+        if self == vanishing and vanishing.exists():
+            vanishing.unlink()
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", stat_then_vanish)
+
+    removed = sweep_expired_backups(datetime.now(tz=timezone.utc))
+
+    monkeypatch.undo()
+    assert not vanishing.exists()
+    assert not survivor.exists()
+    assert removed == 1

--- a/tests/supervisor/test_agent_backups.py
+++ b/tests/supervisor/test_agent_backups.py
@@ -721,8 +721,10 @@ def test_sweep_survives_a_backup_that_vanishes_mid_pass(backup_dir, monkeypatch)
     real_stat = Path.stat
 
     def stat_then_vanish(self, *args, **kwargs):
-        if self == vanishing and vanishing.exists():
-            vanishing.unlink()
+        # No Path calls in here besides unlink: on Python 3.12 Path.exists()
+        # goes through Path.stat, which is this very patch, and recurses.
+        if self == vanishing:
+            vanishing.unlink(missing_ok=True)
         return real_stat(self, *args, **kwargs)
 
     monkeypatch.setattr(Path, "stat", stat_then_vanish)

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -942,8 +942,7 @@ def test_requirements_put_a_vprogram_in_the_instance_bucket():
 
 def test_available_disk_counts_reclaimable_bytes_as_free(mocker):
     """Retained volumes are a cache, not usage: they are advertised as free
-    because the reconciler evicts them when a placement needs the room
-    (spec section 1)."""
+    because the reconciler evicts them when a placement needs the room."""
     mocker.patch("aleph.vm.agent.capacity.storage_pools.pools_disk_usage", return_value=(100, 10))
     mocker.patch("aleph.vm.agent.capacity.reclaimable_bytes", return_value=5)
     assert CapacityManager._available_disk_bytes() == 15
@@ -952,7 +951,7 @@ def test_available_disk_counts_reclaimable_bytes_as_free(mocker):
 def test_max_volume_check_counts_that_pools_reclaimable_bytes(mocker):
     """Retention is a budgeted cache: a volume that fits once the pool's
     retained directories are evicted must be admitted, since the room maker
-    evicts them at placement time (spec section 1)."""
+    evicts them at placement time."""
     manager = _manager()
     _patch_host(mocker, memory_bytes=64 * 1024**3, cores=16, disk_bytes=900 * 1024**3)
     # 200 GiB free, 300 GiB retained: a 400 GiB volume still fits.

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -545,7 +545,7 @@ def test_simulate_counts_a_released_vm_as_freed(mocker):
 def test_simulate_judges_disk(mocker):
     # _patch_host only stubs _available_disk_bytes; the per-pool check reads
     # storage_pools directly, so stub it too or it hits the real filesystem.
-    mocker.patch("aleph.vm.agent.capacity.storage_pools.roomiest_pool_free_bytes", return_value=1024 * 1024 * 1024)
+    _patch_pools(mocker, 1024 * 1024 * 1024)
     _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16, disk_bytes=1024 * 1024 * 1024)
 
     verdicts = _manager().simulate([(_HASH_A, _requirements(memory_mib=1024, disk_mib=100_000))])
@@ -588,7 +588,7 @@ def test_simulate_is_cumulative_on_disk_too(mocker):
     10 GiB free, two candidates wanting 6000 MiB each: the first fits, the
     second does not.
     """
-    mocker.patch("aleph.vm.agent.capacity.storage_pools.roomiest_pool_free_bytes", return_value=20 * 1024**3)
+    _patch_pools(mocker, 20 * 1024**3)
     _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16, disk_bytes=10 * 1024**3)
     candidates = [
         (_HASH_A, _requirements(memory_mib=1024, disk_mib=6000)),
@@ -805,7 +805,7 @@ def test_simulate_does_not_credit_disk_back_on_release(mocker):
     """Stopping a VM does not delete its volumes, so the space is still gone.
     Crediting it would make the advisory answer stronger than the enforced one.
     """
-    mocker.patch("aleph.vm.agent.capacity.storage_pools.roomiest_pool_free_bytes", return_value=100 * 1024**3)
+    _patch_pools(mocker, 100 * 1024**3)
     _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16, disk_bytes=10 * 1024**3)
     registry = AgentVmRegistry()
     content = _make_qemu_instance_message(memory=1024)

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -8,6 +8,7 @@ mocked supervisor HostInfo (the supervisor only supplies the GPU inventory).
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -438,14 +439,22 @@ def test_requirements_carry_the_largest_single_volume():
     assert requirements.disk_mib >= requirements.max_volume_mib
 
 
+def _patch_pools(mocker, *free_bytes: int, reclaimable: int = 0):
+    """One eligible pool per free-bytes figure, each holding ``reclaimable``
+    retained bytes."""
+    pools = [SimpleNamespace(path=Path(f"/pool{index}"), index=index) for index in range(len(free_bytes))]
+    mocker.patch(
+        "aleph.vm.agent.capacity.storage_pools.eligible_pool_free_bytes",
+        return_value=list(zip(pools, free_bytes)),
+    )
+    mocker.patch("aleph.vm.agent.capacity.reclaimable_bytes", return_value=reclaimable)
+
+
 def test_check_capacity_rejects_a_volume_no_pool_can_hold(mocker):
     manager = _manager()
     _patch_host(mocker, memory_bytes=64 * 1024**3, cores=16, disk_bytes=900 * 1024**3)
     # Aggregate says 900 GiB free, but the roomiest single pool has 400 GiB.
-    mocker.patch(
-        "aleph.vm.agent.capacity.storage_pools.roomiest_pool_free_bytes",
-        return_value=400 * 1024**3,
-    )
+    _patch_pools(mocker, 400 * 1024**3)
     with pytest.raises(InsufficientResourcesError, match="single volume"):
         manager.check_capacity(
             memory_mib=1024,
@@ -459,10 +468,7 @@ def test_check_capacity_rejects_a_volume_no_pool_can_hold(mocker):
 def test_check_capacity_accepts_when_the_roomiest_pool_fits(mocker):
     manager = _manager()
     _patch_host(mocker, memory_bytes=64 * 1024**3, cores=16, disk_bytes=900 * 1024**3)
-    mocker.patch(
-        "aleph.vm.agent.capacity.storage_pools.roomiest_pool_free_bytes",
-        return_value=400 * 1024**3,
-    )
+    _patch_pools(mocker, 400 * 1024**3)
     manager.check_capacity(
         memory_mib=1024,
         vcpus=1,
@@ -940,3 +946,26 @@ def test_available_disk_counts_reclaimable_bytes_as_free(mocker):
     mocker.patch("aleph.vm.agent.capacity.storage_pools.pools_disk_usage", return_value=(100, 10))
     mocker.patch("aleph.vm.agent.capacity.reclaimable_bytes", return_value=5)
     assert CapacityManager._available_disk_bytes() == 15
+
+
+def test_max_volume_check_counts_that_pools_reclaimable_bytes(mocker):
+    """Retention is a budgeted cache: a volume that fits once the pool's
+    retained directories are evicted must be admitted, since the room maker
+    evicts them at placement time (spec section 1)."""
+    manager = _manager()
+    _patch_host(mocker, memory_bytes=64 * 1024**3, cores=16, disk_bytes=900 * 1024**3)
+    # 200 GiB free, 300 GiB retained: a 400 GiB volume still fits.
+    _patch_pools(mocker, 200 * 1024**3, reclaimable=300 * 1024**3)
+
+    manager.check_capacity(memory_mib=1024, vcpus=1, disk_mib=400 * 1024, max_volume_mib=400 * 1024, is_instance=True)
+
+
+def test_max_volume_check_still_refuses_what_no_pool_can_hold_even_after_eviction(mocker):
+    manager = _manager()
+    _patch_host(mocker, memory_bytes=64 * 1024**3, cores=16, disk_bytes=900 * 1024**3)
+    _patch_pools(mocker, 200 * 1024**3, reclaimable=100 * 1024**3)
+
+    with pytest.raises(InsufficientResourcesError, match="single volume"):
+        manager.check_capacity(
+            memory_mib=1024, vcpus=1, disk_mib=400 * 1024, max_volume_mib=400 * 1024, is_instance=True
+        )

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -23,6 +23,7 @@ from aleph.vm.agent.capacity import (
     ResourceRequirements,
     requirements_from_message,
 )
+from aleph.vm.agent.run import _admit
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 from aleph.vm.resources import GpuDevice, GpuDeviceClass, InsufficientResourcesError
@@ -969,3 +970,32 @@ def test_max_volume_check_still_refuses_what_no_pool_can_hold_even_after_evictio
         manager.check_capacity(
             memory_mib=1024, vcpus=1, disk_mib=400 * 1024, max_volume_mib=400 * 1024, is_instance=True
         )
+
+
+def test_a_phantom_record_never_blocks_the_retry_of_its_own_create(mocker):
+    """A create that fails against volumes that already existed retires
+    RECREATE, which keeps the registry record on purpose: dropping it while
+    keeping the disks would make the reconciler treat the directory as an
+    orphan. The record then describes a VM that is not running and counts in
+    the committed sums until the next allocation cycle. The one thing that
+    must not happen is the retry being refused by its own phantom, and it is
+    not: the create path admits through _admit, which excludes the VM's own
+    record."""
+    _patch_host(mocker, memory_bytes=16 * 1024 * 1024 * 1024, cores=16)
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 4096)
+    mocker.patch.object(CapacityManager, "_check_max_volume", return_value=None)
+
+    vm_hash = "i" * 64
+    message = _make_qemu_instance_message(vcpus=2, memory=8192)
+    registry = AgentVmRegistry()
+    # The record _retire_after_create_failure leaves behind on a RECREATE.
+    registry.record(vm_hash, message=message, original=message, persistent=True)
+    manager = _manager(registry=registry)
+
+    assert _admit(manager, message, vm_hash) is None
+
+    # The phantom is not free: it still counts against every *other* VM until
+    # the next allocation cycle drops it.
+    with pytest.raises(InsufficientResourcesError):
+        _admit(manager, message, "j" * 64)

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -477,6 +477,7 @@ def test_available_disk_bytes_is_the_pooled_aggregate(mocker):
         "aleph.vm.agent.capacity.storage_pools.pools_disk_usage",
         return_value=(2 * 1024**4, 3 * 1024**3),
     )
+    mocker.patch("aleph.vm.agent.capacity.reclaimable_bytes", return_value=0)
     assert CapacityManager._available_disk_bytes() == 3 * 1024**3
 
 
@@ -930,3 +931,12 @@ def test_requirements_put_a_vprogram_in_the_instance_bucket():
     content = load_vprogram_message().content
 
     assert requirements_from_message(content).is_instance is True
+
+
+def test_available_disk_counts_reclaimable_bytes_as_free(mocker):
+    """Retained volumes are a cache, not usage: they are advertised as free
+    because the reconciler evicts them when a placement needs the room
+    (spec section 1)."""
+    mocker.patch("aleph.vm.agent.capacity.storage_pools.pools_disk_usage", return_value=(100, 10))
+    mocker.patch("aleph.vm.agent.capacity.reclaimable_bytes", return_value=5)
+    assert CapacityManager._available_disk_bytes() == 15

--- a/tests/supervisor/test_agent_no_direct_delete.py
+++ b/tests/supervisor/test_agent_no_direct_delete.py
@@ -1,0 +1,26 @@
+"""Every agent delete goes through retire_vm.
+
+A call site that reaches supervisor.delete_vm directly has no reason, and a
+delete without a reason is how disks leaked (spec S1). retire.py is the one
+allowed caller."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import aleph.vm.agent as agent_package
+
+AGENT_ROOT = Path(agent_package.__file__).parent
+ALLOWED = {AGENT_ROOT / "vm" / "retire.py"}
+
+
+@pytest.mark.parametrize(
+    "path",
+    sorted(p for p in AGENT_ROOT.rglob("*.py") if p not in ALLOWED and "migrations" not in p.parts),
+    ids=lambda p: str(p.relative_to(AGENT_ROOT)),
+)
+def test_agent_module_never_calls_delete_vm_directly(path):
+    source = path.read_text()
+    assert ".delete_vm(" not in source, f"{path.relative_to(AGENT_ROOT)} must retire VMs through retire_vm"

--- a/tests/supervisor/test_agent_no_direct_delete.py
+++ b/tests/supervisor/test_agent_no_direct_delete.py
@@ -1,7 +1,7 @@
 """Every agent delete goes through retire_vm.
 
 A call site that reaches supervisor.delete_vm directly has no reason, and a
-delete without a reason is how disks leaked (spec S1). retire.py is the one
+delete without a reason is how disks leaked. retire.py is the one
 allowed caller."""
 
 from __future__ import annotations

--- a/tests/supervisor/test_agent_no_direct_delete.py
+++ b/tests/supervisor/test_agent_no_direct_delete.py
@@ -16,6 +16,8 @@ AGENT_ROOT = Path(agent_package.__file__).parent
 ALLOWED = {AGENT_ROOT / "vm" / "retire.py"}
 
 
+# "migrations" is alembic's generated DB-migration package (agent/migrations);
+# the live-migration package (agent/migration, singular) stays covered.
 @pytest.mark.parametrize(
     "path",
     sorted(p for p in AGENT_ROOT.rglob("*.py") if p not in ALLOWED and "migrations" not in p.parts),

--- a/tests/supervisor/test_allocation_teardown.py
+++ b/tests/supervisor/test_allocation_teardown.py
@@ -12,7 +12,7 @@ import pytest
 from aleph_message.models import ItemHash
 
 from aleph.vm.agent.allocation.teardown import is_removable_by_allocation, teardown_vm
-from aleph.vm.supervisor_interface.errors import VmNotFoundError
+from aleph.vm.agent.vm.retire import RetireReason
 from aleph.vm.supervisor_interface.types import ConfidentialMode, GpuDevice, PciAddress
 
 _HASH = ItemHash("deadbeef" * 8)
@@ -61,40 +61,16 @@ class TestRemovability:
 
 class TestTeardown:
     @pytest.mark.asyncio
-    async def test_deletes_forgets_and_clears_every_side_channel(self, monkeypatch):
-        delete_records = AsyncMock()
-        vprogram_staging = MagicMock()
-        snp_staging = MagicMock()
-        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.delete_records_for_vm", delete_records)
-        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.remove_vprogram_staging", vprogram_staging)
-        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.remove_snp_instance_staging", snp_staging)
+    async def test_teardown_retires_the_vm_as_gone(self, monkeypatch):
+        """The composite this module used to spell out by hand (supervisor
+        delete, registry forget, DB rows, staging) is exactly what GONE does,
+        so stopping is one retire_vm call and nothing else."""
+        retire = AsyncMock()
+        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.retire_vm", retire)
         supervisor = SimpleNamespace(delete_vm=AsyncMock())
         registry = MagicMock()
 
         await teardown_vm(_HASH, supervisor=supervisor, registry=registry)
 
-        supervisor.delete_vm.assert_awaited_once()
-        registry.forget.assert_called_once_with(_HASH)
-        delete_records.assert_awaited_once_with(str(_HASH))
-        vprogram_staging.assert_called_once_with(_HASH)
-        snp_staging.assert_called_once_with(_HASH)
-
-    @pytest.mark.asyncio
-    async def test_a_vm_the_supervisor_does_not_know_is_still_cleaned_up(self, monkeypatch):
-        """The supervisor forgetting first must not strand the agent's own
-        state: the registry entry, the DB rows and the staging dirs are ours."""
-        delete_records = AsyncMock()
-        vprogram_staging = MagicMock()
-        snp_staging = MagicMock()
-        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.delete_records_for_vm", delete_records)
-        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.remove_vprogram_staging", vprogram_staging)
-        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.remove_snp_instance_staging", snp_staging)
-        supervisor = SimpleNamespace(delete_vm=AsyncMock(side_effect=VmNotFoundError(str(_HASH))))
-        registry = MagicMock()
-
-        await teardown_vm(_HASH, supervisor=supervisor, registry=registry)
-
-        registry.forget.assert_called_once_with(_HASH)
-        delete_records.assert_awaited_once_with(str(_HASH))
-        vprogram_staging.assert_called_once_with(_HASH)
-        snp_staging.assert_called_once_with(_HASH)
+        retire.assert_awaited_once_with(_HASH, RetireReason.GONE, supervisor=supervisor, registry=registry)
+        supervisor.delete_vm.assert_not_awaited()

--- a/tests/supervisor/test_checkpayment.py
+++ b/tests/supervisor/test_checkpayment.py
@@ -5,6 +5,7 @@ from aleph_message.models import Chain, InstanceContent, ItemHash, PaymentType
 from aleph_message.status import MessageStatus
 
 from aleph.vm.agent.tasks import _group_executions_by_payment, check_payment
+from aleph.vm.agent.vm.retire import RetireReason
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 from aleph.vm.supervisor_interface.types import (
@@ -162,6 +163,7 @@ async def test_not_enough_flow(mocker, fake_instance_content):
     mocker.patch("aleph.vm.agent.tasks.get_stream", return_value=2, autospec=True)
     mocker.patch("aleph.vm.agent.tasks.get_message_status", return_value=MessageStatus.PROCESSED)
     mocker.patch("aleph.vm.agent.tasks.compute_required_flow", return_value=5)
+    retire = mocker.patch("aleph.vm.agent.tasks.retire_vm", new_callable=AsyncMock)
     message = InstanceContent.model_validate(fake_instance_content)
 
     hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
@@ -175,10 +177,10 @@ async def test_not_enough_flow(mocker, fake_instance_content):
 
     await check_payment(supervisor=supervisor, registry=registry)
 
-    # Insufficient-funds stop: supervisor.delete_vm is called, registry.forget is NOT called
-    # (VM may be re-paid and restarted).
-    supervisor.delete_vm.assert_awaited_once_with(VmId(str(hash)))
-    assert ItemHash(hash) in registry
+    # Insufficient-funds stop: retire_vm is called with GONE, not supervisor.delete_vm
+    # directly.
+    retire.assert_awaited_once_with(ItemHash(hash), RetireReason.GONE, supervisor=supervisor, registry=registry)
+    supervisor.delete_vm.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -199,6 +201,7 @@ async def test_not_enough_community_flow(mocker, fake_instance_content):
     mocker.patch("aleph.vm.agent.tasks.get_community_wallet_address", return_value=mock_community_wallet_address)
     mocker.patch("aleph.vm.agent.tasks.get_message_status", return_value=MessageStatus.PROCESSED)
     mocker.patch("aleph.vm.agent.tasks.compute_required_flow", return_value=5)
+    retire = mocker.patch("aleph.vm.agent.tasks.retire_vm", new_callable=AsyncMock)
     message = InstanceContent.model_validate(fake_instance_content)
 
     hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
@@ -212,9 +215,10 @@ async def test_not_enough_community_flow(mocker, fake_instance_content):
 
     await check_payment(supervisor=supervisor, registry=registry)
 
-    # Insufficient-funds stop: supervisor.delete_vm is called, registry.forget is NOT called.
-    supervisor.delete_vm.assert_awaited_once_with(VmId(str(hash)))
-    assert ItemHash(hash) in registry
+    # Insufficient-funds stop: retire_vm is called with GONE, not supervisor.delete_vm
+    # directly.
+    retire.assert_awaited_once_with(ItemHash(hash), RetireReason.GONE, supervisor=supervisor, registry=registry)
+    supervisor.delete_vm.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -258,7 +262,7 @@ async def test_removed_message_status(mocker, fake_instance_content):
     mocker.patch("aleph.vm.agent.tasks.get_community_wallet_address", return_value=mock_community_wallet_address)
     mocker.patch("aleph.vm.agent.tasks.get_message_status", return_value=MessageStatus.REMOVED)
     mocker.patch("aleph.vm.agent.tasks.compute_required_flow", return_value=5)
-    mock_delete_records = mocker.patch("aleph.vm.agent.tasks.delete_records_for_vm", new_callable=mocker.AsyncMock)
+    retire = mocker.patch("aleph.vm.agent.tasks.retire_vm", new_callable=AsyncMock)
     message = InstanceContent.model_validate(fake_instance_content)
 
     hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadece"
@@ -278,9 +282,65 @@ async def test_removed_message_status(mocker, fake_instance_content):
     supervisor.delete_vm.assert_not_called()
 
     await check_payment(supervisor=supervisor, registry=registry)
-    # Terminal-status dealloc: supervisor.delete_vm (which owns port-mapping
-    # cleanup hypervisor-side) + registry.forget + delete the persisted record.
-    supervisor.delete_vm.assert_awaited_once_with(VmId(str(hash)))
-    mock_delete_records.assert_awaited_once_with(hash)
-    assert ItemHash(hash) not in registry
-    # pool.stop_vm and pool.forget_vm must NOT be called
+    # Terminal-status dealloc retires the VM as GONE: retire_vm owns the
+    # supervisor quiesce, the registry forget and the persisted record cleanup.
+    retire.assert_awaited_once_with(ItemHash(hash), RetireReason.GONE, supervisor=supervisor, registry=registry)
+    supervisor.delete_vm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_terminal_status_retires_as_gone(mocker, fake_instance_content):
+    from aleph.vm.agent import tasks
+
+    mocker.patch.object(settings, "ALLOW_VM_NETWORKING", False)
+    mocker.patch.object(settings, "PAYMENT_RECEIVER_ADDRESS", "0xD39C335404a78E0BDCf6D50F29B86EFd57924288")
+    mocker.patch("aleph.vm.agent.tasks.get_message_status", return_value=MessageStatus.FORGOTTEN)
+    mocker.patch("aleph.vm.agent.tasks.get_community_wallet_address", return_value="0x" + "1" * 40)
+    # The payment loops still run over the same snapshot: keep them satisfied
+    # so only the terminal-status branch retires anything.
+    mocker.patch("aleph.vm.agent.tasks.is_after_community_wallet_start", return_value=True)
+    mocker.patch("aleph.vm.agent.tasks.get_stream", return_value=10_000, autospec=True)
+    mocker.patch("aleph.vm.agent.tasks.compute_required_flow", return_value=0)
+    retire = mocker.patch("aleph.vm.agent.tasks.retire_vm", new_callable=AsyncMock)
+    tasks._terminal_strike_count.clear()
+
+    # settings.FAKE_INSTANCE_ID is explicitly skipped by the terminal-status
+    # loop (it has no real on-chain message to check), so use a distinct hash
+    # here, same as test_removed_message_status does.
+    hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadecf"
+    vm_hash = ItemHash(hash)
+    registry = _make_registry()
+    message = InstanceContent.model_validate(fake_instance_content)
+    registry.record(vm_hash, message=message, original=message, persistent=True)
+    info = _make_info(hash)
+    supervisor = _make_supervisor([info])
+
+    for _ in range(tasks.STOP_AFTER_CONFIRMATIONS):
+        await check_payment(supervisor=supervisor, registry=registry)
+
+    retire.assert_awaited_once_with(vm_hash, RetireReason.GONE, supervisor=supervisor, registry=registry)
+    supervisor.delete_vm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_insufficient_stream_retires_as_gone(mocker, fake_instance_content):
+    mocker.patch.object(settings, "ALLOW_VM_NETWORKING", False)
+    mocker.patch.object(settings, "PAYMENT_RECEIVER_ADDRESS", "0xD39C335404a78E0BDCf6D50F29B86EFd57924288")
+    mocker.patch("aleph.vm.agent.tasks.get_community_wallet_address", return_value="0x" + "1" * 40)
+    mocker.patch("aleph.vm.agent.tasks.is_after_community_wallet_start", return_value=True)
+    mocker.patch("aleph.vm.agent.tasks.get_stream", return_value=2, autospec=True)
+    mocker.patch("aleph.vm.agent.tasks.get_message_status", return_value=MessageStatus.PROCESSED)
+    mocker.patch("aleph.vm.agent.tasks.compute_required_flow", return_value=5)
+    retire = mocker.patch("aleph.vm.agent.tasks.retire_vm", new_callable=AsyncMock)
+    registry = _make_registry()
+    message = InstanceContent.model_validate(fake_instance_content)
+
+    hash = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
+    vm_hash = ItemHash(hash)
+    registry.record(vm_hash, message=message, original=message, persistent=False)
+    info = _make_info(hash)
+    supervisor = _make_supervisor([info])
+
+    await check_payment(supervisor=supervisor, registry=registry)
+
+    retire.assert_awaited_once_with(vm_hash, RetireReason.GONE, supervisor=supervisor, registry=registry)

--- a/tests/supervisor/test_checkpayment.py
+++ b/tests/supervisor/test_checkpayment.py
@@ -73,6 +73,24 @@ def _make_info(vm_hash: str, *, started_at_ns: int = 0, confidential: bool = Fal
 
 
 @pytest.mark.asyncio
+async def test_check_payment_tolerates_a_non_hash_vm_id(mocker):
+    """One supervisor id that is not an item hash must not take the whole
+    payment sweep down: it is dropped at the snapshot (the reconciler's
+    supervisor_hashes rule) and the other VMs are still checked."""
+    mocker.patch("aleph.vm.agent.tasks.get_community_wallet_address", return_value="0x23C7")
+    status = mocker.patch("aleph.vm.agent.tasks.get_message_status", return_value=MessageStatus.PROCESSED)
+    retire = mocker.patch("aleph.vm.agent.tasks.retire_vm", new_callable=AsyncMock)
+
+    checked = "cafe" * 16  # not FAKE_INSTANCE_ID, which the sweep skips
+    supervisor = _make_supervisor([_make_info("not-an-item-hash"), _make_info(checked)])
+
+    await check_payment(supervisor=supervisor, registry=_make_registry())
+
+    status.assert_awaited_once_with(ItemHash(checked))
+    retire.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_enough_flow(mocker, fake_instance_content):
     """Execution with community flow
 

--- a/tests/supervisor/test_create_path_disk_admission.py
+++ b/tests/supervisor/test_create_path_disk_admission.py
@@ -24,6 +24,7 @@ from aleph_message.models.execution.environment import HypervisorType
 from test_supervisor_translate import _make_qemu_instance_message
 
 from aleph.vm.agent import run as run_module
+from aleph.vm.agent.vm.reconciler import is_creating
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.utils import get_message_executable_content
@@ -191,3 +192,73 @@ class TestBothChecksOnTheHappyPath:
         await _create(capacity, supervisor)
 
         assert _disk_args(capacity) == [(INSTANCE_ROOTFS_MIB, INSTANCE_ROOTFS_MIB), (0, 0)]
+
+
+class TestCreateGuard:
+    """Every create path runs inside ``creating()``.
+
+    The reconciler decides what is an orphan from the filesystem, so a create
+    that stages files outside the guard can have them removed from under it
+    once it outlives VOLUME_CREATE_GUARD. Admission is the first thing that
+    can block for long, so the guard is taken before it: a concurrent create
+    under pressure must not evict the retained directory this one is about to
+    adopt.
+    """
+
+    @staticmethod
+    def _capacity_watching_the_guard(seen: list[bool]):
+        """An admission stub that records whether the guard is held when it
+        runs, then refuses (which ends the create right there)."""
+        error = InsufficientResourcesError("no room", required={}, available={})
+
+        def check(**kwargs):
+            seen.append(is_creating(str(_HASH)))
+            raise error
+
+        return SimpleNamespace(check_capacity=MagicMock(side_effect=check), resolve_gpus=AsyncMock(return_value=[]))
+
+    @pytest.mark.asyncio
+    async def test_the_instance_path_holds_the_guard(self, monkeypatch):
+        _patch_message(monkeypatch, _make_qemu_instance_message(hypervisor=HypervisorType.qemu))
+        monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock())
+        seen: list[bool] = []
+
+        with pytest.raises(InsufficientResourcesError):
+            await _create(self._capacity_watching_the_guard(seen))
+
+        assert seen == [True]
+        assert not is_creating(str(_HASH))
+
+    @pytest.mark.asyncio
+    async def test_the_program_path_holds_the_guard(self, monkeypatch):
+        _patch_message(monkeypatch, _program_content())
+        monkeypatch.setattr(run_module, "build_program_create_vm_spec", AsyncMock())
+        seen: list[bool] = []
+
+        with pytest.raises(InsufficientResourcesError):
+            await _create(self._capacity_watching_the_guard(seen))
+
+        assert seen == [True]
+        assert not is_creating(str(_HASH))
+
+    @pytest.mark.asyncio
+    async def test_the_guard_is_released_on_the_happy_path(self, monkeypatch):
+        from test_supervisor_run_routing import _info, _spec
+
+        _patch_message(monkeypatch, _make_qemu_instance_message(hypervisor=HypervisorType.qemu))
+        monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(return_value=_spec()))
+        monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+        monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+        monkeypatch.setattr(run_module, "persist_record", AsyncMock())
+        held: list[bool] = []
+        supervisor = SimpleNamespace(
+            create_vm=AsyncMock(side_effect=lambda spec: held.append(is_creating(str(_HASH))) or _info()),
+            get_vm=AsyncMock(return_value=_info()),
+            add_port_forward=AsyncMock(),
+            delete_vm=AsyncMock(),
+        )
+
+        await _create(_capacity(), supervisor)
+
+        assert held == [True]
+        assert not is_creating(str(_HASH))

--- a/tests/supervisor/test_create_path_disk_admission.py
+++ b/tests/supervisor/test_create_path_disk_admission.py
@@ -30,6 +30,19 @@ from aleph.vm.utils import get_message_executable_content
 
 _HASH = ItemHash("deadbeef" * 8)
 
+
+@pytest.fixture(autouse=True)
+def _stub_retire_db_write(monkeypatch):
+    """A refused admission now retires the never-created VM as
+    FAILED_CREATE, which writes a DB record deletion; stub it out, since
+    these tests only care about admission ordering, not retire_vm's DB
+    write, which needs an app-level session this unit test does not set up.
+    """
+    from aleph.vm.agent.vm import retire as retire_module
+
+    monkeypatch.setattr(retire_module, "delete_records_for_vm", AsyncMock())
+
+
 # _make_qemu_instance_message declares a single 10000 MiB rootfs and no extra
 # volumes, so both the total and the largest single volume are 10000.
 INSTANCE_ROOTFS_MIB = 10000

--- a/tests/supervisor/test_create_path_disk_admission.py
+++ b/tests/supervisor/test_create_path_disk_admission.py
@@ -251,8 +251,13 @@ class TestCreateGuard:
         monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
         monkeypatch.setattr(run_module, "persist_record", AsyncMock())
         held: list[bool] = []
+
+        def observe_create(spec):
+            held.append(is_creating(str(_HASH)))
+            return _info()
+
         supervisor = SimpleNamespace(
-            create_vm=AsyncMock(side_effect=lambda spec: held.append(is_creating(str(_HASH))) or _info()),
+            create_vm=AsyncMock(side_effect=observe_create),
             get_vm=AsyncMock(return_value=_info()),
             add_port_forward=AsyncMock(),
             delete_vm=AsyncMock(),

--- a/tests/supervisor/test_expiry.py
+++ b/tests/supervisor/test_expiry.py
@@ -31,7 +31,7 @@ async def test_schedule_reaps_after_timeout():
     expiry.schedule(vm_id, 0.001)
     await asyncio.wait_for(expiry._tasks[vm_id], timeout=WAIT_TIMEOUT)
 
-    assert sup.deleted == [("vm-a", False)]
+    assert sup.deleted == [("vm-a", True)]  # RECREATE keeps port mappings
     assert expiry.cancel(vm_id) is False  # task removed itself after firing
 
 
@@ -67,7 +67,7 @@ async def test_reschedule_replaces_pending_timer():
     await asyncio.gather(first, return_exceptions=True)
 
     assert first.cancelled()
-    assert sup.deleted == [("vm-a", False)]  # fired once, on the second timer
+    assert sup.deleted == [("vm-a", True)]  # fired once, on the second timer (RECREATE)
 
 
 @pytest.mark.asyncio
@@ -80,7 +80,7 @@ async def test_expire_swallows_vm_not_found():
     # Awaiting the task directly also surfaces any exception _expire let through.
     await asyncio.wait_for(expiry._tasks[vm_id], timeout=WAIT_TIMEOUT)
 
-    assert sup.deleted == [("vm-gone", False)]
+    assert sup.deleted == [("vm-gone", True)]
     assert expiry.cancel(vm_id) is False
 
 

--- a/tests/supervisor/test_reclaimable.py
+++ b/tests/supervisor/test_reclaimable.py
@@ -26,7 +26,9 @@ NOW = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
 
 
 def test_marker_round_trips_through_json():
-    marker = ReclaimableMarker(reclaimable_since=NOW, reason="gone", size_bytes=42, depends_on=("abc", "def"))
+    marker = ReclaimableMarker(
+        reclaimable_since=NOW, reason="gone", size_bytes=42, depends_on=("abc", "def"), owner="0xOWNER"
+    )
     text = marker.to_json()
     assert json.loads(text) == {
         "version": 1,
@@ -34,8 +36,28 @@ def test_marker_round_trips_through_json():
         "reason": "gone",
         "size_bytes": 42,
         "depends_on": ["abc", "def"],
+        "owner": "0xOWNER",
     }
     assert ReclaimableMarker.from_json(text) == marker
+
+
+def test_a_marker_written_before_the_owner_field_still_parses():
+    """Markers on disk predate the owner field; version stays 1 and they must
+    keep parsing (they are simply markers nobody can be authorized against)."""
+    text = json.dumps(
+        {
+            "version": 1,
+            "reclaimable_since": "2026-08-24T12:00:00+00:00",
+            "reason": "orphan",
+            "size_bytes": 7,
+            "depends_on": [],
+        }
+    )
+
+    marker = ReclaimableMarker.from_json(text)
+
+    assert marker.owner is None
+    assert marker.reason == "orphan" and marker.size_bytes == 7
 
 
 def test_read_marker_is_none_without_file(pools):  # noqa: F811

--- a/tests/supervisor/test_reclaimable.py
+++ b/tests/supervisor/test_reclaimable.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from aleph_message.models import InstanceContent, ProgramContent
+from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
+
+from aleph.vm.agent.vm.reclaimable import (
+    MARKER_NAME,
+    ReclaimableMarker,
+    adopt,
+    clear_marker,
+    depends_on_from_content,
+    directory_size_bytes,
+    iter_reclaimable,
+    mark_reclaimable,
+    read_marker,
+    reclaimable_bytes,
+    write_marker,
+)
+from aleph.vm.storage import get_message
+
+NOW = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def test_marker_round_trips_through_json():
+    marker = ReclaimableMarker(reclaimable_since=NOW, reason="gone", size_bytes=42, depends_on=("abc", "def"))
+    text = marker.to_json()
+    assert json.loads(text) == {
+        "version": 1,
+        "reclaimable_since": "2026-08-24T12:00:00+00:00",
+        "reason": "gone",
+        "size_bytes": 42,
+        "depends_on": ["abc", "def"],
+    }
+    assert ReclaimableMarker.from_json(text) == marker
+
+
+def test_read_marker_is_none_without_file(pools):  # noqa: F811
+    directory = pools["pool0"] / VM_HASH
+    directory.mkdir()
+    assert read_marker(directory) is None
+
+
+def test_read_marker_tolerates_a_corrupt_file(pools, caplog):  # noqa: F811
+    directory = pools["pool0"] / VM_HASH
+    directory.mkdir()
+    (directory / MARKER_NAME).write_text("{not json")
+    assert read_marker(directory) is None
+    assert "corrupt" in caplog.text.lower()
+
+
+def test_write_and_clear_marker(pools):  # noqa: F811
+    directory = pools["pool0"] / VM_HASH
+    directory.mkdir()
+    write_marker(directory, ReclaimableMarker(reclaimable_since=NOW, reason="orphan", size_bytes=0))
+    assert read_marker(directory).reason == "orphan"
+    assert clear_marker(directory) is True
+    assert clear_marker(directory) is False
+    assert read_marker(directory) is None
+
+
+def test_mark_reclaimable_writes_one_marker_per_pool_dir(pools):  # noqa: F811
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=4096)
+    volume(pools["pool1"], VM_HASH, "data.ext4", size=8192)
+
+    written = mark_reclaimable(VM_HASH, "gone", ("parent-ref",), now=NOW)
+
+    assert sorted(written) == sorted([pools["pool0"] / VM_HASH / MARKER_NAME, pools["pool1"] / VM_HASH / MARKER_NAME])
+    marker0 = read_marker(pools["pool0"] / VM_HASH)
+    marker1 = read_marker(pools["pool1"] / VM_HASH)
+    assert marker0.reclaimable_since == NOW
+    assert marker0.depends_on == ("parent-ref",)
+    # size_bytes is per directory, so each pool's budget is local
+    assert marker0.size_bytes == directory_size_bytes(pools["pool0"] / VM_HASH)
+    assert marker1.size_bytes == directory_size_bytes(pools["pool1"] / VM_HASH)
+    assert marker1.size_bytes >= 8192
+
+
+def test_mark_reclaimable_refuses_an_implausible_namespace(pools):  # noqa: F811, ARG001
+    with pytest.raises(ValueError):
+        mark_reclaimable("../etc", "gone")
+
+
+def test_directory_size_counts_only_regular_files_directly_inside(pools):  # noqa: F811
+    directory = pools["pool0"] / VM_HASH
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=4096)
+    (directory / "sub").mkdir()
+    (directory / "sub" / "big").write_bytes(b"x" * 100_000)
+    assert 4096 <= directory_size_bytes(directory) < 100_000
+
+
+def test_adopt_clears_every_marker_of_the_namespace(pools):  # noqa: F811
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    volume(pools["pool1"], VM_HASH, "data.ext4")
+    volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+    mark_reclaimable(OTHER_HASH, "gone", now=NOW)
+
+    assert adopt(VM_HASH) == 2
+
+    assert read_marker(pools["pool0"] / VM_HASH) is None
+    assert read_marker(pools["pool1"] / VM_HASH) is None
+    assert read_marker(pools["pool0"] / OTHER_HASH) is not None
+    assert adopt(VM_HASH) == 0
+
+
+def test_iter_reclaimable_and_reclaimable_bytes(pools):  # noqa: F811
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=4096)
+    volume(pools["pool1"], OTHER_HASH, "rootfs.qcow2", size=4096)
+    volume(pools["pool1"], "dead" * 16, "rootfs.qcow2")  # live, unmarked
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+    mark_reclaimable(OTHER_HASH, "orphan", now=NOW + timedelta(hours=1))
+
+    found = {path.name: marker for path, marker in iter_reclaimable()}
+    assert set(found) == {VM_HASH, OTHER_HASH}
+    assert reclaimable_bytes() == found[VM_HASH].size_bytes + found[OTHER_HASH].size_bytes
+    assert reclaimable_bytes(pools["pool0"]) == found[VM_HASH].size_bytes
+
+
+@pytest.mark.asyncio
+async def test_depends_on_from_instance_content_lists_parent_refs():
+    from aleph.vm.conf import settings
+
+    message = await get_message(ref=settings.FAKE_INSTANCE_ID)
+    content = message.content
+    assert isinstance(content, InstanceContent)
+    depends = depends_on_from_content(content)
+    assert content.rootfs.parent.ref in depends
+    for vol in content.volumes:
+        parent = getattr(vol, "parent", None)
+        if parent is not None:
+            assert parent.ref in depends
+
+
+def test_depends_on_from_program_content_has_no_parents(mocker):
+    """A program's rootfs is the shared runtime cache entry, not a per-VM
+    volume, so nothing here depends on a parent image."""
+    content = mocker.MagicMock(spec=ProgramContent)
+    vol_without_parent = mocker.MagicMock()
+    vol_without_parent.parent = None
+    content.volumes = [vol_without_parent, mocker.MagicMock(spec=[])]
+    assert depends_on_from_content(content) == ()
+
+
+def test_depends_on_deduplicates_parent_refs(mocker):
+    content = mocker.MagicMock(spec=InstanceContent)
+    content.rootfs = mocker.MagicMock()
+    content.rootfs.parent = mocker.MagicMock(ref="same")
+    volume_same = mocker.MagicMock()
+    volume_same.parent = mocker.MagicMock(ref="same")
+    volume_other = mocker.MagicMock()
+    volume_other.parent = mocker.MagicMock(ref="other")
+    content.volumes = [volume_same, volume_other]
+    assert depends_on_from_content(content) == ("same", "other")

--- a/tests/supervisor/test_reclaimable.py
+++ b/tests/supervisor/test_reclaimable.py
@@ -129,6 +129,22 @@ def test_adopt_clears_every_marker_of_the_namespace(pools):  # noqa: F811
     assert adopt(VM_HASH) == 0
 
 
+def test_an_orphan_marker_never_overwrites_an_existing_marker(pools):  # noqa: F811
+    """The periodic pass can decide "orphan" in the window where a GONE
+    retire is writing the real marker; the gone marker carries the owner and
+    the parent-image pins, so the orphan write must lose that race, not win
+    it."""
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", ("parent",), owner="0xOWNER")
+
+    written = mark_reclaimable(VM_HASH, "orphan")
+
+    marker = read_marker(pools["pool0"] / VM_HASH)
+    assert written == []
+    assert marker is not None
+    assert marker.reason == "gone" and marker.owner == "0xOWNER" and marker.depends_on == ("parent",)
+
+
 def test_iter_reclaimable_and_reclaimable_bytes(pools):  # noqa: F811
     volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=4096)
     volume(pools["pool1"], OTHER_HASH, "rootfs.qcow2", size=4096)

--- a/tests/supervisor/test_reclaimable.py
+++ b/tests/supervisor/test_reclaimable.py
@@ -147,6 +147,22 @@ def test_a_failed_marker_write_leaves_no_temp_file(pools, monkeypatch):  # noqa:
     assert list((pools["pool0"] / VM_HASH).glob("*.tmp")) == []
 
 
+@pytest.mark.parametrize("content", ["[]", '"x"', "null", "42", "{not json", '{"reason": "gone"}'])
+def test_a_corrupt_marker_is_removed_and_reads_as_none(pools, content):  # noqa: F811
+    """Valid JSON that is not an object used to escape read_marker as an
+    AttributeError, which iter_reclaimable() fed straight into every
+    admission check. Every corrupt shape now reads as no marker, and the file
+    goes, so the directory is not wedged forever (the exclusive orphan write
+    backs off from any existing file)."""
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    marker_path = pools["pool0"] / VM_HASH / MARKER_NAME
+    marker_path.write_text(content)
+
+    assert read_marker(pools["pool0"] / VM_HASH) is None
+    assert not marker_path.exists()
+    assert reclaimable_bytes() == 0
+
+
 def test_an_orphan_marker_never_overwrites_an_existing_marker(pools):  # noqa: F811
     """The periodic pass can decide "orphan" in the window where a GONE
     retire is writing the real marker; the gone marker carries the owner and

--- a/tests/supervisor/test_reclaimable.py
+++ b/tests/supervisor/test_reclaimable.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
 from aleph_message.models import InstanceContent, ProgramContent
@@ -161,6 +162,62 @@ def test_a_corrupt_marker_is_removed_and_reads_as_none(pools, content):  # noqa:
     assert read_marker(pools["pool0"] / VM_HASH) is None
     assert not marker_path.exists()
     assert reclaimable_bytes() == 0
+
+
+def test_clearing_a_marker_that_vanished_first_is_quiet(pools, monkeypatch):  # noqa: F811
+    """Two adopters, or a pass clearing a stale marker while a create adopts:
+    the loser must not raise out of adopt() and fail the create."""
+    directory = pools["pool0"] / VM_HASH
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone")
+    real_unlink = Path.unlink
+
+    def vanish_then_unlink(self, *args, **kwargs):
+        if self.name == MARKER_NAME:
+            real_unlink(self)
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", vanish_then_unlink)
+
+    assert clear_marker(directory) is False
+    assert read_marker(directory) is None
+
+
+def test_a_failed_marker_write_of_the_temp_file_leaves_nothing_behind(pools, monkeypatch):  # noqa: F811
+    """ENOSPC can hit the temp file write itself, not only the publish."""
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    real_write_text = Path.write_text
+
+    def refuse(self, *args, **kwargs):
+        if self.name.endswith(".tmp"):
+            (self.parent / self.name).touch()
+            raise OSError("no space left on device")
+        return real_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", refuse)
+
+    with pytest.raises(OSError):
+        mark_reclaimable(VM_HASH, "gone")
+
+    assert list((pools["pool0"] / VM_HASH).glob("*.tmp")) == []
+
+
+def test_an_exclusive_write_that_the_filesystem_refuses_is_not_a_marker(pools, monkeypatch, caplog):  # noqa: F811
+    """No hardlinks (or no space): the directory stays unmarked and the pass
+    goes on, rather than aborting on this one directory."""
+    import aleph.vm.agent.vm.reclaimable as reclaimable_module
+
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+
+    def refuse(src, dst):
+        raise PermissionError("hard links not supported")
+
+    monkeypatch.setattr(reclaimable_module.os, "link", refuse)
+
+    assert mark_reclaimable(VM_HASH, "orphan") == []
+    assert read_marker(pools["pool0"] / VM_HASH) is None
+    assert list((pools["pool0"] / VM_HASH).glob("*.tmp")) == []
+    assert "Could not write the reclaimable marker" in caplog.text
 
 
 def test_an_orphan_marker_never_overwrites_an_existing_marker(pools):  # noqa: F811

--- a/tests/supervisor/test_reclaimable.py
+++ b/tests/supervisor/test_reclaimable.py
@@ -130,9 +130,12 @@ def test_adopt_clears_every_marker_of_the_namespace(pools):  # noqa: F811
     assert adopt(VM_HASH) == 0
 
 
-def test_a_failed_marker_write_leaves_no_temp_file(pools, monkeypatch):  # noqa: F811
+def test_a_failed_marker_write_leaves_no_temp_file(pools, monkeypatch, caplog):  # noqa: F811
     """A replace that fails (ENOSPC, EACCES) must not strand the temp file:
-    nothing else would ever collect it from the VM directory."""
+    nothing else would ever collect it from the VM directory. Nor may it
+    raise: a GONE retire and the namespace pass both call this, and at
+    startup the pass runs inside the on_startup hook, where a raise on a
+    full pool would stop the agent from booting."""
     import aleph.vm.agent.vm.reclaimable as reclaimable_module
 
     volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
@@ -142,10 +145,11 @@ def test_a_failed_marker_write_leaves_no_temp_file(pools, monkeypatch):  # noqa:
 
     monkeypatch.setattr(reclaimable_module.os, "replace", refuse)
 
-    with pytest.raises(OSError):
-        mark_reclaimable(VM_HASH, "gone")
+    assert mark_reclaimable(VM_HASH, "gone") == []
 
+    assert read_marker(pools["pool0"] / VM_HASH) is None
     assert list((pools["pool0"] / VM_HASH).glob("*.tmp")) == []
+    assert "Could not write the reclaimable marker" in caplog.text
 
 
 @pytest.mark.parametrize("content", ["[]", '"x"', "null", "42", "{not json", '{"reason": "gone"}'])
@@ -196,8 +200,7 @@ def test_a_failed_marker_write_of_the_temp_file_leaves_nothing_behind(pools, mon
 
     monkeypatch.setattr(Path, "write_text", refuse)
 
-    with pytest.raises(OSError):
-        mark_reclaimable(VM_HASH, "gone")
+    assert mark_reclaimable(VM_HASH, "gone") == []
 
     assert list((pools["pool0"] / VM_HASH).glob("*.tmp")) == []
 

--- a/tests/supervisor/test_reclaimable.py
+++ b/tests/supervisor/test_reclaimable.py
@@ -220,6 +220,38 @@ def test_an_exclusive_write_that_the_filesystem_refuses_is_not_a_marker(pools, m
     assert "Could not write the reclaimable marker" in caplog.text
 
 
+def test_reclaimable_bytes_is_cached_between_marker_changes(pools, monkeypatch):  # noqa: F811
+    """Admission asks on every request; the walk must not happen every time,
+    and must not be stale after a marker is written, cleared, or its whole
+    directory removed."""
+    import shutil
+
+    import aleph.vm.agent.vm.reclaimable as reclaimable_module
+
+    walks = []
+    real_iter = reclaimable_module.iter_reclaimable
+
+    def counting_iter():
+        walks.append(1)
+        return real_iter()
+
+    monkeypatch.setattr(reclaimable_module, "iter_reclaimable", counting_iter)
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
+    volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2", size=8192)
+    mark_reclaimable(VM_HASH, "gone")
+    mark_reclaimable(OTHER_HASH, "gone")
+
+    assert reclaimable_bytes() == 16384
+    assert reclaimable_bytes() == 16384
+    assert len(walks) == 1, "the second call must be served from the cache"
+
+    clear_marker(pools["pool0"] / VM_HASH)
+    assert reclaimable_bytes() == 8192, "an in-process marker change invalidates at once"
+
+    shutil.rmtree(pools["pool0"] / OTHER_HASH)
+    assert reclaimable_bytes() == 0, "a directory that went away changes the pool's mtime"
+
+
 def test_an_orphan_marker_never_overwrites_an_existing_marker(pools):  # noqa: F811
     """The periodic pass can decide "orphan" in the window where a GONE
     retire is writing the real marker; the gone marker carries the owner and

--- a/tests/supervisor/test_reclaimable.py
+++ b/tests/supervisor/test_reclaimable.py
@@ -319,3 +319,26 @@ def test_depends_on_deduplicates_parent_refs(mocker):
     volume_other.parent = mocker.MagicMock(ref="other")
     content.volumes = [volume_same, volume_other]
     assert depends_on_from_content(content) == ("same", "other")
+
+
+def test_the_cache_is_invalidated_after_the_publish_too(pools, monkeypatch):  # noqa: F811
+    """A reader that computes between the pre-write invalidation and the
+    os.replace caches the pre-change sum; the pool directory's mtime does not
+    move on a marker write, so the fingerprint would keep that stale value
+    for the whole TTL. Invalidating after the publish closes the window."""
+    import aleph.vm.agent.vm.reclaimable as reclaimable_module
+
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=4096)
+    real_replace = reclaimable_module.os.replace
+    seen_mid_write = []
+
+    def read_then_replace(src, dst):
+        seen_mid_write.append(reclaimable_bytes())
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(reclaimable_module.os, "replace", read_then_replace)
+
+    mark_reclaimable(VM_HASH, "gone")
+
+    assert seen_mid_write == [0]
+    assert reclaimable_bytes() == 4096

--- a/tests/supervisor/test_reclaimable.py
+++ b/tests/supervisor/test_reclaimable.py
@@ -129,6 +129,24 @@ def test_adopt_clears_every_marker_of_the_namespace(pools):  # noqa: F811
     assert adopt(VM_HASH) == 0
 
 
+def test_a_failed_marker_write_leaves_no_temp_file(pools, monkeypatch):  # noqa: F811
+    """A replace that fails (ENOSPC, EACCES) must not strand the temp file:
+    nothing else would ever collect it from the VM directory."""
+    import aleph.vm.agent.vm.reclaimable as reclaimable_module
+
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+
+    def refuse(src, dst):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(reclaimable_module.os, "replace", refuse)
+
+    with pytest.raises(OSError):
+        mark_reclaimable(VM_HASH, "gone")
+
+    assert list((pools["pool0"] / VM_HASH).glob("*.tmp")) == []
+
+
 def test_an_orphan_marker_never_overwrites_an_existing_marker(pools):  # noqa: F811
     """The periodic pass can decide "orphan" in the window where a GONE
     retire is writing the real marker; the gone marker carries the owner and

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -410,6 +410,25 @@ async def test_startup_purges_nothing_when_the_registry_is_empty_but_vms_run(poo
 
 
 @pytest.mark.asyncio
+async def test_a_refusing_startup_never_promises_a_purge(pools, registry, monkeypatch, caplog):  # noqa: F811
+    """The preview and the pass behind it share one live set and one refusal
+    decision, so the log cannot read "will purge N" above "purging nothing",
+    and the supervisor is asked once."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    old = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    _age(old.parent, 10_000)
+    supervisor = _supervisor(fails=True)
+
+    with caplog.at_level("WARNING"):
+        await reconcile_at_startup(_app(registry, supervisor))
+
+    assert "will purge 1 orphan" not in caplog.text
+    assert "would have purged 1" in caplog.text
+    assert supervisor.list_vms.await_count == 1
+    assert old.exists()
+
+
+@pytest.mark.asyncio
 async def test_startup_hook_logs_a_preview_then_reconciles(pools, registry, monkeypatch, caplog):  # noqa: F811
     """The one-shot cleanup on an upgraded node is announced before it runs:
     an operator reading the log must be able to explain why free space jumped

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from aleph_message.models import ItemHash
+from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
+
+import aleph.vm.agent.vm.reconciler as reconciler_module
+from aleph.vm.agent.vm.reclaimable import mark_reclaimable, read_marker
+from aleph.vm.agent.vm.reconciler import (
+    creating,
+    is_creating,
+    make_room,
+    reconcile_storage,
+)
+from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.conf import settings
+from aleph.vm.storage_pools import get_pools
+
+LIVE = "dead" * 16
+NOW = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _age(path, seconds: int) -> None:
+    """Set the mtime ``seconds`` before NOW: the reconciler threads one ``now``
+    through the whole pass, so ages are relative to it and not to the clock."""
+    stamp = NOW.timestamp() - seconds
+    os.utime(path, (stamp, stamp))
+
+
+@pytest.fixture
+def registry():
+    reg = AgentVmRegistry()
+    content = MagicMock(volumes=[], rootfs=None)
+    reg.record(ItemHash(LIVE), message=content, original=content, persistent=True)
+    return reg
+
+
+@pytest.fixture(autouse=True)
+def _no_backups(mocker):
+    mocker.patch.object(reconciler_module, "sweep_expired_backups", return_value=0)
+
+
+@pytest.fixture(autouse=True)
+def _mount_root(tmp_path, monkeypatch):
+    """Never let a test walk the host's real /mnt."""
+    monkeypatch.setattr(reconciler_module, "MOUNT_ROOT", tmp_path / "unused-mnt")
+
+
+def test_live_dirs_are_left_alone(pools, registry):  # noqa: F811
+    live = volume(pools["pool0"], LIVE, "rootfs.qcow2")
+    _age(live.parent, 10_000)
+
+    report = reconcile_storage(registry, now=NOW)
+
+    assert live.exists()
+    assert report.purged_orphans == [] and report.marked_orphans == []
+
+
+def test_young_orphan_is_inside_the_create_guard(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    young = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    _age(young.parent, 10)
+
+    reconcile_storage(registry, now=NOW)
+
+    assert young.exists()
+
+
+def test_in_flight_create_is_never_an_orphan(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    old = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    _age(old.parent, 10_000)
+
+    with creating(VM_HASH):
+        assert is_creating(VM_HASH)
+        reconcile_storage(registry, now=NOW)
+        assert old.exists()
+    assert not is_creating(VM_HASH)
+
+
+def test_creating_adopts_retained_dirs(pools, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+
+    with creating(VM_HASH):
+        assert read_marker(pools["pool0"] / VM_HASH) is None
+
+
+def test_old_orphan_is_purged_under_reap(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    old = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    _age(old.parent, 10_000)
+
+    report = reconcile_storage(registry, now=NOW)
+
+    assert not old.parent.exists()
+    assert report.purged_orphans == [VM_HASH]
+
+
+def test_old_orphan_is_marked_under_keep(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    old = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    _age(old.parent, 10_000)
+
+    report = reconcile_storage(registry, now=NOW)
+
+    assert old.exists()
+    assert read_marker(old.parent).reason == "orphan"
+    assert report.marked_orphans == [VM_HASH]
+
+
+def test_marked_dir_whose_vm_is_live_again_is_adopted(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    volume(pools["pool0"], LIVE, "rootfs.qcow2")
+    mark_reclaimable(LIVE, "gone", now=NOW)
+
+    reconcile_storage(registry, now=NOW)
+
+    assert read_marker(pools["pool0"] / LIVE) is None
+
+
+def test_implausible_dir_names_are_skipped(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    weird = pools["pool0"] / "lost+found"
+    weird.mkdir()
+    _age(weird, 10_000)
+
+    reconcile_storage(registry, now=NOW)
+
+    assert weird.exists()
+
+
+def test_dry_run_changes_nothing(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    old = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    _age(old.parent, 10_000)
+
+    report = reconcile_storage(registry, now=NOW, dry_run=True)
+
+    assert old.exists()
+    assert report.purged_orphans == [VM_HASH]
+
+
+def test_old_part_files_are_removed_young_ones_kept(pools, registry):  # noqa: F811
+    old_part = pools["runtime"] / "abc.part"
+    old_part.write_bytes(b"x")
+    _age(old_part, 10_000)
+    young_part = pools["code"] / "def.part"
+    young_part.write_bytes(b"x")
+    _age(young_part, 10)
+    pool_part = volume(pools["pool0"], LIVE, "rootfs.qcow2.part")
+    _age(pool_part, 10_000)
+
+    report = reconcile_storage(registry, now=NOW)
+
+    assert not old_part.exists()
+    assert young_part.exists()
+    assert not pool_part.exists()
+    assert report.parts_removed == 2
+
+
+def test_side_dirs_of_unknown_hashes_are_removed(pools, registry):  # noqa: F811
+    stale_session = pools["sessions"] / VM_HASH
+    stale_session.mkdir()
+    live_session = pools["sessions"] / LIVE
+    live_session.mkdir()
+    stale_staging = pools["execution_root"] / "snp-instance" / VM_HASH
+    stale_staging.mkdir(parents=True)
+    stale_mount = pools["execution_root"] / "mnt" / f"{VM_HASH}_data"
+    stale_mount.mkdir(parents=True)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(reconciler_module, "MOUNT_ROOT", pools["execution_root"] / "mnt")
+        report = reconcile_storage(registry, now=NOW)
+
+    assert not stale_session.exists()
+    assert live_session.exists()
+    assert not stale_staging.exists()
+    assert not stale_mount.exists()
+    assert report.side_dirs_removed == 3
+
+
+def test_budget_evicts_oldest_first(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    monkeypatch.setattr(settings, "VOLUME_RETENTION_BUDGET", "8192")
+    oldest = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
+    newest = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2", size=8192)
+    mark_reclaimable(VM_HASH, "gone", now=NOW - timedelta(days=2))
+    mark_reclaimable(OTHER_HASH, "gone", now=NOW - timedelta(days=1))
+
+    report = reconcile_storage(registry, now=NOW)
+
+    assert not oldest.exists()
+    assert newest.exists()
+    assert report.evicted == [VM_HASH]
+
+
+def test_switching_to_reap_evicts_everything_marked(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    kept = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+
+    reconcile_storage(registry, now=NOW)
+
+    assert not kept.exists()
+
+
+def test_make_room_frees_only_what_is_needed(pools, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    oldest = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
+    newest = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2", size=8192)
+    mark_reclaimable(VM_HASH, "gone", now=NOW - timedelta(days=2))
+    mark_reclaimable(OTHER_HASH, "gone", now=NOW - timedelta(days=1))
+
+    freed = make_room(get_pools()[0], needed_bytes=4096)
+
+    assert freed >= 4096
+    assert not oldest.exists()
+    assert newest.exists()

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -207,6 +207,28 @@ def test_side_dirs_of_unknown_hashes_are_removed(pools, registry):  # noqa: F811
     assert report.side_dirs_removed == 3
 
 
+def test_a_non_empty_mnt_directory_is_never_removed(pools, registry):  # noqa: F811
+    """/mnt is the operator's directory. An agent mount point there is empty
+    once unmounted (create_devmapper only mkdirs it), so anything with content
+    under a name that merely matches the pattern is somebody else's disk."""
+    mnt = pools["execution_root"] / "mnt"
+    operator_disk = mnt / f"{VM_HASH}_1"
+    operator_disk.mkdir(parents=True)
+    (operator_disk / "customer-data.img").write_bytes(b"x")
+    stale_mount = mnt / f"{OTHER_HASH}_data"
+    stale_mount.mkdir()
+    for path in (operator_disk, stale_mount):
+        _age(path, 10_000)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(reconciler_module, "MOUNT_ROOT", mnt)
+        report = reconcile_storage(registry, now=NOW)
+
+    assert (operator_disk / "customer-data.img").exists()
+    assert not stale_mount.exists()
+    assert report.side_dirs_removed == 1
+
+
 def test_young_side_dirs_are_inside_the_create_guard(pools, registry):  # noqa: F811
     young = pools["sessions"] / VM_HASH
     young.mkdir()

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,6 +24,18 @@ from aleph.vm.storage_pools import get_pools
 
 LIVE = "dead" * 16
 NOW = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
+GIB = 1024**3
+
+
+def _fake_disk_usage(monkeypatch, free_bytes):
+    """Pin the free space every pool reports. ``free_bytes`` is either a
+    number or a callable, so a test can let evictions give space back."""
+
+    def usage(path):
+        free = free_bytes(Path(path)) if callable(free_bytes) else free_bytes
+        return SimpleNamespace(total=10 * GIB, used=10 * GIB - free, free=free)
+
+    monkeypatch.setattr(reconciler_module.shutil, "disk_usage", usage)
 
 
 def _age(path, seconds: int) -> None:
@@ -173,6 +187,8 @@ def test_side_dirs_of_unknown_hashes_are_removed(pools, registry):  # noqa: F811
     stale_staging.mkdir(parents=True)
     stale_mount = pools["execution_root"] / "mnt" / f"{VM_HASH}_data"
     stale_mount.mkdir(parents=True)
+    for stale in (stale_session, stale_staging, stale_mount):
+        _age(stale, 10_000)
 
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(reconciler_module, "MOUNT_ROOT", pools["execution_root"] / "mnt")
@@ -183,6 +199,21 @@ def test_side_dirs_of_unknown_hashes_are_removed(pools, registry):  # noqa: F811
     assert not stale_staging.exists()
     assert not stale_mount.exists()
     assert report.side_dirs_removed == 3
+
+
+def test_young_side_dirs_are_inside_the_create_guard(pools, registry):  # noqa: F811
+    young = pools["sessions"] / VM_HASH
+    young.mkdir()
+    _age(young, 10)
+    old = pools["sessions"] / OTHER_HASH
+    old.mkdir()
+    _age(old, 10_000)
+
+    report = reconcile_storage(registry, now=NOW)
+
+    assert young.exists()
+    assert not old.exists()
+    assert report.side_dirs_removed == 1
 
 
 def test_budget_evicts_oldest_first(pools, registry, monkeypatch):  # noqa: F811
@@ -210,15 +241,55 @@ def test_switching_to_reap_evicts_everything_marked(pools, registry, monkeypatch
     assert not kept.exists()
 
 
-def test_make_room_frees_only_what_is_needed(pools, monkeypatch):  # noqa: F811
+def test_make_room_evicts_oldest_first_until_the_create_fits(pools, monkeypatch):  # noqa: F811
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
     oldest = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
     newest = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2", size=8192)
     mark_reclaimable(VM_HASH, "gone", now=NOW - timedelta(days=2))
     mark_reclaimable(OTHER_HASH, "gone", now=NOW - timedelta(days=1))
+    # A full pool that gets 8 KiB back for every evicted VM.
+    _fake_disk_usage(monkeypatch, lambda path: 8192 * sum(not (path / h).exists() for h in (VM_HASH, OTHER_HASH)))
 
-    freed = make_room(get_pools()[0], needed_bytes=4096)
+    freed = make_room(get_pools()[0], needed_bytes=8192)
 
-    assert freed >= 4096
+    assert freed == 8192
     assert not oldest.exists()
     assert newest.exists()
+
+
+def test_make_room_evicts_nothing_when_the_pool_already_fits(pools, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    retained = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
+    mark_reclaimable(VM_HASH, "gone", now=NOW - timedelta(days=2))
+    _fake_disk_usage(monkeypatch, 90 * GIB)
+
+    freed = make_room(get_pools()[0], needed_bytes=8192)
+
+    assert freed == 0
+    assert retained.exists()
+
+
+def test_make_room_counts_only_the_bytes_it_frees_on_that_pool(pools, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    on_pool0 = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
+    on_pool1 = volume(pools["pool1"], VM_HASH, "data.ext4", size=8192)
+    mark_reclaimable(VM_HASH, "gone", now=NOW - timedelta(days=2))
+    _fake_disk_usage(monkeypatch, 0)
+
+    freed = make_room(get_pools()[0], needed_bytes=1024**2)
+
+    # The VM is purged whole, but only pool 0's 8 KiB help a pool 0 create.
+    assert freed == 8192
+    assert not on_pool0.exists() and not on_pool1.exists()
+
+
+def test_make_room_never_evicts_a_live_namespace(pools, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    running = volume(pools["pool0"], LIVE, "rootfs.qcow2", size=8192)
+    mark_reclaimable(LIVE, "gone", now=NOW - timedelta(days=2))
+    _fake_disk_usage(monkeypatch, 0)
+
+    freed = make_room(get_pools()[0], needed_bytes=8192, live={LIVE})
+
+    assert freed == 0
+    assert running.exists()

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -16,7 +17,10 @@ from aleph.vm.agent.vm.reconciler import (
     creating,
     is_creating,
     make_room,
+    reconcile_at_startup,
     reconcile_storage,
+    start_storage_reconcile_task,
+    stop_storage_reconcile_task,
 )
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
@@ -293,3 +297,47 @@ def test_make_room_never_evicts_a_live_namespace(pools, monkeypatch):  # noqa: F
 
     assert freed == 0
     assert running.exists()
+
+
+@pytest.mark.asyncio
+async def test_startup_hook_logs_a_preview_then_reconciles(pools, registry, monkeypatch, caplog):  # noqa: F811
+    """The one-shot cleanup on an upgraded node is announced before it runs:
+    an operator reading the log must be able to explain why free space jumped
+    (spec section 6, migration)."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    old = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    _age(old.parent, 10_000)
+
+    with caplog.at_level("WARNING"):
+        await reconcile_at_startup({"vm_registry": registry})
+
+    assert "will purge 1 orphan" in caplog.text
+    # A line per pool, so the operator sees which disk gives the space back.
+    assert f"pool 0 ({pools['pool0']})" in caplog.text
+    assert not old.parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_startup_hook_is_quiet_when_there_is_nothing_to_reclaim(pools, registry, caplog):  # noqa: F811
+    live = volume(pools["pool0"], LIVE, "rootfs.qcow2")
+    _age(live.parent, 10_000)
+
+    with caplog.at_level("WARNING"):
+        await reconcile_at_startup({"vm_registry": registry})
+
+    assert "Startup storage reconcile" not in caplog.text
+    assert live.exists()
+
+
+@pytest.mark.asyncio
+async def test_the_periodic_task_starts_and_is_cancelled_on_shutdown(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RECONCILE_INTERVAL", 3600)
+    app = {"vm_registry": registry}
+
+    await start_storage_reconcile_task(app)
+    task = app["storage_reconcile"]
+    await asyncio.sleep(0)  # let the task reach its first (long) sleep
+    assert not task.done()
+    await stop_storage_reconcile_task(app)
+
+    assert task.done()

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -18,6 +19,7 @@ from aleph.vm.agent.vm.reconciler import (
     is_creating,
     make_room,
     reconcile_at_startup,
+    reconcile_now,
     reconcile_storage,
     start_storage_reconcile_task,
     stop_storage_reconcile_task,
@@ -341,3 +343,52 @@ async def test_the_periodic_task_starts_and_is_cancelled_on_shutdown(pools, regi
     await stop_storage_reconcile_task(app)
 
     assert task.done()
+
+
+def test_a_create_in_flight_keeps_its_directory_and_its_part_files(pools, registry, monkeypatch):  # noqa: F811
+    """A migration import streams multi-GB disks into a namespace no registry
+    record covers yet, for far longer than VOLUME_CREATE_GUARD, and the
+    directory's own mtime does not advance while a file inside it grows. Only
+    ``creating()`` stands between that transfer and the reaper."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    staged = volume(pools["pool0"], VM_HASH, "rootfs.qcow2.part")
+    _age(staged, 10_000)
+    _age(staged.parent, 10_000)
+
+    with creating(VM_HASH):
+        report = reconcile_storage(registry, now=NOW)
+
+    assert staged.exists()
+    assert report.purged_orphans == [] and report.parts_removed == 0
+
+
+def test_evicting_a_directory_that_already_vanished_counts_nothing(pools, monkeypatch):  # noqa: F811
+    """Passes can overlap (a GONE-triggered pass, the periodic one, make_room),
+    so a directory can disappear between being listed and being acted on. That
+    is not an error, and it is not freed space this pass may claim."""
+    report = reconciler_module.ReconcileReport()
+
+    freed = reconciler_module._evict(VM_HASH, report, dry_run=False)
+
+    assert freed == 0
+    assert report.evicted == [] and report.bytes_freed == 0
+
+
+@pytest.mark.asyncio
+async def test_two_reconcile_passes_do_not_overlap(pools, registry, monkeypatch):  # noqa: F811
+    """A GONE fires a pass while the periodic one may be running: without a
+    lock the two threads evict the same directories and double-count."""
+    order = []
+
+    def slow_pass(_registry, **_kwargs):
+        order.append("enter")
+        time.sleep(0.05)
+        order.append("exit")
+        return reconciler_module.ReconcileReport()
+
+    monkeypatch.setattr(reconciler_module, "reconcile_storage", slow_pass)
+    app = {"vm_registry": registry}
+
+    await asyncio.gather(reconcile_now(app), reconcile_now(app))
+
+    assert order == ["enter", "exit", "enter", "exit"]

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -501,6 +501,21 @@ def test_evicting_a_directory_that_already_vanished_counts_nothing(pools, monkey
     assert report.evicted == [] and report.bytes_freed == 0
 
 
+def test_a_refused_purge_is_not_counted_as_an_eviction(pools, monkeypatch):  # noqa: F811
+    """purge_vm_storage refuses a directory a device-mapper target still
+    holds. make_room must not then report room it did not make."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    retained = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+    monkeypatch.setattr(reconciler_module, "purge_vm_storage", lambda _namespace: 0)
+    _fake_disk_usage(monkeypatch, 0)
+
+    freed = make_room(get_pools()[0], needed_bytes=8192)
+
+    assert freed == 0
+    assert retained.exists()
+
+
 @pytest.mark.asyncio
 async def test_two_reconcile_passes_do_not_overlap(pools, registry, monkeypatch):  # noqa: F811
     """A GONE fires a pass while the periodic one may be running: without a

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -6,7 +6,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aleph_message.models import ItemHash
@@ -27,6 +27,7 @@ from aleph.vm.agent.vm.reconciler import (
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 from aleph.vm.storage_pools import get_pools
+from aleph.vm.supervisor_interface.errors import SupervisorError
 
 LIVE = "dead" * 16
 NOW = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
@@ -57,6 +58,17 @@ def registry():
     content = MagicMock(volumes=[], rootfs=None)
     reg.record(ItemHash(LIVE), message=content, original=content, persistent=True)
     return reg
+
+
+def _supervisor(*vm_ids: str, fails: bool = False):
+    """A supervisor handle that lists ``vm_ids``, or refuses to answer."""
+    if fails:
+        return SimpleNamespace(list_vms=AsyncMock(side_effect=SupervisorError("no answer")))
+    return SimpleNamespace(list_vms=AsyncMock(return_value=[SimpleNamespace(vm_id=vm_id) for vm_id in vm_ids]))
+
+
+def _app(registry, supervisor=None):
+    return {"vm_registry": registry, "supervisor": supervisor if supervisor is not None else _supervisor()}
 
 
 @pytest.fixture(autouse=True)
@@ -229,6 +241,33 @@ def test_a_non_empty_mnt_directory_is_never_removed(pools, registry):  # noqa: F
     assert report.side_dirs_removed == 1
 
 
+def test_a_hash_claimed_mid_pass_is_not_purged(pools, registry, monkeypatch):  # noqa: F811
+    """The live set is snapshotted on the loop and the walk runs in a thread:
+    a create that commits in between must not be purged. The directory's mtime
+    is no help, it does not move while a file inside it grows."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    content = MagicMock(volumes=[], rootfs=None)
+    for namespace in (VM_HASH, OTHER_HASH):
+        _age(volume(pools["pool0"], namespace, "rootfs.qcow2").parent, 10_000)
+    real_purge = reconciler_module.purge_vm_storage
+
+    def purge_and_commit_the_other(namespace):
+        # The create for the namespace this pass has not reached yet commits
+        # while the pass is busy with the first one.
+        other = OTHER_HASH if namespace == VM_HASH else VM_HASH
+        registry.record(ItemHash(other), message=content, original=content, persistent=True)
+        return real_purge(namespace)
+
+    monkeypatch.setattr(reconciler_module, "purge_vm_storage", purge_and_commit_the_other)
+    live = reconciler_module.live_hashes(registry)
+
+    report = reconcile_storage(registry, now=NOW, live=live, is_live=reconciler_module.registry_is_live(registry, live))
+
+    assert len(report.purged_orphans) == 1
+    survivor = OTHER_HASH if report.purged_orphans == [VM_HASH] else VM_HASH
+    assert (pools["pool0"] / survivor).is_dir()
+
+
 def test_young_side_dirs_are_inside_the_create_guard(pools, registry):  # noqa: F811
     young = pools["sessions"] / VM_HASH
     young.mkdir()
@@ -324,6 +363,53 @@ def test_make_room_never_evicts_a_live_namespace(pools, monkeypatch):  # noqa: F
 
 
 @pytest.mark.asyncio
+async def test_a_vm_the_supervisor_runs_is_live_even_without_a_record(pools, registry, monkeypatch):  # noqa: F811
+    """The registry is refilled at boot from the agent DB alone, and that
+    rehydration skips records with an empty or unparseable message. A VM the
+    supervisor is still running is live whatever the registry remembers."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    running = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    _age(running.parent, 10_000)
+
+    report = await reconcile_now(_app(registry, _supervisor(VM_HASH)))
+
+    assert running.exists()
+    assert report.purged_orphans == []
+
+
+@pytest.mark.asyncio
+async def test_startup_purges_nothing_when_the_supervisor_cannot_be_listed(pools, registry, monkeypatch, caplog):  # noqa: F811
+    """No answer from the supervisor is not "it runs nothing": without the
+    second opinion the live set is unknown, so the startup pass runs dry."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    old = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    _age(old.parent, 10_000)
+
+    with caplog.at_level("WARNING"):
+        await reconcile_at_startup(_app(registry, _supervisor(fails=True)))
+
+    assert old.exists()
+    assert "running dry" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_startup_purges_nothing_when_the_registry_is_empty_but_vms_run(pools, monkeypatch, caplog):  # noqa: F811
+    """A fresh or lost agent DB rehydrates zero records while the supervisor
+    still runs VMs: every directory would look like an orphan."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    old = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    _age(old.parent, 10_000)
+    other = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2")
+    _age(other.parent, 10_000)
+
+    with caplog.at_level("WARNING"):
+        await reconcile_at_startup(_app(AgentVmRegistry(), _supervisor(LIVE)))
+
+    assert old.exists() and other.exists()
+    assert "registry is empty" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_startup_hook_logs_a_preview_then_reconciles(pools, registry, monkeypatch, caplog):  # noqa: F811
     """The one-shot cleanup on an upgraded node is announced before it runs:
     an operator reading the log must be able to explain why free space jumped
@@ -333,7 +419,7 @@ async def test_startup_hook_logs_a_preview_then_reconciles(pools, registry, monk
     _age(old.parent, 10_000)
 
     with caplog.at_level("WARNING"):
-        await reconcile_at_startup({"vm_registry": registry})
+        await reconcile_at_startup(_app(registry))
 
     assert "will purge 1 orphan" in caplog.text
     # A line per pool, so the operator sees which disk gives the space back.
@@ -347,7 +433,7 @@ async def test_startup_hook_is_quiet_when_there_is_nothing_to_reclaim(pools, reg
     _age(live.parent, 10_000)
 
     with caplog.at_level("WARNING"):
-        await reconcile_at_startup({"vm_registry": registry})
+        await reconcile_at_startup(_app(registry))
 
     assert "Startup storage reconcile" not in caplog.text
     assert live.exists()
@@ -356,7 +442,7 @@ async def test_startup_hook_is_quiet_when_there_is_nothing_to_reclaim(pools, reg
 @pytest.mark.asyncio
 async def test_the_periodic_task_starts_and_is_cancelled_on_shutdown(pools, registry, monkeypatch):  # noqa: F811
     monkeypatch.setattr(settings, "VOLUME_RECONCILE_INTERVAL", 3600)
-    app = {"vm_registry": registry}
+    app = _app(registry)
 
     await start_storage_reconcile_task(app)
     task = app["storage_reconcile"]
@@ -409,7 +495,7 @@ async def test_two_reconcile_passes_do_not_overlap(pools, registry, monkeypatch)
         return reconciler_module.ReconcileReport()
 
     monkeypatch.setattr(reconciler_module, "reconcile_storage", slow_pass)
-    app = {"vm_registry": registry}
+    app = _app(registry)
 
     await asyncio.gather(reconcile_now(app), reconcile_now(app))
 

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -414,11 +414,30 @@ def test_make_room_counts_only_the_bytes_it_frees_on_that_pool(pools, monkeypatc
     mark_reclaimable(VM_HASH, "gone", now=NOW - timedelta(days=2))
     _fake_disk_usage(monkeypatch, 0)
 
-    freed = make_room(get_pools()[0], needed_bytes=1024**2)
+    freed = make_room(get_pools()[0], needed_bytes=8192)
 
     # The VM is purged whole, but only pool 0's 8 KiB help a pool 0 create.
     assert freed == 8192
     assert not on_pool0.exists() and not on_pool1.exists()
+
+
+def test_make_room_evicts_nothing_when_the_create_could_never_fit(pools, monkeypatch):  # noqa: F811
+    """The largest-volume admission check can pass a create that no single
+    pool fits even with every retained directory gone (it looks at the sum).
+    Placement then asks the room maker on each pool in turn: without this
+    bound each of them would evict every retained VM it has and still refuse,
+    wiping retained data across the node for a create that fails anyway."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    retained = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
+    other = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2", size=8192)
+    mark_reclaimable(VM_HASH, "gone", now=NOW - timedelta(days=2))
+    mark_reclaimable(OTHER_HASH, "gone", now=NOW - timedelta(days=1))
+    _fake_disk_usage(monkeypatch, 0)
+
+    freed = make_room(get_pools()[0], needed_bytes=GIB)
+
+    assert freed == 0
+    assert retained.exists() and other.exists()
 
 
 def test_make_room_never_evicts_a_live_namespace(pools, monkeypatch):  # noqa: F811

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -268,6 +268,66 @@ def test_a_hash_claimed_mid_pass_is_not_purged(pools, registry, monkeypatch):  #
     assert (pools["pool0"] / survivor).is_dir()
 
 
+def test_a_hash_entering_creating_mid_pass_is_not_purged(pools, registry, monkeypatch):  # noqa: F811
+    """The creating() twin of the registry race above: a create that enters
+    the guard after _is_orphan judged the directory unowned must keep its
+    disks (the re-check runs immediately before the purge decision)."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    disk = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    _age(disk.parent, 10_000)
+    real_is_orphan = reconciler_module._is_orphan
+
+    def orphan_then_claim(directory, is_live, now, guard, *, dry_run):
+        result = real_is_orphan(directory, is_live, now, guard, dry_run=dry_run)
+        if result:
+            reconciler_module._creating.add(directory.name)
+        return result
+
+    monkeypatch.setattr(reconciler_module, "_is_orphan", orphan_then_claim)
+
+    try:
+        report = reconcile_storage(registry, now=NOW)
+    finally:
+        reconciler_module._creating.discard(VM_HASH)
+
+    assert disk.exists()
+    assert report.purged_orphans == []
+
+
+def test_creating_registers_before_it_adopts(pools, monkeypatch):  # noqa: F811
+    """Between clear_marker and the registration there must be no instant
+    where a directory is neither marked nor creating: adopt runs with the
+    guard already up."""
+    guarded = []
+    real_adopt = reconciler_module.adopt
+
+    def adopt_and_record(namespace):
+        guarded.append(is_creating(namespace))
+        return real_adopt(namespace)
+
+    monkeypatch.setattr(reconciler_module, "adopt", adopt_and_record)
+
+    with creating(VM_HASH):
+        pass
+
+    assert guarded == [True]
+    assert not is_creating(VM_HASH)
+
+
+def test_a_side_dir_claimed_mid_pass_is_not_removed(pools, registry):  # noqa: F811
+    """The live snapshot is stale by the time the sweep removes: a VM that
+    came alive in between keeps its side directories, the same re-check the
+    namespace pass and the evictor make."""
+    session = pools["sessions"] / VM_HASH
+    session.mkdir()
+    _age(session, 10_000)
+
+    report = reconcile_storage(registry, now=NOW, live=set(), is_live=lambda namespace: namespace == VM_HASH)
+
+    assert session.exists()
+    assert report.side_dirs_removed == 0
+
+
 def test_young_side_dirs_are_inside_the_create_guard(pools, registry):  # noqa: F811
     young = pools["sessions"] / VM_HASH
     young.mkdir()

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -438,6 +438,19 @@ async def test_a_vm_the_supervisor_runs_is_live_even_without_a_record(pools, reg
 
 
 @pytest.mark.asyncio
+async def test_the_room_maker_protects_what_the_supervisor_listed_last(pools, registry, monkeypatch):  # noqa: F811
+    """Placement-pressure eviction runs off a synchronous hook that cannot
+    ask the supervisor; it protects the supervisor's VMs as of the last
+    pass, so a running VM whose registry record was lost is still safe."""
+    monkeypatch.setattr(reconciler_module, "_last_supervisor_hashes", set())
+    assert OTHER_HASH not in reconciler_module.known_live_hashes(registry)
+
+    await reconciler_module._live_set(_app(registry, _supervisor(OTHER_HASH)))
+
+    assert reconciler_module.known_live_hashes(registry) >= {LIVE, OTHER_HASH}
+
+
+@pytest.mark.asyncio
 async def test_startup_purges_nothing_when_the_supervisor_cannot_be_listed(pools, registry, monkeypatch, caplog):  # noqa: F811
     """No answer from the supervisor is not "it runs nothing": without the
     second opinion the live set is unknown, so the startup pass runs dry."""

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -501,6 +501,23 @@ def test_evicting_a_directory_that_already_vanished_counts_nothing(pools, monkey
     assert report.evicted == [] and report.bytes_freed == 0
 
 
+def test_evict_declines_a_namespace_whose_create_started_mid_pass(pools, monkeypatch):  # noqa: F811
+    """The budget pass lists a retained VM; its owner then re-creates it.
+    creating() adopts the directory (clearing the marker) before the evictor
+    reaches the stale listing entry, and the registry record only lands when
+    the create commits, so neither the marker nor is_live protects the disks
+    the create is writing. The creating() guard must."""
+    disk = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
+    report = reconciler_module.ReconcileReport()
+
+    with creating(VM_HASH):
+        freed = reconciler_module._evict(VM_HASH, report, dry_run=False)
+
+    assert freed == 0
+    assert disk.exists()
+    assert report.evicted == [] and report.bytes_freed == 0
+
+
 def test_a_refused_purge_is_not_counted_as_an_eviction(pools, monkeypatch):  # noqa: F811
     """purge_vm_storage refuses a directory a device-mapper target still
     holds. make_room must not then report room it did not make."""

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -280,7 +280,7 @@ def test_a_hash_entering_creating_mid_pass_is_not_purged(pools, registry, monkey
     def orphan_then_claim(directory, is_live, now, guard, *, dry_run):
         result = real_is_orphan(directory, is_live, now, guard, dry_run=dry_run)
         if result:
-            reconciler_module._creating.add(directory.name)
+            reconciler_module._creating[directory.name] = 1
         return result
 
     monkeypatch.setattr(reconciler_module, "_is_orphan", orphan_then_claim)
@@ -288,10 +288,21 @@ def test_a_hash_entering_creating_mid_pass_is_not_purged(pools, registry, monkey
     try:
         report = reconcile_storage(registry, now=NOW)
     finally:
-        reconciler_module._creating.discard(VM_HASH)
+        reconciler_module._creating.pop(VM_HASH, None)
 
     assert disk.exists()
     assert report.purged_orphans == []
+
+
+def test_overlapping_creates_of_one_hash_stay_guarded_until_the_last_exits(pools):  # noqa: F811
+    """A scheduler push and an operator reinstall take no common per-hash
+    lock, so two creating() spans for one hash can overlap: the first exit
+    must not unguard the second."""
+    with creating(VM_HASH):
+        with creating(VM_HASH):
+            assert is_creating(VM_HASH)
+        assert is_creating(VM_HASH)
+    assert not is_creating(VM_HASH)
 
 
 def test_creating_registers_before_it_adopts(pools, monkeypatch):  # noqa: F811

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -681,6 +681,21 @@ async def test_two_reconcile_passes_do_not_overlap(pools, registry, monkeypatch)
     assert order == ["enter", "exit", "enter", "exit"]
 
 
+def test_an_adopt_that_raises_does_not_leave_the_guard_up(pools, monkeypatch):  # noqa: F811
+    """adopt() runs inside creating()'s try: a marker that cannot be unlinked
+    must not leave the namespace exempt from every future pass."""
+
+    def refuse(namespace):
+        raise PermissionError("marker is read-only")
+
+    monkeypatch.setattr(reconciler_module, "adopt", refuse)
+
+    with pytest.raises(PermissionError), creating(VM_HASH):
+        pass
+
+    assert not is_creating(VM_HASH)
+
+
 def test_a_directory_that_fails_does_not_abort_the_pass(pools, registry, monkeypatch, caplog):  # noqa: F811
     """One namespace whose marking raises is logged and skipped; the next one
     is still handled, like a failing item in the parts and side-dir sweeps."""

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -501,6 +501,32 @@ def test_evicting_a_directory_that_already_vanished_counts_nothing(pools, monkey
     assert report.evicted == [] and report.bytes_freed == 0
 
 
+def test_budget_keeps_evicting_past_a_refused_purge(pools, registry, monkeypatch):  # noqa: F811
+    """A dm-held directory's bytes never left the disk, so the budget pass
+    must not spend them: doing so would stop every pass early at the same
+    entry (the marker survives, the next pass recomputes the same total) and
+    the pool would sit over budget forever. Younger entries are evicted to
+    make up for the held one."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    monkeypatch.setattr(settings, "VOLUME_RETENTION_BUDGET", "8192")
+    held = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
+    evictable = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2", size=8192)
+    mark_reclaimable(VM_HASH, "gone", now=NOW - timedelta(days=2))
+    mark_reclaimable(OTHER_HASH, "gone", now=NOW - timedelta(days=1))
+    real_purge = reconciler_module.purge_vm_storage
+    monkeypatch.setattr(
+        reconciler_module,
+        "purge_vm_storage",
+        lambda namespace: 0 if namespace == VM_HASH else real_purge(namespace),
+    )
+
+    report = reconcile_storage(registry, now=NOW)
+
+    assert held.exists()
+    assert not evictable.exists()
+    assert report.evicted == [OTHER_HASH]
+
+
 def test_evict_declines_a_namespace_whose_create_started_mid_pass(pools, monkeypatch):  # noqa: F811
     """The budget pass lists a retained VM; its owner then re-creates it.
     creating() adopts the directory (clearing the marker) before the evictor

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -534,8 +534,7 @@ async def test_a_refusing_startup_never_promises_a_purge(pools, registry, monkey
 @pytest.mark.asyncio
 async def test_startup_hook_logs_a_preview_then_reconciles(pools, registry, monkeypatch, caplog):  # noqa: F811
     """The one-shot cleanup on an upgraded node is announced before it runs:
-    an operator reading the log must be able to explain why free space jumped
-    (spec section 6, migration)."""
+    an operator reading the log must be able to explain why free space jumped."""
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
     old = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
     _age(old.parent, 10_000)

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -661,3 +661,44 @@ async def test_two_reconcile_passes_do_not_overlap(pools, registry, monkeypatch)
     await asyncio.gather(reconcile_now(app), reconcile_now(app))
 
     assert order == ["enter", "exit", "enter", "exit"]
+
+
+def test_a_directory_that_fails_does_not_abort_the_pass(pools, registry, monkeypatch, caplog):  # noqa: F811
+    """One namespace whose marking raises is logged and skipped; the next one
+    is still handled, like a failing item in the parts and side-dir sweeps."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    first = volume(pools["pool0"], "aaaa" * 16, "rootfs.qcow2")
+    second = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    _age(first.parent, 10_000)
+    _age(second.parent, 10_000)
+    real_mark = reconciler_module.mark_reclaimable
+
+    def mark_unless_first(namespace, *args, **kwargs):
+        if namespace == "aaaa" * 16:
+            raise OSError("no space left on device")
+        return real_mark(namespace, *args, **kwargs)
+
+    monkeypatch.setattr(reconciler_module, "mark_reclaimable", mark_unless_first)
+
+    report = reconcile_storage(registry, now=NOW)
+
+    assert report.marked_orphans == [VM_HASH]
+    assert read_marker(second.parent) is not None
+    assert read_marker(first.parent) is None
+    assert "Reconcile of aaaa" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_failing_startup_pass_does_not_stop_the_boot(pools, registry, monkeypatch, caplog):  # noqa: F811
+    """reconcile_at_startup is an on_startup hook: a raise there stops the
+    agent, and a full pool (the condition the pass exists to relieve) would
+    become a boot loop."""
+
+    def broken_pass(*args, **kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(reconciler_module, "reconcile_storage", broken_pass)
+
+    await reconcile_at_startup(_app(registry))
+
+    assert "Startup storage reconcile failed" in caplog.text

--- a/tests/supervisor/test_resources.py
+++ b/tests/supervisor/test_resources.py
@@ -61,3 +61,34 @@ def test_get_gpu_devices():
             assert expected_gpu_devices[0].device_class == "0300"
             assert expected_gpu_devices[0].pci_host == "01:00.0"
             assert expected_gpu_devices[0].device_id == "10de:27b0"
+
+
+def test_disk_usage_counts_reclaimable_bytes_as_available(mocker):
+    """What the node advertises must match what it will admit: retained
+    volumes are evicted on demand, so they are available disk, not usage
+    (spec section 1). Advertising less than admission accepts would make the
+    scheduler stop sending work the node can still take."""
+    from types import SimpleNamespace
+
+    from aleph.vm.agent.resources import _disk_usage_from_pools
+
+    mocker.patch("aleph.vm.agent.resources.pools_disk_usage", return_value=(1_000_000, 400_000))
+    mocker.patch("aleph.vm.agent.resources.reclaimable_bytes", return_value=100_000)
+
+    usage = _disk_usage_from_pools(SimpleNamespace(available_disk_bytes=0))
+
+    assert usage.total_kB == 1000
+    assert usage.available_kB == 500
+
+
+def test_disk_usage_adds_reclaimable_to_the_supervisors_figure(mocker):
+    from types import SimpleNamespace
+
+    from aleph.vm.agent.resources import _disk_usage_from_pools
+
+    mocker.patch("aleph.vm.agent.resources.pools_disk_usage", return_value=(1_000_000, 400_000))
+    mocker.patch("aleph.vm.agent.resources.reclaimable_bytes", return_value=100_000)
+
+    usage = _disk_usage_from_pools(SimpleNamespace(available_disk_bytes=200_000))
+
+    assert usage.available_kB == 300

--- a/tests/supervisor/test_resources.py
+++ b/tests/supervisor/test_resources.py
@@ -65,8 +65,8 @@ def test_get_gpu_devices():
 
 def test_disk_usage_counts_reclaimable_bytes_as_available(mocker):
     """What the node advertises must match what it will admit: retained
-    volumes are evicted on demand, so they are available disk, not usage
-    (spec section 1). Advertising less than admission accepts would make the
+    volumes are evicted on demand, so they are available disk, not usage.
+    Advertising less than admission accepts would make the
     scheduler stop sending work the node can still take."""
     from types import SimpleNamespace
 

--- a/tests/supervisor/test_retire.py
+++ b/tests/supervisor/test_retire.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -9,12 +10,14 @@ from aleph_message.models import InstanceContent, ItemHash
 from reclaim_fixtures import VM_HASH, pools, volume  # noqa: F401
 
 import aleph.vm.agent.vm.retire as retire_module
-from aleph.vm.agent.vm.reclaimable import read_marker
+from aleph.vm.agent.vm.reclaimable import MARKER_NAME, read_marker
 from aleph.vm.agent.vm.retire import RetireReason, retire_vm
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 from aleph.vm.supervisor_interface.errors import VmNotFoundError
 from aleph.vm.supervisor_interface.types import VmId
+
+OWNER = "0x1234567890123456789012345678901234567890"
 
 
 @pytest.fixture
@@ -25,6 +28,7 @@ def env(pools, mocker):  # noqa: F811
     rootfs = MagicMock()
     rootfs.parent.ref = "parent-ref"
     content = MagicMock(spec=InstanceContent, volumes=[], rootfs=rootfs)
+    content.address = OWNER
     registry.record(ItemHash(VM_HASH), message=content, original=content, persistent=True)
     rootfs = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=4096)
     data = volume(pools["pool1"], VM_HASH, "data.ext4", size=4096)
@@ -97,6 +101,22 @@ async def test_gone_under_keep_marks_volumes_and_removes_the_rest(env, monkeypat
     assert not env["staging"].exists()
     assert ItemHash(VM_HASH) not in env["registry"]
     env["purge_backups"].assert_called_once_with(VM_HASH)
+
+
+@pytest.mark.asyncio
+async def test_gone_under_keep_records_the_owner_in_the_marker(env, monkeypatch, pools):  # noqa: F811
+    """The marker is the only thing left that says whose disks these are: the
+    registry record is forgotten and delete_records_for_vm drops the DB rows
+    at GONE. Without the owner in the marker, nobody can ever be authorized
+    to ask for the retained data to be erased."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+
+    await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
+
+    written = json.loads((pools["pool0"] / VM_HASH / MARKER_NAME).read_text())
+    assert written["owner"] == OWNER
+    assert written["version"] == 1
+    assert read_marker(pools["pool1"] / VM_HASH).owner == OWNER
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_retire.py
+++ b/tests/supervisor/test_retire.py
@@ -176,3 +176,21 @@ async def test_erase_does_not_run_the_after_gone_hook(env, monkeypatch):
         retire_module.set_after_gone_hook(None)
 
     hook.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_failing_after_gone_hook_does_not_break_the_retire(env, monkeypatch, caplog):
+    """The GONE call sites sweep in a loop (terminal messages, unpaid VMs)
+    without a local try: a reconcile pass that raises must not take the rest
+    of the sweep down with it."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    retire_module.set_after_gone_hook(AsyncMock(side_effect=RuntimeError("pool on fire")))
+    try:
+        with caplog.at_level("WARNING"):
+            await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
+    finally:
+        retire_module.set_after_gone_hook(None)
+
+    # The retire itself completed: the volumes are marked, not lost.
+    assert read_marker(env["rootfs"].parent) is not None
+    assert "pool on fire" in caplog.text

--- a/tests/supervisor/test_retire.py
+++ b/tests/supervisor/test_retire.py
@@ -1,0 +1,135 @@
+"""retire_vm: the one agent-side deletion function and its reasons."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aleph_message.models import InstanceContent, ItemHash
+from reclaim_fixtures import VM_HASH, pools, volume  # noqa: F401
+
+import aleph.vm.agent.vm.retire as retire_module
+from aleph.vm.agent.vm.reclaimable import read_marker
+from aleph.vm.agent.vm.retire import RetireReason, retire_vm
+from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.conf import settings
+from aleph.vm.supervisor_interface.errors import VmNotFoundError
+from aleph.vm.supervisor_interface.types import VmId
+
+
+@pytest.fixture
+def env(pools, mocker):  # noqa: F811
+    """A registry with one recorded VM, its files on disk, and every side
+    effect that leaves the filesystem mocked."""
+    registry = AgentVmRegistry()
+    rootfs = MagicMock()
+    rootfs.parent.ref = "parent-ref"
+    content = MagicMock(spec=InstanceContent, volumes=[], rootfs=rootfs)
+    registry.record(ItemHash(VM_HASH), message=content, original=content, persistent=True)
+    rootfs = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=4096)
+    data = volume(pools["pool1"], VM_HASH, "data.ext4", size=4096)
+    session = pools["sessions"] / VM_HASH
+    session.mkdir()
+    (session / "vm_session.b64").write_bytes(b"s")
+    staging = pools["execution_root"] / "vprogram" / VM_HASH
+    staging.mkdir(parents=True)
+    (staging / "bundle").write_bytes(b"b")
+    delete_records = mocker.patch.object(retire_module, "delete_records_for_vm", new_callable=AsyncMock)
+    purge_backups = mocker.patch.object(retire_module, "purge_vm_backups")
+    supervisor = MagicMock(delete_vm=AsyncMock())
+    return {
+        "registry": registry,
+        "supervisor": supervisor,
+        "rootfs": rootfs,
+        "data": data,
+        "session": session,
+        "staging": staging,
+        "delete_records": delete_records,
+        "purge_backups": purge_backups,
+    }
+
+
+def _all_present(env) -> bool:
+    return all(env[k].exists() for k in ("rootfs", "data", "session", "staging"))
+
+
+@pytest.mark.asyncio
+async def test_recreate_only_quiesces(env):
+    await retire_vm(VM_HASH, RetireReason.RECREATE, supervisor=env["supervisor"])
+
+    env["supervisor"].delete_vm.assert_awaited_once_with(VmId(VM_HASH), keep_port_mappings=True)
+    assert _all_present(env)
+    assert ItemHash(VM_HASH) in env["registry"]
+    env["delete_records"].assert_not_awaited()
+    env["purge_backups"].assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reason", [RetireReason.GONE, RetireReason.ERASE, RetireReason.FAILED_CREATE])
+async def test_purging_reasons_under_reap(env, monkeypatch, reason):
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+
+    await retire_vm(VM_HASH, reason, supervisor=env["supervisor"], registry=env["registry"])
+
+    env["supervisor"].delete_vm.assert_awaited_once_with(VmId(VM_HASH), keep_port_mappings=False)
+    assert not env["rootfs"].exists()
+    assert not env["data"].exists()
+    assert not env["session"].exists()
+    assert not env["staging"].exists()
+    assert ItemHash(VM_HASH) not in env["registry"]
+    env["delete_records"].assert_awaited_once_with(VM_HASH)
+    env["purge_backups"].assert_called_once_with(VM_HASH)
+
+
+@pytest.mark.asyncio
+async def test_gone_under_keep_marks_volumes_and_removes_the_rest(env, monkeypatch, pools):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+
+    await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
+
+    assert env["rootfs"].exists()
+    assert env["data"].exists()
+    marker = read_marker(pools["pool0"] / VM_HASH)
+    assert marker is not None and marker.reason == "gone"
+    assert marker.depends_on == ("parent-ref",)
+    assert read_marker(pools["pool1"] / VM_HASH) is not None
+    assert not env["session"].exists()
+    assert not env["staging"].exists()
+    assert ItemHash(VM_HASH) not in env["registry"]
+    env["purge_backups"].assert_called_once_with(VM_HASH)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reason", [RetireReason.ERASE, RetireReason.FAILED_CREATE])
+async def test_erase_and_failed_create_ignore_keep(env, monkeypatch, reason):
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+
+    await retire_vm(VM_HASH, reason, supervisor=env["supervisor"], registry=env["registry"])
+
+    assert not env["rootfs"].exists()
+    assert not env["data"].exists()
+
+
+@pytest.mark.asyncio
+async def test_vm_unknown_to_the_supervisor_is_still_retired(env, monkeypatch):
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    env["supervisor"].delete_vm.side_effect = VmNotFoundError(VM_HASH)
+
+    await retire_vm(VM_HASH, RetireReason.FAILED_CREATE, supervisor=env["supervisor"], registry=env["registry"])
+
+    assert not env["rootfs"].exists()
+    assert not env["staging"].exists()
+
+
+@pytest.mark.asyncio
+async def test_non_recreate_requires_a_registry(env):
+    with pytest.raises(ValueError):
+        await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"])
+
+
+@pytest.mark.asyncio
+async def test_retire_is_idempotent(env, monkeypatch):
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
+    await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
+    assert env["supervisor"].delete_vm.await_count == 2

--- a/tests/supervisor/test_retire.py
+++ b/tests/supervisor/test_retire.py
@@ -133,3 +133,46 @@ async def test_retire_is_idempotent(env, monkeypatch):
     await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
     await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
     assert env["supervisor"].delete_vm.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_gone_under_keep_runs_the_after_gone_hook(env, monkeypatch):
+    """Retention is a budget, so it is enforced the moment a VM becomes
+    reclaimable, not only at the next periodic pass (spec section 1)."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    hook = AsyncMock()
+    retire_module.set_after_gone_hook(hook)
+    try:
+        await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
+    finally:
+        retire_module.set_after_gone_hook(None)
+
+    hook.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_gone_under_reap_does_not_run_the_after_gone_hook(env, monkeypatch):
+    """Nothing is retained under reap: the disks are already gone, so there is
+    no budget to enforce."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    hook = AsyncMock()
+    retire_module.set_after_gone_hook(hook)
+    try:
+        await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
+    finally:
+        retire_module.set_after_gone_hook(None)
+
+    hook.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_erase_does_not_run_the_after_gone_hook(env, monkeypatch):
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    hook = AsyncMock()
+    retire_module.set_after_gone_hook(hook)
+    try:
+        await retire_vm(VM_HASH, RetireReason.ERASE, supervisor=env["supervisor"], registry=env["registry"])
+    finally:
+        retire_module.set_after_gone_hook(None)
+
+    hook.assert_not_awaited()

--- a/tests/supervisor/test_retire.py
+++ b/tests/supervisor/test_retire.py
@@ -199,6 +199,25 @@ async def test_erase_does_not_run_the_after_gone_hook(env, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_a_failing_storage_release_does_not_break_the_retire(env, monkeypatch, caplog):
+    """A marker or purge that fails (ENOSPC, EACCES) must not raise out of
+    retire_vm: the VM is already gone and its records dropped, and the
+    callers sweep in loops. The next reconcile pass finds the directory."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+
+    def refuse(*args):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(retire_module, "_release_storage", refuse)
+
+    await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
+
+    assert env["registry"].get(ItemHash(VM_HASH)) is None
+    env["purge_backups"].assert_called_once()
+    assert "Storage release of" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_a_failing_after_gone_hook_does_not_break_the_retire(env, monkeypatch, caplog):
     """The GONE call sites sweep in a loop (terminal messages, unpaid VMs)
     without a local try: a reconcile pass that raises must not take the rest

--- a/tests/supervisor/test_retire.py
+++ b/tests/supervisor/test_retire.py
@@ -158,7 +158,7 @@ async def test_retire_is_idempotent(env, monkeypatch):
 @pytest.mark.asyncio
 async def test_gone_under_keep_runs_the_after_gone_hook(env, monkeypatch):
     """Retention is a budget, so it is enforced the moment a VM becomes
-    reclaimable, not only at the next periodic pass (spec section 1)."""
+    reclaimable, not only at the next periodic pass."""
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
     hook = AsyncMock()
     retire_module.set_after_gone_hook(hook)

--- a/tests/supervisor/test_run_idle_teardown.py
+++ b/tests/supervisor/test_run_idle_teardown.py
@@ -19,7 +19,9 @@ import msgpack
 import pytest
 from aleph_message.models import ItemHash, ProgramContent
 
+from aleph.vm.agent import run as run_module
 from aleph.vm.agent.run import run_code_on_event, run_code_on_request
+from aleph.vm.agent.vm.retire import RetireReason
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 from aleph.vm.supervisor_interface.types import (
@@ -230,3 +232,55 @@ async def test_event_never_schedules_expiry_for_persistent_vm(reuse_settings):
     assert result == "ok"
     supervisor.run_program_code.assert_awaited_once()
     assert expiry.scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_request_teardown_retires_as_recreate_when_reuse_timeout_zero(monkeypatch):
+    """REUSE_TIMEOUT == 0 tears an on-demand VM down after every request, but
+    the same VM comes back on the next one: retire_vm(RECREATE) keeps its
+    host-port forwards and disks, not a plain supervisor.delete_vm."""
+    monkeypatch.setattr(settings, "REUSE_TIMEOUT", 0)
+    monkeypatch.setattr(settings, "WATCH_FOR_UPDATES", False)
+
+    content, expiry, supervisor, program_client, app = _on_demand_fakes()
+    app["update_watcher"] = MagicMock()
+    retire = AsyncMock()
+    monkeypatch.setattr(run_module, "retire_vm", retire)
+
+    response = await run_code_on_request(VM_HASH, "/", FakeRequest(app=app))
+
+    assert response.status == 200
+    retire.assert_awaited_once_with(VM_HASH, RetireReason.RECREATE, supervisor=supervisor)
+    supervisor.delete_vm.assert_not_awaited()
+    assert program_client.forgotten == [str(VM_HASH)]
+
+
+@pytest.mark.asyncio
+async def test_event_teardown_retires_as_recreate_when_reuse_timeout_zero(monkeypatch):
+    """Same as the request path, for the event path."""
+    monkeypatch.setattr(settings, "REUSE_TIMEOUT", 0)
+    monkeypatch.setattr(settings, "WATCH_FOR_UPDATES", False)
+
+    content = _program_content(persistent=False)
+    program_client = FakeProgramClient({"body": "ok"})
+    supervisor = SimpleNamespace(get_vm=AsyncMock(return_value=_running_info()), delete_vm=AsyncMock())
+    update_watcher = MagicMock()
+    retire = AsyncMock()
+    monkeypatch.setattr(run_module, "retire_vm", retire)
+
+    result = await run_code_on_event(
+        VM_HASH,
+        None,
+        None,
+        supervisor=supervisor,
+        expiry=SpyExpiry(),
+        update_watcher=update_watcher,
+        registry=_registry_with(content),
+        capacity=_fake_capacity(),
+        program_client=program_client,
+    )
+
+    assert result == "ok"
+    retire.assert_awaited_once_with(VM_HASH, RetireReason.RECREATE, supervisor=supervisor)
+    supervisor.delete_vm.assert_not_awaited()
+    assert program_client.forgotten == [str(VM_HASH)]

--- a/tests/supervisor/test_run_program_path.py
+++ b/tests/supervisor/test_run_program_path.py
@@ -159,15 +159,21 @@ async def test_reuses_running_configured_vm(patched_build):
 
 
 @pytest.mark.asyncio
-async def test_recreates_unconfigured_running_vm(patched_build):
+async def test_recreates_unconfigured_running_vm(patched_build, monkeypatch):
     """A running VM this agent process never configured cannot be trusted to
-    accept run_code (the runtime takes one config push per boot): recreate."""
+    accept run_code (the runtime takes one config push per boot): recreate.
+    retire_vm(RECREATE) is what tears the old instance down, not a plain
+    delete_vm."""
+    from aleph.vm.agent.vm.retire import RetireReason
+
     supervisor = SimpleNamespace(
         get_vm=AsyncMock(side_effect=[_info(VmStatus.RUNNING), VmNotFoundError(VM_ID), _info(VmStatus.RUNNING)]),
         create_vm=AsyncMock(return_value=_info(VmStatus.RUNNING)),
         delete_vm=AsyncMock(),
     )
     program_client = FakeProgramClient(ready=False)
+    retire = AsyncMock()
+    monkeypatch.setattr(run_module, "retire_vm", retire)
 
     await run_module._ensure_program_vm(
         VM_HASH,
@@ -179,13 +185,18 @@ async def test_recreates_unconfigured_running_vm(patched_build):
         program_client=program_client,
     )
 
-    supervisor.delete_vm.assert_awaited()  # old instance torn down
+    retire.assert_awaited_once_with(VM_HASH, RetireReason.RECREATE, supervisor=supervisor)
+    supervisor.delete_vm.assert_not_awaited()
     supervisor.create_vm.assert_awaited_once()
     assert program_client.setups == [VM_ID]
 
 
 @pytest.mark.asyncio
-async def test_setup_failure_tears_down(patched_build):
+async def test_setup_failure_tears_down(patched_build, monkeypatch):
+    """A config-push failure retires the half-started VM as FAILED_CREATE
+    (no pre-existing volumes here, so not RECREATE)."""
+    from aleph.vm.agent.vm.retire import RetireReason
+
     supervisor = SimpleNamespace(
         get_vm=AsyncMock(side_effect=[VmNotFoundError(VM_ID), _info(VmStatus.RUNNING)]),
         create_vm=AsyncMock(return_value=_info(VmStatus.RUNNING)),
@@ -194,6 +205,8 @@ async def test_setup_failure_tears_down(patched_build):
     registry = AgentVmRegistry()
     program_client = FakeProgramClient()
     program_client.setup_program = AsyncMock(side_effect=RuntimeError("config push failed"))  # type: ignore[method-assign]
+    retire = AsyncMock()
+    monkeypatch.setattr(run_module, "retire_vm", retire)
 
     with pytest.raises(web.HTTPInternalServerError):
         await run_module._ensure_program_vm(
@@ -206,8 +219,8 @@ async def test_setup_failure_tears_down(patched_build):
             program_client=program_client,
         )
 
-    supervisor.delete_vm.assert_awaited()
-    assert registry.get(VM_HASH) is None
+    retire.assert_awaited_once_with(VM_HASH, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
+    supervisor.delete_vm.assert_not_awaited()
     run_module.persist_record.assert_not_awaited()
 
 

--- a/tests/supervisor/test_snp_instance_run.py
+++ b/tests/supervisor/test_snp_instance_run.py
@@ -279,9 +279,12 @@ async def test_legacy_sev_instance_path_untouched(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_snp_instance_failure_cleans_staging(monkeypatch):
-    """supervisor.create_vm raises: the failure path must call
-    remove_snp_instance_staging and forget the registry record, mirroring the
-    V-PROGRAM build/create failure branch."""
+    """supervisor.create_vm raises: the failure path must retire the VM as
+    FAILED_CREATE (which drops the record and purges any staged bundle),
+    mirroring the V-PROGRAM build/create failure branch. No pre-existing
+    volumes here, so FAILED_CREATE, not RECREATE."""
+    from aleph.vm.agent.vm.retire import RetireReason
+
     content = snp_instance_content()
     message = MagicMock(content=content, sender=_SENDER)
     monkeypatch.setattr(
@@ -290,8 +293,8 @@ async def test_snp_instance_failure_cleans_staging(monkeypatch):
     spec = _snp_spec()
     monkeypatch.setattr(run_module, "build_snp_instance_spec", AsyncMock(return_value=(spec, _ATTEST_PORT)))
     monkeypatch.setattr(run_module, "resolve_instance_attestation_port", AsyncMock(return_value=_ATTEST_PORT))
-    remove_staging = MagicMock()
-    monkeypatch.setattr(run_module, "remove_snp_instance_staging", remove_staging)
+    retire = AsyncMock()
+    monkeypatch.setattr(run_module, "retire_vm", retire)
 
     supervisor = _fake_supervisor()
     supervisor.create_vm = AsyncMock(side_effect=RuntimeError("qemu spawn failed"))
@@ -302,16 +305,19 @@ async def test_snp_instance_failure_cleans_staging(monkeypatch):
             VM_HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
         )
 
-    remove_staging.assert_called_once_with(VM_HASH)
-    assert registry.get(VM_HASH) is None
+    retire.assert_awaited_once_with(VM_HASH, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
+    supervisor.delete_vm.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_snp_instance_port_forward_failure_cleans_staging(monkeypatch):
     """The second teardown path: create_vm succeeds but the port-forward
     application inside finish_instance_create fails. The half-started VM must
-    be deleted and its staging removed, mirroring the create-failure branch
-    (run.py's finish_instance_create/attest-gate except block)."""
+    retire as FAILED_CREATE (records, staging and volumes go), mirroring the
+    create-failure branch (run.py's finish_instance_create/attest-gate except
+    block)."""
+    from aleph.vm.agent.vm.retire import RetireReason
+
     content = snp_instance_content()
     message = MagicMock(content=content, sender=_SENDER)
     monkeypatch.setattr(
@@ -319,12 +325,15 @@ async def test_snp_instance_port_forward_failure_cleans_staging(monkeypatch):
     )
     spec = _snp_spec()
     monkeypatch.setattr(run_module, "build_snp_instance_spec", AsyncMock(return_value=(spec, _ATTEST_PORT)))
+    # finish_instance_create runs for real: the attestation port is part of
+    # the desired forward set it applies, so the raising add_port_forward
+    # below lands the failure in the second except block.
     monkeypatch.setattr(run_module, "resolve_instance_attestation_port", AsyncMock(return_value=_ATTEST_PORT))
     monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
     monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
     monkeypatch.setattr(run_module, "_wait_until_attest_endpoint_listens", AsyncMock())
-    remove_staging = MagicMock()
-    monkeypatch.setattr(run_module, "remove_snp_instance_staging", remove_staging)
+    retire = AsyncMock()
+    monkeypatch.setattr(run_module, "retire_vm", retire)
 
     supervisor = _fake_supervisor()  # create_vm returns RUNNING, not awaiting init
     supervisor.add_port_forward = AsyncMock(side_effect=RuntimeError("nftables rule failed"))
@@ -335,6 +344,5 @@ async def test_snp_instance_port_forward_failure_cleans_staging(monkeypatch):
             VM_HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
         )
 
-    remove_staging.assert_called_once_with(VM_HASH)
-    supervisor.delete_vm.assert_awaited_once()
-    assert registry.get(VM_HASH) is None
+    retire.assert_awaited_once_with(VM_HASH, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
+    supervisor.delete_vm.assert_not_awaited()

--- a/tests/supervisor/test_storage_budget.py
+++ b/tests/supervisor/test_storage_budget.py
@@ -1,0 +1,36 @@
+import pytest
+
+from aleph.vm.conf import settings
+from aleph.vm.storage_budget import parse_budget
+
+
+@pytest.mark.parametrize(
+    ("value", "total", "expected"),
+    [
+        ("10%", 1000, 100),
+        ("0%", 1000, 0),
+        ("100%", 1000, 1000),
+        ("512M", 0, 512 * 1024 * 1024),
+        ("50G", 0, 50 * 1024**3),
+        ("2T", 0, 2 * 1024**4),
+        ("4096", 0, 4096),
+        (4096, 0, 4096),
+    ],
+)
+def test_parse_budget(value, total, expected):
+    assert parse_budget(value, total) == expected
+
+
+@pytest.mark.parametrize("value", ["", "ten percent", "-5%", "150%", "10X", "-1"])
+def test_parse_budget_rejects_garbage(value):
+    with pytest.raises(ValueError):
+        parse_budget(value, 1000)
+
+
+def test_settings_defaults():
+    assert settings.VOLUME_RETENTION == "reap"
+    assert settings.VOLUME_RETENTION_BUDGET == "10%"
+    assert settings.VOLUME_RECONCILE_INTERVAL == 3600
+    assert settings.VOLUME_CREATE_GUARD == 600
+    assert settings.CACHE_BUDGET == "20%"
+    assert settings.MAX_RUNTIME_ARCHIVE_SIZE == 100 * 1024**3

--- a/tests/supervisor/test_storage_pools_room_maker.py
+++ b/tests/supervisor/test_storage_pools_room_maker.py
@@ -1,0 +1,123 @@
+"""Placement asks the agent's evictor before refusing a create.
+
+Split out of the old ``tests/supervisor/test_storage_pools.py``, which was
+removed with the Python supervisor daemon (one test in it reached into
+``aleph.vm.supervisor.daemon``). These cases only exercise
+``aleph.vm.storage_pools``, which is unchanged.
+"""
+
+from __future__ import annotations
+
+import shutil as shutil_module
+from pathlib import Path
+
+import pytest
+
+import aleph.vm.storage_pools as storage_pools_module
+from aleph.vm.conf import settings
+from aleph.vm.resources import InsufficientResourcesError
+from aleph.vm.storage_pools import MediaClass, StoragePool, reset_pools, select_pool
+
+
+@pytest.fixture()
+def pool_settings(tmp_path, monkeypatch):
+    """Isolated settings roots + a clean module cache; yields the tmp root."""
+    execution_root = tmp_path / "execution"
+    default_pool = execution_root / "volumes" / "persistent"
+    default_pool.mkdir(parents=True)
+    monkeypatch.setattr(settings, "EXECUTION_ROOT", execution_root)
+    monkeypatch.setattr(settings, "PERSISTENT_VOLUMES_DIR", default_pool)
+    monkeypatch.setattr(settings, "VOLUME_POOLS", [])
+    reset_pools()
+    yield tmp_path
+    reset_pools()
+
+
+@pytest.fixture()
+def three_pools(pool_settings, monkeypatch):
+    """Pool 0 (default) + one NVMe + one SSD pool, module cache primed."""
+    pool1 = pool_settings / "mnt" / "nvme1"
+    pool2 = pool_settings / "mnt" / "ssd1"
+    pool1.mkdir(parents=True)
+    pool2.mkdir(parents=True)
+    pools = [
+        StoragePool(path=Path(settings.PERSISTENT_VOLUMES_DIR), media_class=MediaClass.SSD, index=0),
+        StoragePool(path=pool1, media_class=MediaClass.NVME, index=1),
+        StoragePool(path=pool2, media_class=MediaClass.SSD, index=2),
+    ]
+    monkeypatch.setattr(storage_pools_module, "_pools", pools)
+    return pools
+
+
+def _fake_disk_usage(monkeypatch, free_by_path: dict[Path, int], total: int = 10**12):
+    """shutil.disk_usage keyed by pool path; unknown paths raise OSError."""
+
+    def fake(path):
+        for pool_path, free in free_by_path.items():
+            if str(pool_path) == str(path):
+                return shutil_module._ntuple_diskusage(total, total - free, free)
+        msg = f"no fake usage for {path}"
+        raise OSError(msg)
+
+    monkeypatch.setattr(storage_pools_module.shutil, "disk_usage", fake)
+
+
+@pytest.fixture()
+def room_maker():
+    """Register an evictor for one test, and always unregister it: the hook is
+    module state, and a leaked one would evict from every later test."""
+    yield storage_pools_module.set_room_maker
+    storage_pools_module.set_room_maker(None)
+
+
+class TestRoomMaker:
+    """Placement asks the agent's evictor before refusing: reclaimable bytes
+    are advertised as free, so a create that does not fit must first get the
+    chance to take the space back (spec section 1)."""
+
+    def test_the_room_maker_is_asked_before_refusing(self, three_pools, monkeypatch, room_maker):
+        calls = []
+        monkeypatch.setattr(storage_pools_module, "_pool_free_bytes", lambda pool: 0)
+        room_maker(lambda pool, needed: calls.append((pool.index, needed)) or 0)
+
+        with pytest.raises(InsufficientResourcesError):
+            select_pool(size_mib=1)
+
+        # The roomiest eligible pool, asked for the placement's own size.
+        assert calls == [(0, 1024 * 1024)]
+
+    def test_placement_succeeds_when_the_room_maker_frees_enough(self, three_pools, monkeypatch, room_maker):
+        # One reading per pool (nothing fits), then the post-eviction reading.
+        frees = iter([0, 0, 0])
+        monkeypatch.setattr(storage_pools_module, "_pool_free_bytes", lambda pool: next(frees, 4 * 1024 * 1024))
+        room_maker(lambda pool, needed: 4 * 1024 * 1024)
+
+        assert select_pool(size_mib=1) == three_pools[0]
+
+    def test_placement_still_fails_when_eviction_frees_too_little(self, three_pools, monkeypatch, room_maker):
+        monkeypatch.setattr(storage_pools_module, "_pool_free_bytes", lambda pool: 1024)
+        room_maker(lambda pool, needed: 1024)
+
+        with pytest.raises(InsufficientResourcesError):
+            select_pool(size_mib=1)
+
+    def test_the_room_maker_is_not_asked_when_a_pool_already_fits(self, three_pools, monkeypatch, room_maker):
+        _fake_disk_usage(monkeypatch, {pool.path: 50 * 1024**3 for pool in three_pools})
+        calls = []
+        room_maker(lambda pool, needed: calls.append(pool) or 0)
+
+        assert select_pool(size_mib=1024) == three_pools[0]
+        assert calls == []
+
+    def test_every_pool_unreachable_still_offers_the_room_maker_a_target(self, three_pools, monkeypatch, room_maker):
+        """No pool reports free space (dead disks, unmounted): there is no
+        roomiest pool, so the evictor gets the first eligible one rather than
+        nothing at all."""
+        monkeypatch.setattr(storage_pools_module, "_pool_free_bytes", lambda pool: None)
+        calls = []
+        room_maker(lambda pool, needed: calls.append(pool.index) or 0)
+
+        with pytest.raises(InsufficientResourcesError):
+            select_pool(size_mib=1)
+
+        assert calls == [0]

--- a/tests/supervisor/test_storage_pools_room_maker.py
+++ b/tests/supervisor/test_storage_pools_room_maker.py
@@ -78,7 +78,12 @@ class TestRoomMaker:
     def test_the_room_maker_is_asked_before_refusing(self, three_pools, monkeypatch, room_maker):
         calls = []
         monkeypatch.setattr(storage_pools_module, "_pool_free_bytes", lambda pool: 0)
-        room_maker(lambda pool, needed: calls.append((pool.index, needed)) or 0)
+
+        def evictor(pool, needed):
+            calls.append((pool.index, needed))
+            return 0
+
+        room_maker(evictor)
 
         with pytest.raises(InsufficientResourcesError):
             select_pool(size_mib=1)
@@ -104,7 +109,12 @@ class TestRoomMaker:
     def test_the_room_maker_is_not_asked_when_a_pool_already_fits(self, three_pools, monkeypatch, room_maker):
         _fake_disk_usage(monkeypatch, {pool.path: 50 * 1024**3 for pool in three_pools})
         calls = []
-        room_maker(lambda pool, needed: calls.append(pool) or 0)
+
+        def evictor(pool, needed):
+            calls.append(pool)
+            return 0
+
+        room_maker(evictor)
 
         assert select_pool(size_mib=1024) == three_pools[0]
         assert calls == []
@@ -115,7 +125,12 @@ class TestRoomMaker:
         nothing at all."""
         monkeypatch.setattr(storage_pools_module, "_pool_free_bytes", lambda pool: None)
         calls = []
-        room_maker(lambda pool, needed: calls.append(pool.index) or 0)
+
+        def evictor(pool, needed):
+            calls.append(pool.index)
+            return 0
+
+        room_maker(evictor)
 
         with pytest.raises(InsufficientResourcesError):
             select_pool(size_mib=1)

--- a/tests/supervisor/test_storage_pools_room_maker.py
+++ b/tests/supervisor/test_storage_pools_room_maker.py
@@ -73,7 +73,7 @@ def room_maker():
 class TestRoomMaker:
     """Placement asks the agent's evictor before refusing: reclaimable bytes
     are advertised as free, so a create that does not fit must first get the
-    chance to take the space back (spec section 1)."""
+    chance to take the space back."""
 
     def test_the_room_maker_is_asked_before_refusing(self, three_pools, monkeypatch, room_maker):
         calls = []

--- a/tests/supervisor/test_storage_pools_room_maker.py
+++ b/tests/supervisor/test_storage_pools_room_maker.py
@@ -88,8 +88,8 @@ class TestRoomMaker:
         with pytest.raises(InsufficientResourcesError):
             select_pool(size_mib=1)
 
-        # The roomiest eligible pool, asked for the placement's own size.
-        assert calls == [(0, 1024 * 1024)]
+        # Every eligible pool in free order, asked for the placement's own size.
+        assert calls == [(0, 1024 * 1024), (1, 1024 * 1024), (2, 1024 * 1024)]
 
     def test_placement_succeeds_when_the_room_maker_frees_enough(self, three_pools, monkeypatch, room_maker):
         # One reading per pool (nothing fits), then the post-eviction reading.
@@ -98,6 +98,27 @@ class TestRoomMaker:
         room_maker(lambda pool, needed: 4 * 1024 * 1024)
 
         assert select_pool(size_mib=1) == three_pools[0]
+
+    def test_placement_reaches_a_pool_that_only_fits_after_eviction(self, three_pools, monkeypatch, room_maker):
+        """Admission counts every pool's reclaimable bytes as free, so the
+        eviction fallback must reach every pool too: the volume here only
+        fits on pool 1 once its retained directories are evicted, and pool 0
+        (the free-max pool) has nothing to give back."""
+        evicted = []
+        frees = {0: 2 * 1024 * 1024, 1: 1024, 2: 512}
+        monkeypatch.setattr(storage_pools_module, "_pool_free_bytes", lambda pool: frees[pool.index])
+
+        def evictor(pool, needed):
+            evicted.append(pool.index)
+            if pool.index == 1:
+                frees[1] = 8 * 1024 * 1024
+                return 8 * 1024 * 1024
+            return 0
+
+        room_maker(evictor)
+
+        assert select_pool(size_mib=4) == three_pools[1]
+        assert evicted == [0, 1]
 
     def test_placement_still_fails_when_eviction_frees_too_little(self, three_pools, monkeypatch, room_maker):
         monkeypatch.setattr(storage_pools_module, "_pool_free_bytes", lambda pool: 1024)
@@ -121,7 +142,7 @@ class TestRoomMaker:
 
     def test_every_pool_unreachable_still_offers_the_room_maker_a_target(self, three_pools, monkeypatch, room_maker):
         """No pool reports free space (dead disks, unmounted): there is no
-        roomiest pool, so the evictor gets the first eligible one rather than
+        roomiest pool, so every eligible pool still gets a turn rather than
         nothing at all."""
         monkeypatch.setattr(storage_pools_module, "_pool_free_bytes", lambda pool: None)
         calls = []
@@ -135,4 +156,4 @@ class TestRoomMaker:
         with pytest.raises(InsufficientResourcesError):
             select_pool(size_mib=1)
 
-        assert calls == [0]
+        assert calls == [0, 1, 2]

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -184,7 +184,9 @@ async def test_owner_record_recorded_before_resource_download(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_eligible_instance_timeout_tears_down(monkeypatch):
+async def test_eligible_instance_timeout_retires_as_failed_create(monkeypatch):
+    from aleph.vm.agent.vm.retire import RetireReason
+
     content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
     message = MagicMock(content=content)
     monkeypatch.setattr(
@@ -194,6 +196,8 @@ async def test_eligible_instance_timeout_tears_down(monkeypatch):
     monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
     monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
     monkeypatch.setattr(run_module, "_START_POLL_TIMEOUT_SECONDS", 0)
+    retire = AsyncMock()
+    monkeypatch.setattr(run_module, "retire_vm", retire)
 
     supervisor = _fake_supervisor(get_status=VmStatus.BOOTING)  # never RUNNING
     registry = AgentVmRegistry()
@@ -203,14 +207,16 @@ async def test_eligible_instance_timeout_tears_down(monkeypatch):
             _HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
         )
 
-    supervisor.delete_vm.assert_awaited_once_with(VmId(str(_HASH)))
-    assert registry.get(_HASH) is None  # forgotten on failure
+    retire.assert_awaited_once_with(_HASH, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
+    supervisor.delete_vm.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_eligible_instance_port_forward_failure_tears_down(monkeypatch):
+async def test_eligible_instance_port_forward_failure_retires_as_failed_create(monkeypatch):
     # Readiness succeeds but applying a port forward fails: the other failure
     # source in the same try block must trigger the same teardown.
+    from aleph.vm.agent.vm.retire import RetireReason
+
     content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
     message = MagicMock(content=content)
     monkeypatch.setattr(
@@ -223,14 +229,16 @@ async def test_eligible_instance_port_forward_failure_tears_down(monkeypatch):
     supervisor = _fake_supervisor()  # get_vm reports RUNNING immediately
     supervisor.add_port_forward = AsyncMock(side_effect=RuntimeError("nftables boom"))
     registry = AgentVmRegistry()
+    retire = AsyncMock()
+    monkeypatch.setattr(run_module, "retire_vm", retire)
 
     with pytest.raises(RuntimeError, match="nftables boom"):
         await run_module.create_vm_execution(
             _HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
         )
 
-    supervisor.delete_vm.assert_awaited_once_with(VmId(str(_HASH)))
-    assert registry.get(_HASH) is None  # forgotten on failure
+    retire.assert_awaited_once_with(_HASH, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
+    supervisor.delete_vm.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -249,6 +257,12 @@ async def test_firecracker_instance_rejected_via_spec_path(monkeypatch):
         "build_create_vm_spec",
         AsyncMock(side_effect=InvalidBackendError("instances are QEMU-only")),
     )
+    # The rejection retires the never-created VM as FAILED_CREATE for real
+    # (not mocked): stub out its DB write, which needs an app-level session
+    # this unit test does not set up.
+    from aleph.vm.agent.vm import retire as retire_module
+
+    monkeypatch.setattr(retire_module, "delete_records_for_vm", AsyncMock())
 
     supervisor = _fake_supervisor()
     registry = AgentVmRegistry()
@@ -628,10 +642,14 @@ async def test_reconcile_adopted_program_content_is_a_noop():
 
 @pytest.mark.asyncio
 async def test_start_persistent_recreates_after_failed(monkeypatch):
+    from aleph.vm.agent.vm.retire import RetireReason
+
     sup = _fake_supervisor(get_status=VmStatus.FAILED)
     created = AsyncMock()
     monkeypatch.setattr(run_module, "create_vm_execution", created)
     monkeypatch.setattr(run_module, "_wait_until_running", AsyncMock())
+    retire = AsyncMock()
+    monkeypatch.setattr(run_module, "retire_vm", retire)
 
     await run_module.start_persistent_vm(
         ItemHash(_HASH),
@@ -642,9 +660,10 @@ async def test_start_persistent_recreates_after_failed(monkeypatch):
         expiry=MagicMock(),
         update_watcher=MagicMock(),
     )
-    # FAILED -> delete then recreate: a recovery cycle, so the persisted
-    # host-port forwards must survive the delete.
-    sup.delete_vm.assert_awaited_once_with(VmId(_HASH), keep_port_mappings=True)
+    # FAILED -> delete then recreate: a recovery cycle, so RECREATE keeps the
+    # persisted host-port forwards.
+    retire.assert_awaited_once_with(ItemHash(_HASH), RetireReason.RECREATE, supervisor=sup)
+    sup.delete_vm.assert_not_awaited()
     created.assert_awaited_once()
     sup.start_vm.assert_not_awaited()
 

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -19,6 +19,7 @@ from test_supervisor_translate import _make_qemu_instance_message
 
 from aleph.vm.agent import run as run_module
 from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.conf import settings
 from aleph.vm.supervisor_interface.errors import InvalidBackendError, VmNotFoundError
 from aleph.vm.supervisor_interface.types import (
     Backend,
@@ -239,6 +240,105 @@ async def test_eligible_instance_port_forward_failure_retires_as_failed_create(m
 
     retire.assert_awaited_once_with(_HASH, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
     supervisor.delete_vm.assert_not_awaited()
+
+
+@pytest.fixture
+def _persistent_pool(tmp_path, monkeypatch):
+    """A single real volume pool (the PERSISTENT_VOLUMES_DIR fallback
+    get_pools() uses when setup_pools() has not run), so vm_has_volumes can
+    see actual files on disk."""
+    pool0 = tmp_path / "pool0"
+    pool0.mkdir()
+    monkeypatch.setattr(settings, "PERSISTENT_VOLUMES_DIR", pool0)
+    return pool0
+
+
+@pytest.mark.asyncio
+async def test_eligible_instance_failure_with_existing_volumes_retires_as_recreate(monkeypatch, _persistent_pool):
+    """A failed create against volumes that already existed before the
+    attempt (the re-create path for a host-persistent VM whose disks
+    downloader._make_writable_volume left alone) must not wipe them: it
+    retires RECREATE, which keeps the record and the disks -- not
+    FAILED_CREATE, which would purge them."""
+    volume_dir = _persistent_pool / str(_HASH)
+    volume_dir.mkdir()
+    rootfs = volume_dir / "rootfs.qcow2"
+    rootfs.write_bytes(b"pre-existing-owner-data")
+
+    content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
+    message = MagicMock(content=content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
+    )
+    monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(return_value=_spec()))
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+
+    supervisor = _fake_supervisor()  # get_vm reports RUNNING immediately
+    supervisor.add_port_forward = AsyncMock(side_effect=RuntimeError("nftables boom"))
+    registry = AgentVmRegistry()
+
+    with pytest.raises(RuntimeError, match="nftables boom"):
+        await run_module.create_vm_execution(
+            _HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
+        )
+
+    # RECREATE: the record and the pre-existing volume both survive.
+    assert registry.get(_HASH) is not None
+    assert rootfs.exists()
+    assert rootfs.read_bytes() == b"pre-existing-owner-data"
+    supervisor.delete_vm.assert_awaited_once_with(VmId(str(_HASH)), keep_port_mappings=True)
+
+
+@pytest.mark.asyncio
+async def test_eligible_instance_failure_without_existing_volumes_retires_as_failed_create(
+    monkeypatch, _persistent_pool
+):
+    """A failed create that allocated fresh disks (nothing existed before
+    the attempt) retires FAILED_CREATE, which purges what it just
+    allocated and drops the record."""
+    from aleph.vm.agent.vm import retire as retire_module
+
+    # retire_vm(FAILED_CREATE) writes a DB record deletion; stub it out, this
+    # test only cares about the volume/registry outcome.
+    monkeypatch.setattr(retire_module, "delete_records_for_vm", AsyncMock())
+
+    volume_dir = _persistent_pool / str(_HASH)
+    rootfs = volume_dir / "rootfs.qcow2"
+
+    async def _build_create_vm_spec(vm_hash, content):
+        # Simulate the real build_create_vm_spec: it allocates the volume
+        # file before create_vm_execution's had_volumes snapshot has a
+        # chance to see it (the snapshot runs before this call).
+        volume_dir.mkdir(parents=True, exist_ok=True)
+        rootfs.write_bytes(b"freshly-allocated")
+        return _spec()
+
+    content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
+    message = MagicMock(content=content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
+    )
+    monkeypatch.setattr(run_module, "build_create_vm_spec", _build_create_vm_spec)
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+
+    supervisor = _fake_supervisor()  # get_vm reports RUNNING immediately
+    supervisor.add_port_forward = AsyncMock(side_effect=RuntimeError("nftables boom"))
+    registry = AgentVmRegistry()
+
+    assert not rootfs.exists()  # nothing allocated yet: had_volumes will be False
+
+    with pytest.raises(RuntimeError, match="nftables boom"):
+        await run_module.create_vm_execution(
+            _HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
+        )
+
+    # FAILED_CREATE: the record is dropped and the freshly-allocated volume
+    # is purged.
+    assert registry.get(_HASH) is None
+    assert not rootfs.exists()
+    supervisor.delete_vm.assert_awaited_once_with(VmId(str(_HASH)), keep_port_mappings=False)
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_update_watcher.py
+++ b/tests/supervisor/test_update_watcher.py
@@ -215,7 +215,7 @@ async def test_expiry_reap_cancels_update_watch():
     # task completes, so awaiting the task is enough to observe the cancellation.
     await asyncio.wait_for(expiry._tasks[vm_id], timeout=WAIT_TIMEOUT)
 
-    assert sup.deleted == [(_HASH, False)]  # expiry reaped: plain dealloc
+    assert sup.deleted == [(_HASH, True)]  # expiry reaped: RECREATE keeps port mappings
     assert watcher.cancel(vm_id) is False  # the watch was cancelled (gone)
 
 

--- a/tests/supervisor/test_vm_purge.py
+++ b/tests/supervisor/test_vm_purge.py
@@ -251,3 +251,16 @@ def test_erase_leaves_a_directory_that_still_holds_a_dm_backed_volume(pools, mon
     assert held.parent.exists(), "the directory holding the dm-backed volume must survive"
     assert not other_pool_dir.exists(), "directories with nothing held are still removed"
     assert "still holds device-mapper-backed volumes" in caplog.text
+
+
+def test_purge_side_dirs_leaves_the_volumes(pools):
+    from aleph.vm.agent.vm.purge import purge_vm_side_dirs
+
+    rootfs = _volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    session_dir = pools["sessions"] / VM_HASH
+    session_dir.mkdir(parents=True)
+
+    purge_vm_side_dirs(VM_HASH)
+
+    assert rootfs.exists()
+    assert not session_dir.exists()

--- a/tests/supervisor/test_vm_purge.py
+++ b/tests/supervisor/test_vm_purge.py
@@ -19,6 +19,7 @@ from aleph.vm.agent.vm.purge import (
     iter_volume_files,
     purge_vm_storage,
     purge_vm_volumes,
+    vm_has_volumes,
 )
 from aleph.vm.conf import settings
 from aleph.vm.storage_pools import (
@@ -156,6 +157,32 @@ def test_only_regular_files_directly_in_the_directory_are_volumes(pools):
     (nested / "not-a-volume").write_bytes(b"x")
 
     assert [path.name for path in iter_volume_files(VM_HASH)] == ["rootfs.qcow2"]
+
+
+def test_vm_has_volumes_false_for_an_empty_namespace(pools):
+    """Used by the create paths to tell a fresh create (nothing on disk yet,
+    safe to purge on failure) apart from a re-create of an existing
+    host-persistent VM (must not wipe it)."""
+    assert vm_has_volumes(VM_HASH) is False
+
+
+def test_vm_has_volumes_true_once_any_volume_exists(pools):
+    _volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+
+    assert vm_has_volumes(VM_HASH) is True
+
+
+def test_vm_has_volumes_true_for_a_data_volume_on_another_pool(pools):
+    """Any volume on any pool counts, not just the rootfs on pool 0."""
+    _volume(pools["pool1"], VM_HASH, "data.ext4")
+
+    assert vm_has_volumes(VM_HASH) is True
+
+
+def test_vm_has_volumes_does_not_see_another_vm(pools):
+    _volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2")
+
+    assert vm_has_volumes(VM_HASH) is False
 
 
 def test_purged_volumes_are_rebuilt_on_the_pools_they_came_from(pools):

--- a/tests/supervisor/test_vm_purge.py
+++ b/tests/supervisor/test_vm_purge.py
@@ -172,6 +172,16 @@ def test_vm_has_volumes_true_once_any_volume_exists(pools):
     assert vm_has_volumes(VM_HASH) is True
 
 
+def test_vm_has_volumes_ignores_a_partial_download(pools):
+    """A `.part` left by an interrupted attempt is not a volume: counting it
+    would turn the next fresh create into a re-create, which on failure
+    keeps a record and a directory holding nothing bootable."""
+    _volume(pools["pool0"], VM_HASH, "rootfs.qcow2.part")
+    _volume(pools["pool0"], VM_HASH, "data.btrfs.tmp")
+
+    assert vm_has_volumes(VM_HASH) is False
+
+
 def test_vm_has_volumes_true_for_a_data_volume_on_another_pool(pools):
     """Any volume on any pool counts, not just the rootfs on pool 0."""
     _volume(pools["pool1"], VM_HASH, "data.ext4")

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -274,8 +274,9 @@ def _failed_vm_info(vm_hash: str) -> VmInfo:
 @pytest.mark.asyncio
 async def test_create_vm_execution_vprogram_wait_failure_tears_down(mocker):
     """create_vm succeeds but the VM never reaches RUNNING: the launch path
-    must tear the half-started VM down (supervisor.delete_vm) and forget its
-    registry record, without persisting."""
+    must retire the half-started VM as FAILED_CREATE, without persisting."""
+    from aleph.vm.agent.vm.retire import RetireReason
+
     message = load_vprogram_message()
     vm_hash = message.item_hash
     mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
@@ -292,6 +293,7 @@ async def test_create_vm_execution_vprogram_wait_failure_tears_down(mocker):
         delete_vm=AsyncMock(),
     )
     registry = AgentVmRegistry()
+    retire = mocker.patch("aleph.vm.agent.run.retire_vm", new_callable=AsyncMock)
 
     with pytest.raises(VmStartupError):
         await create_vm_execution(
@@ -302,8 +304,8 @@ async def test_create_vm_execution_vprogram_wait_failure_tears_down(mocker):
             persistent=True,
         )
 
-    supervisor.delete_vm.assert_awaited_once_with(info.vm_id)
-    assert vm_hash not in registry
+    retire.assert_awaited_once_with(vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
+    supervisor.delete_vm.assert_not_awaited()
     mock_persist.assert_not_awaited()
 
 
@@ -312,6 +314,8 @@ async def test_create_vm_execution_vprogram_build_failure_forgets_record(mocker)
     """A failed bundle fetch/verify must surface the create-path vocabulary
     (VmSetupError, reported per-VM by update_allocations) and leave no
     dangling registry record behind."""
+    from aleph.vm.agent.vm.retire import RetireReason
+
     message = load_vprogram_message()
     mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
     mocker.patch(
@@ -322,6 +326,7 @@ async def test_create_vm_execution_vprogram_build_failure_forgets_record(mocker)
 
     supervisor = MagicMock(create_vm=AsyncMock())
     registry = AgentVmRegistry()
+    retire = mocker.patch("aleph.vm.agent.run.retire_vm", new_callable=AsyncMock)
 
     with pytest.raises(VmSetupError, match="sha256 mismatch"):
         await create_vm_execution(
@@ -333,7 +338,9 @@ async def test_create_vm_execution_vprogram_build_failure_forgets_record(mocker)
         )
 
     supervisor.create_vm.assert_not_awaited()
-    assert message.item_hash not in registry
+    retire.assert_awaited_once_with(
+        message.item_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry
+    )
 
 
 @pytest.mark.asyncio
@@ -347,7 +354,9 @@ async def test_create_vm_execution_vprogram_capacity_failure_forgets_record(mock
 
     capacity = MagicMock()
     capacity.check_capacity.side_effect = InsufficientResourcesError("no room", required={}, available={})
-    supervisor = MagicMock(create_vm=AsyncMock())
+    # retire_vm(FAILED_CREATE) always quiesces through the supervisor first
+    # (swallowing VmNotFoundError), even though no VM was ever created here.
+    supervisor = MagicMock(create_vm=AsyncMock(), delete_vm=AsyncMock())
     registry = AgentVmRegistry()
 
     with pytest.raises(InsufficientResourcesError):

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -155,8 +155,10 @@ async def test_update_allocations_starts_v_programs(aiohttp_client, mocker, sche
 @pytest.mark.asyncio
 async def test_update_allocations_stops_descheduled_vprogram(aiohttp_client, mocker, scheduler_auth):
     """The scheduler is the single source of truth for v-programs: absence from
-    the allocation stops them, despite being credit-paid and confidential
-    (both of which spare other VM types)."""
+    the allocation retires them as GONE, despite being credit-paid and
+    confidential (both of which spare other VM types)."""
+    from aleph.vm.agent.vm.retire import RetireReason
+
     message = load_vprogram_message()
     vm_hash = str(message.item_hash)
 
@@ -167,19 +169,17 @@ async def test_update_allocations_stops_descheduled_vprogram(aiohttp_client, moc
     fake_supervisor = MagicMock(delete_vm=AsyncMock(), list_vms=AsyncMock(return_value=[_running_vm_info(vm_hash)]))
     app["supervisor"] = fake_supervisor
 
-    mock_delete_records = mocker.patch(
-        "aleph.vm.agent.allocation.teardown.delete_records_for_vm", new_callable=AsyncMock
-    )
+    retire = mocker.patch("aleph.vm.agent.allocation.teardown.retire_vm", new_callable=AsyncMock)
     client = await aiohttp_client(app)
 
     body, headers = scheduler_auth({"persistent_vms": []})
     response = await client.post("/control/allocations", data=body, headers=headers)
     assert response.status == 200
-    resp_json = await response.json()
-    assert vm_hash in resp_json["stopped"]
-    fake_supervisor.delete_vm.assert_awaited_once_with(VmId(vm_hash))
-    mock_delete_records.assert_awaited_once_with(vm_hash)
-    assert ItemHash(vm_hash) not in app["vm_registry"]
+    assert vm_hash in (await response.json())["stopped"]
+    retire.assert_awaited_once_with(
+        ItemHash(vm_hash), RetireReason.GONE, supervisor=fake_supervisor, registry=app["vm_registry"]
+    )
+    fake_supervisor.delete_vm.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/views/test_allocations_retire.py
+++ b/tests/supervisor/views/test_allocations_retire.py
@@ -1,0 +1,171 @@
+"""The allocation stop loop retires deallocated VMs as GONE.
+
+Split out of the old ``tests/supervisor/test_views.py``, which was removed
+with the Python supervisor daemon: these cases only ever needed a
+``Supervisor``, so they drive ``setup_webapp`` with a mock of that interface.
+"""
+
+import json
+import time as time_module
+from hashlib import sha256
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aleph_message.models import InstanceContent, ItemHash
+from eth_account import Account
+from eth_account.messages import encode_defunct
+
+from aleph.vm.agent.supervisor import setup_webapp
+from aleph.vm.agent.vm.retire import RetireReason
+from aleph.vm.conf import settings
+from aleph.vm.supervisor_interface.types import (
+    Backend,
+    ConfidentialMode,
+    IpAssignment,
+    VmId,
+    VmInfo,
+    VmStatus,
+)
+
+VM_HASH = ItemHash("decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca")
+
+# A non-stream, non-credit payment type, so the stop-loop condition is
+# satisfied (superfluid / credit executions are excluded from the dealloc loop).
+_HOLD_INSTANCE_CONTENT = {
+    "address": "0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9",
+    "time": 1713874241.800818,
+    "allow_amend": False,
+    "metadata": None,
+    "authorized_keys": None,
+    "variables": None,
+    "environment": {"reproducible": False, "internet": True, "aleph_api": True, "shared_cache": False},
+    "resources": {"vcpus": 1, "memory": 256, "seconds": 30, "published_ports": None},
+    "payment": {"type": "hold", "chain": "BASE"},
+    "requirements": None,
+    "replaces": None,
+    "rootfs": {
+        "parent": {"ref": "63f07193e6ee9d207b7d1fcf8286f9aee34e6f12f101d2ec77c1229f92964696"},
+        "ref": "63f07193e6ee9d207b7d1fcf8286f9aee34e6f12f101d2ec77c1229f92964696",
+        "use_latest": True,
+        "comment": "",
+        "persistence": "host",
+        "size_mib": 1000,
+    },
+}
+
+
+def _make_aleph_eip191_v1_header(account, *, method="POST", path="/control/allocations", body=b"", iat=None) -> str:
+    payload = {
+        "method": method,
+        "path": path,
+        "body_sha256": sha256(body).hexdigest(),
+        "iat": iat if iat is not None else int(time_module.time()),
+    }
+    payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    signed = account.sign_message(encode_defunct(payload_bytes))
+    return f"Aleph-EIP191-V1 sig={signed.signature.hex()},payload={payload_bytes.hex()}"
+
+
+@pytest.fixture()
+def scheduler_auth(monkeypatch):
+    """Authorize a throwaway scheduler key and sign requests as it.
+
+    Returns a callable that serializes the body and produces the matching
+    `Aleph-EIP191-V1` headers. The signature binds method, path and body hash,
+    so the caller must send the returned bytes verbatim (`data=`, not `json=`).
+    """
+    account = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [account.address])
+
+    def _sign(body_dict=None, *, path="/control/allocations", method="POST"):
+        body = b"" if body_dict is None else json.dumps(body_dict).encode()
+        header = _make_aleph_eip191_v1_header(account, method=method, path=path, body=body)
+        headers = {"Authorization": header}
+        if body_dict is not None:
+            headers["Content-Type"] = "application/json"
+        return body, headers
+
+    return _sign
+
+
+def _running_vm_info(vm_hash=VM_HASH):
+    return VmInfo(
+        vm_id=VmId(str(vm_hash)),
+        status=VmStatus.RUNNING,
+        ipv4=IpAssignment(),
+        ipv6=IpAssignment(),
+        uptime_secs=0,
+        backend=Backend.QEMU,
+        numa_node=None,
+        status_message="",
+        confidential_mode=ConfidentialMode.NONE,
+        gpus=[],
+    )
+
+
+def _make_app_with_supervisor(supervisor):
+    """Create a minimal webapp whose supervisor is the given double."""
+    app = setup_webapp(supervisor=supervisor)
+    app["pubsub"] = None
+    app["supervisor"] = supervisor
+    return app
+
+
+@pytest.mark.asyncio
+async def test_update_allocations_stop_loop_uses_supervisor(aiohttp_client, mocker, scheduler_auth):
+    """update_allocations' stop loop must retire executions no longer in the
+    allocation rather than hand-rolling delete_vm plus the record cleanup.
+
+    Status is read from supervisor.list_vms() (VmInfo); persistence from the
+    registry.
+    """
+    vm_hash = str(VM_HASH)
+    message = InstanceContent.model_validate(_HOLD_INSTANCE_CONTENT)
+
+    fake_supervisor = MagicMock(delete_vm=AsyncMock(), list_vms=AsyncMock(return_value=[_running_vm_info(vm_hash)]))
+    app = _make_app_with_supervisor(fake_supervisor)
+
+    # Seed registry so the app knows the VM.
+    app["vm_registry"].record(vm_hash, message=message, original=message, persistent=True)
+
+    retire = mocker.patch("aleph.vm.agent.views.retire_vm", new_callable=AsyncMock)
+    client = await aiohttp_client(app)
+
+    # Empty allocation: vm_hash is not in persistent_vms or instances, so it must be stopped.
+    body, headers = scheduler_auth({"persistent_vms": []})
+    response = await client.post("/control/allocations", data=body, headers=headers)
+    assert response.status == 200
+    resp_json = await response.json()
+    assert vm_hash in resp_json["stopped"]
+
+    # Permanent dealloc goes through retire_vm(GONE), which owns the supervisor
+    # quiesce, registry.forget and the persisted record cleanup.
+    retire.assert_awaited_once_with(
+        ItemHash(vm_hash), RetireReason.GONE, supervisor=fake_supervisor, registry=app["vm_registry"]
+    )
+    fake_supervisor.delete_vm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stop_loop_stops_eligible_vm(aiohttp_client, mocker, scheduler_auth):
+    """A running, persistent, hold-tier VM not in the allocation must be
+    retired as GONE and reported in stopped[]."""
+    message = InstanceContent.model_validate(_HOLD_INSTANCE_CONTENT)
+
+    fake_supervisor = MagicMock(
+        delete_vm=AsyncMock(),
+        list_vms=AsyncMock(return_value=[_running_vm_info()]),
+    )
+    app = _make_app_with_supervisor(fake_supervisor)
+    app["vm_registry"].record(VM_HASH, message=message, original=message, persistent=True)
+    retire = mocker.patch("aleph.vm.agent.views.retire_vm", new_callable=AsyncMock)
+
+    client = await aiohttp_client(app)
+    body, headers = scheduler_auth({"persistent_vms": []})
+    response = await client.post("/control/allocations", data=body, headers=headers)
+    assert response.status == 200
+    resp_json = await response.json()
+
+    assert str(VM_HASH) in resp_json["stopped"]
+    retire.assert_awaited_once_with(VM_HASH, RetireReason.GONE, supervisor=fake_supervisor, registry=app["vm_registry"])
+    fake_supervisor.delete_vm.assert_not_awaited()

--- a/tests/supervisor/views/test_allocations_retire.py
+++ b/tests/supervisor/views/test_allocations_retire.py
@@ -128,7 +128,7 @@ async def test_update_allocations_stop_loop_uses_supervisor(aiohttp_client, mock
     # Seed registry so the app knows the VM.
     app["vm_registry"].record(vm_hash, message=message, original=message, persistent=True)
 
-    retire = mocker.patch("aleph.vm.agent.views.retire_vm", new_callable=AsyncMock)
+    retire = mocker.patch("aleph.vm.agent.allocation.teardown.retire_vm", new_callable=AsyncMock)
     client = await aiohttp_client(app)
 
     # Empty allocation: vm_hash is not in persistent_vms or instances, so it must be stopped.
@@ -158,7 +158,7 @@ async def test_stop_loop_stops_eligible_vm(aiohttp_client, mocker, scheduler_aut
     )
     app = _make_app_with_supervisor(fake_supervisor)
     app["vm_registry"].record(VM_HASH, message=message, original=message, persistent=True)
-    retire = mocker.patch("aleph.vm.agent.views.retire_vm", new_callable=AsyncMock)
+    retire = mocker.patch("aleph.vm.agent.allocation.teardown.retire_vm", new_callable=AsyncMock)
 
     client = await aiohttp_client(app)
     body, headers = scheduler_auth({"persistent_vms": []})

--- a/tests/supervisor/views/test_migration_cleanup_retire.py
+++ b/tests/supervisor/views/test_migration_cleanup_retire.py
@@ -1,0 +1,101 @@
+"""Migration cleanup retires the migrated-away source as GONE.
+
+Split out of the old ``tests/supervisor/views/test_migration.py``, which was
+removed with the Python supervisor daemon: this case only ever needed a
+``Supervisor``, so it drives ``setup_webapp`` with a mock of that interface.
+"""
+
+from http import HTTPStatus
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp.test_utils import TestClient
+from aleph_message.models import ItemHash
+
+from aleph.vm.agent.migration.jobs import MigrationState
+from aleph.vm.agent.supervisor import setup_webapp
+from aleph.vm.conf import settings
+from aleph.vm.supervisor_interface.errors import VmNotFoundError
+
+
+def _migration_supervisor(get_vm=None, **overrides):
+    """A MagicMock supervisor wired with the migration-relevant methods.
+
+    get_vm defaults to raising VmNotFoundError (no VM present); pass an
+    AsyncMock to model a present VM. Override any method via keyword.
+    """
+    sup = MagicMock()
+    sup.get_vm = get_vm if get_vm is not None else AsyncMock(side_effect=VmNotFoundError("absent"))
+    sup.stop_vm = AsyncMock()
+    sup.start_vm = AsyncMock()
+    sup.create_vm = AsyncMock(return_value=MagicMock())
+    sup.delete_vm = AsyncMock()
+    for name, value in overrides.items():
+        setattr(sup, name, value)
+    return sup
+
+
+@pytest.fixture(autouse=True)
+def _clear_migration_registries():
+    from aleph.vm.agent.migration.jobs import export_jobs, import_jobs
+
+    export_jobs.clear()
+    import_jobs.clear()
+    yield
+    export_jobs.clear()
+    import_jobs.clear()
+
+
+@pytest.fixture
+def mock_scheduler_auth(mocker):
+    """Mock the scheduler authentication to always pass.
+
+    The migration handlers wrap themselves with @requires_allocation_auth, which
+    looks up authenticate_api_request in its own module
+    (aleph.vm.agent.views.allocation_auth) - patch there.
+    """
+    mocker.patch(
+        "aleph.vm.agent.views.allocation_auth.authenticate_api_request",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
+
+
+@pytest.fixture
+def mock_vm_hash():
+    """Return a valid VM hash for testing."""
+    return ItemHash(settings.FAKE_INSTANCE_ID)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_success(aiohttp_client, mocker, mock_scheduler_auth, mock_vm_hash):
+    """Test successful cleanup when an EXPORTED job is present."""
+    from datetime import datetime, timezone
+
+    from aleph.vm.agent.migration.jobs import ExportJob, export_jobs
+    from aleph.vm.agent.vm.retire import RetireReason
+
+    export_jobs[mock_vm_hash] = ExportJob(
+        vm_hash=mock_vm_hash,
+        state=MigrationState.EXPORTED,
+        started_at=datetime.now(timezone.utc),
+    )
+
+    supervisor = _migration_supervisor()
+    app = setup_webapp(supervisor=supervisor)
+    app["supervisor"] = supervisor
+    retire = mocker.patch("aleph.vm.agent.views.migration.retire_vm", new_callable=AsyncMock)
+    client: TestClient = await aiohttp_client(app)
+
+    response = await client.post(f"/control/machine/{mock_vm_hash}/migration/cleanup")
+
+    assert response.status == HTTPStatus.OK
+    data = await response.json()
+    assert data["status"] == "completed"
+    # Cleanup retires the migrated-away source as GONE: the destination
+    # owns the data now, so under VOLUME_RETENTION=reap the disks go.
+    retire.assert_awaited_once()
+    args, kwargs = retire.await_args
+    assert args[0] == mock_vm_hash
+    assert args[1] is RetireReason.GONE
+    assert kwargs["supervisor"] is supervisor

--- a/tests/supervisor/views/test_operator_retire.py
+++ b/tests/supervisor/views/test_operator_retire.py
@@ -1,0 +1,445 @@
+"""Operator endpoints that retire through ``retire_vm``.
+
+Split out of the old ``tests/supervisor/views/test_operator.py``, which was
+removed with the Python supervisor daemon: these cases only ever needed a
+``Supervisor``, so they drive ``setup_webapp`` with a mock of that interface.
+
+Covers the erase/stop/reboot/reinstall paths converted to ``retire_vm`` and
+the erase of data the supervisor has forgotten (a retained ``.reclaimable``
+directory), whose owner is proven from the marker or the agent DB.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp.test_utils import TestClient
+from aleph_message.models import ItemHash
+from aleph_message.models.execution.environment import TrustedExecutionEnvironment
+
+from aleph.vm.agent import metrics
+from aleph.vm.agent.supervisor import setup_webapp
+from aleph.vm.agent.views.operator import _security_aggregate_cache
+from aleph.vm.agent.vm.reclaimable import ReclaimableMarker
+from aleph.vm.agent.vm.retire import RetireReason
+from aleph.vm.conf import settings
+from aleph.vm.storage import get_message
+from aleph.vm.supervisor_interface.errors import VmNotFoundError
+from aleph.vm.supervisor_interface.types import (
+    Backend,
+    ConfidentialMode,
+    IpAssignment,
+    VmId,
+    VmInfo,
+    VmStatus,
+)
+
+_FAKE_HASH = "decadecadecadecadecadecadecadecadecadecadecadecadecadecadecadeca"
+
+
+def _vm_info(
+    status: VmStatus = VmStatus.RUNNING,
+    vm_id: str = _FAKE_HASH,
+    confidential_mode: ConfidentialMode = ConfidentialMode.NONE,
+    awaiting_confidential_init: bool = False,
+) -> VmInfo:
+    return VmInfo(
+        vm_id=VmId(vm_id),
+        status=status,
+        ipv4=IpAssignment(),
+        ipv6=IpAssignment(),
+        uptime_secs=0,
+        backend=Backend.QEMU,
+        numa_node=None,
+        status_message="",
+        confidential_mode=confidential_mode,
+        awaiting_confidential_init=awaiting_confidential_init,
+    )
+
+
+def _fake_supervisor(status: VmStatus = VmStatus.RUNNING) -> MagicMock:
+    return MagicMock(
+        get_vm=AsyncMock(return_value=_vm_info(status)),
+        delete_vm=AsyncMock(),
+        stop_vm=AsyncMock(return_value=_vm_info(VmStatus.STOPPED)),
+        start_vm=AsyncMock(return_value=_vm_info(VmStatus.RUNNING)),
+        reboot_vm=AsyncMock(),
+        freeze_guest=AsyncMock(return_value=True),
+        thaw_guest=AsyncMock(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """Clear all API response caches between tests."""
+    _security_aggregate_cache.clear()
+    yield
+    _security_aggregate_cache.clear()
+
+
+@pytest.mark.asyncio
+async def test_operator_erase_with_delegation(aiohttp_client, mocker):
+    """Test that a delegated address can successfully erase a VM via the supervisor."""
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    delegated_address = "0x9999999999999999999999999999999999999999"
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+
+    mocker.patch(
+        "aleph.vm.agent.views.authentication.authenticate_jwk",
+        return_value=delegated_address,
+    )
+
+    # Mock the API response for security aggregate with valid delegation
+    mock_response = mocker.AsyncMock()
+    mock_response.json = mocker.AsyncMock(
+        return_value={
+            "data": {
+                "security": {
+                    "authorizations": [
+                        {
+                            "address": delegated_address,
+                            "types": ["INSTANCE"],
+                        }
+                    ]
+                }
+            }
+        }
+    )
+    mock_response.raise_for_status = mocker.Mock()
+
+    mock_session = mocker.AsyncMock()
+    mock_session.get = mocker.AsyncMock(return_value=mock_response)
+    mocker.patch("aleph.vm.agent.views.operator.get_session", return_value=mock_session)
+
+    app = setup_webapp(supervisor=_fake_supervisor())
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    fake_sup = _fake_supervisor()
+    app["supervisor"] = fake_sup
+    retire = mocker.patch("aleph.vm.agent.views.operator.retire_vm", new_callable=AsyncMock)
+    client: TestClient = await aiohttp_client(app)
+    response = await client.post(
+        f"/control/machine/{vm_hash}/erase",
+    )
+
+    assert response.status == 200
+    retire.assert_awaited_once_with(vm_hash, RetireReason.ERASE, supervisor=fake_sup, registry=app["vm_registry"])
+    fake_sup.delete_vm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_operator_erase_when_the_supervisor_forgot_the_vm(aiohttp_client, mocker):
+    """The supervisor forgets a VM on restart or after a delete while its
+    disks stay. The registry still knows who owns them, so the owner's erase
+    must go through instead of 404ing on the supervisor's ignorance."""
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    mocker.patch(
+        "aleph.vm.agent.views.authentication.authenticate_jwk",
+        return_value=instance_message.sender,
+    )
+
+    app = setup_webapp(supervisor=_fake_supervisor())
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    fake_sup = _fake_supervisor()
+    fake_sup.get_vm = AsyncMock(side_effect=VmNotFoundError(str(vm_hash)))
+    app["supervisor"] = fake_sup
+    retire = mocker.patch("aleph.vm.agent.views.operator.retire_vm", new_callable=AsyncMock)
+
+    client: TestClient = await aiohttp_client(app)
+    response = await client.post(f"/control/machine/{vm_hash}/erase")
+
+    assert response.status == 200
+    retire.assert_awaited_once_with(vm_hash, RetireReason.ERASE, supervisor=fake_sup, registry=app["vm_registry"])
+
+
+def _retained(owner: str | None):
+    """A .reclaimable marker as retire_vm(GONE) leaves it under keep."""
+    return ReclaimableMarker(
+        reclaimable_since=datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc),
+        reason="gone",
+        size_bytes=4096,
+        owner=owner,
+    )
+
+
+async def _erase_a_retained_vm(aiohttp_client, mocker, *, sender: str, marker):
+    """Erase a VM the node only knows through its marker: no registry record,
+    no DB rows (the state a GONE under keep actually leaves)."""
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    mocker.patch("aleph.vm.agent.views.authentication.authenticate_jwk", return_value=sender)
+    mocker.patch("aleph.vm.agent.views.operator.retained_marker", return_value=marker)
+    mocker.patch.object(metrics, "get_last_record_for_vm", AsyncMock(return_value=None))
+
+    app = setup_webapp(supervisor=_fake_supervisor())
+    fake_sup = _fake_supervisor()
+    fake_sup.get_vm = AsyncMock(side_effect=VmNotFoundError(str(vm_hash)))
+    app["supervisor"] = fake_sup
+    retire = mocker.patch("aleph.vm.agent.views.operator.retire_vm", new_callable=AsyncMock)
+
+    client: TestClient = await aiohttp_client(app)
+    response = await client.post(f"/control/machine/{vm_hash}/erase")
+    return response, retire, app, fake_sup, vm_hash
+
+
+@pytest.mark.asyncio
+async def test_operator_erase_wipes_retained_data_for_its_owner(aiohttp_client, mocker):
+    """Under VOLUME_RETENTION=keep a GONE drops the registry record and the DB
+    rows and keeps the disks behind a .reclaimable marker. The marker's owner
+    is the only thing left to authorize against, and the owner must be able to
+    have their retained data wiped."""
+    owner = "0x1234567890123456789012345678901234567890"
+
+    response, retire, app, fake_sup, vm_hash = await _erase_a_retained_vm(
+        aiohttp_client, mocker, sender=owner, marker=_retained(owner)
+    )
+
+    assert response.status == 200
+    retire.assert_awaited_once_with(vm_hash, RetireReason.ERASE, supervisor=fake_sup, registry=app["vm_registry"])
+
+
+@pytest.mark.asyncio
+async def test_operator_erase_of_retained_data_by_a_stranger_is_403(aiohttp_client, mocker):
+    """Retention is not a hole: only the marker's owner may wipe it."""
+    response, retire, _app, _sup, _hash = await _erase_a_retained_vm(
+        aiohttp_client,
+        mocker,
+        sender="0x9999999999999999999999999999999999999999",
+        marker=_retained("0x1234567890123456789012345678901234567890"),
+    )
+
+    assert response.status == 403
+    retire.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_operator_erase_of_a_marker_without_an_owner_is_403(aiohttp_client, mocker):
+    """A marker written before the owner field, or an orphan directory for a
+    VM whose message this node never held: nothing can prove ownership, so
+    nothing is wiped on request."""
+    response, retire, _app, _sup, _hash = await _erase_a_retained_vm(
+        aiohttp_client,
+        mocker,
+        sender="0x1234567890123456789012345678901234567890",
+        marker=_retained(None),
+    )
+
+    assert response.status == 403
+    retire.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_operator_erase_of_a_hash_nothing_knows_is_404(aiohttp_client, mocker):
+    """No record and no retained directory: there is nothing to erase."""
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    mocker.patch(
+        "aleph.vm.agent.views.authentication.authenticate_jwk",
+        return_value=instance_message.sender,
+    )
+    mocker.patch("aleph.vm.agent.views.operator.retained_marker", return_value=None)
+    mocker.patch.object(metrics, "get_last_record_for_vm", AsyncMock(return_value=None))
+
+    app = setup_webapp(supervisor=_fake_supervisor())
+    app["supervisor"] = _fake_supervisor()
+    retire = mocker.patch("aleph.vm.agent.views.operator.retire_vm", new_callable=AsyncMock)
+
+    client: TestClient = await aiohttp_client(app)
+    response = await client.post(f"/control/machine/{vm_hash}/erase")
+
+    assert response.status == 404
+    retire.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_operator_stop_non_persistent_retires_as_recreate(aiohttp_client, mocker):
+    """Stop a non-persistent (ephemeral) VM: no stop state, so the stop cycle
+    is retire_vm(RECREATE), not stop_vm nor a plain delete_vm."""
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+
+    mocker.patch(
+        "aleph.vm.agent.views.authentication.authenticate_jwk",
+        return_value=instance_message.sender,
+    )
+
+    app = setup_webapp(supervisor=_fake_supervisor())
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=False,
+    )
+    fake_sup = _fake_supervisor(VmStatus.RUNNING)
+    app["supervisor"] = fake_sup
+    retire = mocker.patch("aleph.vm.agent.views.operator.retire_vm", new_callable=AsyncMock)
+
+    client: TestClient = await aiohttp_client(app)
+    response = await client.post(f"/control/machine/{vm_hash}/stop")
+
+    assert response.status == 200
+    assert await response.text() == f"Stopped VM with ref {vm_hash}"
+    retire.assert_awaited_once_with(vm_hash, RetireReason.RECREATE, supervisor=fake_sup)
+    fake_sup.stop_vm.assert_not_awaited()
+    fake_sup.delete_vm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_operator_reboot_non_persistent(aiohttp_client, mocker):
+    """Reboot a non-persistent VM: retire_vm(RECREATE) then
+    create_vm_execution_or_raise_http_error called."""
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+
+    mocker.patch(
+        "aleph.vm.agent.views.authentication.authenticate_jwk",
+        return_value=instance_message.sender,
+    )
+
+    mock_create_vm = mocker.patch(
+        "aleph.vm.agent.views.operator.create_vm_execution_or_raise_http_error",
+        new=AsyncMock(),
+    )
+
+    app = setup_webapp(supervisor=_fake_supervisor())
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=False,
+    )
+    fake_sup = _fake_supervisor(VmStatus.RUNNING)
+    app["supervisor"] = fake_sup
+    retire = mocker.patch("aleph.vm.agent.views.operator.retire_vm", new_callable=AsyncMock)
+
+    client: TestClient = await aiohttp_client(app)
+    response = await client.post(f"/control/machine/{vm_hash}/reboot")
+
+    assert response.status == 200
+    assert await response.text() == f"Rebooted VM with ref {vm_hash}"
+    retire.assert_awaited_once_with(vm_hash, RetireReason.RECREATE, supervisor=fake_sup)
+    fake_sup.delete_vm.assert_not_awaited()
+    fake_sup.reboot_vm.assert_not_awaited()
+    mock_create_vm.assert_awaited_once_with(
+        vm_hash=vm_hash,
+        supervisor=fake_sup,
+        registry=app["vm_registry"],
+        capacity=app["capacity"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_operator_reinstall_persistent_confidential_rebuilds_from_scratch(aiohttp_client, mocker):
+    """A persistent confidential instance is not reinstalled in place: its
+    rootfs is measured and staged, so it goes delete -> purge -> create,
+    keeping its host ports and its persistent flag."""
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+    content = instance_message.content.model_copy(deep=True)
+    content.environment.trusted_execution = TrustedExecutionEnvironment()
+
+    mocker.patch(
+        "aleph.vm.agent.views.authentication.authenticate_jwk",
+        return_value=instance_message.sender,
+    )
+    mock_create_vm = mocker.patch(
+        "aleph.vm.agent.views.operator.create_vm_execution_or_raise_http_error",
+        new=AsyncMock(),
+    )
+
+    app = setup_webapp(supervisor=_fake_supervisor())
+    app["vm_registry"].record(vm_hash, message=content, original=content, persistent=True)
+    fake_sup = _fake_supervisor()
+    app["supervisor"] = fake_sup
+    retire = mocker.patch("aleph.vm.agent.views.operator.retire_vm", new_callable=AsyncMock)
+    mock_purge = mocker.patch("aleph.vm.agent.views.operator.purge_vm_volumes")
+    mock_staging = mocker.patch("aleph.vm.agent.views.operator.purge_vm_staging")
+    mock_recreate = mocker.patch("aleph.vm.agent.views.operator.recreate_vm_volumes", new=AsyncMock())
+
+    client: TestClient = await aiohttp_client(app)
+    response = await client.post(f"/control/machine/{vm_hash}/reinstall")
+
+    assert response.status == 200
+    fake_sup.stop_vm.assert_not_awaited()
+    mock_recreate.assert_not_awaited()
+    retire.assert_awaited_once_with(vm_hash, RetireReason.RECREATE, supervisor=fake_sup)
+    fake_sup.delete_vm.assert_not_awaited()
+    mock_purge.assert_called_once_with(vm_hash, include_data_volumes=True)
+    mock_staging.assert_called_once_with(vm_hash)
+    mock_create_vm.assert_awaited_once_with(
+        vm_hash=vm_hash,
+        supervisor=fake_sup,
+        registry=app["vm_registry"],
+        capacity=app["capacity"],
+        persistent=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_operator_reinstall_non_persistent_recreates(aiohttp_client, mocker):
+    """Non-persistent record: the VM is deleted, its storage purged, and it is
+    rebuilt through the create path."""
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+
+    mocker.patch(
+        "aleph.vm.agent.views.authentication.authenticate_jwk",
+        return_value=instance_message.sender,
+    )
+
+    mock_create_vm = mocker.patch(
+        "aleph.vm.agent.views.operator.create_vm_execution_or_raise_http_error",
+        new=AsyncMock(),
+    )
+
+    app = setup_webapp(supervisor=_fake_supervisor())
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=False,  # non-persistent
+    )
+    fake_sup = _fake_supervisor()
+    app["supervisor"] = fake_sup
+    retire = mocker.patch("aleph.vm.agent.views.operator.retire_vm", new_callable=AsyncMock)
+    mock_purge = mocker.patch("aleph.vm.agent.views.operator.purge_vm_volumes")
+    mock_staging = mocker.patch("aleph.vm.agent.views.operator.purge_vm_staging")
+
+    client: TestClient = await aiohttp_client(app)
+    response = await client.post(f"/control/machine/{vm_hash}/reinstall")
+
+    assert response.status == 200
+    # A delete+recreate cycle: RECREATE keeps the host ports for the
+    # recreated VM to reload.
+    retire.assert_awaited_once_with(vm_hash, RetireReason.RECREATE, supervisor=fake_sup)
+    fake_sup.delete_vm.assert_not_awaited()
+    mock_purge.assert_called_once_with(vm_hash, include_data_volumes=True)
+    mock_staging.assert_called_once_with(vm_hash)
+    mock_create_vm.assert_awaited_once_with(
+        vm_hash=vm_hash,
+        supervisor=fake_sup,
+        registry=app["vm_registry"],
+        capacity=app["capacity"],
+        persistent=False,
+    )

--- a/tests/supervisor/views/test_operator_retire.py
+++ b/tests/supervisor/views/test_operator_retire.py
@@ -350,6 +350,49 @@ async def test_operator_reboot_non_persistent(aiohttp_client, mocker):
 
 
 @pytest.mark.asyncio
+async def test_operator_reinstall_in_place_runs_under_the_create_guard(aiohttp_client, mocker):
+    """The in-place rebuild is a create path: the reconciler's part sweep
+    spares only namespaces inside creating(), so the rebuild's downloads must
+    run under the guard (the registry record the reinstall keeps does not
+    protect them)."""
+    from aleph.vm.agent.vm.reconciler import is_creating
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+
+    mocker.patch(
+        "aleph.vm.agent.views.authentication.authenticate_jwk",
+        return_value=instance_message.sender,
+    )
+
+    app = setup_webapp(supervisor=_fake_supervisor())
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    fake_sup = _fake_supervisor(VmStatus.RUNNING)
+    app["supervisor"] = fake_sup
+    mocker.patch("aleph.vm.agent.views.operator.purge_vm_volumes", return_value=[])
+    guarded: list[bool] = []
+
+    async def observe(_content, namespace):
+        guarded.append(is_creating(namespace))
+
+    mocker.patch("aleph.vm.agent.views.operator.recreate_vm_volumes", new=AsyncMock(side_effect=observe))
+
+    client: TestClient = await aiohttp_client(app)
+    response = await client.post(f"/control/machine/{vm_hash}/reinstall")
+
+    assert response.status == 200
+    assert guarded == [True]
+    assert not is_creating(str(vm_hash))
+    fake_sup.stop_vm.assert_awaited_once()
+    fake_sup.start_vm.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_operator_reinstall_persistent_confidential_rebuilds_from_scratch(aiohttp_client, mocker):
     """A persistent confidential instance is not reinstalled in place: its
     rootfs is measured and staged, so it goes delete -> purge -> create,


### PR DESCRIPTION
## Summary

PR A of the 2.1 disk reclamation work. The design and implementation plan are not part of the repository; `docs/architecture/storage.md` and `vm-lifecycle.md` (included) are the reference for what the code does and why.

- **One deletion function with a mandatory reason.** `retire_vm(vm_hash, RetireReason)` with `RECREATE` / `GONE` / `ERASE` / `FAILED_CREATE`; every agent delete site (`tasks.py`, `expiry.py`, `run.py`, `views/__init__.py`, `update_watcher.py`, `operator.py`, `migration.py`) converted; a test pins that no agent module except `retire.py` calls `supervisor.delete_vm`. A failed re-create of a VM whose volumes already existed retires `RECREATE` (spec amended): owner data is never wiped by a boot timeout or an admission refusal.
- **Retention policy.** `VOLUME_RETENTION = reap | keep` (default `reap`), `VOLUME_RETENTION_BUDGET` (10% per pool). Under `keep`, a GONE VM's directories get a `.reclaimable` marker (`reclaimable_since`, `reason`, `size_bytes`, `depends_on`, `owner`); reclaimable space counts as free in all three disk figures; a create adopts a retained directory of the same hash; `ERASE` always purges and works from the marker's owner after the record is gone.
- **Reconciler.** `reconcile_storage()` at startup, every `VOLUME_RECONCILE_INTERVAL`, after every GONE and on placement pressure (`storage_pools.set_room_maker`, evicts oldest-first until the create fits, never a live hash). Passes: orphan namespaces (outside `VOLUME_CREATE_GUARD` and the `creating()` guard), `.part` files, side dirs (session, staging, empty `/mnt` mount points via `rmdir` only), retention budget, backup TTL sweep. Live set is the registry union `supervisor.list_vms()`; the startup pass refuses to purge if the supervisor cannot be asked or the registry rehydrated empty while VMs are running. Startup logs a per-pool summary before purging.
- **Transactional creates:** every create path (program, instance, V-PROGRAM, migration import) runs inside `creating()`; the migration import now records the imported VM in the registry.
- Settings: `VOLUME_RETENTION`, `VOLUME_RETENTION_BUDGET`, `VOLUME_RECONCILE_INTERVAL`, `VOLUME_CREATE_GUARD`, `CACHE_BUDGET` (consumed by PR D), `MAX_RUNTIME_ARCHIVE_SIZE` (PR D). Docs: `docs/architecture/storage.md`, `vm-lifecycle.md`.

Follow-up PRs (stacked): B admission from the message, C device-mapper teardown, D cache bounds + in-stream size cap, E `aleph-vm storage` CLI.

## Behaviour changes (upgrade notes)
- **Payment shortfalls now retire `GONE`.** On 1.x an insufficient held balance, credit balance or stream stopped the VM but kept its record and disks for a later top-up (and nothing ever reclaimed them). Now such a VM is retired like a forgotten one: record and ports dropped, volumes purged under the default `VOLUME_RETENTION=reap`, marked reclaimable (with the owner, adopted back on re-create) under `keep`. Operators who want a grace period for re-paying owners set `keep`.
- The first start on an existing node reclaims every leaked directory under `reap`; the log carries a per-pool count and byte total before it does.

## Known limitations (deliberate)
- Orphan markers written by the reconciler carry no owner, so such data can only leave via the budget.
- Erase from a marker cannot honour delegation (the security aggregate needs the message).
- The periodic pass runs with a registry-only live set when the supervisor is unreachable (startup refuses; periodic does not).
- `GONE` under `keep` queues one serialized pass per VM; not coalesced.

## Test plan
- `tests/supervisor`: 1320 passed, 48 pre-existing environment failures (identical set to `dev`).
- New: `test_storage_budget.py`, `test_reclaimable.py`, `test_retire.py`, `test_reconciler.py`, `test_agent_no_direct_delete.py`; extended capacity, resources, operator, run, migration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvDhr5NKq3AY17E1vwV3zk



