### PR TITLE
feat(agent): batch, release-aware capacity simulation

### DIFF
--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -162,6 +162,7 @@ class CapacityManager:
         committed_instance_memory_mib: int,
         committed_program_memory_mib: int,
         committed_vcpus: int,
+        committed_disk_mib: int = 0,
     ) -> None:
         """The admission arithmetic, against caller-supplied commitments.
 
@@ -197,7 +198,9 @@ class CapacityManager:
             committed_memory_mib = committed_program_memory_mib
             memory_cap_mib = program_memory_cap_mib
 
-        available_disk_mib = self._available_disk_bytes() // (1024 * 1024)
+        # Free space is a live figure, not a committed sum, so a batch caller
+        # passes what it has already promised to the candidates before this one.
+        available_disk_mib = max(self._available_disk_bytes() // (1024 * 1024) - committed_disk_mib, 0)
 
         errors: list[str] = []
 
@@ -254,13 +257,31 @@ class CapacityManager:
         """Judge a whole plan at once.
 
         Cumulative: each accepted candidate is committed before the next is
-        judged, so three VMs that only fit twice get two yeses and one no.
+        judged, so three VMs that only fit twice get two yeses and one no. This
+        covers memory, vCPUs and disk. Disk needs the accumulator because free
+        space is read live and no record of it exists until the volumes are
+        actually written.
 
         Release-aware: hashes the plan is about to stop are subtracted from the
         committed sums, so "allocate C, delete B" admits C against B's memory.
+        Their disk is not credited back: nothing has been deleted yet, so the
+        space is genuinely still occupied, and guessing otherwise would make
+        the advisory answer stronger than the enforced one.
 
         Side-effect free: nothing here reserves or holds anything, which is
         what makes it safe for the speculative capacity-check endpoint.
+
+        GPUs are out of scope. Card availability comes from the supervisor's
+        async host info and is claimed through stateful holds, neither of which
+        fits a synchronous side-effect-free call, so a GPU plan needs a
+        separate answer.
+
+        The third element of a candidate is the caller's memory-bucket choice,
+        NOT ResourceRequirements.is_instance. The two disagree for V-PROGRAMs:
+        requirements_from_message reports is_instance=False (the content is not
+        an InstanceContent) while a V-PROGRAM is committed to the instance
+        bucket, which is what _committed_resources and _admit both do. Pass
+        isinstance(content, (InstanceContent, VerifiableProgramContent)).
         """
         committed_instance, committed_program, committed_vcpus = self._committed_resources(None)
         for vm_hash in releasing:
@@ -273,8 +294,14 @@ class CapacityManager:
             else:
                 committed_program -= resources.memory
             committed_vcpus -= resources.vcpus
+        # A registry inconsistency must not make admission more permissive than
+        # an empty node.
+        committed_instance = max(committed_instance, 0)
+        committed_program = max(committed_program, 0)
+        committed_vcpus = max(committed_vcpus, 0)
 
         verdicts: list[AdmissionVerdict] = []
+        committed_disk = 0
         for vm_hash, requirements, is_instance in candidates:
             try:
                 self._check_against(
@@ -286,6 +313,7 @@ class CapacityManager:
                     committed_instance_memory_mib=committed_instance,
                     committed_program_memory_mib=committed_program,
                     committed_vcpus=committed_vcpus,
+                    committed_disk_mib=committed_disk,
                 )
             except InsufficientResourcesError as error:
                 logger.info("Plan candidate %s refused: %s", vm_hash, error)
@@ -298,6 +326,7 @@ class CapacityManager:
             else:
                 committed_program += requirements.memory_mib
             committed_vcpus += requirements.vcpus
+            committed_disk += requirements.disk_mib
             verdicts.append(AdmissionVerdict(vm_hash, True))
         return verdicts
 

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -49,6 +49,20 @@ class ResourceRequirements:
     gpu_device_ids: list[str] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class AdmissionVerdict:
+    """One candidate's admission answer.
+
+    ``code`` and ``detail`` are safe to hand back to the scheduler; the full
+    error text stays in the logs.
+    """
+
+    vm_hash: ItemHash
+    accepted: bool
+    code: str = ""
+    detail: str = ""
+
+
 def requirements_from_message(content: ExecutableContent) -> ResourceRequirements:
     """Extract the resources a message requests into a message-free DTO."""
     is_instance = isinstance(content, InstanceContent)
@@ -115,21 +129,50 @@ class CapacityManager:
         Two-bucket memory accounting: instances share
         physical - HOST_MEMORY_RESERVED_MIB - PROGRAM_MEMORY_RESERVED_MIB,
         programs share PROGRAM_MEMORY_RESERVED_MIB. vCPUs are capped at
-        physical cores times VCPU_OVERCOMMIT_FACTOR. Disk is only checked for
-        disk_mib > 0 (the reserve path; the create path passes 0).
+        physical cores times VCPU_OVERCOMMIT_FACTOR. Disk is checked whenever
+        disk_mib > 0, which every create path now passes (#1153).
 
         ``exclude_vm_hash`` skips that VM's own registry record from the
         committed sums: the create paths record the VM before admission (the
         early owner record, or a leftover record on a recreate), and its own
         record must not count against its own request.
         """
-        required_memory_mib = memory_mib
-        required_vcpus = vcpus
-        required_disk_mib = disk_mib
-
         committed_instance_memory_mib, committed_program_memory_mib, committed_vcpus = self._committed_resources(
             exclude_vm_hash
         )
+        self._check_against(
+            memory_mib=memory_mib,
+            vcpus=vcpus,
+            disk_mib=disk_mib,
+            max_volume_mib=max_volume_mib,
+            is_instance=is_instance,
+            committed_instance_memory_mib=committed_instance_memory_mib,
+            committed_program_memory_mib=committed_program_memory_mib,
+            committed_vcpus=committed_vcpus,
+        )
+
+    def _check_against(
+        self,
+        *,
+        memory_mib: int,
+        vcpus: int,
+        disk_mib: int,
+        max_volume_mib: int,
+        is_instance: bool,
+        committed_instance_memory_mib: int,
+        committed_program_memory_mib: int,
+        committed_vcpus: int,
+    ) -> None:
+        """The admission arithmetic, against caller-supplied commitments.
+
+        Split out so simulate() can judge a candidate against sums it is
+        accumulating itself, while check_capacity keeps judging against the
+        registry as it stands. One implementation, so an advisory answer can
+        never be stronger or weaker than the enforced one.
+        """
+        required_memory_mib = memory_mib
+        required_vcpus = vcpus
+        required_disk_mib = disk_mib
 
         physical_memory_mib = psutil.virtual_memory().total // (1024 * 1024)
         physical_cores = psutil.cpu_count() or 1
@@ -201,6 +244,62 @@ class CapacityManager:
                     "disk_mib": available_disk_mib,
                 },
             )
+
+    def simulate(
+        self,
+        candidates: list[tuple[ItemHash, ResourceRequirements, bool]],
+        *,
+        releasing: frozenset[ItemHash] = frozenset(),
+    ) -> list[AdmissionVerdict]:
+        """Judge a whole plan at once.
+
+        Cumulative: each accepted candidate is committed before the next is
+        judged, so three VMs that only fit twice get two yeses and one no.
+
+        Release-aware: hashes the plan is about to stop are subtracted from the
+        committed sums, so "allocate C, delete B" admits C against B's memory.
+
+        Side-effect free: nothing here reserves or holds anything, which is
+        what makes it safe for the speculative capacity-check endpoint.
+        """
+        committed_instance, committed_program, committed_vcpus = self._committed_resources(None)
+        for vm_hash in releasing:
+            record = self.registry.get(vm_hash)
+            if record is None or not record.message.resources:
+                continue
+            resources = record.message.resources
+            if isinstance(record.message, InstanceContent) or record.is_vprogram:
+                committed_instance -= resources.memory
+            else:
+                committed_program -= resources.memory
+            committed_vcpus -= resources.vcpus
+
+        verdicts: list[AdmissionVerdict] = []
+        for vm_hash, requirements, is_instance in candidates:
+            try:
+                self._check_against(
+                    memory_mib=requirements.memory_mib,
+                    vcpus=requirements.vcpus,
+                    disk_mib=requirements.disk_mib,
+                    max_volume_mib=requirements.max_volume_mib,
+                    is_instance=is_instance,
+                    committed_instance_memory_mib=committed_instance,
+                    committed_program_memory_mib=committed_program,
+                    committed_vcpus=committed_vcpus,
+                )
+            except InsufficientResourcesError as error:
+                logger.info("Plan candidate %s refused: %s", vm_hash, error)
+                verdicts.append(
+                    AdmissionVerdict(vm_hash, False, "insufficient_capacity", "not enough capacity on this CRN")
+                )
+                continue
+            if is_instance:
+                committed_instance += requirements.memory_mib
+            else:
+                committed_program += requirements.memory_mib
+            committed_vcpus += requirements.vcpus
+            verdicts.append(AdmissionVerdict(vm_hash, True))
+        return verdicts
 
     def _committed_resources(self, exclude_vm_hash: ItemHash | None) -> tuple[int, int, int]:
         """(committed_instance_memory_mib, committed_program_memory_mib,

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -46,6 +46,8 @@ class ResourceRequirements:
     memory_mib: int
     disk_mib: int
     max_volume_mib: int = 0
+    # The memory bucket, from is_instance_bucket: True for a V-PROGRAM even
+    # though it is not an InstanceContent.
     is_instance: bool = False
     gpu_device_ids: list[str] = field(default_factory=list)
 
@@ -77,7 +79,7 @@ def is_instance_bucket(content: ExecutableContent) -> bool:
 
 def requirements_from_message(content: ExecutableContent) -> ResourceRequirements:
     """Extract the resources a message requests into a message-free DTO."""
-    is_instance = isinstance(content, InstanceContent)
+    is_instance = is_instance_bucket(content)
     volume_sizes_mib: list[int] = []
     if isinstance(content, InstanceContent) and content.rootfs:
         volume_sizes_mib.append(content.rootfs.size_mib)
@@ -264,7 +266,7 @@ class CapacityManager:
 
     def simulate(
         self,
-        candidates: list[tuple[ItemHash, ResourceRequirements, bool]],
+        candidates: list[tuple[ItemHash, ResourceRequirements]],
         *,
         releasing: frozenset[ItemHash] = frozenset(),
         available_gpus: list[GpuDevice] | None = None,
@@ -312,14 +314,8 @@ class CapacityManager:
         allocate C onto B's card" is answered no even though doing it in that
         order would work.
 
-        The third element of a candidate is the caller's memory-bucket choice,
-        NOT ResourceRequirements.is_instance. The two disagree for V-PROGRAMs:
-        requirements_from_message reports is_instance=False (the content is not
-        an InstanceContent) while a V-PROGRAM is committed to the instance
-        bucket, which is what _committed_resources and _admit both do. Pass
-        is_instance_bucket(content) rather than restating the rule.
         """
