### PR TITLE
feat(agent): admit VMs from the message before allocating (2.1, PR B)

### DIFF
--- a/docs/architecture/vm-lifecycle.md
+++ b/docs/architecture/vm-lifecycle.md
@@ -107,35 +107,44 @@ never survives on disk, so there is nothing to reattach to.
 Admission happens in two layers that never overlap in what they check:
 
 - **Agent-side policy** (`src/aleph/vm/agent/capacity.py`,
-  `CapacityManager.check_capacity`) runs before every `create_vm` call, after
-  the spec is built (so a failed download or bundle fetch never consumes
-  capacity). It enforces two-bucket memory accounting: instances (and
-  V-PROGRAMs, which are full SNP VMs admitted against the instance bucket)
-  share `physical - HOST_MEMORY_RESERVED_MIB - PROGRAM_MEMORY_RESERVED_MIB`;
+  `CapacityManager.check_message`) runs once per create, from the message
+  and before any download or allocation, so a host without room refuses
+  before the downloader has written anything. It is the single admission
+  path of every create-path caller in `src/aleph/vm/agent/run.py`
+  (`create_vm_execution`, which covers instances, programs and V-PROGRAMs,
+  and `_ensure_program_vm`, the on-demand program path), of the cold
+  migration import (`src/aleph/vm/agent/migration/runner.py`) and of the
+  `/control/reserve_resources` dry-run endpoint (`operate_reserve_resources`
+  in `src/aleph/vm/agent/views/__init__.py`), which reports capacity ahead
+  of a scheduler placement decision without creating anything. It enforces
+  two-bucket memory accounting: instances (and V-PROGRAMs, which are full
+  SNP VMs admitted against the instance bucket) share
+  `physical - HOST_MEMORY_RESERVED_MIB - PROGRAM_MEMORY_RESERVED_MIB`;
   programs share `PROGRAM_MEMORY_RESERVED_MIB` alone. vCPUs are capped at
