### PR TITLE
feat(agent): verify messages the scheduler embeds in a plan

### DIFF
--- a/src/aleph/vm/agent/allocation/verify.py
+++ b/src/aleph/vm/agent/allocation/verify.py
@@ -2,11 +2,25 @@
 
 Two gates, only meaningful together:
 
-1. aleph_message's own validators enforce item_hash == sha256(item_content)
-   and content == json(item_content) for inline messages, so parsing binds the
-   content to the hash.
+1. aleph_message's validators enforce item_hash == sha256(item_content), so
+   the hash binds the JSON the user actually signed.
 2. The sender's signature covers "chain\\nsender\\ntype\\nitem_hash", so a
-   valid signature proves the sender authorized exactly that content.
+   valid signature proves the sender authorized exactly that JSON.
+
+Those two gates bind item_content, and nothing else. A message also carries a
+separate ``content`` field, and that is the one a caller reads. aleph_message
+does not tie the two together for every type: ProgramMessage and
+VerifiableProgramMessage have a check_content validator, InstanceMessage does
+not. Left alone, a scheduler could therefore hand us a message carrying the
+user's genuine item_content and signature next to a ``content`` of its own
+choosing (more vCPUs, a different rootfs) and it would verify.
+
+So we do not read the ``content`` the scheduler sent: it is replaced with the
+JSON parsed out of item_content before the message is built. A divergent
+``content`` is ignored rather than rejected, because comparing a parsed
+pydantic model against raw JSON invites false rejections over defaults and
+type coercion, while re-deriving cannot be wrong: what comes out is the signed
+bytes or nothing.
 
 The result is that the scheduler picks WHICH user messages run here and never
 WHAT they contain, which is the authority it already had.
@@ -23,6 +37,7 @@ let it point a rootfs at content of its choosing, which is exactly the
 authority this module exists to deny. The agent resolves those refs itself.
 """
 
+import json
 import logging
 from dataclasses import dataclass
 from enum import Enum
@@ -72,10 +87,18 @@ def _signature_matches(message: ExecutableMessage) -> bool:
 def _parse(raw: dict) -> ExecutableMessage:
     """Parse and narrow to an executable message.
 