-        candidate_hashes = {vm_hash for vm_hash, _, _ in candidates}
+        candidate_hashes = {vm_hash for vm_hash, _ in candidates}
         committed_instance, committed_program, committed_vcpus = self._committed_resources(candidate_hashes)
         for vm_hash in releasing:
             if vm_hash in candidate_hashes:
@@ -342,7 +338,7 @@ class CapacityManager:
 
         verdicts: list[AdmissionVerdict] = []
         committed_disk = 0
-        for vm_hash, requirements, is_instance in candidates:
+        for vm_hash, requirements in candidates:
             refusal: tuple[str, str] | None = None
             try:
                 self._check_against(
@@ -350,7 +346,7 @@ class CapacityManager:
                     vcpus=requirements.vcpus,
                     disk_mib=requirements.disk_mib,
                     max_volume_mib=requirements.max_volume_mib,
-                    is_instance=is_instance,
+                    is_instance=requirements.is_instance,
                     committed_instance_memory_mib=committed_instance,
                     committed_program_memory_mib=committed_program,
                     committed_vcpus=committed_vcpus,
@@ -380,7 +376,7 @@ class CapacityManager:
                     committed_program += kept[1]
                     committed_vcpus += kept[2]
                 continue
-            if is_instance:
+            if requirements.is_instance:
                 committed_instance += requirements.memory_mib
             else:
                 committed_program += requirements.memory_mib

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -273,9 +273,11 @@ class CapacityManager:
 
         Cumulative: each accepted candidate is committed before the next is
         judged, so three VMs that only fit twice get two yeses and one no. This
-        covers memory, vCPUs and disk. Disk needs the accumulator because free
-        space is read live and no record of it exists until the volumes are
-        actually written.
+        covers memory, vCPUs and aggregate disk. Disk needs the accumulator
+        because free space is read live and no record of it exists until the
+        volumes are actually written. Aggregate only: the per-volume check asks
+        whether the roomiest pool could hold the largest volume, and which pool
+        a volume lands on is a placement decision nothing models here.
 
         A candidate's own registry record never counts against it. A hash can
         already be recorded here and still be a candidate: a recreate, or an
@@ -304,6 +306,11 @@ class CapacityManager:
         memory alone. An advisory yes must never be read as one that covered
         the GPU.
 
+        Releases are not credited back for cards either, and for the same
+        reason as disk: the inventory is the cards not currently attached, so a
+        card still held by a VM the plan stops is absent from it. "Stop B,
+        allocate C onto B's card" is answered no even though doing it in that
+        order would work.
 
         The third element of a candidate is the caller's memory-bucket choice,
         NOT ResourceRequirements.is_instance. The two disagree for V-PROGRAMs:

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -266,6 +266,7 @@ class CapacityManager:
         candidates: list[tuple[ItemHash, ResourceRequirements, bool]],
         *,
         releasing: frozenset[ItemHash] = frozenset(),
+        available_gpus: list[GpuDevice] | None = None,
     ) -> list[AdmissionVerdict]:
         """Judge a whole plan at once.
 
@@ -284,10 +285,17 @@ class CapacityManager:
         Side-effect free: nothing here reserves or holds anything, which is
         what makes it safe for the speculative capacity-check endpoint.
 
-        GPUs are out of scope. Card availability comes from the supervisor's
-        async host info and is claimed through stateful holds, neither of which
-        fits a synchronous side-effect-free call, so a GPU plan needs a
-        separate answer.
+        GPUs are judged from ``available_gpus``, the host's unattached cards,
+        which the caller reads from the supervisor because that read is async
+        and this call is not. Matching is cumulative like the rest: two
+        candidates wanting the only card of a kind get one yes. A card under a
+        live hold counts as taken, since the hold is some user's pending
+        create.
+
+        Without ``available_gpus`` there is no inventory to judge against, so a
+        candidate that asks for a card is refused rather than admitted on
+        memory alone. An advisory yes must never be read as one that covered
+        the GPU.
 
         The third element of a candidate is the caller's memory-bucket choice,
         NOT ResourceRequirements.is_instance. The two disagree for V-PROGRAMs:
@@ -313,6 +321,8 @@ class CapacityManager:
         committed_program = max(committed_program, 0)
         committed_vcpus = max(committed_vcpus, 0)
 
+        gpu_pool = None if available_gpus is None else self._unheld_gpus(available_gpus)
+
         verdicts: list[AdmissionVerdict] = []
         committed_disk = 0
         for vm_hash, requirements, is_instance in candidates:
@@ -334,6 +344,14 @@ class CapacityManager:
                     AdmissionVerdict(vm_hash, False, "insufficient_capacity", "not enough capacity on this CRN")
                 )
                 continue
+            # Last, and only once the candidate has cleared everything else:
+            # taking cards is what makes the pool cumulative, so a candidate
+            # refused on memory must not walk off with the cards first.
+            gpu_refusal = self._take_gpus(requirements.gpu_device_ids, gpu_pool)
+            if gpu_refusal is not None:
+                logger.info("Plan candidate %s refused: %s", vm_hash, gpu_refusal)
+                verdicts.append(AdmissionVerdict(vm_hash, False, "gpu_unavailable", gpu_refusal))
+                continue
             if is_instance:
                 committed_instance += requirements.memory_mib
             else:
@@ -342,6 +360,39 @@ class CapacityManager:
             committed_disk += requirements.disk_mib
             verdicts.append(AdmissionVerdict(vm_hash, True))
         return verdicts
+
+    def _unheld_gpus(self, available_gpus: list[GpuDevice]) -> list[GpuDevice]:
+        """The cards a plan may count on: unattached and not under a live hold.
+
+        A hold is some user's pending create, so a held card is treated as
+        taken. Read-only on purpose: unlike _get_valid_hold this leaves expired
+        entries in the ledger, because simulate mutates nothing.
+        """
+        return [gpu for gpu in available_gpus if (hold := self.holds.get(gpu.pci_host)) is None or hold.is_expired()]
+
+    @staticmethod
+    def _take_gpus(device_ids: list[str], pool: list[GpuDevice] | None) -> str | None:
+        """Consume one card per requested id from ``pool``. None if it fits.
+
+        All or nothing, like reserve_gpus: a candidate that cannot get every
+        card it asked for takes none, so it does not strand cards a later
+        candidate could have used.
+        """
+        if not device_ids:
+            return None
+        if pool is None:
+            return "GPU availability was not checked for this plan"
+        taken: list[GpuDevice] = []
+        for device_id in device_ids:
+            for gpu in pool:
+                if gpu.device_id == device_id and gpu not in taken:
+                    taken.append(gpu)
+                    break
+            else:
+                return f"No available GPU matching device_id {device_id!r}"
+        for gpu in taken:
+            pool.remove(gpu)
+        return None
 
     def _committed_resources(self, exclude_vm_hash: ItemHash | None) -> tuple[int, int, int]:
         """(committed_instance_memory_mib, committed_program_memory_mib,

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -63,6 +63,17 @@ class AdmissionVerdict:
     detail: str = ""
 
 
+def is_instance_bucket(content: ExecutableContent) -> bool:
+    """Whether this content is admitted against the instance memory bucket.
+
+    A V-PROGRAM is a full SNP VM and belongs with the instances even though it
+    is not an InstanceContent. Bucketing one as a program would both starve the
+    small program bucket and hide its memory from instance admission, so the
+    rule lives here instead of being restated wherever a bucket is picked.
+    """
+    return isinstance(content, (InstanceContent, VerifiableProgramContent))
+
+
 def requirements_from_message(content: ExecutableContent) -> ResourceRequirements:
     """Extract the resources a message requests into a message-free DTO."""
     is_instance = isinstance(content, InstanceContent)
@@ -281,7 +292,7 @@ class CapacityManager:
         requirements_from_message reports is_instance=False (the content is not
         an InstanceContent) while a V-PROGRAM is committed to the instance
         bucket, which is what _committed_resources and _admit both do. Pass
-        isinstance(content, (InstanceContent, VerifiableProgramContent)).
+        is_instance_bucket(content) rather than restating the rule.
         """
         committed_instance, committed_program, committed_vcpus = self._committed_resources(None)
         for vm_hash in releasing:
@@ -289,7 +300,7 @@ class CapacityManager:
             if record is None or not record.message.resources:
                 continue
             resources = record.message.resources
-            if isinstance(record.message, InstanceContent) or record.is_vprogram:
+            if is_instance_bucket(record.message):
                 committed_instance -= resources.memory
             else:
                 committed_program -= resources.memory
@@ -345,12 +356,7 @@ class CapacityManager:
             record_vcpus = resources.vcpus
             if not memory and not record_vcpus:
                 continue
-            # V-PROGRAMs are full SNP VMs, admitted against the instance
-            # bucket (run.py passes is_instance=True), so they must also be
-            # counted there. Bucketing them as programs would both starve the
-            # small program bucket and hide their memory from instance
-            # admission (silent over-commit).
-            if isinstance(record.message, (InstanceContent, VerifiableProgramContent)):
+            if is_instance_bucket(record.message):
                 committed_instance_memory_mib += memory
             else:
                 committed_program_memory_mib += memory

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Collection
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
@@ -151,7 +152,7 @@ class CapacityManager:
         record must not count against its own request.
         """
         committed_instance_memory_mib, committed_program_memory_mib, committed_vcpus = self._committed_resources(
-            exclude_vm_hash
+            () if exclude_vm_hash is None else (exclude_vm_hash,)
         )
         self._check_against(
             memory_mib=memory_mib,
@@ -276,6 +277,12 @@ class CapacityManager:
         space is read live and no record of it exists until the volumes are
         actually written.
 
+        A candidate's own registry record never counts against it. A hash can
+        already be recorded here and still be a candidate: a recreate, or an
+        owner record left by a create that failed part way. Counting both the
+        record and the request would make the VM refuse itself, so the record
+        is discounted the way check_capacity's exclude_vm_hash does it.
+
         Release-aware: hashes the plan is about to stop are subtracted from the
         committed sums, so "allocate C, delete B" admits C against B's memory.
         Their disk is not credited back: nothing has been deleted yet, so the
@@ -297,6 +304,7 @@ class CapacityManager:
         memory alone. An advisory yes must never be read as one that covered
         the GPU.
 
+
         The third element of a candidate is the caller's memory-bucket choice,
         NOT ResourceRequirements.is_instance. The two disagree for V-PROGRAMs:
         requirements_from_message reports is_instance=False (the content is not
@@ -304,8 +312,13 @@ class CapacityManager:
         bucket, which is what _committed_resources and _admit both do. Pass
         is_instance_bucket(content) rather than restating the rule.
         """
-        committed_instance, committed_program, committed_vcpus = self._committed_resources(None)
+        candidate_hashes = {vm_hash for vm_hash, _, _ in candidates}
+        committed_instance, committed_program, committed_vcpus = self._committed_resources(candidate_hashes)
         for vm_hash in releasing:
+            if vm_hash in candidate_hashes:
+                # Already discounted above. Subtracting again would credit the
+                # same VM twice and admit against memory nobody freed.
+                continue
             record = self.registry.get(vm_hash)
             if record is None or not record.message.resources:
                 continue
@@ -394,15 +407,15 @@ class CapacityManager:
             pool.remove(gpu)
         return None
 
-    def _committed_resources(self, exclude_vm_hash: ItemHash | None) -> tuple[int, int, int]:
+    def _committed_resources(self, excluded: Collection[ItemHash]) -> tuple[int, int, int]:
         """(committed_instance_memory_mib, committed_program_memory_mib,
-        committed_vcpus) summed over the registry, skipping
-        ``exclude_vm_hash``'s own record (see ``check_capacity``)."""
+        committed_vcpus) summed over the registry, skipping the records of
+        ``excluded`` (see ``check_capacity`` and ``simulate``)."""
         committed_instance_memory_mib = 0
         committed_program_memory_mib = 0
         committed_vcpus = 0
         for vm_hash, record in tuple(self.registry.items()):
-            if exclude_vm_hash is not None and vm_hash == exclude_vm_hash:
+            if vm_hash in excluded:
                 continue
             resources = record.message.resources
             memory = resources.memory

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -141,7 +141,9 @@ class CapacityManager:
         physical - HOST_MEMORY_RESERVED_MIB - PROGRAM_MEMORY_RESERVED_MIB,
         programs share PROGRAM_MEMORY_RESERVED_MIB. vCPUs are capped at
         physical cores times VCPU_OVERCOMMIT_FACTOR. Disk is checked whenever
-        disk_mib > 0, which every create path now passes (#1153).
+        disk_mib > 0: the create paths pass the message's volume total when
+        they admit a VM, and 0 in the re-checks they run once the images are
+        downloaded, which are about the images rather than the volumes.
 
         ``exclude_vm_hash`` skips that VM's own registry record from the
         committed sums: the create paths record the VM before admission (the

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -326,15 +326,12 @@ class CapacityManager:
                 # Already discounted above. Subtracting again would credit the
                 # same VM twice and admit against memory nobody freed.
                 continue
-            record = self.registry.get(vm_hash)
-            if record is None or not record.message.resources:
+            freed = self._record_commitment(vm_hash)
+            if freed is None:
                 continue
-            resources = record.message.resources
-            if is_instance_bucket(record.message):
-                committed_instance -= resources.memory
-            else:
-                committed_program -= resources.memory
-            committed_vcpus -= resources.vcpus
+            committed_instance -= freed[0]
+            committed_program -= freed[1]
+            committed_vcpus -= freed[2]
         # A registry inconsistency must not make admission more permissive than
         # an empty node.
         committed_instance = max(committed_instance, 0)
@@ -346,6 +343,7 @@ class CapacityManager:
         verdicts: list[AdmissionVerdict] = []
         committed_disk = 0
         for vm_hash, requirements, is_instance in candidates:
+            refusal: tuple[str, str] | None = None
             try:
                 self._check_against(
                     memory_mib=requirements.memory_mib,
@@ -360,17 +358,27 @@ class CapacityManager:
                 )
             except InsufficientResourcesError as error:
                 logger.info("Plan candidate %s refused: %s", vm_hash, error)
-                verdicts.append(
-                    AdmissionVerdict(vm_hash, False, "insufficient_capacity", "not enough capacity on this CRN")
-                )
-                continue
-            # Last, and only once the candidate has cleared everything else:
-            # taking cards is what makes the pool cumulative, so a candidate
-            # refused on memory must not walk off with the cards first.
-            gpu_refusal = self._take_gpus(requirements.gpu_device_ids, gpu_pool)
-            if gpu_refusal is not None:
-                logger.info("Plan candidate %s refused: %s", vm_hash, gpu_refusal)
-                verdicts.append(AdmissionVerdict(vm_hash, False, "gpu_unavailable", gpu_refusal))
+                refusal = ("insufficient_capacity", "not enough capacity on this CRN")
+            if refusal is None:
+                # Last, and only once the candidate has cleared everything
+                # else: taking cards is what makes the pool cumulative, so a
+                # candidate refused on memory must not walk off with them.
+                gpu_refusal = self._take_gpus(requirements.gpu_device_ids, gpu_pool)
+                if gpu_refusal is not None:
+                    logger.info("Plan candidate %s refused: %s", vm_hash, gpu_refusal)
+                    refusal = ("gpu_unavailable", "no available GPU matches this request")
+            if refusal is not None:
+                verdicts.append(AdmissionVerdict(vm_hash, False, *refusal))
+                # Discounting the record was a bet that the request would
+                # replace it. It did not: whatever is recorded here is still
+                # here, so it has to weigh on the rest of the batch again.
+                # Unless the plan is stopping it anyway, in which case the
+                # release already accounts for it.
+                kept = None if vm_hash in releasing else self._record_commitment(vm_hash)
+                if kept is not None:
+                    committed_instance += kept[0]
+                    committed_program += kept[1]
+                    committed_vcpus += kept[2]
                 continue
             if is_instance:
                 committed_instance += requirements.memory_mib
@@ -380,6 +388,19 @@ class CapacityManager:
             committed_disk += requirements.disk_mib
             verdicts.append(AdmissionVerdict(vm_hash, True))
         return verdicts
+
+    def _record_commitment(self, vm_hash: ItemHash) -> tuple[int, int, int] | None:
+        """What this VM's registry record adds to (instance, program, vcpus).
+
+        None when there is no record, or one with no resources to speak of.
+        """
+        record = self.registry.get(vm_hash)
+        if record is None or not record.message.resources:
+            return None
+        resources = record.message.resources
+        if is_instance_bucket(record.message):
+            return resources.memory, 0, resources.vcpus
+        return 0, resources.memory, resources.vcpus
 
     def _unheld_gpus(self, available_gpus: list[GpuDevice]) -> list[GpuDevice]:
         """The cards a plan may count on: unattached and not under a live hold.

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -26,6 +26,7 @@ from multidict import CIMultiDict
 from aleph.vm.agent.aggregate import get_user_settings
 from aleph.vm.agent.capacity import (
     CapacityManager,
+    is_instance_bucket,
     requested_gpu_ids,
     requirements_from_message,
 )
@@ -426,7 +427,7 @@ async def _wait_until_gone(
         await asyncio.sleep(interval)
 
 
-def _admit(capacity: CapacityManager, content: ExecutableContent, vm_hash: ItemHash, *, is_instance: bool) -> None:
+def _admit(capacity: CapacityManager, content: ExecutableContent, vm_hash: ItemHash) -> None:
     """Agent-side admission, ahead of any download.
 
     Disk is judged here and only here: build_*_spec downloads the resources and
@@ -434,9 +435,9 @@ def _admit(capacity: CapacityManager, content: ExecutableContent, vm_hash: ItemH
     VM has already taken. Refusing here also means a host with no room never
     pays for the download.
 
-    ``is_instance`` is passed explicitly rather than taken from the message:
-    a V-PROGRAM is an SNP VM and belongs in the instance memory bucket, but it
-    is not an InstanceContent, which is all requirements_from_message can see.
+    The memory bucket comes from is_instance_bucket rather than from
+    requirements_from_message, which reports is_instance=False for a V-PROGRAM
+    because the content is not an InstanceContent.
     """
     requirements = requirements_from_message(content)
     capacity.check_capacity(
@@ -444,7 +445,7 @@ def _admit(capacity: CapacityManager, content: ExecutableContent, vm_hash: ItemH
         vcpus=requirements.vcpus,
         disk_mib=requirements.disk_mib,
         max_volume_mib=requirements.max_volume_mib,
-        is_instance=is_instance,
+        is_instance=is_instance_bucket(content),
         exclude_vm_hash=vm_hash,
     )
 
@@ -480,13 +481,13 @@ async def create_vm_execution(
         # on the first request through _ensure_program_vm. On-demand programs
         # are created and configured per request there too, so this branch only
         # does eager work for the persistent (scheduled) case.
-        _admit(capacity, content, vm_hash, is_instance=False)
+        _admit(capacity, content, vm_hash)
         spec, _resources = await build_program_create_vm_spec(vm_hash, content)
         capacity.check_capacity(
             memory_mib=content.resources.memory,
             vcpus=content.resources.vcpus,
             disk_mib=0,
-            is_instance=False,
+            is_instance=is_instance_bucket(content),
             exclude_vm_hash=vm_hash,
         )
         info = await supervisor.create_vm(spec)
@@ -521,7 +522,7 @@ async def create_vm_execution(
         snp_instance = is_snp_instance(content)
         attest_port: int | None = None
         try:
-            _admit(capacity, content, vm_hash, is_instance=True)
+            _admit(capacity, content, vm_hash)
             if snp_instance:
                 # SEV-SNP confidential instances build through the dedicated
                 # LUKS-rootfs SNP launch path, not build_create_vm_spec (which
@@ -545,7 +546,7 @@ async def create_vm_execution(
                 memory_mib=content.resources.memory,
                 vcpus=content.resources.vcpus,
                 disk_mib=0,
-                is_instance=True,
+                is_instance=is_instance_bucket(content),
                 exclude_vm_hash=vm_hash,
             )
             if not snp_instance:
@@ -614,7 +615,7 @@ async def create_vm_execution(
         # set), so the plain readiness wait applies.
         record = registry.record(vm_hash, message=content, original=original_message.content, persistent=True)
         try:
-            _admit(capacity, content, vm_hash, is_instance=True)
+            _admit(capacity, content, vm_hash)
             spec, attest_port = await build_vprogram_spec(vm_hash, content)
             # Agent-side admission after the download, like the instance path:
             # a failed bundle fetch never consumes capacity.
@@ -622,7 +623,7 @@ async def create_vm_execution(
                 memory_mib=content.resources.memory,
                 vcpus=content.resources.vcpus,
                 disk_mib=0,
-                is_instance=True,
+                is_instance=is_instance_bucket(content),
                 exclude_vm_hash=vm_hash,
             )
             info = await supervisor.create_vm(spec)
@@ -814,7 +815,7 @@ async def _ensure_program_vm(
                 memory_mib=content.resources.memory,
                 vcpus=content.resources.vcpus,
                 disk_mib=0,
-                is_instance=False,
+                is_instance=is_instance_bucket(content),
                 exclude_vm_hash=vm_hash,
             )
             await supervisor.create_vm(spec)

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -434,10 +434,6 @@ def _admit(capacity: CapacityManager, content: ExecutableContent, vm_hash: ItemH
     creates the volume files, so a disk check after it would measure space this
     VM has already taken. Refusing here also means a host with no room never
     pays for the download.
-
-    The memory bucket comes from is_instance_bucket rather than from
-    requirements_from_message, which reports is_instance=False for a V-PROGRAM
-    because the content is not an InstanceContent.
     """
     requirements = requirements_from_message(content)
     capacity.check_capacity(
@@ -445,7 +441,7 @@ def _admit(capacity: CapacityManager, content: ExecutableContent, vm_hash: ItemH
         vcpus=requirements.vcpus,
         disk_mib=requirements.disk_mib,
         max_volume_mib=requirements.max_volume_mib,
-        is_instance=is_instance_bucket(content),
+        is_instance=requirements.is_instance,
         exclude_vm_hash=vm_hash,
     )
 

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -549,5 +549,28 @@ def test_simulate_reserves_nothing(mocker):
     first = manager.simulate([candidate])
     second = manager.simulate([candidate])
 
+    # The repeated call is the assertion: had the first committed anything, the
+    # second would see it and could answer differently.
     assert first[0].accepted is second[0].accepted is True
-    assert manager.holds == {}
+
+
+def test_simulate_is_cumulative_on_disk_too(mocker):
+    """Disk has no committed sum anywhere: free space is read live, and nothing
+    is written until the VM is actually created. Without an accumulator each
+    candidate sees the same free space and a plan that cannot fit is admitted
+    whole.
+
+    10 GiB free, two candidates wanting 6000 MiB each: the first fits, the
+    second does not.
+    """
+    mocker.patch("aleph.vm.agent.capacity.storage_pools.roomiest_pool_free_bytes", return_value=20 * 1024**3)
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16, disk_bytes=10 * 1024**3)
+    candidates = [
+        (_HASH_A, _requirements(memory_mib=1024, disk_mib=6000), True),
+        (_HASH_B, _requirements(memory_mib=1024, disk_mib=6000), True),
+    ]
+
+    verdicts = _manager().simulate(candidates)
+
+    assert [v.accepted for v in verdicts] == [True, False]
+    assert verdicts[1].code == "insufficient_capacity"

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -12,12 +12,14 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aleph_message.models import ItemHash
 from test_supervisor_translate import _make_qemu_instance_message
 
 from aleph.vm.agent.capacity import (
     RESERVATION_TTL_SECONDS,
     CapacityManager,
     GpuHold,
+    ResourceRequirements,
     requirements_from_message,
 )
 from aleph.vm.agent.vm_registry import AgentVmRegistry
@@ -26,6 +28,9 @@ from aleph.vm.resources import GpuDevice, GpuDeviceClass, InsufficientResourcesE
 from aleph.vm.supervisor_interface.types import HostInfo
 
 _DEVICE_ID = "10de:2504"
+_HASH_A = ItemHash("a" * 64)
+_HASH_B = ItemHash("b" * 64)
+_HASH_C = ItemHash("c" * 64)
 
 
 def _gpu_device(pci_host: str = "0000:01:00.0", *, device_id: str = _DEVICE_ID) -> GpuDevice:
@@ -472,3 +477,77 @@ def test_available_disk_bytes_is_the_pooled_aggregate(mocker):
         return_value=(2 * 1024**4, 3 * 1024**3),
     )
     assert CapacityManager._available_disk_bytes() == 3 * 1024**3
+
+
+# ── simulate: batch admission for a whole plan ─────────────────────────────
+
+
+def _requirements(*, memory_mib: int, vcpus: int = 1, disk_mib: int = 0) -> ResourceRequirements:
+    return ResourceRequirements(
+        vcpus=vcpus, memory_mib=memory_mib, disk_mib=disk_mib, max_volume_mib=disk_mib, is_instance=True
+    )
+
+
+def test_simulate_is_cumulative(mocker):
+    """Three VMs that only fit twice get two yeses. Judging each candidate
+    independently against current commitments would say yes three times.
+
+    48 GiB physical, minus HOST_MEMORY_RESERVED_MIB (2048) and
+    PROGRAM_MEMORY_RESERVED_MIB (8192), leaves a 38912 MiB instance bucket:
+    room for two 16384 MiB instances and not a third.
+    """
+    _patch_host(mocker, memory_bytes=48 * 1024 * 1024 * 1024, cores=16)
+    candidates = [
+        (_HASH_A, _requirements(memory_mib=16384), True),
+        (_HASH_B, _requirements(memory_mib=16384), True),
+        (_HASH_C, _requirements(memory_mib=16384), True),
+    ]
+
+    verdicts = _manager().simulate(candidates)
+
+    assert [v.accepted for v in verdicts] == [True, True, False]
+    assert verdicts[2].code == "insufficient_capacity"
+    assert verdicts[2].vm_hash == _HASH_C
+
+
+def test_simulate_counts_a_released_vm_as_freed(mocker):
+    """'allocate C and delete B' must admit C against B's memory.
+
+    40 GiB gives a 30720 MiB bucket, so B (16384) plus C (16384) does not fit
+    but C alone does: the release is the whole difference.
+    """
+    _patch_host(mocker, memory_bytes=40 * 1024 * 1024 * 1024, cores=16)
+    registry = AgentVmRegistry()
+    content = _make_qemu_instance_message(memory=16384)
+    registry.record(_HASH_B, message=content, original=content, persistent=True)
+    manager = _manager(registry=registry)
+    candidate = (_HASH_C, _requirements(memory_mib=16384), True)
+
+    assert manager.simulate([candidate])[0].accepted is False
+    assert manager.simulate([candidate], releasing=frozenset({_HASH_B}))[0].accepted is True
+
+
+def test_simulate_judges_disk(mocker):
+    # _patch_host only stubs _available_disk_bytes; the per-pool check reads
+    # storage_pools directly, so stub it too or it hits the real filesystem.
+    mocker.patch("aleph.vm.agent.capacity.storage_pools.roomiest_pool_free_bytes", return_value=1024 * 1024 * 1024)
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16, disk_bytes=1024 * 1024 * 1024)
+
+    verdicts = _manager().simulate([(_HASH_A, _requirements(memory_mib=1024, disk_mib=100_000), True)])
+
+    assert verdicts[0].accepted is False
+    assert verdicts[0].code == "insufficient_capacity"
+
+
+def test_simulate_reserves_nothing(mocker):
+    """The capacity-check endpoint calls this speculatively against several
+    CRNs, so a call must leave no trace."""
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
+    manager = _manager()
+    candidate = (_HASH_A, _requirements(memory_mib=2048), True)
+
+    first = manager.simulate([candidate])
+    second = manager.simulate([candidate])
+
+    assert first[0].accepted is second[0].accepted is True
+    assert manager.holds == {}

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -483,9 +483,11 @@ def test_available_disk_bytes_is_the_pooled_aggregate(mocker):
 # ── simulate: batch admission for a whole plan ─────────────────────────────
 
 
-def _requirements(*, memory_mib: int, vcpus: int = 1, disk_mib: int = 0) -> ResourceRequirements:
+def _requirements(
+    *, memory_mib: int, vcpus: int = 1, disk_mib: int = 0, is_instance: bool = True
+) -> ResourceRequirements:
     return ResourceRequirements(
-        vcpus=vcpus, memory_mib=memory_mib, disk_mib=disk_mib, max_volume_mib=disk_mib, is_instance=True
+        vcpus=vcpus, memory_mib=memory_mib, disk_mib=disk_mib, max_volume_mib=disk_mib, is_instance=is_instance
     )
 
 
@@ -501,9 +503,9 @@ def test_simulate_is_cumulative(mocker):
     mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 8192)
     _patch_host(mocker, memory_bytes=48 * 1024 * 1024 * 1024, cores=16)
     candidates = [
-        (_HASH_A, _requirements(memory_mib=16384), True),
-        (_HASH_B, _requirements(memory_mib=16384), True),
-        (_HASH_C, _requirements(memory_mib=16384), True),
+        (_HASH_A, _requirements(memory_mib=16384)),
+        (_HASH_B, _requirements(memory_mib=16384)),
+        (_HASH_C, _requirements(memory_mib=16384)),
     ]
 
     verdicts = _manager().simulate(candidates)
@@ -526,7 +528,7 @@ def test_simulate_counts_a_released_vm_as_freed(mocker):
     content = _make_qemu_instance_message(memory=16384)
     registry.record(_HASH_B, message=content, original=content, persistent=True)
     manager = _manager(registry=registry)
-    candidate = (_HASH_C, _requirements(memory_mib=16384), True)
+    candidate = (_HASH_C, _requirements(memory_mib=16384))
 
     assert manager.simulate([candidate])[0].accepted is False
     assert manager.simulate([candidate], releasing=frozenset({_HASH_B}))[0].accepted is True
@@ -538,7 +540,7 @@ def test_simulate_judges_disk(mocker):
     mocker.patch("aleph.vm.agent.capacity.storage_pools.roomiest_pool_free_bytes", return_value=1024 * 1024 * 1024)
     _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16, disk_bytes=1024 * 1024 * 1024)
 
-    verdicts = _manager().simulate([(_HASH_A, _requirements(memory_mib=1024, disk_mib=100_000), True)])
+    verdicts = _manager().simulate([(_HASH_A, _requirements(memory_mib=1024, disk_mib=100_000))])
 
     assert verdicts[0].accepted is False
     assert verdicts[0].code == "insufficient_capacity"
@@ -559,7 +561,7 @@ def test_simulate_reserves_nothing(mocker):
     _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
     registry = AgentVmRegistry()
     manager = _manager(registry=registry)
-    candidate = (_HASH_A, _requirements(memory_mib=30000), True)
+    candidate = (_HASH_A, _requirements(memory_mib=30000))
 
     first = manager.simulate([candidate])
     second = manager.simulate([candidate])
@@ -581,8 +583,8 @@ def test_simulate_is_cumulative_on_disk_too(mocker):
     mocker.patch("aleph.vm.agent.capacity.storage_pools.roomiest_pool_free_bytes", return_value=20 * 1024**3)
     _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16, disk_bytes=10 * 1024**3)
     candidates = [
-        (_HASH_A, _requirements(memory_mib=1024, disk_mib=6000), True),
-        (_HASH_B, _requirements(memory_mib=1024, disk_mib=6000), True),
+        (_HASH_A, _requirements(memory_mib=1024, disk_mib=6000)),
+        (_HASH_B, _requirements(memory_mib=1024, disk_mib=6000)),
     ]
 
     verdicts = _manager().simulate(candidates)
@@ -601,7 +603,7 @@ def test_simulate_ignores_a_release_of_a_vm_it_does_not_know(mocker):
     content = _make_qemu_instance_message(memory=16384)
     registry.record(_HASH_B, message=content, original=content, persistent=True)
     manager = _manager(registry=registry)
-    candidate = (_HASH_C, _requirements(memory_mib=16384), True)
+    candidate = (_HASH_C, _requirements(memory_mib=16384))
 
     verdicts = manager.simulate([candidate], releasing=frozenset({_HASH_A}))
 
@@ -617,7 +619,7 @@ def test_simulate_releases_vcpus_not_only_memory(mocker):
     content = _make_qemu_instance_message(memory=1024, vcpus=6)
     registry.record(_HASH_B, message=content, original=content, persistent=True)
     manager = _manager(registry=registry)
-    candidate = (_HASH_C, _requirements(memory_mib=1024, vcpus=6), True)
+    candidate = (_HASH_C, _requirements(memory_mib=1024, vcpus=6))
 
     assert manager.simulate([candidate])[0].accepted is False
     assert manager.simulate([candidate], releasing=frozenset({_HASH_B}))[0].accepted is True
@@ -638,7 +640,7 @@ def test_simulate_refuses_a_gpu_candidate_when_no_inventory_was_given(mocker):
     yes earned on memory alone."""
     _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
 
-    verdicts = _manager().simulate([(_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID]), True)])
+    verdicts = _manager().simulate([(_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID]))])
 
     assert verdicts[0].accepted is False
     assert verdicts[0].code == "gpu_unavailable"
@@ -648,7 +650,7 @@ def test_simulate_admits_a_gpu_candidate_the_host_can_serve(mocker):
     _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
     gpu = _gpu_device()
 
-    verdicts = _manager().simulate([(_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID]), True)], available_gpus=[gpu])
+    verdicts = _manager().simulate([(_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID]))], available_gpus=[gpu])
 
     assert verdicts[0].accepted is True
 
