### PR TITLE
refactor(agent): extract the allocation teardown and its removability rule

### DIFF
--- a/src/aleph/vm/agent/allocation/__init__.py
+++ b/src/aleph/vm/agent/allocation/__init__.py
@@ -1,0 +1,1 @@
+"""Scheduler allocation: the plan the CRN was handed, and converging to it."""

--- a/src/aleph/vm/agent/allocation/teardown.py
+++ b/src/aleph/vm/agent/allocation/teardown.py
@@ -1,0 +1,56 @@
+"""Stopping a VM because the scheduler's plan no longer lists it.
+
+Removability is not uniform. A VM the user pays for directly (a payment stream
+or credits), one holding GPUs, or a confidential one is retained: the scheduler
+is not the authority on those. A v-program inverts that, because the scheduler
+IS its single source of truth, and it is credit-paid and confidential by
+construction.
+
+Tearing down is a composite: the supervisor owns the VM, the agent owns the
+registry record, the DB rows and the staging directories, so all of them have
+to go.
+"""
+
+import logging
+
+from aleph_message.models import ItemHash
+
+from aleph.vm.agent.metrics import delete_records_for_vm
+from aleph.vm.agent.snp_instance_launch import remove_snp_instance_staging
+from aleph.vm.agent.vm_registry import AgentVmRecord, AgentVmRegistry
+from aleph.vm.agent.vprogram_launch import remove_vprogram_staging
+from aleph.vm.supervisor_interface.abc import Supervisor
+from aleph.vm.supervisor_interface.errors import VmNotFoundError
+from aleph.vm.supervisor_interface.types import ConfidentialMode, VmId, VmInfo
+
+logger = logging.getLogger(__name__)
+
+
+def is_removable_by_allocation(record: AgentVmRecord, info: VmInfo) -> bool:
+    """Whether an allocation push may stop this VM when the plan drops it."""
+    if not record.persistent:
+        return False
+    if record.is_vprogram:
+        return True
+    return (
+        not record.uses_payment_stream
+        and not record.uses_payment_credit
+        and not info.gpus
+        and info.confidential_mode is ConfidentialMode.NONE
+    )
+
+
+async def teardown_vm(vm_hash: ItemHash, *, supervisor: Supervisor, registry: AgentVmRegistry) -> None:
+    """Delete the VM and every piece of agent-side state that belongs to it.
+
+    Idempotent: a VM the supervisor has already forgotten still has its agent
+    state cleaned, since that state is ours and would otherwise leak.
+    """
+    try:
+        await supervisor.delete_vm(VmId(str(vm_hash)))
+    except VmNotFoundError:
+        logger.info("Supervisor no longer knows %s; cleaning agent state anyway", vm_hash)
+    registry.forget(vm_hash)
+    await delete_records_for_vm(str(vm_hash))
+    remove_vprogram_staging(vm_hash)
+    remove_snp_instance_staging(vm_hash)

--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -22,11 +22,11 @@ from pydantic import ValidationError
 from aleph.vm import haproxy
 from aleph.vm.agent import payment, status
 from aleph.vm.agent.aggregate import update_aggregate_settings
+from aleph.vm.agent.allocation.teardown import is_removable_by_allocation, teardown_vm
 from aleph.vm.agent.capacity import CapacityManager, requirements_from_message
 from aleph.vm.agent.custom_logs import set_vm_for_logging
 from aleph.vm.agent.haproxy_sync import sync_domain_mappings
 from aleph.vm.agent.messages import try_get_message