-  `physical_cores * VCPU_OVERCOMMIT_FACTOR` across both buckets. Every real
-  create-path caller in `src/aleph/vm/agent/run.py` (`create_vm_execution`,
-  which covers instances, programs and V-PROGRAMs, and `_ensure_program_vm`,
-  the on-demand program path) passes `disk_mib=0` and no `max_volume_mib`,
-  so `check_capacity`'s disk checks no-op on create: disk is not actually
-  gated at create time. `check_capacity` also implements an
-  aggregate-free-space check and a single-largest-volume-fits-the-roomiest-
-  pool check (`_check_max_volume`), but the only caller that exercises them
-  with real figures is the separate `/control/reserve_resources` dry-run
-  endpoint (`operate_reserve_resources` in
-  `src/aleph/vm/agent/views/__init__.py`), which reports capacity ahead of a
-  scheduler placement decision without creating anything. The VM's own
-  early registry record (recorded before the spec build, to make owner-auth
-  answerable during a slow confidential download) is excluded from the
-  committed memory/vCPU sums via `exclude_vm_hash`, or a create would count
-  its own request against itself. GPU admission is a separate reservation
-  ledger (`CapacityManager.holds`, keyed by concrete `pci_host`) with a
-  short-lived hold/resolve two-step: `reserve_gpus` (used by the same
+  `physical_cores * VCPU_OVERCOMMIT_FACTOR` across both buckets. Disk is
+  judged from the sizes the message declares (the instance rootfs and every
+  `size_mib` volume): the total must fit the pools' free space plus what the
+  reclaimer could free, and the single largest volume must fit one pool
+  (`_check_max_volume`). A re-create is not charged for what it already
+  holds: each declared volume is matched to its existing file by name inside
+  `{pool}/{vm_hash}/`, the credit is capped at the declared size, one file
+  discounts at most one volume, and the largest volume's held bytes are
+  credited to the pool holding its file rather than shrinking the
+  requirement. Files that back no declared volume never discount. Since
+  `creating()` adopts a retained directory before admission runs, held
+  bytes are neither counted as reclaimable nor discounted twice. The VM's
+  own early registry record (recorded before the spec build, to make
+  owner-auth answerable during a slow confidential download) is excluded
+  from the committed memory/vCPU sums via `exclude_vm_hash`, or a create
+  would count its own request against itself. GPU admission is a separate
+  reservation ledger (`CapacityManager.holds`, keyed by concrete `pci_host`)
+  with a short-lived hold/resolve two-step: `reserve_gpus` (used by the same
   dry-run endpoint) holds a card for a user for `RESERVATION_TTL_SECONDS`,
-  `resolve_gpus` (called from the create path) consumes the caller's own
-  holds and skips cards held by another user. So create-time admission is,
-  in practice, memory plus vCPUs plus GPU holds; disk admission is a
-  dry-run-only feature of the same `CapacityManager`.
+  `resolve_gpus` (called from the create path after the spec is built)
+  consumes the caller's own holds and skips cards held by another user.
+  `check_capacity` remains underneath as the scalar seam that `simulate`
+  (batch placement advice) uses; it cannot apply the held-volume discount,
+  so an advisory answer is at most more conservative than the enforced one.
 - **Supervisor mechanism backstops** (`check_memory_backstop`,
   `validate_spec_gpus` in `lifecycle.rs`) run under `creation_lock` inside
   `create_vm_inner` itself: committed memory (summed from every tracked

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -15,16 +15,23 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from collections.abc import Collection
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import psutil
 from aleph_message.models import ExecutableContent, ItemHash, VerifiableProgramContent
 from aleph_message.models.execution.instance import InstanceContent
 
 from aleph.vm import storage_pools
-from aleph.vm.agent.vm.reclaimable import directory_size_bytes, reclaimable_bytes
+from aleph.vm.agent.vm.purge import ROOTFS_STEM, _checked_namespace
+from aleph.vm.agent.vm.reclaimable import (
+    MARKER_NAME,
+    file_size_bytes,
+    reclaimable_bytes,
+)
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 from aleph.vm.resources import GpuDevice, InsufficientResourcesError
@@ -78,27 +85,123 @@ def is_instance_bucket(content: ExecutableContent) -> bool:
     return isinstance(content, (InstanceContent, VerifiableProgramContent))
 
 
+@dataclass(frozen=True)
+class DeclaredVolume:
+    """One volume a message asks the node to allocate.
+
+    ``stems`` are the filename stems the volume's file can carry inside
+    ``{pool}/{vm_hash}/``: "rootfs" for the boot disk, the volume's name for
+    an extra persistent volume (see ``purge.ROOTFS_STEM`` and the naming
+    convention it documents). Both spellings of a name are listed because
+    ``storage.get_volume_path`` sanitizes a name that is not already
+    ``[\\w\\-_/]+`` while ``downloader._make_writable_volume`` does not.
+    """
+
+    stems: tuple[str, ...]
+    size_mib: int
+
+
+@dataclass(frozen=True)
+class HeldVolume:
+    """An existing file that already backs a declared volume.
+
+    ``size_bytes`` is what the file allocates on disk, capped at the size the
+    volume declares: a file cannot discount more than the message asks for.
+    """
+
+    path: Path
+    size_bytes: int
+
+    @property
+    def pool_path(self) -> Path:
+        """The pool holding the file (``{pool}/{vm_hash}/{name.ext}``)."""
+        return self.path.parent.parent
+
+
+def _volume_stems(name: str) -> tuple[str, ...]:
+    """The filename stems a declared volume's file can carry on disk."""
+    sanitized = name if re.match(r"^[\w\-_/]+$", name) else re.sub(r"[^\w\-_]", "_", name)
+    return (name,) if sanitized == name else (name, sanitized)
+
+
+def declared_volumes(content: ExecutableContent) -> list[DeclaredVolume]:
+    """The per-VM volumes a message asks the node to allocate.
+
+    Immutable volumes are absent on purpose: they resolve to a shared cache
+    entry, not to a file this VM owns.
+    """
+    volumes: list[DeclaredVolume] = []
+    if isinstance(content, InstanceContent) and content.rootfs:
+        volumes.append(DeclaredVolume(stems=(ROOTFS_STEM,), size_mib=content.rootfs.size_mib))
+    for volume in content.volumes or []:
+        size_mib = getattr(volume, "size_mib", 0) or 0
+        name = getattr(volume, "name", "") or ""
+        volumes.append(DeclaredVolume(stems=_volume_stems(name) if name else (), size_mib=size_mib))
+    return volumes
+
+
 def requirements_from_message(content: ExecutableContent) -> ResourceRequirements:
     """Extract the resources a message requests into a message-free DTO."""
-    is_instance = is_instance_bucket(content)
-    volume_sizes_mib: list[int] = []
-    if isinstance(content, InstanceContent) and content.rootfs:
-        volume_sizes_mib.append(content.rootfs.size_mib)
-    for volume in content.volumes or []:
-        volume_sizes_mib.append(getattr(volume, "size_mib", 0) or 0)
+    volume_sizes_mib = [volume.size_mib for volume in declared_volumes(content)]
     return ResourceRequirements(
         vcpus=content.resources.vcpus,
         memory_mib=content.resources.memory,
         disk_mib=sum(volume_sizes_mib),
         max_volume_mib=max(volume_sizes_mib, default=0),
-        is_instance=is_instance,
+        is_instance=is_instance_bucket(content),
         gpu_device_ids=requested_gpu_ids(content),
     )
 
 
-def allocated_bytes_for(vm_hash: ItemHash | str) -> int:
-    """Bytes already sitting under this VM's directories on every pool."""
-    return sum(directory_size_bytes(directory) for directory in storage_pools.iter_namespace_dirs(str(vm_hash)))
+def existing_volume_files(vm_hash: ItemHash | str) -> dict[str, Path]:
+    """``{stem: path}`` of the VM's existing volume files, on every pool.
+
+    The namespace is validated before it reaches a path join, like every
+    other caller of ``iter_namespace_dirs``: ``pool.path / namespace`` is a
+    bare join, so an unchecked hash lets "../.." resolve and be counted as
+    space the VM already holds, and an inflated discount relaxes admission.
+
+    Symlinks and the marker are skipped, and pools are walked in order with
+    the first match winning, so the result does not depend on iteration luck.
+    """
+    namespace = _checked_namespace(vm_hash)
+    files: dict[str, Path] = {}
+    for directory in storage_pools.iter_namespace_dirs(namespace):
+        try:
+            entries = sorted(directory.iterdir())
+        except OSError:
+            logger.warning("Volume directory %s not readable, not discounting it", directory)
+            continue
+        for entry in entries:
+            if entry.name == MARKER_NAME or entry.is_symlink() or not entry.is_file():
+                continue
+            files.setdefault(entry.stem, entry)
+    return files
+
+
+def held_volumes(vm_hash: ItemHash | str, volumes: list[DeclaredVolume]) -> list[HeldVolume | None]:
+    """What the VM already holds for each declared volume, positionally.
+
+    The discount is per declared volume, never per directory: a file that
+    backs no declared volume (a volume the updated message renamed or
+    dropped, left behind on a node the VM is re-scheduled to) discounts
+    nothing. Summing the directory instead would let such a leftover cancel
+    the space a genuinely new volume still needs, turning the disk check off
+    for exactly the create that needs it.
+
+    Each hit is capped at the size its volume declares, so a file that grew
+    past its declaration cannot credit the difference either.
+    """
+    existing = existing_volume_files(vm_hash)
+    held: list[HeldVolume | None] = []
+    for volume in volumes:
+        path = next((existing[stem] for stem in volume.stems if stem in existing), None)
+        if path is None:
+            held.append(None)
+            continue
+        size_bytes = min(file_size_bytes(path), volume.size_mib * 1024 * 1024)
+        held.append(HeldVolume(path=path, size_bytes=size_bytes))
+    return held
 
 
 def requested_gpu_ids(content: ExecutableContent) -> list[str]:
@@ -143,28 +246,36 @@ class CapacityManager:
         written the volumes. Judging disk after the build would measure space
         this very VM has just taken, which is why there is no second check.
 
-        What the VM already holds on disk is subtracted, so an existing VM is
-        never refused for space it already occupies. This matters for a
-        RECREATE and for an adoption: ``creating()`` adopts the retained
-        directory on entry, which drops its ``.reclaimable`` marker, so those
-        bytes stop counting as free in ``_available_disk_bytes`` at the very
-        moment the VM asks for them again.
+        What the VM already holds for each volume the message declares is
+        subtracted, so an existing VM is never refused for space it already
+        occupies. This matters for a RECREATE and for an adoption:
+        ``creating()`` adopts the retained directory on entry, which drops its
+        ``.reclaimable`` marker, so those bytes stop counting as free in
+        ``_available_disk_bytes`` at the very moment the VM asks for them
+        again.
+
+        The discount is matched volume by volume (see ``held_volumes``), never
+        summed over the directory: a leftover file from a volume the message
+        no longer declares must not pay for a new one.
         """
+        volumes = declared_volumes(content)
+        held = held_volumes(exclude_vm_hash, volumes) if exclude_vm_hash is not None else [None] * len(volumes)
+        declared_mib = sum(volume.size_mib for volume in volumes)
+        held_mib = sum(hit.size_bytes for hit in held if hit is not None) // (1024 * 1024)
+        # The largest declared volume decides the per-pool check, and it is
+        # judged at its declared size: shrinking that figure by what is held
+        # elsewhere would let a discount from one volume excuse the placement
+        # of another. What the VM already holds *for that volume* is instead
+        # credited to the pool its file sits on, which is the only pool that
+        # would have to find room for it again.
+        largest = max(range(len(volumes)), key=lambda index: volumes[index].size_mib, default=None)
         requirements = requirements_from_message(content)
-        held_mib = allocated_bytes_for(exclude_vm_hash) // (1024 * 1024) if exclude_vm_hash is not None else 0
-        disk_mib = max(requirements.disk_mib - held_mib, 0)
-        # The largest-single-volume check is per pool, and it needs the same
-        # discount: a volume the VM already holds is already placed, so no
-        # pool has to find room for it. Capping the figure at what is still to
-        # be allocated is the discount that needs no per-volume bookkeeping,
-        # and it is exact in the two cases that matter: nothing held (the cap
-        # never binds) and everything held (nothing left to place).
-        max_volume_mib = min(requirements.max_volume_mib, disk_mib)
         self.check_capacity(
             memory_mib=requirements.memory_mib,
             vcpus=requirements.vcpus,
-            disk_mib=disk_mib,
-            max_volume_mib=max_volume_mib,
+            disk_mib=max(declared_mib - held_mib, 0),
+            max_volume_mib=volumes[largest].size_mib if largest is not None else 0,
+            max_volume_credit=held[largest] if largest is not None else None,
             is_instance=requirements.is_instance,
             exclude_vm_hash=exclude_vm_hash,
         )
@@ -176,6 +287,7 @@ class CapacityManager:
         vcpus: int,
         disk_mib: int,
         max_volume_mib: int = 0,
+        max_volume_credit: HeldVolume | None = None,
         is_instance: bool,
         exclude_vm_hash: ItemHash | None = None,
     ) -> None:
@@ -187,6 +299,10 @@ class CapacityManager:
         physical cores times VCPU_OVERCOMMIT_FACTOR. Disk is only checked for
         disk_mib > 0, so a caller with nothing left to allocate (a recreate
         whose volumes are all on disk already) skips it.
+
+        ``max_volume_credit`` is the file already backing the largest declared
+        volume, if any: see ``_check_max_volume``, which credits it to the one
+        pool that holds it.
 
         Callers that hold a message should go through ``check_message``, which
         derives every figure here from it; the scalars are the seam for the
@@ -205,6 +321,7 @@ class CapacityManager:
             vcpus=vcpus,
             disk_mib=disk_mib,
             max_volume_mib=max_volume_mib,
+            max_volume_credit=max_volume_credit,
             is_instance=is_instance,
             committed_instance_memory_mib=committed_instance_memory_mib,
             committed_program_memory_mib=committed_program_memory_mib,
@@ -220,6 +337,7 @@ class CapacityManager:
         max_volume_mib: int,
         is_instance: bool,
         committed_instance_memory_mib: int,
+        max_volume_credit: HeldVolume | None = None,
         committed_program_memory_mib: int,
         committed_vcpus: int,
         committed_disk_mib: int = 0,
@@ -286,7 +404,7 @@ class CapacityManager:
         if required_disk_mib > 0 and required_disk_mib > available_disk_mib:
             errors.append(f"Disk: required {required_disk_mib} MiB, " f"available {available_disk_mib} MiB")
 
-        max_volume_error = self._check_max_volume(max_volume_mib)
+        max_volume_error = self._check_max_volume(max_volume_mib, max_volume_credit)
         if max_volume_error:
             errors.append(max_volume_error)
 
@@ -506,7 +624,7 @@ class CapacityManager:
         return committed_instance_memory_mib, committed_program_memory_mib, committed_vcpus
 
     @staticmethod
-    def _check_max_volume(max_volume_mib: int) -> str | None:
+    def _check_max_volume(max_volume_mib: int, credit: HeldVolume | None = None) -> str | None:
         """None when ``max_volume_mib`` fits the roomiest eligible pool, else
         an error string describing the shortfall. No pool holds a volume
         split across disks, so this catches a request the aggregate free
@@ -515,11 +633,25 @@ class CapacityManager:
         A pool's room is its free bytes plus the reclaimable bytes it holds,
         for the same reason the aggregate figure counts them: placement
         evicts that pool's retained directories before it refuses the volume.
+
+        ``credit`` is the file that already backs this very volume, if there
+        is one. Its bytes are added to the room of the one pool that holds it
+        and to no other: that pool does not have to find the space again,
+        while a pool that has never seen this volume still has to fit it whole.
+        Crediting it globally (by shrinking ``max_volume_mib``) would instead
+        excuse every pool, which is how a stale file could switch this check
+        off entirely.
         """
         if max_volume_mib <= 0:
             return None
+        credited_pool = credit.pool_path if credit is not None else None
         roomiest_bytes = max(
-            (free + reclaimable_bytes(pool.path) for pool, free in storage_pools.eligible_pool_free_bytes()),
+            (
+                free
+                + reclaimable_bytes(pool.path)
+                + (credit.size_bytes if credit is not None and pool.path == credited_pool else 0)
+                for pool, free in storage_pools.eligible_pool_free_bytes()
+            ),
             default=0,
         )
         roomiest_mib = roomiest_bytes // (1024 * 1024)

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -60,6 +60,16 @@ class ResourceRequirements:
     gpu_device_ids: list[str] = field(default_factory=list)
 
 
+# The filename suffixes a volume's file carries in ``{pool}/{vm_hash}/``. A
+# QEMU boot disk is the qcow2 ``downloader._make_writable_volume`` creates; a
+# Firecracker one is the ``.btrfs`` device-mapper base of
+# ``storage.create_devmapper``. An extra persistent volume is an ``.ext4``
+# (``storage.get_volume_path``), a ``.btrfs`` when it has a parent, or a qcow2
+# when it goes through the writable-volume path.
+BOOT_DISK_SUFFIXES = (".qcow2", ".btrfs")
+VOLUME_SUFFIXES = (".ext4", ".btrfs", ".qcow2")
+
+
 @dataclass(frozen=True)
 class AdmissionVerdict:
     """One candidate's admission answer.
@@ -89,15 +99,20 @@ def is_instance_bucket(content: ExecutableContent) -> bool:
 class DeclaredVolume:
     """One volume a message asks the node to allocate.
 
-    ``stems`` are the filename stems the volume's file can carry inside
-    ``{pool}/{vm_hash}/``: "rootfs" for the boot disk, the volume's name for
-    an extra persistent volume (see ``purge.ROOTFS_STEM`` and the naming
-    convention it documents). Both spellings of a name are listed because
-    ``storage.get_volume_path`` sanitizes a name that is not already
-    ``[\\w\\-_/]+`` while ``downloader._make_writable_volume`` does not.
+    ``filenames`` are the names the volume's file can carry inside
+    ``{pool}/{vm_hash}/``: a stem ("rootfs" for the boot disk, the volume's
+    name for an extra persistent volume, see ``purge.ROOTFS_STEM`` and the
+    naming convention it documents) joined to each suffix that kind of volume
+    can take. The suffix is part of the match because a stem alone is not
+    unique: ``rootfs.qcow2`` and ``rootfs.ext4`` can sit side by side in one
+    directory and belong to different volumes.
+
+    Both spellings of a name are listed because ``storage.get_volume_path``
+    sanitizes a name that is not already ``[\\w\\-_/]+`` while
+    ``downloader._make_writable_volume`` does not.
     """
 
-    stems: tuple[str, ...]
+    filenames: tuple[str, ...]
     size_mib: int
 
 
@@ -124,25 +139,51 @@ def _volume_stems(name: str) -> tuple[str, ...]:
     return (name,) if sanitized == name else (name, sanitized)
 
 
+def _volume_filenames(stems: tuple[str, ...], suffixes: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(f"{stem}{suffix}" for stem in stems for suffix in suffixes)
+
+
 def declared_volumes(content: ExecutableContent) -> list[DeclaredVolume]:
     """The per-VM volumes a message asks the node to allocate.
 
-    Immutable volumes are absent on purpose: they resolve to a shared cache
-    entry, not to a file this VM owns.
+    Every entry of ``content.volumes`` is listed, in message order, plus the
+    boot disk of an instance. A volume that owns no file in the VM's directory
+    carries no filenames and so can never discount anything: an immutable
+    volume resolves to a shared cache entry rather than to a file this VM
+    owns, and it declares no size either, so it adds nothing to the total.
+
+    A persistent volume named "rootfs" does not claim the "rootfs" stem when
+    the message also declares a boot disk: that stem belongs to the boot disk,
+    and letting both claim it would discount one file twice.
     """
     volumes: list[DeclaredVolume] = []
-    if isinstance(content, InstanceContent) and content.rootfs:
-        volumes.append(DeclaredVolume(stems=(ROOTFS_STEM,), size_mib=content.rootfs.size_mib))
+    boot_disk = content.rootfs if isinstance(content, InstanceContent) else None
+    if boot_disk:
+        volumes.append(
+            DeclaredVolume(
+                filenames=_volume_filenames((ROOTFS_STEM,), BOOT_DISK_SUFFIXES),
+                size_mib=boot_disk.size_mib,
+            )
+        )
     for volume in content.volumes or []:
         size_mib = getattr(volume, "size_mib", 0) or 0
         name = getattr(volume, "name", "") or ""
-        volumes.append(DeclaredVolume(stems=_volume_stems(name) if name else (), size_mib=size_mib))
+        stems = _volume_stems(name) if name else ()
+        if boot_disk:
+            stems = tuple(stem for stem in stems if stem != ROOTFS_STEM)
+        volumes.append(DeclaredVolume(filenames=_volume_filenames(stems, VOLUME_SUFFIXES), size_mib=size_mib))
     return volumes
 
 
-def requirements_from_message(content: ExecutableContent) -> ResourceRequirements:
-    """Extract the resources a message requests into a message-free DTO."""
-    volume_sizes_mib = [volume.size_mib for volume in declared_volumes(content)]
+def requirements_from_message(
+    content: ExecutableContent, volumes: list[DeclaredVolume] | None = None
+) -> ResourceRequirements:
+    """Extract the resources a message requests into a message-free DTO.
+
+    ``volumes`` is ``declared_volumes(content)``, which a caller that already
+    has that list (``check_message``) passes in rather than deriving it twice.
+    """
+    volume_sizes_mib = [volume.size_mib for volume in (declared_volumes(content) if volumes is None else volumes)]
     return ResourceRequirements(
         vcpus=content.resources.vcpus,
         memory_mib=content.resources.memory,
@@ -154,7 +195,11 @@ def requirements_from_message(content: ExecutableContent) -> ResourceRequirement
 
 
 def existing_volume_files(vm_hash: ItemHash | str) -> dict[str, Path]:
-    """``{stem: path}`` of the VM's existing volume files, on every pool.
+    """``{filename: path}`` of the VM's existing volume files, on every pool.
+
+    Keyed by the whole name, suffix included: ``rootfs.qcow2`` and
+    ``rootfs.ext4`` share a stem but are two different volumes, and keying by
+    stem would let one shadow the other and be credited in its place.
 
     The namespace is validated before it reaches a path join, like every
     other caller of ``iter_namespace_dirs``: ``pool.path / namespace`` is a
@@ -175,7 +220,7 @@ def existing_volume_files(vm_hash: ItemHash | str) -> dict[str, Path]:
         for entry in entries:
             if entry.name == MARKER_NAME or entry.is_symlink() or not entry.is_file():
                 continue
-            files.setdefault(entry.stem, entry)
+            files.setdefault(entry.name, entry)
     return files
 
 
@@ -189,16 +234,22 @@ def held_volumes(vm_hash: ItemHash | str, volumes: list[DeclaredVolume]) -> list
     the space a genuinely new volume still needs, turning the disk check off
     for exactly the create that needs it.
 
+    A matched file is consumed, so one file discounts at most one volume.
+    Two declared volumes can name the same file (two spellings of one name,
+    one of which storage sanitizes into the other), and a file the node holds
+    once cannot pay for two volumes it is about to allocate.
+
     Each hit is capped at the size its volume declares, so a file that grew
     past its declaration cannot credit the difference either.
     """
     existing = existing_volume_files(vm_hash)
     held: list[HeldVolume | None] = []
     for volume in volumes:
-        path = next((existing[stem] for stem in volume.stems if stem in existing), None)
-        if path is None:
+        filename = next((name for name in volume.filenames if name in existing), None)
+        if filename is None:
             held.append(None)
             continue
+        path = existing.pop(filename)
         size_bytes = min(file_size_bytes(path), volume.size_mib * 1024 * 1024)
         held.append(HeldVolume(path=path, size_bytes=size_bytes))
     return held
@@ -256,7 +307,8 @@ class CapacityManager:
 
         The discount is matched volume by volume (see ``held_volumes``), never
         summed over the directory: a leftover file from a volume the message
-        no longer declares must not pay for a new one.
+        no longer declares must not pay for a new one, and a file that backs
+        one declared volume must not pay for a second one too.
         """
         volumes = declared_volumes(content)
         held = held_volumes(exclude_vm_hash, volumes) if exclude_vm_hash is not None else [None] * len(volumes)
@@ -269,7 +321,7 @@ class CapacityManager:
         # credited to the pool its file sits on, which is the only pool that
         # would have to find room for it again.
         largest = max(range(len(volumes)), key=lambda index: volumes[index].size_mib, default=None)
-        requirements = requirements_from_message(content)
+        requirements = requirements_from_message(content, volumes)
         self.check_capacity(
             memory_mib=requirements.memory_mib,
             vcpus=requirements.vcpus,

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -122,6 +122,13 @@ class HeldVolume:
 
     ``size_bytes`` is what the file allocates on disk, capped at the size the
     volume declares: a file cannot discount more than the message asks for.
+
+    Allocated bytes, not the declared size, on purpose. Admission demands
+    room for a volume to grow to what it declares, and a fresh create is
+    charged that in full even though its new file starts sparse. Charging a
+    recreate the declared size minus what its file already occupies is the
+    same rule, not a stricter one; crediting the declared size instead would
+    admit a VM whose disk has nowhere left to grow.
     """
 
     path: Path
@@ -241,6 +248,15 @@ def held_volumes(vm_hash: ItemHash | str, volumes: list[DeclaredVolume]) -> list
 
     Each hit is capped at the size its volume declares, so a file that grew
     past its declaration cannot credit the difference either.
+
+    One residual case is matched on purpose: a volume matches its stem under
+    every suffix its kind can take, so a file left in another format (a
+    ``data.qcow2`` where this node now allocates ``data.ext4``, after a
+    hypervisor-default or storage-layer change) discounts a volume the
+    create will allocate afresh. The relaxation is bounded by that volume's
+    declared size, and placement checks real free space at allocation, so
+    such a create fails late rather than over-committing. Deriving the one
+    exact filename belongs with the storage layer's naming, not here.
     """
     existing = existing_volume_files(vm_hash)
     held: list[HeldVolume | None] = []

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -24,7 +24,7 @@ from aleph_message.models import ExecutableContent, ItemHash, VerifiableProgramC
 from aleph_message.models.execution.instance import InstanceContent
 
 from aleph.vm import storage_pools
-from aleph.vm.agent.vm.reclaimable import reclaimable_bytes
+from aleph.vm.agent.vm.reclaimable import directory_size_bytes, reclaimable_bytes
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 from aleph.vm.resources import GpuDevice, InsufficientResourcesError
@@ -96,6 +96,11 @@ def requirements_from_message(content: ExecutableContent) -> ResourceRequirement
     )
 
 
+def allocated_bytes_for(vm_hash: ItemHash | str) -> int:
+    """Bytes already sitting under this VM's directories on every pool."""
+    return sum(directory_size_bytes(directory) for directory in storage_pools.iter_namespace_dirs(str(vm_hash)))
+
+
 def requested_gpu_ids(content: ExecutableContent) -> list[str]:
     """The vendor:device ids of the GPUs a message requests."""
     requested = content.requirements.gpu if content.requirements and content.requirements.gpu else []
@@ -129,6 +134,41 @@ class CapacityManager:
         self.holds: dict[str, GpuHold] = {}
         self._lock = asyncio.Lock()
 
+    def check_message(self, content: ExecutableContent, *, exclude_vm_hash: ItemHash | None = None) -> None:
+        """Admission from the message alone, before a byte is allocated.
+
+        The single admission path of every create path: the sizes come from
+        the message (rootfs and volume ``size_mib``), so a host with no room
+        refuses before the downloader runs rather than after it has already
+        written the volumes. Judging disk after the build would measure space
+        this very VM has just taken, which is why there is no second check.
+
+        What the VM already holds on disk is subtracted, so an existing VM is
+        never refused for space it already occupies. This matters for a
+        RECREATE and for an adoption: ``creating()`` adopts the retained
+        directory on entry, which drops its ``.reclaimable`` marker, so those
+        bytes stop counting as free in ``_available_disk_bytes`` at the very
+        moment the VM asks for them again.
+        """
+        requirements = requirements_from_message(content)
+        held_mib = allocated_bytes_for(exclude_vm_hash) // (1024 * 1024) if exclude_vm_hash is not None else 0
+        disk_mib = max(requirements.disk_mib - held_mib, 0)
+        # The largest-single-volume check is per pool, and it needs the same
+        # discount: a volume the VM already holds is already placed, so no
+        # pool has to find room for it. Capping the figure at what is still to
+        # be allocated is the discount that needs no per-volume bookkeeping,
+        # and it is exact in the two cases that matter: nothing held (the cap
+        # never binds) and everything held (nothing left to place).
+        max_volume_mib = min(requirements.max_volume_mib, disk_mib)
+        self.check_capacity(
+            memory_mib=requirements.memory_mib,
+            vcpus=requirements.vcpus,
+            disk_mib=disk_mib,
+            max_volume_mib=max_volume_mib,
+            is_instance=requirements.is_instance,
+            exclude_vm_hash=exclude_vm_hash,
+        )
+
     def check_capacity(
         self,
         *,
@@ -144,10 +184,13 @@ class CapacityManager:
         Two-bucket memory accounting: instances share
         physical - HOST_MEMORY_RESERVED_MIB - PROGRAM_MEMORY_RESERVED_MIB,
         programs share PROGRAM_MEMORY_RESERVED_MIB. vCPUs are capped at
-        physical cores times VCPU_OVERCOMMIT_FACTOR. Disk is checked whenever
-        disk_mib > 0: the create paths pass the message's volume total when
-        they admit a VM, and 0 in the re-checks they run once the images are
-        downloaded, which are about the images rather than the volumes.
+        physical cores times VCPU_OVERCOMMIT_FACTOR. Disk is only checked for
+        disk_mib > 0, so a caller with nothing left to allocate (a recreate
+        whose volumes are all on disk already) skips it.
+
+        Callers that hold a message should go through ``check_message``, which
+        derives every figure here from it; the scalars are the seam for the
+        paths that build a request themselves (the migration import).
 
         ``exclude_vm_hash`` skips that VM's own registry record from the
         committed sums: the create paths record the VM before admission (the

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -372,9 +372,9 @@ class CapacityManager:
         volume, if any: see ``_check_max_volume``, which credits it to the one
         pool that holds it.
 
-        Callers that hold a message should go through ``check_message``, which
-        derives every figure here from it; the scalars are the seam for the
-        paths that build a request themselves (the migration import).
+        Callers that hold a message go through ``check_message``, which
+        derives every figure here from it; the scalars are the seam for
+        ``simulate`` and for a caller that builds a request itself.
 
         ``exclude_vm_hash`` skips that VM's own registry record from the
         committed sums: the create paths record the VM before admission (the

--- a/src/aleph/vm/agent/migration/runner.py
+++ b/src/aleph/vm/agent/migration/runner.py
@@ -280,6 +280,15 @@ async def run_import(
                     msg = "Migration not supported for confidential VMs"
                     raise RuntimeError(msg)
 
+                # The same single admission path as the create paths, from the
+                # message and before any transfer: memory, vCPUs and the
+                # declared disk sizes are judged now, so a destination without
+                # room refuses before it streams an overlay it would then
+                # discard. A retried import is not charged for overlays already
+                # staged under its hash. GPU requests are resolved to concrete
+                # host cards after the build, as on a normal create.
+                capacity.check_message(message.content, exclude_vm_hash=job.vm_hash)
+
                 job.current_step = "downloading_parent"
                 parent_ref = message.content.rootfs.parent.ref
                 parent_path = await get_rootfs_base_path(parent_ref)
@@ -343,16 +352,9 @@ async def run_import(
                 # recreating it, so create_vm reuses the staged disk (no
                 # re-download).
                 spec = await build_create_vm_spec(job.vm_hash, message.content)
-                # Same agent-side admission as the normal create: bucket from the
-                # message type, GPU requests resolved to concrete host cards on
-                # this destination (owner = message.address).
-                capacity.check_capacity(
-                    memory_mib=message.content.resources.memory,
-                    vcpus=message.content.resources.vcpus,
-                    disk_mib=0,
-                    is_instance=True,
-                    exclude_vm_hash=job.vm_hash,
-                )
+                # GPU requests resolved to concrete host cards on this
+                # destination (owner = message.address), admission itself ran
+                # before the download.
                 requested_gpus = requested_gpu_ids(message.content)
                 if requested_gpus:
                     resolved_gpus = await capacity.resolve_gpus(requested_gpus, owner=message.content.address)

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -14,7 +14,6 @@ from aiohttp.web_exceptions import (
     HTTPServiceUnavailable,
 )
 from aleph_message.models import (
-    ExecutableContent,
     InstanceContent,
     ItemHash,
     ProgramContent,
@@ -24,12 +23,7 @@ from msgpack import UnpackValueError
 from multidict import CIMultiDict
 
 from aleph.vm.agent.aggregate import get_user_settings
-from aleph.vm.agent.capacity import (
-    CapacityManager,
-    is_instance_bucket,
-    requested_gpu_ids,
-    requirements_from_message,
-)
+from aleph.vm.agent.capacity import CapacityManager, requested_gpu_ids
 from aleph.vm.agent.expiry import ExpiryManager
 from aleph.vm.agent.snp_instance_launch import (
     build_snp_instance_spec,
@@ -428,25 +422,6 @@ async def _wait_until_gone(
         await asyncio.sleep(interval)
 
 
-def _admit(capacity: CapacityManager, content: ExecutableContent, vm_hash: ItemHash) -> None:
-    """Agent-side admission, ahead of any download.
-
-    Disk is judged here and only here: build_*_spec downloads the resources and
-    creates the volume files, so a disk check after it would measure space this
-    VM has already taken. Refusing here also means a host with no room never
-    pays for the download.
-    """
-    requirements = requirements_from_message(content)
-    capacity.check_capacity(
-        memory_mib=requirements.memory_mib,
-        vcpus=requirements.vcpus,
-        disk_mib=requirements.disk_mib,
-        max_volume_mib=requirements.max_volume_mib,
-        is_instance=requirements.is_instance,
-        exclude_vm_hash=vm_hash,
-    )
-
-
 async def _retire_after_create_failure(
     vm_hash: ItemHash,
     *,
@@ -473,8 +448,8 @@ async def _retire_after_create_failure(
     running, and it counts in CapacityManager's committed memory and vCPU
     sums (see ``_committed_resources``) until the next allocation cycle
     replaces or retires it. It never blocks the retry of its own create,
-    which admits through ``_admit`` with ``exclude_vm_hash`` set, but it does
-    hold capacity against other VMs in the meantime. Straightening that out
+    which admits through ``check_message`` with ``exclude_vm_hash`` set, but
+    it does hold capacity against other VMs in the meantime. Straightening that out
     means a record lifecycle that separates "allocated" from "running",
     which is not this work.
 
@@ -523,19 +498,12 @@ async def create_vm_execution(
         # create guard: it adopts any retained volumes for this hash and keeps
         # the storage reconciler off a VM that is still being built.
         with creating(str(vm_hash)):
-            _admit(capacity, content, vm_hash)
+            capacity.check_message(content, exclude_vm_hash=vm_hash)
             # Snapshot before any allocation: a persistent program's volumes may
             # already exist (host persistence), and a failed create must not
             # wipe them (see _retire_after_create_failure).
             had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
             spec, _resources = await build_program_create_vm_spec(vm_hash, content)
-            capacity.check_capacity(
-                memory_mib=content.resources.memory,
-                vcpus=content.resources.vcpus,
-                disk_mib=0,
-                is_instance=is_instance_bucket(content),
-                exclude_vm_hash=vm_hash,
-            )
             info = await supervisor.create_vm(spec)
             record = registry.record(
                 vm_hash, message=content, original=original_message.content, persistent=bool(content.on.persistent)
@@ -578,7 +546,7 @@ async def create_vm_execution(
             # they cover the same create attempt.
             had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
             try:
-                _admit(capacity, content, vm_hash)
+                capacity.check_message(content, exclude_vm_hash=vm_hash)
                 if snp_instance:
                     # SEV-SNP confidential instances build through the dedicated
                     # LUKS-rootfs SNP launch path, not build_create_vm_spec (which
@@ -592,19 +560,11 @@ async def create_vm_execution(
                     spec, attest_port = await build_snp_instance_spec(vm_hash, content, str(message.sender))
                 else:
                     spec = await build_create_vm_spec(vm_hash, content)
-                # Agent-side admission, after the download so a failed download
-                # never consumes a GPU hold: bucket from the message type, then
-                # resolve the requested device_ids to concrete host cards (owner =
-                # message.address, consuming this owner's own holds). This VM's
-                # own registry record (the early owner record above) is excluded
-                # from the committed sums.
-                capacity.check_capacity(
-                    memory_mib=content.resources.memory,
-                    vcpus=content.resources.vcpus,
-                    disk_mib=0,
-                    is_instance=is_instance_bucket(content),
-                    exclude_vm_hash=vm_hash,
-                )
+                # GPU holds are still taken after the download, so a failed
+                # download never consumes one: the requested device_ids are
+                # resolved to concrete host cards here (owner = message.address,
+                # consuming this owner's own holds). Disk, memory and vCPUs were
+                # judged before the download, by check_message above.
                 if not snp_instance:
                     # GPU resolution only applies to the legacy spec path: SNP
                     # instances are rejected above before reaching here.
@@ -673,17 +633,8 @@ async def create_vm_execution(
             # create attempt.
             had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
             try:
-                _admit(capacity, content, vm_hash)
+                capacity.check_message(content, exclude_vm_hash=vm_hash)
                 spec, attest_port = await build_vprogram_spec(vm_hash, content)
-                # Agent-side admission after the download, like the instance path:
-                # a failed bundle fetch never consumes capacity.
-                capacity.check_capacity(
-                    memory_mib=content.resources.memory,
-                    vcpus=content.resources.vcpus,
-                    disk_mib=0,
-                    is_instance=is_instance_bucket(content),
-                    exclude_vm_hash=vm_hash,
-                )
                 info = await supervisor.create_vm(spec)
             except Exception:
                 # build or create failed: retire the early record, and drop any
@@ -870,18 +821,12 @@ async def _ensure_program_vm(
             # the create guard: it adopts any retained volumes for this hash
             # and keeps the storage reconciler off a VM still being built.
             with creating(str(vm_hash)):
+                capacity.check_message(content, exclude_vm_hash=vm_hash)
                 # Snapshot before any allocation: a persistent program's volumes
                 # may already exist (host persistence, or the recreate just
                 # above), and a failed create must not wipe them.
                 had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
                 spec, resources = await build_program_create_vm_spec(vm_hash, content)
-                capacity.check_capacity(
-                    memory_mib=content.resources.memory,
-                    vcpus=content.resources.vcpus,
-                    disk_mib=0,
-                    is_instance=is_instance_bucket(content),
-                    exclude_vm_hash=vm_hash,
-                )
                 await supervisor.create_vm(spec)
                 record = registry.record(
                     vm_hash, message=content, original=original, persistent=bool(content.on.persistent)

--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -829,8 +829,8 @@ async def notify_allocation(request: web.Request):
     update_watcher = request.app["update_watcher"]
 
     # Capacity admission is not checked here: the create path runs the
-    # agent-side policy (CapacityManager.check_capacity) before create_vm,
-    # raising the typed InsufficientResourcesError. The
+    # agent-side policy (CapacityManager.check_message) before it downloads a
+    # byte, raising the typed InsufficientResourcesError. The
     # vm_creation_exceptions / 503 path below surfaces that error to the
     # caller.
 

--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -23,7 +23,7 @@ from aleph.vm import haproxy
 from aleph.vm.agent import payment, status
 from aleph.vm.agent.aggregate import update_aggregate_settings
 from aleph.vm.agent.allocation.teardown import is_removable_by_allocation, teardown_vm
-from aleph.vm.agent.capacity import CapacityManager, requirements_from_message
+from aleph.vm.agent.capacity import CapacityManager, requested_gpu_ids
 from aleph.vm.agent.custom_logs import set_vm_for_logging
 from aleph.vm.agent.haproxy_sync import sync_domain_mappings
 from aleph.vm.agent.messages import try_get_message
@@ -1006,16 +1006,11 @@ async def operate_reserve_resources(request: web.Request, authenticated_sender: 
     # (refuse here rather than let the client pay and be rejected at create),
     # then the agent's own ledger holds the requested GPUs. The supervisor is
     # only consulted for its GPU inventory.
-    requirements = requirements_from_message(message)
     try:
-        capacity.check_capacity(
-            memory_mib=requirements.memory_mib,
-            vcpus=requirements.vcpus,
-            disk_mib=requirements.disk_mib,
-            max_volume_mib=requirements.max_volume_mib,
-            is_instance=requirements.is_instance,
-        )
-        expiration_date = await capacity.reserve_gpus(requirements.gpu_device_ids, authenticated_sender)
+        # The same message-driven admission the create paths run, with no VM
+        # hash to discount: nothing is allocated for this message yet.
+        capacity.check_message(message)
+        expiration_date = await capacity.reserve_gpus(requested_gpu_ids(message), authenticated_sender)
     except InsufficientResourcesError as error:
         logger.warning("Refusing resource reservation: %s", error)
         return web.HTTPServiceUnavailable(

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -73,28 +73,36 @@ class ReclaimableMarker:
         )
 
 
+def file_size_bytes(path: Path) -> int:
+    """Allocated bytes of one regular file, 0 for anything else.
+
+    Uses st_blocks so a sparse qcow2 counts what it really occupies rather
+    than its virtual size. A symlink counts 0: what it points at is not this
+    directory's space, and counting it would let a link inflate any figure
+    derived from here (a reclaim estimate, an admission discount).
+
+    The single definition of "how much disk does this file actually hold" for
+    the agent: everything that measures a VM's storage goes through here or
+    through ``directory_size_bytes``."""
+    try:
+        st = path.lstat()
+    except OSError:
+        return 0
+    if path.is_symlink() or not path.is_file():
+        return 0
+    return st.st_blocks * 512
+
+
 def directory_size_bytes(directory: Path) -> int:
     """Allocated bytes of the regular files directly inside ``directory``.
 
-    Uses st_blocks so a sparse qcow2 counts what it really occupies. The
-    marker itself is excluded, so the recorded size_bytes does not shift
+    The marker itself is excluded, so the recorded size_bytes does not shift
     depending on whether the marker already exists when this runs."""
-    total = 0
     try:
         entries = list(directory.iterdir())
     except OSError:
         return 0
-    for entry in entries:
-        if entry.name == MARKER_NAME:
-            continue
-        try:
-            st = entry.lstat()
-        except OSError:
-            continue
-        if not entry.is_file() or entry.is_symlink():
-            continue
-        total += st.st_blocks * 512
-    return total
+    return sum(file_size_bytes(entry) for entry in entries if entry.name != MARKER_NAME)
 
 
 def read_marker(namespace_dir: Path) -> ReclaimableMarker | None:

--- a/tests/migration/test_runner.py
+++ b/tests/migration/test_runner.py
@@ -22,10 +22,14 @@ from aleph.vm.supervisor_interface.errors import VmNotFoundError
 
 
 def _fake_capacity():
-    """Agent-side admission stub: capacity always passes, no GPUs requested."""
+    """Agent-side admission stub: capacity always passes, no GPUs requested.
+
+    Only ``check_message`` is exposed: the import admits from the message
+    like every create path, and a reintroduced direct ``check_capacity`` call
+    fails loudly here rather than silently skipping disk admission."""
     from types import SimpleNamespace
 
-    return SimpleNamespace(check_capacity=MagicMock(), resolve_gpus=AsyncMock(return_value=[]))
+    return SimpleNamespace(check_message=MagicMock(), resolve_gpus=AsyncMock(return_value=[]))
 
 
 @pytest.fixture(autouse=True)
@@ -894,3 +898,56 @@ async def test_a_failure_after_create_vm_retires_the_half_imported_vm(
 
     assert job.state == MigrationState.IMPORT_FAILED
     retire.assert_awaited_once_with(vm_hash, RetireReason.FAILED_CREATE, supervisor=supervisor, registry=registry)
+
+
+@pytest.mark.asyncio
+async def test_import_admits_from_the_message_before_any_download(tmp_path, monkeypatch):
+    """The import admits like every create path: from the message, before a
+    byte of the overlay is streamed. A destination without room refuses
+    before the transfer, so nothing is staged and nothing needs cleaning."""
+    from aleph.vm.agent.migration.jobs import DiskFileInfo, ImportJob
+    from aleph.vm.agent.migration.runner import run_import
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    monkeypatch.setattr(settings, "PERSISTENT_VOLUMES_DIR", tmp_path)
+    monkeypatch.setattr(settings, "INSTANCE_DEFAULT_HYPERVISOR", HypervisorType.qemu)
+
+    fake_message = MagicMock()
+    fake_message.type = MessageType.instance
+    fake_message.content.environment.hypervisor = HypervisorType.qemu
+    fake_message.content.environment.trusted_execution = None
+    fake_message.content.rootfs.parent.ref = "parentref"
+
+    download = AsyncMock()
+    monkeypatch.setattr(
+        "aleph.vm.agent.migration.runner.load_updated_message",
+        AsyncMock(return_value=(fake_message, fake_message)),
+    )
+    get_parent = AsyncMock(return_value=tmp_path / "parent.qcow2")
+    monkeypatch.setattr("aleph.vm.agent.migration.runner.get_rootfs_base_path", get_parent)
+    monkeypatch.setattr("aleph.vm.agent.migration.runner.download_disk_from_source", download)
+
+    capacity = _fake_capacity()
+    capacity.check_message.side_effect = RuntimeError("no room for 20 GiB")
+    job = ImportJob(
+        vm_hash=vm_hash,
+        state=MigrationState.IMPORTING,
+        started_at=datetime.now(timezone.utc),
+        source_host="src",
+        source_port=443,
+    )
+    await run_import(
+        job,
+        _import_supervisor(has_vm=False),
+        capacity=capacity,
+        registry=AgentVmRegistry(),
+        disk_files=[DiskFileInfo(name="rootfs.qcow2", size_bytes=10, sha256="0" * 64, download_path="/x")],
+        export_token="t",
+    )
+
+    capacity.check_message.assert_called_once_with(fake_message.content, exclude_vm_hash=vm_hash)
+    assert job.state == MigrationState.IMPORT_FAILED
+    assert "no room" in job.error
+    get_parent.assert_not_awaited()
+    download.assert_not_awaited()
+    assert not (tmp_path / str(vm_hash)).exists()

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -1123,6 +1123,43 @@ def test_check_message_ignores_a_file_no_declared_volume_claims(mocker, tmp_path
     assert kwargs["max_volume_credit"] is None
 
 
+def test_two_spellings_of_a_name_discount_one_file_once(mocker, tmp_path):
+    """Two declared volumes can look up the same file: "a b" is sanitized to
+    "a_b" by storage.get_volume_path, so a message declaring both names has
+    two volumes claiming a_b.ext4. One file backs one volume, so it discounts
+    once and the second volume is still required whole."""
+    manager = _manager()
+    check = mocker.patch.object(manager, "check_capacity")
+    directory = _stage_volume_files(mocker, tmp_path / "pool0", {"a_b.ext4": 10_000 * 1024 * 1024})
+    _patch_namespace_dirs(mocker, directory)
+    content = _instance_content(rootfs_mib=None, volumes=(_volume("a b", 10_000), _volume("a_b", 10_000)))
+
+    manager.check_message(content, exclude_vm_hash=_VM_HASH)
+
+    assert check.call_args.kwargs["disk_mib"] == 10_000
+
+
+def test_the_boot_disk_is_credited_its_own_file(mocker, tmp_path):
+    """Matching on the stem alone let rootfs.ext4 shadow rootfs.qcow2 (they
+    share a stem, and the ext4 sorts first), crediting the boot disk a file it
+    will not use. The suffix decides: a QEMU boot disk is a qcow2."""
+    manager = _manager()
+    check = mocker.patch.object(manager, "check_capacity")
+    directory = _stage_volume_files(
+        mocker,
+        tmp_path / "pool0",
+        {"rootfs.ext4": 1_000 * 1024 * 1024, "rootfs.qcow2": 20_000 * 1024 * 1024},
+    )
+    _patch_namespace_dirs(mocker, directory)
+    content = _instance_content(rootfs_mib=20_000)
+
+    manager.check_message(content, exclude_vm_hash=_VM_HASH)
+
+    kwargs = check.call_args.kwargs
+    assert kwargs["disk_mib"] == 0
+    assert kwargs["max_volume_credit"].path == directory / "rootfs.qcow2"
+
+
 def test_check_message_without_a_hash_discounts_nothing(mocker):
     """The reserve endpoint admits a message no VM owns yet: there is no
     directory to discount, and none is looked for."""
@@ -1213,6 +1250,27 @@ def test_the_credit_goes_only_to_the_pool_that_holds_the_file(mocker, tmp_path):
         manager.check_message(content, exclude_vm_hash=_VM_HASH)
 
 
+def test_a_colliding_stem_never_discounts_one_file_twice(mocker, tmp_path):
+    """A schema-valid message can declare a rootfs AND a persistent volume
+    named "rootfs": both look up the same stem. The directory holds one file,
+    which may pay for one of them and never for both. Here the node still has
+    to allocate a 20 GiB volume with 5 GiB free, so the create is refused;
+    letting the single qcow2 discount both declarations would have floored the
+    total to 0 and admitted it."""
+    manager = _manager()
+    _patch_host(mocker, memory_bytes=64 * 1024**3, cores=16, disk_bytes=5 * 1024**3)
+    pool = tmp_path / "pool0"
+    directory = _stage_volume_files(mocker, pool, {"rootfs.qcow2": 20 * 1024**3})
+    _patch_namespace_dirs(mocker, directory)
+    _patch_eligible_pools(mocker, (pool, 5 * 1024**3))
+    content = _instance_content(rootfs_mib=20 * 1024, volumes=(_volume("rootfs", 20 * 1024),))
+
+    with pytest.raises(InsufficientResourcesError) as excinfo:
+        manager.check_message(content, exclude_vm_hash=_VM_HASH)
+
+    assert "Disk: required 20480 MiB" in str(excinfo.value)
+
+
 # ── existing_volume_files ───────────────────────────────────────────────────
 
 
@@ -1243,6 +1301,8 @@ def test_existing_volume_files_spans_pools_and_skips_what_is_not_a_volume(mocker
     found = existing_volume_files(_VM_HASH)
 
     # The marker is not a volume, and a symlink is not this directory's space.
-    assert set(found) == {"rootfs", "data"}
-    assert found["rootfs"] == first / "rootfs.qcow2"
-    assert found["data"] == second / "data.ext4"
+    # Files are keyed by name, suffix included: rootfs.qcow2 and rootfs.ext4
+    # share a stem but are different volumes.
+    assert set(found) == {"rootfs.qcow2", "data.ext4"}
+    assert found["rootfs.qcow2"] == first / "rootfs.qcow2"
+    assert found["data.ext4"] == second / "data.ext4"

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -984,7 +984,7 @@ def test_a_phantom_record_never_blocks_the_retry_of_its_own_create(mocker):
     mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
     mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 4096)
     mocker.patch.object(CapacityManager, "_check_max_volume", return_value=None)
-    mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for", return_value=0)
+    mocker.patch("aleph.vm.agent.capacity.existing_volume_files", return_value={})
 
     vm_hash = "i" * 64
     message = _make_qemu_instance_message(vcpus=2, memory=8192)
@@ -1003,24 +1003,67 @@ def test_a_phantom_record_never_blocks_the_retry_of_its_own_create(mocker):
 
 # ── check_message: one admission path, ahead of any allocation ─────────────
 
+_VM_HASH = ItemHash("ab" * 32)
 
-def _instance_content(*, rootfs_mib: int = 20_000, volumes_mib: tuple[int, ...] = ()) -> MagicMock:
+
+def _volume(name: str, size_mib: int) -> MagicMock:
+    """A persistent volume declaration. ``name`` is set after construction:
+    passing it to MagicMock() would name the mock, not the attribute."""
+    volume = MagicMock(size_mib=size_mib)
+    volume.name = name
+    return volume
+
+
+def _instance_content(*, rootfs_mib: int | None = 20_000, volumes: tuple[MagicMock, ...] = ()) -> MagicMock:
     """An InstanceContent stand-in with the sizes admission reads."""
     content = MagicMock(spec=InstanceContent)
     content.resources = MagicMock(vcpus=2, memory=2048)
-    content.rootfs = MagicMock(size_mib=rootfs_mib)
-    content.volumes = [MagicMock(size_mib=size) for size in volumes_mib]
+    content.rootfs = MagicMock(size_mib=rootfs_mib) if rootfs_mib is not None else None
+    content.volumes = list(volumes)
     content.requirements = None
     return content
+
+
+def _hold_nothing(mocker) -> None:
+    """No file on disk for this VM."""
+    mocker.patch("aleph.vm.agent.capacity.existing_volume_files", return_value={})
+
+
+def _stage_volume_files(mocker, pool: Path, files: dict[str, int]) -> Path:
+    """Create ``{pool}/{vm_hash}/`` holding ``{filename: allocated bytes}``.
+
+    The files are real (so the stem matching, the symlink skip and the pool
+    layout are exercised for real); only the allocated-bytes measurement is
+    stubbed, since a test cannot cheaply allocate 20 GiB.
+    """
+    directory = pool / str(_VM_HASH)
+    directory.mkdir(parents=True, exist_ok=True)
+    sizes = {}
+    for name, size_bytes in files.items():
+        (directory / name).write_bytes(b"")
+        sizes[directory / name] = size_bytes
+    mocker.patch("aleph.vm.agent.capacity.file_size_bytes", side_effect=lambda path: sizes.get(path, 0))
+    return directory
+
+
+def _patch_namespace_dirs(mocker, *directories: Path) -> None:
+    mocker.patch("aleph.vm.agent.capacity.storage_pools.iter_namespace_dirs", return_value=list(directories))
+
+
+def _patch_eligible_pools(mocker, *pools: tuple[Path, int]) -> None:
+    """Eligible pools, given as (path, free bytes), with nothing reclaimable."""
+    entries = [(SimpleNamespace(path=path, index=index), free) for index, (path, free) in enumerate(pools)]
+    mocker.patch("aleph.vm.agent.capacity.storage_pools.eligible_pool_free_bytes", return_value=entries)
+    mocker.patch("aleph.vm.agent.capacity.reclaimable_bytes", return_value=0)
 
 
 def test_check_message_admits_disk_from_the_message(mocker):
     manager = _manager()
     check = mocker.patch.object(manager, "check_capacity")
-    mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for", return_value=0)
-    content = _instance_content(rootfs_mib=20_000, volumes_mib=(5_000,))
+    _hold_nothing(mocker)
+    content = _instance_content(rootfs_mib=20_000, volumes=(_volume("data", 5_000),))
 
-    manager.check_message(content, exclude_vm_hash=ItemHash("ab" * 32))
+    manager.check_message(content, exclude_vm_hash=_VM_HASH)
 
     kwargs = check.call_args.kwargs
     assert kwargs["disk_mib"] == 25_000
@@ -1028,34 +1071,56 @@ def test_check_message_admits_disk_from_the_message(mocker):
     assert kwargs["is_instance"] is True
     assert kwargs["memory_mib"] == 2048
     assert kwargs["vcpus"] == 2
-    assert kwargs["exclude_vm_hash"] == ItemHash("ab" * 32)
+    assert kwargs["exclude_vm_hash"] == _VM_HASH
 
 
-def test_check_message_discounts_bytes_the_vm_already_holds(mocker):
+def test_check_message_discounts_bytes_the_vm_already_holds(mocker, tmp_path):
     """A RECREATE of a VM whose disks are still on the host must not be
     refused for space it already occupies: creating() adopted the directory,
     so those bytes are neither free nor reclaimable any more."""
     manager = _manager()
     check = mocker.patch.object(manager, "check_capacity")
-    mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for", return_value=20_000 * 1024 * 1024)
+    directory = _stage_volume_files(mocker, tmp_path / "pool0", {"rootfs.qcow2": 20_000 * 1024 * 1024})
+    _patch_namespace_dirs(mocker, directory)
     content = _instance_content(rootfs_mib=20_000)
 
-    manager.check_message(content, exclude_vm_hash=ItemHash("ab" * 32))
+    manager.check_message(content, exclude_vm_hash=_VM_HASH)
 
     assert check.call_args.kwargs["disk_mib"] == 0
 
 
-def test_check_message_never_asks_for_negative_disk(mocker):
-    """A VM holding more than the message declares (an extra staged file)
-    floors the requirement at 0 rather than crediting the difference."""
+def test_check_message_caps_a_volumes_discount_at_what_it_declares(mocker, tmp_path):
+    """A file that outgrew its declaration credits only the declared size,
+    and the total never goes negative."""
     manager = _manager()
     check = mocker.patch.object(manager, "check_capacity")
-    mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for", return_value=90_000 * 1024 * 1024)
-    content = _instance_content(rootfs_mib=20_000)
+    directory = _stage_volume_files(mocker, tmp_path / "pool0", {"rootfs.qcow2": 90_000 * 1024 * 1024})
+    _patch_namespace_dirs(mocker, directory)
+    content = _instance_content(rootfs_mib=20_000, volumes=(_volume("data", 5_000),))
 
-    manager.check_message(content, exclude_vm_hash=ItemHash("ab" * 32))
+    manager.check_message(content, exclude_vm_hash=_VM_HASH)
 
-    assert check.call_args.kwargs["disk_mib"] == 0
+    # 25 000 declared, the rootfs discounts its declared 20 000 and not the
+    # 90 000 it occupies, so the unallocated data volume is still required.
+    assert check.call_args.kwargs["disk_mib"] == 5_000
+
+
+def test_check_message_ignores_a_file_no_declared_volume_claims(mocker, tmp_path):
+    """The discount is per declared volume, not per directory. A user who
+    renames or drops a persistent volume in an updated message leaves the old
+    file behind; it must not pay for the new one."""
+    manager = _manager()
+    check = mocker.patch.object(manager, "check_capacity")
+    directory = _stage_volume_files(mocker, tmp_path / "pool0", {"old.ext4": 10_000 * 1024 * 1024})
+    _patch_namespace_dirs(mocker, directory)
+    content = _instance_content(rootfs_mib=None, volumes=(_volume("new", 10_000),))
+
+    manager.check_message(content, exclude_vm_hash=_VM_HASH)
+
+    kwargs = check.call_args.kwargs
+    assert kwargs["disk_mib"] == 10_000
+    assert kwargs["max_volume_mib"] == 10_000
+    assert kwargs["max_volume_credit"] is None
 
 
 def test_check_message_without_a_hash_discounts_nothing(mocker):
@@ -1063,12 +1128,12 @@ def test_check_message_without_a_hash_discounts_nothing(mocker):
     directory to discount, and none is looked for."""
     manager = _manager()
     check = mocker.patch.object(manager, "check_capacity")
-    allocated = mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for")
+    existing = mocker.patch("aleph.vm.agent.capacity.existing_volume_files")
     content = _instance_content(rootfs_mib=20_000)
 
     manager.check_message(content)
 
-    allocated.assert_not_called()
+    existing.assert_not_called()
     assert check.call_args.kwargs["disk_mib"] == 20_000
     assert check.call_args.kwargs["exclude_vm_hash"] is None
 
@@ -1082,60 +1147,102 @@ def test_check_message_buckets_a_vprogram_as_an_instance(mocker):
 
     manager = _manager()
     check = mocker.patch.object(manager, "check_capacity")
-    mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for", return_value=0)
+    _hold_nothing(mocker)
     content = MagicMock(spec=VerifiableProgramContent)
     content.resources = MagicMock(vcpus=2, memory=4096)
     content.volumes = []
     content.requirements = None
 
-    manager.check_message(content, exclude_vm_hash=ItemHash("ab" * 32))
+    manager.check_message(content, exclude_vm_hash=_VM_HASH)
 
     assert check.call_args.kwargs["is_instance"] is True
 
 
-def test_allocated_bytes_for_sums_the_vms_dirs_on_every_pool(mocker, tmp_path):
-    """The discount is measured from the real directories, one per pool."""
-    from aleph.vm.agent.capacity import allocated_bytes_for
-
-    vm_hash = "ab" * 32
-    dirs = []
-    for pool in ("pool0", "pool1"):
-        directory = tmp_path / pool / vm_hash
-        directory.mkdir(parents=True)
-        (directory / "rootfs.qcow2").write_bytes(b"x" * 8192)
-        dirs.append(directory)
-    mocker.patch("aleph.vm.agent.capacity.storage_pools.iter_namespace_dirs", return_value=iter(dirs))
-
-    # st_blocks rounds to the filesystem block size, so assert the shape
-    # (both pools counted) rather than an exact byte count.
-    assert allocated_bytes_for(vm_hash) >= 2 * 8192
+# ── the stale-file counter-example, end to end through check_capacity ───────
 
 
-def test_allocated_bytes_for_looks_up_the_hash_as_a_namespace(mocker):
-    """ItemHash goes to iter_namespace_dirs as a plain string."""
-    from aleph.vm.agent.capacity import allocated_bytes_for
-
-    iter_dirs = mocker.patch("aleph.vm.agent.capacity.storage_pools.iter_namespace_dirs", return_value=iter(()))
-
-    assert allocated_bytes_for(ItemHash("ab" * 32)) == 0
-    iter_dirs.assert_called_once_with("ab" * 32)
-
-
-def test_check_message_caps_the_single_volume_figure_at_what_is_left_to_place(mocker):
-    """The per-pool largest-volume check gets the same discount as the total.
-
-    A recreate whose 20 GiB rootfs is already on a pool must not require a
-    pool with 20 GiB free: creating() adopted the directory, so those bytes
-    stopped counting as reclaimable, and no pool has to place that volume
-    again."""
+def test_a_stale_file_never_admits_a_volume_the_node_cannot_hold(mocker, tmp_path):
+    """The reviewer's counter-example. A directory holding a stale 10 GiB
+    old.ext4, a message declaring only a fresh 10 GiB "new" volume, and a
+    node with 5 GiB free: refused. A discount summed over the directory would
+    have floored the total to 0 and the per-pool figure with it, switching
+    both disk guards off for exactly the create that needs the space."""
     manager = _manager()
-    check = mocker.patch.object(manager, "check_capacity")
-    mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for", return_value=20_000 * 1024 * 1024)
-    content = _instance_content(rootfs_mib=20_000, volumes_mib=(5_000,))
+    _patch_host(mocker, memory_bytes=64 * 1024**3, cores=16, disk_bytes=5 * 1024**3)
+    pool = tmp_path / "pool0"
+    directory = _stage_volume_files(mocker, pool, {"old.ext4": 10 * 1024**3})
+    _patch_namespace_dirs(mocker, directory)
+    _patch_eligible_pools(mocker, (pool, 5 * 1024**3))
+    content = _instance_content(rootfs_mib=None, volumes=(_volume("new", 10 * 1024),))
 
-    manager.check_message(content, exclude_vm_hash=ItemHash("ab" * 32))
+    with pytest.raises(InsufficientResourcesError) as excinfo:
+        manager.check_message(content, exclude_vm_hash=_VM_HASH)
 
-    kwargs = check.call_args.kwargs
-    # 25 000 declared, 20 000 already held: 5 000 left to allocate, and no
-    # single volume larger than that still needs placing.
-    assert (kwargs["disk_mib"], kwargs["max_volume_mib"]) == (5_000, 5_000)
+    detail = str(excinfo.value)
+    assert "Disk: required 10240 MiB" in detail
+    assert "single volume" in detail
+
+
+def test_a_plain_recreate_is_admitted_with_its_own_pool_credited(mocker, tmp_path):
+    """The other side of the same coin: the file backing the declared volume
+    is on pool0, so pool0 does not have to find that room again even though
+    its free space alone could never fit the volume."""
+    manager = _manager()
+    _patch_host(mocker, memory_bytes=64 * 1024**3, cores=16, disk_bytes=1 * 1024**3)
+    pool = tmp_path / "pool0"
+    directory = _stage_volume_files(mocker, pool, {"rootfs.qcow2": 20 * 1024**3})
+    _patch_namespace_dirs(mocker, directory)
+    _patch_eligible_pools(mocker, (pool, 1 * 1024**3))
+    content = _instance_content(rootfs_mib=20 * 1024)
+
+    assert manager.check_message(content, exclude_vm_hash=_VM_HASH) is None
+
+
+def test_the_credit_goes_only_to_the_pool_that_holds_the_file(mocker, tmp_path):
+    """Crediting globally (by shrinking max_volume_mib) would excuse every
+    pool. The file sits on a pool that is not eligible for new volumes, so
+    no eligible pool may claim its bytes."""
+    manager = _manager()
+    _patch_host(mocker, memory_bytes=64 * 1024**3, cores=16, disk_bytes=1 * 1024**3)
+    directory = _stage_volume_files(mocker, tmp_path / "pool0", {"rootfs.qcow2": 20 * 1024**3})
+    _patch_namespace_dirs(mocker, directory)
+    _patch_eligible_pools(mocker, (tmp_path / "pool1", 1 * 1024**3))
+    content = _instance_content(rootfs_mib=20 * 1024)
+
+    with pytest.raises(InsufficientResourcesError, match="single volume"):
+        manager.check_message(content, exclude_vm_hash=_VM_HASH)
+
+
+# ── existing_volume_files ───────────────────────────────────────────────────
+
+
+def test_existing_volume_files_refuses_an_implausible_hash():
+    """The namespace reaches a bare ``pool.path / namespace`` join, so it is
+    validated like every other iter_namespace_dirs caller: without this,
+    "../.." resolves, its bytes are summed as space the VM already holds, and
+    the inflated discount relaxes admission."""
+    from aleph.vm.agent.capacity import existing_volume_files
+
+    with pytest.raises(ValueError, match="implausible VM hash"):
+        existing_volume_files("../..")
+
+
+def test_existing_volume_files_spans_pools_and_skips_what_is_not_a_volume(mocker, tmp_path):
+    from aleph.vm.agent.capacity import existing_volume_files
+
+    first = tmp_path / "pool0" / str(_VM_HASH)
+    second = tmp_path / "pool1" / str(_VM_HASH)
+    for directory in (first, second):
+        directory.mkdir(parents=True)
+    (first / "rootfs.qcow2").write_bytes(b"x")
+    (first / ".reclaimable").write_text("{}")
+    (first / "elsewhere.ext4").symlink_to(tmp_path / "somewhere-else")
+    (second / "data.ext4").write_bytes(b"x")
+    _patch_namespace_dirs(mocker, first, second)
+
+    found = existing_volume_files(_VM_HASH)
+
+    # The marker is not a volume, and a symlink is not this directory's space.
+    assert set(found) == {"rootfs", "data"}
+    assert found["rootfs"] == first / "rootfs.qcow2"
+    assert found["data"] == second / "data.ext4"

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aleph_message.models import ItemHash
+from aleph_message.models.execution.instance import InstanceContent
 from test_supervisor_translate import _make_qemu_instance_message
 
 from aleph.vm.agent.capacity import (
@@ -23,7 +24,6 @@ from aleph.vm.agent.capacity import (
     ResourceRequirements,
     requirements_from_message,
 )
-from aleph.vm.agent.run import _admit
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 from aleph.vm.resources import GpuDevice, GpuDeviceClass, InsufficientResourcesError
@@ -978,12 +978,13 @@ def test_a_phantom_record_never_blocks_the_retry_of_its_own_create(mocker):
     orphan. The record then describes a VM that is not running and counts in
     the committed sums until the next allocation cycle. The one thing that
     must not happen is the retry being refused by its own phantom, and it is
-    not: the create path admits through _admit, which excludes the VM's own
-    record."""
+    not: the create path admits through check_message, which excludes the VM's
+    own record."""
     _patch_host(mocker, memory_bytes=16 * 1024 * 1024 * 1024, cores=16)
     mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
     mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 4096)
     mocker.patch.object(CapacityManager, "_check_max_volume", return_value=None)
+    mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for", return_value=0)
 
     vm_hash = "i" * 64
     message = _make_qemu_instance_message(vcpus=2, memory=8192)
@@ -992,9 +993,149 @@ def test_a_phantom_record_never_blocks_the_retry_of_its_own_create(mocker):
     registry.record(vm_hash, message=message, original=message, persistent=True)
     manager = _manager(registry=registry)
 
-    assert _admit(manager, message, vm_hash) is None
+    assert manager.check_message(message, exclude_vm_hash=vm_hash) is None
 
     # The phantom is not free: it still counts against every *other* VM until
     # the next allocation cycle drops it.
     with pytest.raises(InsufficientResourcesError):
-        _admit(manager, message, "j" * 64)
+        manager.check_message(message, exclude_vm_hash="j" * 64)
+
+
+# ── check_message: one admission path, ahead of any allocation ─────────────
+
+
+def _instance_content(*, rootfs_mib: int = 20_000, volumes_mib: tuple[int, ...] = ()) -> MagicMock:
+    """An InstanceContent stand-in with the sizes admission reads."""
+    content = MagicMock(spec=InstanceContent)
+    content.resources = MagicMock(vcpus=2, memory=2048)
+    content.rootfs = MagicMock(size_mib=rootfs_mib)
+    content.volumes = [MagicMock(size_mib=size) for size in volumes_mib]
+    content.requirements = None
+    return content
+
+
+def test_check_message_admits_disk_from_the_message(mocker):
+    manager = _manager()
+    check = mocker.patch.object(manager, "check_capacity")
+    mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for", return_value=0)
+    content = _instance_content(rootfs_mib=20_000, volumes_mib=(5_000,))
+
+    manager.check_message(content, exclude_vm_hash=ItemHash("ab" * 32))
+
+    kwargs = check.call_args.kwargs
+    assert kwargs["disk_mib"] == 25_000
+    assert kwargs["max_volume_mib"] == 20_000
+    assert kwargs["is_instance"] is True
+    assert kwargs["memory_mib"] == 2048
+    assert kwargs["vcpus"] == 2
+    assert kwargs["exclude_vm_hash"] == ItemHash("ab" * 32)
+
+
+def test_check_message_discounts_bytes_the_vm_already_holds(mocker):
+    """A RECREATE of a VM whose disks are still on the host must not be
+    refused for space it already occupies: creating() adopted the directory,
+    so those bytes are neither free nor reclaimable any more."""
+    manager = _manager()
+    check = mocker.patch.object(manager, "check_capacity")
+    mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for", return_value=20_000 * 1024 * 1024)
+    content = _instance_content(rootfs_mib=20_000)
+
+    manager.check_message(content, exclude_vm_hash=ItemHash("ab" * 32))
+
+    assert check.call_args.kwargs["disk_mib"] == 0
+
+
+def test_check_message_never_asks_for_negative_disk(mocker):
+    """A VM holding more than the message declares (an extra staged file)
+    floors the requirement at 0 rather than crediting the difference."""
+    manager = _manager()
+    check = mocker.patch.object(manager, "check_capacity")
+    mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for", return_value=90_000 * 1024 * 1024)
+    content = _instance_content(rootfs_mib=20_000)
+
+    manager.check_message(content, exclude_vm_hash=ItemHash("ab" * 32))
+
+    assert check.call_args.kwargs["disk_mib"] == 0
+
+
+def test_check_message_without_a_hash_discounts_nothing(mocker):
+    """The reserve endpoint admits a message no VM owns yet: there is no
+    directory to discount, and none is looked for."""
+    manager = _manager()
+    check = mocker.patch.object(manager, "check_capacity")
+    allocated = mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for")
+    content = _instance_content(rootfs_mib=20_000)
+
+    manager.check_message(content)
+
+    allocated.assert_not_called()
+    assert check.call_args.kwargs["disk_mib"] == 20_000
+    assert check.call_args.kwargs["exclude_vm_hash"] is None
+
+
+def test_check_message_buckets_a_vprogram_as_an_instance(mocker):
+    """A V-PROGRAM is a full SNP VM: it belongs in the instance memory
+    bucket, which is where _committed_resources already counts it. Bucketing
+    it as a program would both starve the small program bucket and hide its
+    memory from instance admission."""
+    from aleph_message.models import VerifiableProgramContent
+
+    manager = _manager()
+    check = mocker.patch.object(manager, "check_capacity")
+    mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for", return_value=0)
+    content = MagicMock(spec=VerifiableProgramContent)
+    content.resources = MagicMock(vcpus=2, memory=4096)
+    content.volumes = []
+    content.requirements = None
+
+    manager.check_message(content, exclude_vm_hash=ItemHash("ab" * 32))
+
+    assert check.call_args.kwargs["is_instance"] is True
+
+
+def test_allocated_bytes_for_sums_the_vms_dirs_on_every_pool(mocker, tmp_path):
+    """The discount is measured from the real directories, one per pool."""
+    from aleph.vm.agent.capacity import allocated_bytes_for
+
+    vm_hash = "ab" * 32
+    dirs = []
+    for pool in ("pool0", "pool1"):
+        directory = tmp_path / pool / vm_hash
+        directory.mkdir(parents=True)
+        (directory / "rootfs.qcow2").write_bytes(b"x" * 8192)
+        dirs.append(directory)
+    mocker.patch("aleph.vm.agent.capacity.storage_pools.iter_namespace_dirs", return_value=iter(dirs))
+
+    # st_blocks rounds to the filesystem block size, so assert the shape
+    # (both pools counted) rather than an exact byte count.
+    assert allocated_bytes_for(vm_hash) >= 2 * 8192
+
+
+def test_allocated_bytes_for_looks_up_the_hash_as_a_namespace(mocker):
+    """ItemHash goes to iter_namespace_dirs as a plain string."""
+    from aleph.vm.agent.capacity import allocated_bytes_for
+
+    iter_dirs = mocker.patch("aleph.vm.agent.capacity.storage_pools.iter_namespace_dirs", return_value=iter(()))
+
+    assert allocated_bytes_for(ItemHash("ab" * 32)) == 0
+    iter_dirs.assert_called_once_with("ab" * 32)
+
+
+def test_check_message_caps_the_single_volume_figure_at_what_is_left_to_place(mocker):
+    """The per-pool largest-volume check gets the same discount as the total.
+
+    A recreate whose 20 GiB rootfs is already on a pool must not require a
+    pool with 20 GiB free: creating() adopted the directory, so those bytes
+    stopped counting as reclaimable, and no pool has to place that volume
+    again."""
+    manager = _manager()
+    check = mocker.patch.object(manager, "check_capacity")
+    mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for", return_value=20_000 * 1024 * 1024)
+    content = _instance_content(rootfs_mib=20_000, volumes_mib=(5_000,))
+
+    manager.check_message(content, exclude_vm_hash=ItemHash("ab" * 32))
+
+    kwargs = check.call_args.kwargs
+    # 25 000 declared, 20 000 already held: 5 000 left to allocate, and no
+    # single volume larger than that still needs placing.
+    assert (kwargs["disk_mib"], kwargs["max_volume_mib"]) == (5_000, 5_000)

--- a/tests/supervisor/test_create_path_disk_admission.py
+++ b/tests/supervisor/test_create_path_disk_admission.py
@@ -1,4 +1,4 @@
-"""Capacity admission runs before the download, and it accounts for disk.
+"""Capacity admission runs before the download, once, and accounts for disk.
 
 Every create path called check_capacity with disk_mib=0, so neither the total
 disk requirement nor the largest-single-volume check ran: only the reserve
@@ -8,8 +8,9 @@ downloads the resources and creates the volume files: by then the space is
 already allocated and requiring it again would double-count it.
 
 So the admission gate moves ahead of the build, where refusing still saves the
-download, and the post-build call keeps disk_mib=0 as the memory/vCPU re-check
-and the GPU resolution point.
+download, and the post-build call goes away (spec section 2): memory and vCPUs
+are judged in the same single pass as disk, and only GPU resolution stays after
+the build.
 """
 
 from __future__ import annotations
@@ -56,10 +57,15 @@ def _program_content():
 
 def _capacity(*, refuse: bool = False):
     """Admission stub. `refuse` makes every check fail, standing in for a host
-    with no room left."""
+    with no room left.
+
+    ``check_capacity`` is deliberately not exposed: run.py must reach capacity
+    only through ``check_message``, so a stray direct call AttributeErrors here
+    instead of passing silently.
+    """
     error = InsufficientResourcesError("no room", required={}, available={})
     return SimpleNamespace(
-        check_capacity=MagicMock(side_effect=error if refuse else None),
+        check_message=MagicMock(side_effect=error if refuse else None),
         resolve_gpus=AsyncMock(return_value=[]),
     )
 
@@ -76,6 +82,7 @@ def _patch_message(monkeypatch, content):
     monkeypatch.setattr(
         run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
     )
+    return content
 
 
 async def _create(capacity, supervisor=None):
@@ -88,11 +95,21 @@ async def _create(capacity, supervisor=None):
     )
 
 
-def _disk_args(capacity):
-    """(disk_mib, max_volume_mib) of every check_capacity call."""
-    return [
-        (c.kwargs.get("disk_mib"), c.kwargs.get("max_volume_mib", 0)) for c in capacity.check_capacity.call_args_list
-    ]
+def _admissions(capacity):
+    """(content, exclude_vm_hash) of every admission call."""
+    return [(c.args[0], c.kwargs.get("exclude_vm_hash")) for c in capacity.check_message.call_args_list]
+
+
+def _real_capacity(mocker, *, refuse: bool = False):
+    """A real CapacityManager with only check_capacity stubbed, so a test can
+    read the scalars check_message derived from the message."""
+    from aleph.vm.agent.capacity import CapacityManager
+
+    manager = CapacityManager(supervisor=MagicMock(), registry=AgentVmRegistry())
+    error = InsufficientResourcesError("no room", required={}, available={})
+    mocker.patch.object(manager, "check_capacity", side_effect=error if refuse else None)
+    mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for", return_value=0)
+    return manager
 
 
 class TestInstancePath:
@@ -109,15 +126,33 @@ class TestInstancePath:
         build.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_admission_carries_the_declared_disk(self, monkeypatch):
+    async def test_admission_carries_the_declared_disk(self, monkeypatch, mocker):
+        """End to end through the real check_message: the message's rootfs
+        size is what admission requires, as both the total and the largest
+        single volume."""
         _patch_message(monkeypatch, _make_qemu_instance_message(hypervisor=HypervisorType.qemu))
+        monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock())
+        capacity = _real_capacity(mocker, refuse=True)
+
+        with pytest.raises(InsufficientResourcesError):
+            await _create(capacity)
+
+        kwargs = capacity.check_capacity.call_args.kwargs
+        assert (kwargs["disk_mib"], kwargs["max_volume_mib"]) == (INSTANCE_ROOTFS_MIB, INSTANCE_ROOTFS_MIB)
+        assert kwargs["exclude_vm_hash"] == _HASH
+
+    @pytest.mark.asyncio
+    async def test_admission_runs_once(self, monkeypatch):
+        """The post-build re-check is gone (spec section 2): one message, one
+        admission decision."""
+        content = _patch_message(monkeypatch, _make_qemu_instance_message(hypervisor=HypervisorType.qemu))
         monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock())
         capacity = _capacity(refuse=True)
 
         with pytest.raises(InsufficientResourcesError):
             await _create(capacity)
 
-        assert _disk_args(capacity) == [(INSTANCE_ROOTFS_MIB, INSTANCE_ROOTFS_MIB)]
+        assert _admissions(capacity) == [(content, _HASH)]
 
 
 class TestProgramPath:
@@ -150,16 +185,15 @@ class TestVProgramPath:
         build.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_admission_uses_the_instance_memory_bucket(self, monkeypatch):
+    async def test_admission_uses_the_instance_memory_bucket(self, monkeypatch, mocker):
         """A v-program is an SNP VM, not a Firecracker program: it is admitted
-        against the instance bucket, as the pre-existing post-build check
-        already did. requirements_from_message alone would say otherwise, since
-        VerifiableProgramContent is not an InstanceContent."""
+        against the instance bucket, which is also where _committed_resources
+        counts it."""
         from test_vprogram import load_vprogram_message
 
         _patch_message(monkeypatch, load_vprogram_message().content)
         monkeypatch.setattr(run_module, "build_vprogram_spec", AsyncMock())
-        capacity = _capacity(refuse=True)
+        capacity = _real_capacity(mocker, refuse=True)
 
         with pytest.raises(InsufficientResourcesError):
             await _create(capacity)
@@ -167,16 +201,16 @@ class TestVProgramPath:
         assert [c.kwargs["is_instance"] for c in capacity.check_capacity.call_args_list] == [True]
 
 
-class TestBothChecksOnTheHappyPath:
-    """The two checks are a contract, not a duplicate: the pre-build one owns
-    disk, the post-build one re-checks memory and vCPUs (and is where GPU holds
-    are resolved) without re-requiring space this VM has already taken."""
+class TestOneAdmissionOnTheHappyPath:
+    """One decision per create: the pre-build admission owns disk, memory and
+    vCPUs. Only GPU resolution stays after the build, so a failed download
+    never consumes a GPU hold."""
 
     @pytest.mark.asyncio
-    async def test_disk_is_required_once_before_the_build_and_never_again(self, monkeypatch):
+    async def test_admission_is_asked_once_and_never_again(self, monkeypatch):
         from test_supervisor_run_routing import _info, _spec
 
-        _patch_message(monkeypatch, _make_qemu_instance_message(hypervisor=HypervisorType.qemu))
+        content = _patch_message(monkeypatch, _make_qemu_instance_message(hypervisor=HypervisorType.qemu))
         monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(return_value=_spec()))
         monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
         monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
@@ -191,7 +225,7 @@ class TestBothChecksOnTheHappyPath:
 
         await _create(capacity, supervisor)
 
-        assert _disk_args(capacity) == [(INSTANCE_ROOTFS_MIB, INSTANCE_ROOTFS_MIB), (0, 0)]
+        assert _admissions(capacity) == [(content, _HASH)]
 
 
 class TestCreateGuard:
@@ -211,11 +245,11 @@ class TestCreateGuard:
         runs, then refuses (which ends the create right there)."""
         error = InsufficientResourcesError("no room", required={}, available={})
 
-        def check(**kwargs):
+        def check(_content, **kwargs):
             seen.append(is_creating(str(_HASH)))
             raise error
 
-        return SimpleNamespace(check_capacity=MagicMock(side_effect=check), resolve_gpus=AsyncMock(return_value=[]))
+        return SimpleNamespace(check_message=MagicMock(side_effect=check), resolve_gpus=AsyncMock(return_value=[]))
 
     @pytest.mark.asyncio
     async def test_the_instance_path_holds_the_guard(self, monkeypatch):

--- a/tests/supervisor/test_create_path_disk_admission.py
+++ b/tests/supervisor/test_create_path_disk_admission.py
@@ -108,7 +108,7 @@ def _real_capacity(mocker, *, refuse: bool = False):
     manager = CapacityManager(supervisor=MagicMock(), registry=AgentVmRegistry())
     error = InsufficientResourcesError("no room", required={}, available={})
     mocker.patch.object(manager, "check_capacity", side_effect=error if refuse else None)
-    mocker.patch("aleph.vm.agent.capacity.allocated_bytes_for", return_value=0)
+    mocker.patch("aleph.vm.agent.capacity.existing_volume_files", return_value={})
     return manager
 
 

--- a/tests/supervisor/test_create_path_disk_admission.py
+++ b/tests/supervisor/test_create_path_disk_admission.py
@@ -8,7 +8,7 @@ downloads the resources and creates the volume files: by then the space is
 already allocated and requiring it again would double-count it.
 
 So the admission gate moves ahead of the build, where refusing still saves the
-download, and the post-build call goes away (spec section 2): memory and vCPUs
+download, and the post-build call goes away: memory and vCPUs
 are judged in the same single pass as disk, and only GPU resolution stays after
 the build.
 """
@@ -143,7 +143,7 @@ class TestInstancePath:
 
     @pytest.mark.asyncio
     async def test_admission_runs_once(self, monkeypatch):
-        """The post-build re-check is gone (spec section 2): one message, one
+        """The post-build re-check is gone: one message, one
         admission decision."""
         content = _patch_message(monkeypatch, _make_qemu_instance_message(hypervisor=HypervisorType.qemu))
         monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock())

--- a/tests/supervisor/test_run_idle_teardown.py
+++ b/tests/supervisor/test_run_idle_teardown.py
@@ -101,7 +101,7 @@ class FakeProgramClient:
 
 def _fake_capacity() -> SimpleNamespace:
     """Agent-side admission stub: capacity always passes."""
-    return SimpleNamespace(check_capacity=MagicMock(), resolve_gpus=AsyncMock(return_value=[]))
+    return SimpleNamespace(check_message=MagicMock(), resolve_gpus=AsyncMock(return_value=[]))
 
 
 class FakeRequest:

--- a/tests/supervisor/test_run_program_path.py
+++ b/tests/supervisor/test_run_program_path.py
@@ -37,9 +37,18 @@ def _content() -> MagicMock:
     return content
 
 
-def _fake_capacity() -> SimpleNamespace:
-    """Agent-side admission stub: capacity always passes."""
-    return SimpleNamespace(check_capacity=MagicMock(), resolve_gpus=AsyncMock(return_value=[]))
+def _fake_capacity(*, refuse: bool = False) -> SimpleNamespace:
+    """Agent-side admission stub: capacity passes unless ``refuse``.
+
+    Only ``check_message`` is exposed: run.py must reach capacity through the
+    single message-driven admission path, so a stray ``check_capacity`` call
+    would AttributeError here rather than pass silently.
+    """
+    error = InsufficientResourcesError("full")
+    return SimpleNamespace(
+        check_message=MagicMock(side_effect=error if refuse else None),
+        resolve_gpus=AsyncMock(return_value=[]),
+    )
 
 
 def _info(status: VmStatus) -> VmInfo:
@@ -282,3 +291,32 @@ async def test_insufficient_resources_maps_to_503(patched_build):
             capacity=_fake_capacity(),
             program_client=FakeProgramClient(),
         )
+
+
+@pytest.mark.asyncio
+async def test_admission_runs_before_the_download(patched_build):
+    """The on-demand program path admits from the message too: a host with no
+    room refuses before build_program_create_vm_spec fetches the runtime and
+    the code, and before create_vm."""
+    supervisor = SimpleNamespace(
+        get_vm=AsyncMock(side_effect=VmNotFoundError(VM_ID)),
+        create_vm=AsyncMock(),
+        delete_vm=AsyncMock(),
+    )
+    content = _content()
+    capacity = _fake_capacity(refuse=True)
+
+    with pytest.raises(web.HTTPServiceUnavailable):
+        await run_module._ensure_program_vm(
+            VM_HASH,
+            content,
+            _content(),
+            supervisor=supervisor,
+            registry=AgentVmRegistry(),
+            capacity=capacity,
+            program_client=FakeProgramClient(),
+        )
+
+    capacity.check_message.assert_called_once_with(content, exclude_vm_hash=VM_HASH)
+    patched_build.assert_not_awaited()
+    supervisor.create_vm.assert_not_awaited()

--- a/tests/supervisor/test_snp_instance_run.py
+++ b/tests/supervisor/test_snp_instance_run.py
@@ -10,6 +10,7 @@ regression check.
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -89,7 +90,13 @@ def _info(status: VmStatus = VmStatus.RUNNING, *, awaiting_confidential_init: bo
 
 
 def _fake_capacity():
-    return MagicMock(check_capacity=MagicMock(), resolve_gpus=AsyncMock())
+    """Admission stub exposing only ``check_message``.
+
+    A SimpleNamespace, not a MagicMock: run.py must reach capacity through
+    the single message-driven admission path, and a MagicMock would answer a
+    stray ``check_capacity`` call instead of failing on it.
+    """
+    return SimpleNamespace(check_message=MagicMock(), resolve_gpus=AsyncMock(return_value=[]))
 
 
 def _fake_supervisor(*, create_status: VmStatus = VmStatus.RUNNING, get_status: VmStatus = VmStatus.RUNNING):

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -89,7 +89,7 @@ def _fake_capacity(resolved: list[GpuSpec] | None = None):
     """Agent-side admission stub: capacity always passes, GPU resolution
     returns the given resolved cards."""
     return SimpleNamespace(
-        check_capacity=MagicMock(),
+        check_message=MagicMock(),
         resolve_gpus=AsyncMock(return_value=list(resolved or [])),
     )
 

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -344,16 +344,16 @@ async def test_create_vm_execution_vprogram_build_failure_forgets_record(mocker)
 
 
 @pytest.mark.asyncio
-async def test_create_vm_execution_vprogram_capacity_failure_forgets_record(mocker):
-    """Capacity admission runs after the bundle is staged and before create_vm:
-    an InsufficientResourcesError there must forget the record and never reach
-    create_vm (a distinct failure path from a build failure)."""
+async def test_create_vm_execution_vprogram_capacity_failure_refuses_before_staging(mocker):
+    """Admission runs from the message, before build_vprogram_spec stages a
+    byte: an InsufficientResourcesError never reaches the downloader, and the
+    early owner record is forgotten."""
     message = load_vprogram_message()
     mocker.patch("aleph.vm.agent.run.load_updated_message", new_callable=AsyncMock, return_value=(message, message))
-    mocker.patch("aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=(MagicMock(), 8443))
+    build = mocker.patch("aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock)
 
     capacity = MagicMock()
-    capacity.check_capacity.side_effect = InsufficientResourcesError("no room", required={}, available={})
+    capacity.check_message.side_effect = InsufficientResourcesError("no room", required={}, available={})
     # retire_vm(FAILED_CREATE) always quiesces through the supervisor first
     # (swallowing VmNotFoundError), even though no VM was ever created here.
     supervisor = MagicMock(create_vm=AsyncMock(), delete_vm=AsyncMock())
@@ -368,7 +368,9 @@ async def test_create_vm_execution_vprogram_capacity_failure_forgets_record(mock
             persistent=True,
         )
 
+    build.assert_not_awaited()
     supervisor.create_vm.assert_not_awaited()
+    capacity.check_message.assert_called_once_with(message.content, exclude_vm_hash=message.item_hash)
     assert message.item_hash not in registry
 
 


### PR DESCRIPTION
## Summary

PR B of the 2.1 disk reclamation work (spec Section 2, "Admission before allocation"). Stacked on #1155.

- `CapacityManager.check_message(content, *, exclude_vm_hash=None)`: admission from the message (disk, memory, vCPUs) before a byte is downloaded or allocated. One admission path: `_admit` is gone, and the four post-download `check_capacity(disk_mib=0)` blocks that #1153 had left on the create paths are removed.
- `_ensure_program_vm` (on-demand programs) and the cold migration import now admit before their downloads; #1153 had not covered either. The reserve endpoint uses the same path.
- Re-creates are not charged for what they already hold: the discount is per declared volume, matched by on-disk filename and capped at the declared size; stale files never discount; one file discounts at most one volume; the held bytes of the largest volume are credited to the pool that holds its file rather than shrinking the requirement.

## Known follow-ups
- Volume-name-to-filename derivation is a convention duplicated between capacity, storage and downloader; one shared function would remove the duplication.
- A persistent volume literally named `rootfs` next to a boot disk never discounts (fail-closed).
- A volume matches its stem under every suffix its kind can take, so a file left in another on-disk format still discounts a volume the create allocates afresh; bounded by that volume's declared size, and placement still checks real free space. The exact filename belongs with the shared naming helper above.

## Test plan
- `tests/supervisor`: 1336 passed, 48 pre-existing environment failures (identical set to base).
- New/extended: `test_agent_capacity.py` (per-volume discount, stale files, colliding names, per-pool credit, counter-examples), `test_create_path_disk_admission.py` (stubs expose only `check_message`, so a reintroduced direct `check_capacity` fails loudly), `test_run_program_path.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvDhr5NKq3AY17E1vwV3zk