@@ -657,7 +659,7 @@ def test_simulate_refuses_a_card_the_host_does_not_have(mocker):
     _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
 
     verdicts = _manager().simulate(
-        [(_HASH_A, _gpu_requirements(device_ids=["10de:dead"]), True)], available_gpus=[_gpu_device()]
+        [(_HASH_A, _gpu_requirements(device_ids=["10de:dead"]))], available_gpus=[_gpu_device()]
     )
 
     assert verdicts[0].accepted is False
@@ -669,8 +671,8 @@ def test_simulate_is_cumulative_on_gpus(mocker):
     against the same inventory would hand the same card out twice."""
     _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
     candidates = [
-        (_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID]), True),
-        (_HASH_B, _gpu_requirements(device_ids=[_DEVICE_ID]), True),
+        (_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID])),
+        (_HASH_B, _gpu_requirements(device_ids=[_DEVICE_ID])),
     ]
 
     verdicts = _manager().simulate(candidates, available_gpus=[_gpu_device()])
@@ -689,7 +691,7 @@ def test_simulate_treats_a_held_card_as_taken(mocker):
         user="someone-else", expiration=datetime.now(tz=timezone.utc) + timedelta(hours=1)
     )
 
-    verdicts = manager.simulate([(_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID]), True)], available_gpus=[gpu])
+    verdicts = manager.simulate([(_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID]))], available_gpus=[gpu])
 
     assert verdicts[0].accepted is False
 
@@ -703,7 +705,7 @@ def test_simulate_does_not_evict_expired_holds(mocker):
     expired = GpuHold(user="someone-else", expiration=datetime.now(tz=timezone.utc) - timedelta(hours=1))
     manager.holds[gpu.pci_host] = expired
 
-    verdicts = manager.simulate([(_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID]), True)], available_gpus=[gpu])
+    verdicts = manager.simulate([(_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID]))], available_gpus=[gpu])
 
     assert verdicts[0].accepted is True
     assert manager.holds[gpu.pci_host] is expired
@@ -714,8 +716,8 @@ def test_simulate_takes_no_card_when_it_cannot_take_them_all(mocker):
     could only get one must not strand that one away from the next candidate."""
     _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
     candidates = [
-        (_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID, _DEVICE_ID]), True),
-        (_HASH_B, _gpu_requirements(device_ids=[_DEVICE_ID]), True),
+        (_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID, _DEVICE_ID])),
+        (_HASH_B, _gpu_requirements(device_ids=[_DEVICE_ID])),
     ]
 
     verdicts = _manager().simulate(candidates, available_gpus=[_gpu_device()])