-from aleph.vm.agent.allocation.teardown import is_removable_by_allocation, teardown_vm
 from aleph.vm.agent.metrics import get_execution_records
 from aleph.vm.agent.node_identity import NodeIdentity
 from aleph.vm.agent.payment import (
@@ -72,12 +72,7 @@ from aleph.vm.supervisor_interface.errors import (
     SupervisorError,
     VmNotFoundError,
 )
-from aleph.vm.supervisor_interface.types import (
-    PortForwardInfo,
-    VmId,
-    VmInfo,
-    VmStatus,
-)
+from aleph.vm.supervisor_interface.types import PortForwardInfo, VmId, VmInfo, VmStatus
 from aleph.vm.utils import (
     HostNotFoundError,
     b32_to_b16,

--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -26,7 +26,8 @@ from aleph.vm.agent.capacity import CapacityManager, requirements_from_message
 from aleph.vm.agent.custom_logs import set_vm_for_logging
 from aleph.vm.agent.haproxy_sync import sync_domain_mappings
 from aleph.vm.agent.messages import try_get_message
-from aleph.vm.agent.metrics import delete_records_for_vm, get_execution_records
+from aleph.vm.agent.allocation.teardown import is_removable_by_allocation, teardown_vm
+from aleph.vm.agent.metrics import get_execution_records
 from aleph.vm.agent.node_identity import NodeIdentity
 from aleph.vm.agent.payment import (
     InvalidAddressError,
@@ -42,7 +43,6 @@ from aleph.vm.agent.run import (
     run_code_on_request,
     start_persistent_vm,
 )
-from aleph.vm.agent.snp_instance_launch import remove_snp_instance_staging
 from aleph.vm.agent.tasks import COMMUNITY_STREAM_RATIO
 from aleph.vm.agent.utils import (
     format_cost,
@@ -63,7 +63,6 @@ from aleph.vm.agent.views.host_status import (
 )
 from aleph.vm.agent.views.operator import get_itemhash_or_400
 from aleph.vm.agent.vm_registry import AgentVmRecord, AgentVmRegistry
-from aleph.vm.agent.vprogram_launch import remove_vprogram_staging
 from aleph.vm.chains import STREAM_CHAINS
 from aleph.vm.conf import settings
 from aleph.vm.resources import InsufficientResourcesError
@@ -74,7 +73,6 @@ from aleph.vm.supervisor_interface.errors import (
     VmNotFoundError,
 )
 from aleph.vm.supervisor_interface.types import (
-    ConfidentialMode,
     PortForwardInfo,
     VmId,
     VmInfo,
@@ -584,32 +582,13 @@ async def update_allocations(request: web.Request):
             record = registry.get(vm_hash)
             if (
                 record is not None
-                and record.persistent
                 and vm_hash not in allocations
                 and info.status is VmStatus.RUNNING
-                and (
-                    # The scheduler is the single source of truth for
-                    # v-programs: absence from the allocation stops them,
-                    # even though they are credit-paid and confidential.
-                    record.is_vprogram
-                    or (
-                        not record.uses_payment_stream
-                        and not record.uses_payment_credit
-                        and not info.gpus
-                        and info.confidential_mode is ConfidentialMode.NONE
-                    )
-                )
+                and is_removable_by_allocation(record, info)
             ):
                 vm_type = VmType.from_message_content(record.message).name
                 logger.info("Stopping %s %s", vm_type, vm_hash)
-                try:
-                    await supervisor.delete_vm(VmId(str(vm_hash)))
-                except VmNotFoundError:
-                    pass
-                registry.forget(vm_hash)
-                await delete_records_for_vm(str(vm_hash))
-                remove_vprogram_staging(vm_hash)
-                remove_snp_instance_staging(vm_hash)
+                await teardown_vm(vm_hash, supervisor=supervisor, registry=registry)
                 stopped_vms.append(vm_hash)
 
         # Second start persistent VMs and instances sequentially to limit resource usage.

--- a/tests/supervisor/test_allocation_teardown.py
+++ b/tests/supervisor/test_allocation_teardown.py
@@ -1,0 +1,94 @@
+"""The stop half of an allocation: who may be stopped, and what stopping means.
+
+Both rules are shared by the legacy endpoint and (soon) the v2 reconciler, so
+they live in one module. The v-program inversion is the reason the predicate is
+a named function rather than an inline boolean.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aleph_message.models import ItemHash
+
+from aleph.vm.agent.allocation.teardown import is_removable_by_allocation, teardown_vm
+from aleph.vm.supervisor_interface.errors import VmNotFoundError
+from aleph.vm.supervisor_interface.types import ConfidentialMode, GpuDevice, PciAddress, VmStatus
+
+_HASH = ItemHash("deadbeef" * 8)
+
+
+def _record(*, stream=False, credit=False, vprogram=False, persistent=True):
+    return SimpleNamespace(
+        persistent=persistent,
+        uses_payment_stream=stream,
+        uses_payment_credit=credit,
+        is_vprogram=vprogram,
+        message=MagicMock(),
+    )
+
+
+def _info(*, gpus=(), confidential=ConfidentialMode.NONE, status=VmStatus.RUNNING):
+    return SimpleNamespace(vm_id=str(_HASH), status=status, gpus=list(gpus), confidential_mode=confidential)
+
+
+class TestRemovability:
+    def test_a_plain_persistent_vm_is_removable(self):
+        assert is_removable_by_allocation(_record(), _info()) is True
+
+    def test_a_stream_paid_vm_is_retained(self):
+        assert is_removable_by_allocation(_record(stream=True), _info()) is False
+
+    def test_a_credit_paid_vm_is_retained(self):
+        assert is_removable_by_allocation(_record(credit=True), _info()) is False
+
+    def test_a_gpu_vm_is_retained(self):
+        gpu = GpuDevice(pci_host=PciAddress("0000:01:00.0"), device_id="10de:2504", model="x", supports_x_vga=True)
+        assert is_removable_by_allocation(_record(), _info(gpus=[gpu])) is False
+
+    def test_a_confidential_vm_is_retained(self):
+        assert is_removable_by_allocation(_record(), _info(confidential=ConfidentialMode.SEV_SNP)) is False
+
+    def test_a_vprogram_is_removable_despite_being_credit_paid_and_confidential(self):
+        """The scheduler is the single source of truth for v-programs, so
+        absence from the plan stops them. This inverts every rule above."""
+        record = _record(credit=True, vprogram=True)
+        assert is_removable_by_allocation(record, _info(confidential=ConfidentialMode.SEV_SNP)) is True
+
+    def test_a_non_persistent_vm_is_not_touched(self):
+        assert is_removable_by_allocation(_record(persistent=False), _info()) is False
+
+
+class TestTeardown:
+    @pytest.mark.asyncio
+    async def test_deletes_forgets_and_clears_every_side_channel(self, monkeypatch):
+        delete_records = AsyncMock()
+        vprogram_staging = MagicMock()
+        snp_staging = MagicMock()
+        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.delete_records_for_vm", delete_records)
+        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.remove_vprogram_staging", vprogram_staging)
+        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.remove_snp_instance_staging", snp_staging)
+        supervisor = SimpleNamespace(delete_vm=AsyncMock())
+        registry = MagicMock()
+
+        await teardown_vm(_HASH, supervisor=supervisor, registry=registry)
+
+        supervisor.delete_vm.assert_awaited_once()
+        registry.forget.assert_called_once_with(_HASH)
+        delete_records.assert_awaited_once_with(str(_HASH))
+        vprogram_staging.assert_called_once_with(_HASH)
+        snp_staging.assert_called_once_with(_HASH)
+
+    @pytest.mark.asyncio
+    async def test_a_vm_the_supervisor_does_not_know_is_still_cleaned_up(self, monkeypatch):
+        """The supervisor forgetting first must not strand the agent's own
+        state: the registry entry, the DB rows and the staging dirs are ours."""
+        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.delete_records_for_vm", AsyncMock())
+        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.remove_vprogram_staging", MagicMock())
+        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.remove_snp_instance_staging", MagicMock())
+        supervisor = SimpleNamespace(delete_vm=AsyncMock(side_effect=VmNotFoundError(str(_HASH))))
+        registry = MagicMock()
+
+        await teardown_vm(_HASH, supervisor=supervisor, registry=registry)
+
+        registry.forget.assert_called_once_with(_HASH)

--- a/tests/supervisor/test_allocation_teardown.py
+++ b/tests/supervisor/test_allocation_teardown.py
@@ -13,7 +13,7 @@ from aleph_message.models import ItemHash
 
 from aleph.vm.agent.allocation.teardown import is_removable_by_allocation, teardown_vm
 from aleph.vm.supervisor_interface.errors import VmNotFoundError
-from aleph.vm.supervisor_interface.types import ConfidentialMode, GpuDevice, PciAddress, VmStatus
+from aleph.vm.supervisor_interface.types import ConfidentialMode, GpuDevice, PciAddress
 
 _HASH = ItemHash("deadbeef" * 8)
 
@@ -28,8 +28,8 @@ def _record(*, stream=False, credit=False, vprogram=False, persistent=True):
     )
 
 
-def _info(*, gpus=(), confidential=ConfidentialMode.NONE, status=VmStatus.RUNNING):
-    return SimpleNamespace(vm_id=str(_HASH), status=status, gpus=list(gpus), confidential_mode=confidential)
+def _info(*, gpus=(), confidential=ConfidentialMode.NONE):
+    return SimpleNamespace(vm_id=str(_HASH), gpus=list(gpus), confidential_mode=confidential)
 
 
 class TestRemovability:
@@ -83,12 +83,18 @@ class TestTeardown:
     async def test_a_vm_the_supervisor_does_not_know_is_still_cleaned_up(self, monkeypatch):
         """The supervisor forgetting first must not strand the agent's own
         state: the registry entry, the DB rows and the staging dirs are ours."""
-        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.delete_records_for_vm", AsyncMock())
-        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.remove_vprogram_staging", MagicMock())
-        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.remove_snp_instance_staging", MagicMock())
+        delete_records = AsyncMock()
+        vprogram_staging = MagicMock()
+        snp_staging = MagicMock()
+        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.delete_records_for_vm", delete_records)
+        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.remove_vprogram_staging", vprogram_staging)
+        monkeypatch.setattr("aleph.vm.agent.allocation.teardown.remove_snp_instance_staging", snp_staging)
         supervisor = SimpleNamespace(delete_vm=AsyncMock(side_effect=VmNotFoundError(str(_HASH))))
         registry = MagicMock()
 
         await teardown_vm(_HASH, supervisor=supervisor, registry=registry)
 
         registry.forget.assert_called_once_with(_HASH)
+        delete_records.assert_awaited_once_with(str(_HASH))
+        vprogram_staging.assert_called_once_with(_HASH)
+        snp_staging.assert_called_once_with(_HASH)

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -167,7 +167,9 @@ async def test_update_allocations_stops_descheduled_vprogram(aiohttp_client, moc
     fake_supervisor = MagicMock(delete_vm=AsyncMock(), list_vms=AsyncMock(return_value=[_running_vm_info(vm_hash)]))
     app["supervisor"] = fake_supervisor
 
-    mock_delete_records = mocker.patch("aleph.vm.agent.views.delete_records_for_vm", new_callable=AsyncMock)
+    mock_delete_records = mocker.patch(
+        "aleph.vm.agent.allocation.teardown.delete_records_for_vm", new_callable=AsyncMock
+    )
     client = await aiohttp_client(app)
 
     body, headers = scheduler_auth({"persistent_vms": []})


### PR DESCRIPTION
First of a stack implementing the async scheduler allocations design (`docs/plans/2026-08-20-async-allocations-design.md`). Behaviour-neutral on its own.

The stop half of `update_allocations` is an inline composite (supervisor delete, registry forget, DB records, two staging removers) guarded by a predicate whose v-program branch inverts every other rule: a v-program is stopped when the plan drops it *because* the scheduler is its single source of truth, even though it is credit-paid and confidential. The v2 reconciler (later in this stack) needs exactly that behaviour, so it becomes one tested module rather than a copy left to drift.

## Changes

- `agent/allocation/teardown.py`: `is_removable_by_allocation(record, info)` and `teardown_vm(vm_hash, *, supervisor, registry)`. The teardown is idempotent: a VM the supervisor has already forgotten still gets its agent-side state cleaned, because that state (registry entry, DB rows, staging dirs) is ours and would otherwise leak.
- `update_allocations` calls both; the four imports that moved with the code are dropped from `views/__init__.py`.
- Three tests patched `aleph.vm.agent.views.delete_records_for_vm`; the symbol moved, so their patch targets follow it. The assertions are unchanged.

## How to test

`pytest tests/supervisor/test_allocation_teardown.py` (9 new tests, written before the implementation).

Behaviour-neutrality is the real check: the whole `tests/supervisor` FAILED set is identical to `dev`.

## Notes

- ~105 pre-existing failures in my environment (`PermissionError: /var/cache/aleph`); the FAILED set is diffed against a `dev` worktree rather than counted.
- mypy unchanged at its 48-error baseline.
- Stack: this -> #verify -> #simulate -> plan/verdict -> reconciler -> v2 endpoints -> status surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