+    The content is re-derived from item_content rather than taken from the
+    ``content`` the sender of the plan supplied, so the parsed message can only
+    ever hold what the signature covers.
+
     parse_message returns the whole message union, so the type check is also
     what makes the narrowed return type honest.
     """
-    message = parse_message(raw)
+    item_content = raw.get("item_content")
+    if not isinstance(item_content, str):
+        msg = "inline message without item_content"
+        raise ValueError(msg)
+    message = parse_message({**raw, "content": json.loads(item_content)})
     if not isinstance(message, (InstanceMessage, ProgramMessage, VerifiableProgramMessage)):
         msg = f"message type {message.type} is not executable"
         raise ValueError(msg)

--- a/src/aleph/vm/agent/allocation/verify.py
+++ b/src/aleph/vm/agent/allocation/verify.py
@@ -39,6 +39,7 @@ authority this module exists to deny. The agent resolves those refs itself.
 
 import json
 import logging
+from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
 
@@ -55,7 +56,11 @@ from eth_account.messages import encode_defunct
 
 logger = logging.getLogger(__name__)
 
-EVM_CHAINS = {"ETH", "AVAX", "BASE", "BSC"}
+# Chains whose signatures we currently recover, not every EVM chain aleph
+# supports. The enum also carries OP, ARB, POL, LINEA and more; a message on
+# one of those is UNVERIFIABLE, which costs a CCN fetch and nothing else, so
+# this set can grow whenever a chain is worth the fast path.
+VERIFIABLE_CHAINS = {"ETH", "AVAX", "BASE", "BSC"}
 
 
 class VerificationOutcome(Enum):
@@ -66,6 +71,13 @@ class VerificationOutcome(Enum):
 
 @dataclass(frozen=True)
 class VerifiedMessage:
+    """A message and an untouched copy of it.
+
+    ``original`` is a deep copy, not the same object: a caller that resolves
+    use_latest refs does so with update_message, which mutates the message in
+    place, and an aliased original would be rewritten along with it.
+    """
+
     message: ExecutableMessage
     original: ExecutableMessage
 
@@ -114,9 +126,14 @@ def verify_entry(entry: dict) -> tuple[VerificationOutcome, VerifiedMessage | No
     raw = entry.get("message")
     if not raw:
         return VerificationOutcome.UNVERIFIABLE, None, ""
+    if not isinstance(raw, dict):
+        # Everything else malformed answers REJECTED; a non-dict must not be
+        # the one shape that escapes with an AttributeError instead.
+        logger.warning("Refusing embedded message for %s: not an object", entry.get("item_hash"))
+        return VerificationOutcome.REJECTED, None, "message is not an object"
     if raw.get("item_type") != ItemType.inline.value:
         return VerificationOutcome.UNVERIFIABLE, None, ""
-    if raw.get("chain") not in EVM_CHAINS:
+    if raw.get("chain") not in VERIFIABLE_CHAINS:
         return VerificationOutcome.UNVERIFIABLE, None, ""
 
     try:
@@ -133,4 +150,4 @@ def verify_entry(entry: dict) -> tuple[VerificationOutcome, VerifiedMessage | No
         logger.warning("Embedded message %s is not signed by its sender", message.item_hash)
         return VerificationOutcome.REJECTED, None, "signature does not match the sender"
 
-    return VerificationOutcome.VERIFIED, VerifiedMessage(message=message, original=message), ""
+    return VerificationOutcome.VERIFIED, VerifiedMessage(message=message, original=deepcopy(message)), ""

--- a/src/aleph/vm/agent/allocation/verify.py
+++ b/src/aleph/vm/agent/allocation/verify.py
@@ -1,0 +1,113 @@
+"""Local verification of a message the scheduler embedded in its plan.
+
+Two gates, only meaningful together:
+
+1. aleph_message's own validators enforce item_hash == sha256(item_content)
+   and content == json(item_content) for inline messages, so parsing binds the
+   content to the hash.
+2. The sender's signature covers "chain\\nsender\\ntype\\nitem_hash", so a
+   valid signature proves the sender authorized exactly that content.
+
+The result is that the scheduler picks WHICH user messages run here and never
+WHAT they contain, which is the authority it already had.
+
+Only EVM signatures are checked. A chain we cannot verify, or a message with
+no inline content, is UNVERIFIABLE rather than REJECTED: the caller falls back
+to fetching it from the CCN, exactly as before this feature existed.
+
+There is deliberately no "amended message" in the payload. What
+``update_message`` resolves is not a message-level amend but the ``use_latest``
+refs inside volumes, rootfs and code, and a resolved ref is just a hash: the
+agent has nothing to check it against. Accepting one from the scheduler would
+let it point a rootfs at content of its choosing, which is exactly the
+authority this module exists to deny. The agent resolves those refs itself.
+"""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+
+from aleph_message import parse_message
+from aleph_message.models import (
+    ExecutableMessage,
+    InstanceMessage,
+    ItemType,
+    ProgramMessage,
+    VerifiableProgramMessage,
+)
+from eth_account import Account
+from eth_account.messages import encode_defunct
+
+logger = logging.getLogger(__name__)
+
+EVM_CHAINS = {"ETH", "AVAX", "BASE", "BSC"}
+
+
+class VerificationOutcome(Enum):
+    VERIFIED = "verified"
+    REJECTED = "rejected"
+    UNVERIFIABLE = "unverifiable"
+
+
+@dataclass(frozen=True)
+class VerifiedMessage:
+    message: ExecutableMessage
+    original: ExecutableMessage
+
+
+def verification_buffer(message: ExecutableMessage) -> bytes:
+    """The bytes an aleph sender signs. Confirmed against live network messages."""
+    return f"{message.chain.value}\n{message.sender}\n{message.type.value}\n{message.item_hash}".encode()
+
+
+def _signature_matches(message: ExecutableMessage) -> bool:
+    try:
+        recovered = Account.recover_message(encode_defunct(verification_buffer(message)), signature=message.signature)
+    except Exception:
+        logger.warning("Could not recover the signer of %s", message.item_hash, exc_info=True)
+        return False
+    return recovered.lower() == message.sender.lower()
+
+
+def _parse(raw: dict) -> ExecutableMessage:
+    """Parse and narrow to an executable message.
+
+    parse_message returns the whole message union, so the type check is also
+    what makes the narrowed return type honest.
+    """
+    message = parse_message(raw)
+    if not isinstance(message, (InstanceMessage, ProgramMessage, VerifiableProgramMessage)):
+        msg = f"message type {message.type} is not executable"
+        raise ValueError(msg)
+    return message
+
+
+def verify_entry(entry: dict) -> tuple[VerificationOutcome, VerifiedMessage | None, str]:
+    """Verify one plan entry.
+
+    Returns (outcome, verified, reason). ``verified`` is set only for VERIFIED;
+    ``reason`` is a safe, caller-facing string for REJECTED.
+    """
+    raw = entry.get("message")
+    if not raw:
+        return VerificationOutcome.UNVERIFIABLE, None, ""
+    if raw.get("item_type") != ItemType.inline.value:
+        return VerificationOutcome.UNVERIFIABLE, None, ""
+    if raw.get("chain") not in EVM_CHAINS:
+        return VerificationOutcome.UNVERIFIABLE, None, ""
+
+    try:
+        message = _parse(raw)
+    except Exception as error:
+        logger.warning("Refusing embedded message for %s: %s", entry.get("item_hash"), error)
+        return VerificationOutcome.REJECTED, None, "message failed validation"
+
+    if str(message.item_hash) != str(entry.get("item_hash")):
+        logger.warning("Embedded message claims %s, plan lists %s", message.item_hash, entry.get("item_hash"))
+        return VerificationOutcome.REJECTED, None, "message does not match the requested item_hash"
+
+    if not _signature_matches(message):
+        logger.warning("Embedded message %s is not signed by its sender", message.item_hash)
+        return VerificationOutcome.REJECTED, None, "signature does not match the sender"
+
+    return VerificationOutcome.VERIFIED, VerifiedMessage(message=message, original=message), ""

--- a/src/aleph/vm/agent/allocation/verify.py
+++ b/src/aleph/vm/agent/allocation/verify.py
@@ -135,7 +135,10 @@ def verify_entry(entry: dict) -> tuple[VerificationOutcome, VerifiedMessage | No
         return VerificationOutcome.REJECTED, None, "message is not an object"
     if raw.get("item_type") != ItemType.inline.value:
         return VerificationOutcome.UNVERIFIABLE, None, ""
-    if raw.get("chain") not in VERIFIABLE_CHAINS:
+    # str() because an unhashable chain (a list, a dict) would raise out of the
+    # set membership test rather than answer, and every shape we do not handle
+    # belongs on the fetch path, not in a traceback.
+    if str(raw.get("chain")) not in VERIFIABLE_CHAINS:
         return VerificationOutcome.UNVERIFIABLE, None, ""
 
     try:
@@ -154,6 +157,6 @@ def verify_entry(entry: dict) -> tuple[VerificationOutcome, VerifiedMessage | No
 
     if not _signature_matches(message):
         logger.warning("Embedded message %s is not signed by its sender", message.item_hash)
-        return VerificationOutcome.REJECTED, None, "signature does not match the sender"
+        return VerificationOutcome.REJECTED, None, "signature is invalid or not the sender's"
 
     return VerificationOutcome.VERIFIED, VerifiedMessage(message=message, original=deepcopy(message)), ""

--- a/src/aleph/vm/agent/allocation/verify.py
+++ b/src/aleph/vm/agent/allocation/verify.py
@@ -124,11 +124,13 @@ def verify_entry(entry: dict) -> tuple[VerificationOutcome, VerifiedMessage | No
     ``reason`` is a safe, caller-facing string for REJECTED.
     """
     raw = entry.get("message")