@@ -730,8 +732,8 @@ def test_simulate_does_not_take_cards_for_a_candidate_refused_on_memory(mocker):
     mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 8192)
     _patch_host(mocker, memory_bytes=48 * 1024 * 1024 * 1024, cores=16)
     candidates = [
-        (_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID], memory_mib=999_999), True),
-        (_HASH_B, _gpu_requirements(device_ids=[_DEVICE_ID]), True),
+        (_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID], memory_mib=999_999)),
+        (_HASH_B, _gpu_requirements(device_ids=[_DEVICE_ID])),
     ]
 
     verdicts = _manager().simulate(candidates, available_gpus=[_gpu_device()])
@@ -756,7 +758,7 @@ def test_simulate_does_not_let_a_recorded_candidate_refuse_itself(mocker):
     registry.record(_HASH_A, message=content, original=content, persistent=True)
     manager = _manager(registry=registry)
 
-    verdicts = manager.simulate([(_HASH_A, _requirements(memory_mib=16384), True)])
+    verdicts = manager.simulate([(_HASH_A, _requirements(memory_mib=16384))])
 
     assert verdicts[0].accepted is True
 
@@ -782,8 +784,8 @@ def test_simulate_does_not_credit_a_candidate_twice_when_also_released(mocker):
     registry.record(_HASH_D, message=staying, original=staying, persistent=True)
     manager = _manager(registry=registry)
     candidates = [
-        (_HASH_A, _requirements(memory_mib=16384), True),
-        (_HASH_B, _requirements(memory_mib=8192), True),
+        (_HASH_A, _requirements(memory_mib=16384)),
+        (_HASH_B, _requirements(memory_mib=8192)),
     ]
 
     verdicts = manager.simulate(candidates, releasing=frozenset({_HASH_A}))
@@ -801,7 +803,7 @@ def test_simulate_does_not_credit_disk_back_on_release(mocker):
     content = _make_qemu_instance_message(memory=1024)
     registry.record(_HASH_B, message=content, original=content, persistent=True)
     manager = _manager(registry=registry)
-    candidate = (_HASH_C, _requirements(memory_mib=1024, disk_mib=50_000), True)
+    candidate = (_HASH_C, _requirements(memory_mib=1024, disk_mib=50_000))
 
     assert manager.simulate([candidate], releasing=frozenset({_HASH_B}))[0].accepted is False
 
@@ -821,7 +823,7 @@ def test_simulate_credits_a_released_program_to_the_program_bucket(mocker):
     content = SimpleNamespace(resources=SimpleNamespace(memory=3072, vcpus=1))
     registry.record(_HASH_B, message=content, original=content, persistent=True)
     manager = _manager(registry=registry)
-    candidate = (_HASH_C, _requirements(memory_mib=3072), False)
+    candidate = (_HASH_C, _requirements(memory_mib=3072, is_instance=False))
 
     assert manager.simulate([candidate])[0].accepted is False
     assert manager.simulate([candidate], releasing=frozenset({_HASH_B}))[0].accepted is True
@@ -844,8 +846,8 @@ def test_simulate_puts_a_refused_candidates_record_back(mocker):
     registry.record(_HASH_A, message=content, original=content, persistent=True)
     manager = _manager(registry=registry)
     candidates = [
-        (_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID], memory_mib=16384), True),
-        (_HASH_B, _requirements(memory_mib=24576), True),
+        (_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID], memory_mib=16384)),
+        (_HASH_B, _requirements(memory_mib=24576)),
     ]
 
     verdicts = manager.simulate(candidates)