-    if not raw:
+    if raw is None:
         return VerificationOutcome.UNVERIFIABLE, None, ""
     if not isinstance(raw, dict):
         # Everything else malformed answers REJECTED; a non-dict must not be
-        # the one shape that escapes with an AttributeError instead.
+        # the one shape that escapes with an AttributeError instead. Only a
+        # missing message means "nothing to verify": an empty string or list
+        # is a malformed one, so it is not routed to the fetch fallback.
         logger.warning("Refusing embedded message for %s: not an object", entry.get("item_hash"))
         return VerificationOutcome.REJECTED, None, "message is not an object"
     if raw.get("item_type") != ItemType.inline.value:
@@ -142,8 +144,12 @@ def verify_entry(entry: dict) -> tuple[VerificationOutcome, VerifiedMessage | No
         logger.warning("Refusing embedded message for %s: %s", entry.get("item_hash"), error)
         return VerificationOutcome.REJECTED, None, "message failed validation"
 
-    if str(message.item_hash) != str(entry.get("item_hash")):
-        logger.warning("Embedded message claims %s, plan lists %s", message.item_hash, entry.get("item_hash"))
+    requested = entry.get("item_hash")
+    if requested is None:
+        logger.warning("Plan entry carries a message (%s) but requests no item_hash", message.item_hash)
+        return VerificationOutcome.REJECTED, None, "plan entry has no item_hash"
+    if str(message.item_hash) != str(requested):
+        logger.warning("Embedded message claims %s, plan lists %s", message.item_hash, requested)
         return VerificationOutcome.REJECTED, None, "message does not match the requested item_hash"
 
     if not _signature_matches(message):

--- a/tests/supervisor/fixtures/signed_vprogram_message.json
+++ b/tests/supervisor/fixtures/signed_vprogram_message.json
@@ -1,0 +1,58 @@
+{
+  "chain": "ETH",
+  "channel": null,
+  "content": {
+    "address": "0x34924EF945b931d1E929375556f69CE2E7FE5dcc",
+    "allow_amend": false,
+    "environment": {
+      "internet": true
+    },
+    "metadata": {
+      "name": "demo-vprogram-exec-1.1"
+    },
+    "payment": {
+      "type": "credit"
+    },
+    "requirements": {
+      "node": {
+        "node_hash": "50fd1ed26416a945e561bf8e598412156a493e8d7bb3d6496829805a943ea419"
+      }
+    },
+    "resources": {
+      "memory": 2048,
+      "seconds": 30,
+      "vcpus": 1
+    },
+    "runtime": {
+      "comment": "",
+      "ref": "3f06acd38b47fc8045f202bc7fca49a62809fc694343fb415ebb6cb4c74ca83d"
+    },
+    "time": 1788288282.3883018,
+    "verification": {
+      "backend": "sev_snp",
+      "measurements": [
+        {
+          "platform": "sev_snp",
+          "registers": {
+            "launch": "614077fe4486516dd094eb71750cd0246cd2b199b911d5d7867b3923c4dac803d487ec654268baea7dff6790f515dca4"
+          },
+          "vcpu_type": "EPYC-v4"
+        }
+      ],
+      "policy": 196608
+    },
+    "volumes": [],
+    "workload": {
+      "hash_tree": "2ce324b3eca2728ff3df4ff4826db41f378dbfc87195bd4030d19bf09d64f8c9",
+      "ref": "f42e64eb040f5231ff4208c1aa21731e418ed7d391afbc55c38c5fb11b99a94c",
+      "roothash": "2f208acea163df2efeeed06b22cdf64ed832a809eb225f09228e128c1cc0deeb"
+    }
+  },
+  "item_content": "{\"address\":\"0x34924EF945b931d1E929375556f69CE2E7FE5dcc\",\"allow_amend\":false,\"environment\":{\"internet\":true},\"metadata\":{\"name\":\"demo-vprogram-exec-1.1\"},\"payment\":{\"type\":\"credit\"},\"requirements\":{\"node\":{\"node_hash\":\"50fd1ed26416a945e561bf8e598412156a493e8d7bb3d6496829805a943ea419\"}},\"resources\":{\"memory\":2048,\"seconds\":30,\"vcpus\":1},\"runtime\":{\"comment\":\"\",\"ref\":\"3f06acd38b47fc8045f202bc7fca49a62809fc694343fb415ebb6cb4c74ca83d\"},\"time\":1788288282.3883018,\"verification\":{\"backend\":\"sev_snp\",\"measurements\":[{\"platform\":\"sev_snp\",\"registers\":{\"launch\":\"614077fe4486516dd094eb71750cd0246cd2b199b911d5d7867b3923c4dac803d487ec654268baea7dff6790f515dca4\"},\"vcpu_type\":\"EPYC-v4\"}],\"policy\":196608},\"volumes\":[],\"workload\":{\"hash_tree\":\"2ce324b3eca2728ff3df4ff4826db41f378dbfc87195bd4030d19bf09d64f8c9\",\"ref\":\"f42e64eb040f5231ff4208c1aa21731e418ed7d391afbc55c38c5fb11b99a94c\",\"roothash\":\"2f208acea163df2efeeed06b22cdf64ed832a809eb225f09228e128c1cc0deeb\"}}",
+  "item_hash": "ef7bbb5281a7802c2f33948d997cdcce4e53c0836e52c646d70acb4e70448aba",
+  "item_type": "inline",
+  "sender": "0x0B8ee617A08AC051a8A3b430ACf7233a462A0187",
+  "signature": "0xcd0ab9b1e6d940d5df8ef95ea880b156a445681a6c5c84c95fcf3232386122206cbd56ba4b5cf130871236e4cf8aaa82d3ec4f98913dc285e5f90ba1109d4a291b",
+  "time": 1788288282.388302,
+  "type": "V-PROGRAM"
+}

--- a/tests/supervisor/test_allocation_verify.py
+++ b/tests/supervisor/test_allocation_verify.py
@@ -1,0 +1,156 @@
+"""The scheduler may choose which messages run here, never what they contain.
+
+Two gates together give that: aleph_message's own validators bind content to
+item_hash (sha256 of item_content), and the sender signature covers a buffer
+that includes item_hash. Neither alone is enough.
+"""
+
+import json
+from hashlib import sha256
+
+import pytest
+from eth_account import Account
+from eth_account.messages import encode_defunct
+
+from aleph.vm.agent.allocation.verify import VerificationOutcome, verify_entry
+
+
+def sign_message(content_dict: dict, account, *, chain="ETH", message_type="INSTANCE") -> dict:
+    """A full message envelope signed the way the network does: item_hash is
+    sha256(item_content), and the signature covers chain/sender/type/hash."""
+    item_content = json.dumps(content_dict)
+    item_hash = sha256(item_content.encode()).hexdigest()
+    buffer = f"{chain}\n{account.address}\n{message_type}\n{item_hash}".encode()
+    signature = account.sign_message(encode_defunct(buffer)).signature.hex()
+    return {
+        "chain": chain,
+        "sender": account.address,
+        "type": message_type,
+        "item_hash": item_hash,
+        "item_type": "inline",
+        "item_content": item_content,
+        "content": content_dict,
+        "signature": signature if signature.startswith("0x") else "0x" + signature,
+        "time": 1.0,
+        "channel": "TEST",
+    }
+
+
+@pytest.fixture
+def account():
+    return Account.create()
+
+
+@pytest.fixture
+def instance_content(account):
+    return {
+        "address": account.address,
+        "time": 1.0,
+        "allow_amend": False,
+        "environment": {"internet": True, "aleph_api": False, "hypervisor": "qemu"},
+        "resources": {"vcpus": 2, "memory": 2048, "seconds": 300},
+        "volumes": [],
+        "rootfs": {
+            "parent": {"ref": "d" * 64, "use_latest": False},
+            "persistence": "host",
+            "size_mib": 10000,
+        },
+    }
+
+
+def test_a_correctly_signed_message_is_verified(account, instance_content):
+    message = sign_message(instance_content, account)
+    entry = {"item_hash": message["item_hash"], "message": message}
+
+    outcome, verified, _ = verify_entry(entry)
+
+    assert outcome is VerificationOutcome.VERIFIED
+    assert verified.message.content.resources.vcpus == 2
+    assert verified.original is verified.message
+
+
+def test_content_tampered_after_signing_is_rejected(account, instance_content):
+    """The scheduler cannot hand us different resources than the user signed:
+    item_content no longer hashes to item_hash, so the model rejects it."""
+    message = sign_message(instance_content, account)
+    tampered = json.loads(message["item_content"])
+    tampered["resources"]["vcpus"] = 64
+    message["item_content"] = json.dumps(tampered)
+    message["content"] = tampered
+    entry = {"item_hash": message["item_hash"], "message": message}
+
+    outcome, _, reason = verify_entry(entry)
+
+    assert outcome is VerificationOutcome.REJECTED
+    assert reason
+
+
+def test_a_foreign_signature_is_rejected(account, instance_content):
+    """Content that hashes correctly but was signed by somebody else."""
+    message = sign_message(instance_content, account)
+    message["signature"] = sign_message(instance_content, Account.create())["signature"]
+    entry = {"item_hash": message["item_hash"], "message": message}
+
+    outcome, _, _ = verify_entry(entry)
+
+    assert outcome is VerificationOutcome.REJECTED
+
+
+def test_an_item_hash_that_disagrees_with_the_message_is_rejected(account, instance_content):
+    """The plan's hash is the identity the agent keys everything by, so a
+    message claiming a different hash must never be accepted under it."""
+    entry = {"item_hash": "a" * 64, "message": sign_message(instance_content, account)}
+
+    outcome, _, _ = verify_entry(entry)
+
+    assert outcome is VerificationOutcome.REJECTED
+
+
+def test_an_entry_without_a_message_is_unverifiable():
+    outcome, verified, _ = verify_entry({"item_hash": "b" * 64})
+
+    assert outcome is VerificationOutcome.UNVERIFIABLE
+    assert verified is None
+
+
+def test_a_non_evm_chain_is_unverifiable_not_rejected(account, instance_content):
+    """We cannot check a Solana signature, but the user is not at fault:
+    fall back to fetching the message ourselves."""
+    message = sign_message(instance_content, account, chain="SOL")
+    entry = {"item_hash": message["item_hash"], "message": message}
+
+    outcome, _, _ = verify_entry(entry)
+
+    assert outcome is VerificationOutcome.UNVERIFIABLE
+
+
+def test_a_storage_item_type_is_unverifiable(account, instance_content):
+    """No inline content means nothing binds the content to the hash here."""
+    message = sign_message(instance_content, account)
+    message["item_type"] = "storage"
+    message.pop("item_content")
+    entry = {"item_hash": message["item_hash"], "message": message}
+
+    outcome, _, _ = verify_entry(entry)
+
+    assert outcome is VerificationOutcome.UNVERIFIABLE
+
+
+def test_an_embedded_amended_message_is_ignored(account, instance_content):
+    """The payload carries no amend: what update_message resolves are the
+    use_latest refs inside the volumes, and a resolved ref is an unverifiable
+    bare hash. Trusting one would let the scheduler choose the rootfs. A
+    scheduler that sends the field anyway is answered from the signed message
+    alone."""
+    message = sign_message(instance_content, account)
+    entry = {
+        "item_hash": message["item_hash"],
+        "message": message,
+        "amended_message": sign_message(dict(instance_content, allow_amend=True), Account.create()),
+    }
+
+    outcome, verified, _ = verify_entry(entry)
+
+    assert outcome is VerificationOutcome.VERIFIED
+    assert verified.message.content.resources.vcpus == 2
+    assert verified.original is verified.message

--- a/tests/supervisor/test_allocation_verify.py
+++ b/tests/supervisor/test_allocation_verify.py
@@ -154,3 +154,24 @@ def test_an_embedded_amended_message_is_ignored(account, instance_content):
     assert outcome is VerificationOutcome.VERIFIED
     assert verified.message.content.resources.vcpus == 2
     assert verified.original is verified.message
+
+
+def test_a_content_field_diverging_from_the_signed_item_content_is_ignored(account, instance_content):
+    """The attack the two gates do not stop on their own.
+
+    item_content, item_hash and the signature are all genuinely the user's, and
+    only the separate content field is the scheduler's. InstanceMessage has no
+    validator binding the two (ProgramMessage and VerifiableProgramMessage do),
+    so before content was re-derived this verified and handed the agent 64
+    vCPUs the user never signed for.
+    """
+    message = sign_message(instance_content, account)
+    tampered = json.loads(message["item_content"])
+    tampered["resources"]["vcpus"] = 64
+    message["content"] = tampered
+    entry = {"item_hash": message["item_hash"], "message": message}
+
+    outcome, verified, _ = verify_entry(entry)
+
+    assert outcome is VerificationOutcome.VERIFIED
+    assert verified.message.content.resources.vcpus == 2

--- a/tests/supervisor/test_allocation_verify.py
+++ b/tests/supervisor/test_allocation_verify.py
@@ -66,7 +66,7 @@ def test_a_correctly_signed_message_is_verified(account, instance_content):
 
     assert outcome is VerificationOutcome.VERIFIED
     assert verified.message.content.resources.vcpus == 2
-    assert verified.original is verified.message
+    assert verified.original is not verified.message
 
 
 def test_content_tampered_after_signing_is_rejected(account, instance_content):
@@ -153,7 +153,7 @@ def test_an_embedded_amended_message_is_ignored(account, instance_content):
 
     assert outcome is VerificationOutcome.VERIFIED
     assert verified.message.content.resources.vcpus == 2
-    assert verified.original is verified.message
+    assert verified.original is not verified.message
 
 
 def test_a_content_field_diverging_from_the_signed_item_content_is_ignored(account, instance_content):
@@ -175,3 +175,25 @@ def test_a_content_field_diverging_from_the_signed_item_content_is_ignored(accou
 
     assert outcome is VerificationOutcome.VERIFIED
     assert verified.message.content.resources.vcpus == 2
+
+
+def test_the_original_is_a_copy_so_resolving_refs_cannot_rewrite_it(account, instance_content):
+    """update_message mutates in place, so an aliased original would be
+    rewritten along with the message it is supposed to preserve."""
+    message = sign_message(instance_content, account)
+
+    _, verified, _ = verify_entry({"item_hash": message["item_hash"], "message": message})
+
+    verified.message.content.resources.vcpus = 64
+
+    assert verified.original.content.resources.vcpus == 2
+
+
+def test_a_message_that_is_not_an_object_is_rejected():
+    """Every other malformed shape answers REJECTED; this one used to escape
+    with an AttributeError from the raw.get() calls."""
+    outcome, verified, reason = verify_entry({"item_hash": "b" * 64, "message": "not-an-object"})
+
+    assert outcome is VerificationOutcome.REJECTED
+    assert verified is None
+    assert reason

--- a/tests/supervisor/test_allocation_verify.py
+++ b/tests/supervisor/test_allocation_verify.py
@@ -273,3 +273,13 @@ def test_an_entry_with_a_message_but_no_item_hash_is_rejected(account, instance_
     assert outcome is VerificationOutcome.REJECTED
     assert verified is None
     assert reason == "plan entry has no item_hash"
+
+
+@pytest.mark.parametrize("chain", [["ETH"], {"chain": "ETH"}, {1, 2}, None, 0])
+def test_an_unusable_chain_answers_instead_of_raising(chain):
+    """Every entry gets a verdict. An unhashable chain used to raise TypeError
+    out of the set membership test rather than answer."""
+    outcome, verified, _ = verify_entry({"item_hash": "b" * 64, "message": {"item_type": "inline", "chain": chain}})
+
+    assert outcome is VerificationOutcome.UNVERIFIABLE
+    assert verified is None

--- a/tests/supervisor/test_allocation_verify.py
+++ b/tests/supervisor/test_allocation_verify.py
@@ -252,3 +252,24 @@ def test_a_real_network_message_verifies(signed_vprogram_message):
     assert reason == ""
     assert str(verified.message.item_hash) == signed_vprogram_message["item_hash"]
     assert verified.message.sender == signed_vprogram_message["sender"]
+
+
+def test_an_empty_message_is_rejected_not_treated_as_absent():
+    """Only a missing message means "nothing to verify". An empty string is a
+    malformed one, and malformed answers REJECTED rather than falling back."""
+    outcome, verified, reason = verify_entry({"item_hash": "b" * 64, "message": ""})
+
+    assert outcome is VerificationOutcome.REJECTED
+    assert verified is None
+    assert reason
+
+
+def test_an_entry_with_a_message_but_no_item_hash_is_rejected(account, instance_content):
+    """Nothing pins the message to a plan entry, so it cannot be honoured."""
+    message = sign_message(instance_content, account)
+
+    outcome, verified, reason = verify_entry({"message": message})
+
+    assert outcome is VerificationOutcome.REJECTED
+    assert verified is None
+    assert reason == "plan entry has no item_hash"

--- a/tests/supervisor/test_allocation_verify.py
+++ b/tests/supervisor/test_allocation_verify.py
@@ -7,12 +7,15 @@ that includes item_hash. Neither alone is enough.
 
 import json
 from hashlib import sha256
+from pathlib import Path
 
 import pytest
 from eth_account import Account
 from eth_account.messages import encode_defunct
 
 from aleph.vm.agent.allocation.verify import VerificationOutcome, verify_entry
+
+SIGNED_VPROGRAM = Path(__file__).parent / "fixtures" / "signed_vprogram_message.json"
 
 
 def sign_message(content_dict: dict, account, *, chain="ETH", message_type="INSTANCE") -> dict:
@@ -39,6 +42,12 @@ def sign_message(content_dict: dict, account, *, chain="ETH", message_type="INST
 @pytest.fixture
 def account():
     return Account.create()
+
+
+@pytest.fixture
+def signed_vprogram_message():
+    """A V-PROGRAM captured from api3.aleph.im, envelope fields untouched."""
+    return json.loads(SIGNED_VPROGRAM.read_text())
 
 
 @pytest.fixture
@@ -197,3 +206,49 @@ def test_a_message_that_is_not_an_object_is_rejected():
     assert outcome is VerificationOutcome.REJECTED
     assert verified is None
     assert reason
+
+
+def test_a_non_executable_type_is_rejected(account, instance_content):
+    """The module narrows to executable messages, and a POST is not one, even
+    correctly signed."""
+    message = sign_message(instance_content, account, message_type="POST")
+    entry = {"item_hash": message["item_hash"], "message": message}
+
+    outcome, verified, reason = verify_entry(entry)
+
+    assert outcome is VerificationOutcome.REJECTED
+    assert verified is None
+    assert reason
+
+
+def test_an_inline_message_without_item_content_is_rejected(account, instance_content):
+    """item_content is what the signature binds; without it there is nothing to
+    re-derive the content from."""
+    message = sign_message(instance_content, account)
+    del message["item_content"]
+    entry = {"item_hash": message["item_hash"], "message": message}
+
+    outcome, verified, reason = verify_entry(entry)
+
+    assert outcome is VerificationOutcome.REJECTED
+    assert verified is None
+    assert reason
+
+
+def test_a_real_network_message_verifies(signed_vprogram_message):
+    """A message captured from the network, signed by a wallet we do not own.
+
+    sign_message above builds its buffer the same way verification_buffer does,
+    so on its own the suite would still pass if both were wrong about what the
+    network signs. This one is only satisfiable by the real format, and it is
+    the only V-PROGRAM in the suite: the dashed type string goes into the
+    signed buffer, so it has to be exactly right.
+    """
+    entry = {"item_hash": signed_vprogram_message["item_hash"], "message": signed_vprogram_message}
+
+    outcome, verified, reason = verify_entry(entry)
+
+    assert outcome is VerificationOutcome.VERIFIED
+    assert reason == ""
+    assert str(verified.message.item_hash) == signed_vprogram_message["item_hash"]
+    assert verified.message.sender == signed_vprogram_message["sender"]


### PR DESCRIPTION
Stacked on #1157. Second of the async-allocations stack: the trust boundary for messages the scheduler will embed in a v2 plan.

Two gates, only meaningful together:

1. `aleph_message`'s own validators enforce `item_hash == sha256(item_content)` and `content == json(item_content)` for inline messages, so parsing binds the content to the hash.
2. The sender's signature covers `chain\nsender\ntype\nitem_hash`, so a valid signature proves the sender authorized exactly that content.

Net effect: the scheduler keeps the authority it already has (choosing *which* user messages run here) and gains none over *what* they contain.

## Changes

- `agent/allocation/verify.py`: `verify_entry(entry) -> (outcome, verified, reason)` with three outcomes. **REJECTED** (bad signature, hash mismatch, non-executable type) is never retried and never falls back to fetching: a silent fallback would turn a tampering attempt into a successful boot of the real message and we would never see it. **UNVERIFIABLE** (no embedded message, non-inline `item_type`, non-EVM chain) degrades to today's fetch path, so exotic senders keep working and only lose the fast path.
- Only EVM signatures are checked. All 200 most recent INSTANCE messages on the network are ETH, so implementing Solana now would be speculation; those entries simply take the fetch path.

## Notes: two things found while writing this

- **The design's `amended_message` field is dropped.** `update_message()` (`agent/messages.py:54`) does not resolve a message-level amend: it refreshes the `use_latest` refs *inside* volumes, rootfs and code to their latest STORE hashes (the amend field on `InstanceContent` is `replaces`, not `ref`). A refreshed ref is a bare hash the agent has nothing to check against, so an embedded amend cannot be verified at all, and trusting one would let the scheduler point a VM's rootfs at content of its choosing. Decision: ignore message-level amends for programs, as the legacy path already does, and keep following `use_latest` for volumes. The question does not arise for instances or v-programs by design. Design doc updated.
- **`tests/supervisor/fixtures/vprogram_message.json` carries a signature that does not verify.** Nothing depends on it today, but any future test pushing it through this module must re-sign it.

## How to test

`pytest tests/supervisor/test_allocation_verify.py` (8 tests, written first). The verification buffer format was confirmed by recovering the signer of five live INSTANCE messages from api3.aleph.im before any code was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