@@ -865,8 +867,8 @@ def test_simulate_puts_the_record_back_when_the_refusal_was_capacity(mocker):
     registry.record(_HASH_A, message=content, original=content, persistent=True)
     manager = _manager(registry=registry)
     candidates = [
-        (_HASH_A, _requirements(memory_mib=999_999), True),
-        (_HASH_B, _requirements(memory_mib=24576), True),
+        (_HASH_A, _requirements(memory_mib=999_999)),
+        (_HASH_B, _requirements(memory_mib=24576)),
     ]
 
     verdicts = manager.simulate(candidates)
@@ -885,8 +887,8 @@ def test_simulate_keeps_a_refused_candidate_released_if_the_plan_stops_it(mocker
     registry.record(_HASH_A, message=content, original=content, persistent=True)
     manager = _manager(registry=registry)
     candidates = [
-        (_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID], memory_mib=16384), True),
-        (_HASH_B, _requirements(memory_mib=24576), True),
+        (_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID], memory_mib=16384)),
+        (_HASH_B, _requirements(memory_mib=24576)),
     ]
 
     verdicts = manager.simulate(candidates, releasing=frozenset({_HASH_A}))
@@ -899,7 +901,32 @@ def test_simulate_does_not_echo_the_requested_device_id_back(mocker):
     the scheduler, and it already knows what it asked for."""
     _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
 
-    verdicts = _manager().simulate([(_HASH_A, _gpu_requirements(device_ids=["10de:evil"]), True)])
+    verdicts = _manager().simulate([(_HASH_A, _gpu_requirements(device_ids=["10de:evil"]))])
 
     assert verdicts[0].accepted is False
     assert "evil" not in verdicts[0].detail
+
+
+def test_simulate_is_cumulative_on_vcpus(mocker):
+    """vCPUs accumulate like memory does. 2 cores at 4x overcommit caps them at
+    8, so two 6-vCPU candidates fit once between them."""
+    mocker.patch.object(settings, "VCPU_OVERCOMMIT_FACTOR", 4.0)
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=2)
+    candidates = [
+        (_HASH_A, _requirements(memory_mib=1024, vcpus=6)),
+        (_HASH_B, _requirements(memory_mib=1024, vcpus=6)),
+    ]
+
+    verdicts = _manager().simulate(candidates)
+
+    assert [v.accepted for v in verdicts] == [True, False]
+
+
+def test_requirements_put_a_vprogram_in_the_instance_bucket():
+    """The bucket travels on the requirements, so a caller cannot pick the
+    wrong one for a V-PROGRAM by reaching for the obvious field."""
+    from test_vprogram import load_vprogram_message
+
+    content = load_vprogram_message().content
+
+    assert requirements_from_message(content).is_instance is True

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -789,3 +789,39 @@ def test_simulate_does_not_credit_a_candidate_twice_when_also_released(mocker):
     verdicts = manager.simulate(candidates, releasing=frozenset({_HASH_A}))
 
     assert [v.accepted for v in verdicts] == [True, False]
+
+
+def test_simulate_does_not_credit_disk_back_on_release(mocker):
+    """Stopping a VM does not delete its volumes, so the space is still gone.
+    Crediting it would make the advisory answer stronger than the enforced one.
+    """
+    mocker.patch("aleph.vm.agent.capacity.storage_pools.roomiest_pool_free_bytes", return_value=100 * 1024**3)
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16, disk_bytes=10 * 1024**3)
+    registry = AgentVmRegistry()
+    content = _make_qemu_instance_message(memory=1024)
+    registry.record(_HASH_B, message=content, original=content, persistent=True)
+    manager = _manager(registry=registry)
+    candidate = (_HASH_C, _requirements(memory_mib=1024, disk_mib=50_000), True)
+
+    assert manager.simulate([candidate], releasing=frozenset({_HASH_B}))[0].accepted is False
+
+
+def test_simulate_credits_a_released_program_to_the_program_bucket(mocker):
+    """The release loop buckets the same way the committed sums do, so a
+    released program frees the program bucket and not the instance one.
+
+    The program bucket is PROGRAM_MEMORY_RESERVED_MIB (4096) on its own: one
+    3072 MiB program fits, two do not.
+    """
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 4096)
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
+    registry = AgentVmRegistry()
+    # Any non-InstanceContent record lands in the program bucket.
+    content = SimpleNamespace(resources=SimpleNamespace(memory=3072, vcpus=1))
+    registry.record(_HASH_B, message=content, original=content, persistent=True)
+    manager = _manager(registry=registry)
+    candidate = (_HASH_C, _requirements(memory_mib=3072), False)
+
+    assert manager.simulate([candidate])[0].accepted is False
+    assert manager.simulate([candidate], releasing=frozenset({_HASH_B}))[0].accepted is True

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -31,6 +31,7 @@ _DEVICE_ID = "10de:2504"
 _HASH_A = ItemHash("a" * 64)
 _HASH_B = ItemHash("b" * 64)
 _HASH_C = ItemHash("c" * 64)
+_HASH_D = ItemHash("d" * 64)
 
 
 def _gpu_device(pci_host: str = "0000:01:00.0", *, device_id: str = _DEVICE_ID) -> GpuDevice:
@@ -737,3 +738,54 @@ def test_simulate_does_not_take_cards_for_a_candidate_refused_on_memory(mocker):
 
     assert [v.accepted for v in verdicts] == [False, True]
     assert verdicts[0].code == "insufficient_capacity"
+
+
+def test_simulate_does_not_let_a_recorded_candidate_refuse_itself(mocker):
+    """A hash can be recorded here and still be a candidate: a recreate, or an
+    owner record from a create that died part way. Counting the record and the
+    request both would judge the VM against its own memory.
+
+    40 GiB leaves 30720 MiB, and 16384 twice does not fit, so a double count
+    turns this into a no.
+    """
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 8192)
+    _patch_host(mocker, memory_bytes=40 * 1024 * 1024 * 1024, cores=16)
+    registry = AgentVmRegistry()
+    content = _make_qemu_instance_message(memory=16384)
+    registry.record(_HASH_A, message=content, original=content, persistent=True)
+    manager = _manager(registry=registry)
+
+    verdicts = manager.simulate([(_HASH_A, _requirements(memory_mib=16384), True)])
+
+    assert verdicts[0].accepted is True
+
+
+def test_simulate_does_not_credit_a_candidate_twice_when_also_released(mocker):
+    """A caller that discounts the record itself, by listing the hash in
+    releasing, must not get the memory back a second time.
+
+    30720 MiB bucket. D holds 8192 and stays, so A (16384, already recorded and
+    also a candidate) is judged against 8192 and fits, leaving 24576 committed
+    and no room for B's 8192. Subtracting A a second time would drop the
+    committed sum to 0 instead, and B would wrongly fit. The other record
+    matters: without it the second subtraction goes negative and the clamp
+    hides the bug.
+    """
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 8192)
+    _patch_host(mocker, memory_bytes=40 * 1024 * 1024 * 1024, cores=16)
+    registry = AgentVmRegistry()
+    recorded = _make_qemu_instance_message(memory=16384)
+    registry.record(_HASH_A, message=recorded, original=recorded, persistent=True)
+    staying = _make_qemu_instance_message(memory=8192)
+    registry.record(_HASH_D, message=staying, original=staying, persistent=True)
+    manager = _manager(registry=registry)
+    candidates = [
+        (_HASH_A, _requirements(memory_mib=16384), True),
+        (_HASH_B, _requirements(memory_mib=8192), True),
+    ]
+
+    verdicts = manager.simulate(candidates, releasing=frozenset({_HASH_A}))
+
+    assert [v.accepted for v in verdicts] == [True, False]

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -496,6 +496,8 @@ def test_simulate_is_cumulative(mocker):
     PROGRAM_MEMORY_RESERVED_MIB (8192), leaves a 38912 MiB instance bucket:
     room for two 16384 MiB instances and not a third.
     """
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 8192)
     _patch_host(mocker, memory_bytes=48 * 1024 * 1024 * 1024, cores=16)
     candidates = [
         (_HASH_A, _requirements(memory_mib=16384), True),
@@ -516,6 +518,8 @@ def test_simulate_counts_a_released_vm_as_freed(mocker):
     40 GiB gives a 30720 MiB bucket, so B (16384) plus C (16384) does not fit
     but C alone does: the release is the whole difference.
     """
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 8192)
     _patch_host(mocker, memory_bytes=40 * 1024 * 1024 * 1024, cores=16)
     registry = AgentVmRegistry()
     content = _make_qemu_instance_message(memory=16384)
@@ -541,17 +545,27 @@ def test_simulate_judges_disk(mocker):
 
 def test_simulate_reserves_nothing(mocker):
     """The capacity-check endpoint calls this speculatively against several
-    CRNs, so a call must leave no trace."""
+    CRNs, so a call must leave no trace.
+
+    The candidate is sized past half the bucket on purpose. 64 GiB leaves
+    55296 MiB for instances, and 30000 fits once: had the first call committed
+    anything, 30000 + 30000 would put the second over and flip it to False. At
+    a smaller size a leaking implementation would answer True twice and the
+    test would pass while proving nothing.
+    """
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 8192)
     _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
-    manager = _manager()
-    candidate = (_HASH_A, _requirements(memory_mib=2048), True)
+    registry = AgentVmRegistry()
+    manager = _manager(registry=registry)
+    candidate = (_HASH_A, _requirements(memory_mib=30000), True)
 
     first = manager.simulate([candidate])
     second = manager.simulate([candidate])
 
-    # The repeated call is the assertion: had the first committed anything, the
-    # second would see it and could answer differently.
     assert first[0].accepted is second[0].accepted is True
+    assert len(tuple(registry.items())) == 0
+    assert manager.holds == {}
 
 
 def test_simulate_is_cumulative_on_disk_too(mocker):
@@ -574,3 +588,35 @@ def test_simulate_is_cumulative_on_disk_too(mocker):
 
     assert [v.accepted for v in verdicts] == [True, False]
     assert verdicts[1].code == "insufficient_capacity"
+
+
+def test_simulate_ignores_a_release_of_a_vm_it_does_not_know(mocker):
+    """The scheduler's plan is its own view of the world. A hash we have no
+    record of frees nothing, and must not throw."""
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 8192)
+    _patch_host(mocker, memory_bytes=40 * 1024 * 1024 * 1024, cores=16)
+    registry = AgentVmRegistry()
+    content = _make_qemu_instance_message(memory=16384)
+    registry.record(_HASH_B, message=content, original=content, persistent=True)
+    manager = _manager(registry=registry)
+    candidate = (_HASH_C, _requirements(memory_mib=16384), True)
+
+    verdicts = manager.simulate([candidate], releasing=frozenset({_HASH_A}))
+
+    assert verdicts[0].accepted is False
+
+
+def test_simulate_releases_vcpus_not_only_memory(mocker):
+    """vCPUs are the binding constraint here, so the release only shows up if
+    the loop subtracts them too. 2 cores at 4x overcommit caps vCPUs at 8."""
+    mocker.patch.object(settings, "VCPU_OVERCOMMIT_FACTOR", 4.0)
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=2)
+    registry = AgentVmRegistry()
+    content = _make_qemu_instance_message(memory=1024, vcpus=6)
+    registry.record(_HASH_B, message=content, original=content, persistent=True)
+    manager = _manager(registry=registry)
+    candidate = (_HASH_C, _requirements(memory_mib=1024, vcpus=6), True)
+
+    assert manager.simulate([candidate])[0].accepted is False
+    assert manager.simulate([candidate], releasing=frozenset({_HASH_B}))[0].accepted is True

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -620,3 +620,120 @@ def test_simulate_releases_vcpus_not_only_memory(mocker):
 
     assert manager.simulate([candidate])[0].accepted is False
     assert manager.simulate([candidate], releasing=frozenset({_HASH_B}))[0].accepted is True
+
+
+# ── simulate: GPU admission ────────────────────────────────────────────────
+
+
+def _gpu_requirements(*, device_ids: list[str], memory_mib: int = 1024) -> ResourceRequirements:
+    return ResourceRequirements(
+        vcpus=1, memory_mib=memory_mib, disk_mib=0, max_volume_mib=0, is_instance=True, gpu_device_ids=device_ids
+    )
+
+
+def test_simulate_refuses_a_gpu_candidate_when_no_inventory_was_given(mocker):
+    """Without an inventory there is nothing to judge the request against. The
+    verdict is all the scheduler sees, so an unchecked GPU must not read as a
+    yes earned on memory alone."""
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
+
+    verdicts = _manager().simulate([(_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID]), True)])
+
+    assert verdicts[0].accepted is False
+    assert verdicts[0].code == "gpu_unavailable"
+
+
+def test_simulate_admits_a_gpu_candidate_the_host_can_serve(mocker):
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
+    gpu = _gpu_device()
+
+    verdicts = _manager().simulate([(_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID]), True)], available_gpus=[gpu])
+
+    assert verdicts[0].accepted is True
+
+
+def test_simulate_refuses_a_card_the_host_does_not_have(mocker):
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
+
+    verdicts = _manager().simulate(
+        [(_HASH_A, _gpu_requirements(device_ids=["10de:dead"]), True)], available_gpus=[_gpu_device()]
+    )
+
+    assert verdicts[0].accepted is False
+    assert verdicts[0].code == "gpu_unavailable"
+
+
+def test_simulate_is_cumulative_on_gpus(mocker):
+    """One card, two candidates that each want it: one yes. Judging each
+    against the same inventory would hand the same card out twice."""
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
+    candidates = [
+        (_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID]), True),
+        (_HASH_B, _gpu_requirements(device_ids=[_DEVICE_ID]), True),
+    ]
+
+    verdicts = _manager().simulate(candidates, available_gpus=[_gpu_device()])
+
+    assert [v.accepted for v in verdicts] == [True, False]
+    assert verdicts[1].code == "gpu_unavailable"
+
+
+def test_simulate_treats_a_held_card_as_taken(mocker):
+    """A hold is some user's pending create. Counting it as free would make the
+    advisory answer stronger than the one create will give."""
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
+    gpu = _gpu_device()
+    manager = _manager()
+    manager.holds[gpu.pci_host] = GpuHold(
+        user="someone-else", expiration=datetime.now(tz=timezone.utc) + timedelta(hours=1)
+    )
+
+    verdicts = manager.simulate([(_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID]), True)], available_gpus=[gpu])
+
+    assert verdicts[0].accepted is False
+
+
+def test_simulate_does_not_evict_expired_holds(mocker):
+    """An expired hold frees the card, but reaping it is a write, and simulate
+    is the one call that must not touch the ledger."""
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
+    gpu = _gpu_device()
+    manager = _manager()
+    expired = GpuHold(user="someone-else", expiration=datetime.now(tz=timezone.utc) - timedelta(hours=1))
+    manager.holds[gpu.pci_host] = expired
+
+    verdicts = manager.simulate([(_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID]), True)], available_gpus=[gpu])
+
+    assert verdicts[0].accepted is True
+    assert manager.holds[gpu.pci_host] is expired
+
+
+def test_simulate_takes_no_card_when_it_cannot_take_them_all(mocker):
+    """All or nothing, like reserve_gpus: a candidate that wanted two cards and
+    could only get one must not strand that one away from the next candidate."""
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
+    candidates = [
+        (_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID, _DEVICE_ID]), True),
+        (_HASH_B, _gpu_requirements(device_ids=[_DEVICE_ID]), True),
+    ]
+
+    verdicts = _manager().simulate(candidates, available_gpus=[_gpu_device()])
+
+    assert [v.accepted for v in verdicts] == [False, True]
+
+
+def test_simulate_does_not_take_cards_for_a_candidate_refused_on_memory(mocker):
+    """The card is only spent once everything else has cleared, so a candidate
+    that fails admission leaves the inventory for the next one."""
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 8192)
+    _patch_host(mocker, memory_bytes=48 * 1024 * 1024 * 1024, cores=16)
+    candidates = [
+        (_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID], memory_mib=999_999), True),
+        (_HASH_B, _gpu_requirements(device_ids=[_DEVICE_ID]), True),
+    ]
+
+    verdicts = _manager().simulate(candidates, available_gpus=[_gpu_device()])
+
+    assert [v.accepted for v in verdicts] == [False, True]
+    assert verdicts[0].code == "insufficient_capacity"

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -825,3 +825,81 @@ def test_simulate_credits_a_released_program_to_the_program_bucket(mocker):
 
     assert manager.simulate([candidate])[0].accepted is False
     assert manager.simulate([candidate], releasing=frozenset({_HASH_B}))[0].accepted is True
+
+
+def test_simulate_puts_a_refused_candidates_record_back(mocker):
+    """Discounting a candidate's record bets that its request will replace it.
+    A refused candidate leaves the recorded VM running, so the bet is off and
+    the rest of the batch has to see that memory again.
+
+    30720 MiB bucket. A is recorded at 16384 and refused on its GPU, so B's
+    24576 does not fit: 16384 + 24576 is over. Leaving A discounted would judge
+    B against an empty node and hand back a yes that create would refuse.
+    """
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 8192)
+    _patch_host(mocker, memory_bytes=40 * 1024 * 1024 * 1024, cores=16)
+    registry = AgentVmRegistry()
+    content = _make_qemu_instance_message(memory=16384)
+    registry.record(_HASH_A, message=content, original=content, persistent=True)
+    manager = _manager(registry=registry)
+    candidates = [
+        (_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID], memory_mib=16384), True),
+        (_HASH_B, _requirements(memory_mib=24576), True),
+    ]
+
+    verdicts = manager.simulate(candidates)
+
+    assert [v.accepted for v in verdicts] == [False, False]
+    assert verdicts[0].code == "gpu_unavailable"
+    assert verdicts[1].code == "insufficient_capacity"
+
+
+def test_simulate_puts_the_record_back_when_the_refusal_was_capacity(mocker):
+    """Same restoration, through the other refusal branch."""
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 8192)
+    _patch_host(mocker, memory_bytes=40 * 1024 * 1024 * 1024, cores=16)
+    registry = AgentVmRegistry()
+    content = _make_qemu_instance_message(memory=16384)
+    registry.record(_HASH_A, message=content, original=content, persistent=True)
+    manager = _manager(registry=registry)
+    candidates = [
+        (_HASH_A, _requirements(memory_mib=999_999), True),
+        (_HASH_B, _requirements(memory_mib=24576), True),
+    ]
+
+    verdicts = manager.simulate(candidates)
+
+    assert [v.accepted for v in verdicts] == [False, False]
+
+
+def test_simulate_keeps_a_refused_candidate_released_if_the_plan_stops_it(mocker):
+    """A refused candidate the plan is also stopping stays discounted: the
+    release frees it whatever the verdict on recreating it was."""
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 8192)
+    _patch_host(mocker, memory_bytes=40 * 1024 * 1024 * 1024, cores=16)
+    registry = AgentVmRegistry()
+    content = _make_qemu_instance_message(memory=16384)
+    registry.record(_HASH_A, message=content, original=content, persistent=True)
+    manager = _manager(registry=registry)
+    candidates = [
+        (_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID], memory_mib=16384), True),
+        (_HASH_B, _requirements(memory_mib=24576), True),
+    ]
+
+    verdicts = manager.simulate(candidates, releasing=frozenset({_HASH_A}))
+
+    assert [v.accepted for v in verdicts] == [False, True]
+
+
+def test_simulate_does_not_echo_the_requested_device_id_back(mocker):
+    """device_id is free-form text off the message. The verdict is what goes to
+    the scheduler, and it already knows what it asked for."""
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
+
+    verdicts = _manager().simulate([(_HASH_A, _gpu_requirements(device_ids=["10de:evil"]), True)])
+
+    assert verdicts[0].accepted is False
+    assert "evil" not in verdicts[0].detail


### PR DESCRIPTION
Stacked on #1158. Third of the async-allocations stack.

A plan asks a different question than a single create: "if I gave you all of these, and dropped those". `check_capacity` answers only "does this one fit right now", which is wrong twice over for a plan:

- Judging each candidate independently makes the CRN answer yes three times for three VMs that only fit twice.
- "Allocate C and delete B" must admit C against B's *release*, or the CRN refuses work it is about to have room for.

## Changes

- `CapacityManager.simulate(candidates, *, releasing)` returns one `AdmissionVerdict` per candidate. Cumulative (each acceptance is committed before the next is judged) and release-aware (hashes the plan will stop are subtracted from the committed sums). It reserves nothing, which is what makes it safe for the upcoming capacity-check endpoint to call speculatively across several CRNs.
- The arithmetic moves to `_check_against`, shared by both entry points: `check_capacity` judges against the registry as it stands, `simulate` against sums it accumulates itself. One implementation means an advisory answer can never be stronger or weaker than the enforced one.
- Drops a docstring line that went stale with #1153 (the create path no longer passes `disk_mib=0`).

## How to test

`pytest tests/supervisor/test_agent_capacity.py` — 49 pass, of which 19 are new. The other 30 are the pre-existing `check_capacity` tests running unchanged through the extracted arithmetic, which is the proof that the refactor preserved behaviour.

The new tests pin `HOST_MEMORY_RESERVED_MIB` and `PROGRAM_MEMORY_RESERVED_MIB` wherever their arithmetic depends on them, as the older tests in the file already do, so a change to the defaults breaks the setting rather than these tests. The figures are computed from 2048 / 8192, making the instance bucket physical - 10240 MiB. 48 GiB fits exactly two 16384 MiB instances; the release test uses 40 GiB, where B plus C does not fit but C alone does. If those defaults change, recompute rather than nudging the numbers: a cumulative test that goes green because *nothing* fits proves nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

