### PR TITLE
feat(agent): tear down loop and device-mapper devices when a VM is retired (2.1, PR C)

### DIFF
--- a/src/aleph/vm/agent/views/operator.py
+++ b/src/aleph/vm/agent/views/operator.py
@@ -31,7 +31,7 @@ from aleph.vm.agent.vm.downloader import recreate_vm_volumes
 from aleph.vm.agent.vm.purge import purge_vm_staging, purge_vm_volumes
 from aleph.vm.agent.vm.reclaimable import retained_marker
 from aleph.vm.agent.vm.reconciler import creating
-from aleph.vm.agent.vm.retire import RetireReason, retire_vm
+from aleph.vm.agent.vm.retire import RetireReason, retire_vm, teardown_vm_devices
 from aleph.vm.agent.vm_registry import AgentVmRecord
 from aleph.vm.backup.archive import InsufficientDiskSpaceError
 from aleph.vm.backup.staging import download_volume_by_ref, get_backup_directory
@@ -767,6 +767,11 @@ async def operate_reinstall(request: web.Request, authenticated_sender: str) -> 
                 # the agent's job because the agent created them; the
                 # supervisor is handed resolved paths and never allocates.
                 await supervisor.stop_vm(vm_id)
+                # A parent-backed volume is a loop device under a dm
+                # snapshot: the purge below refuses to unlink its file while
+                # those are live, and create_devmapper would return the old
+                # device instead of rebuilding it.
+                await teardown_vm_devices(str(vm_hash), record)
                 deleted = await asyncio.to_thread(purge_vm_volumes, vm_hash, include_data_volumes=include_data_volumes)
                 try:
                     # Rebuild each volume on the pool it was deleted from: the

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -55,6 +55,7 @@ from aleph.vm.agent.vm.reclaimable import (
 )
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
+from aleph.vm.storage import MOUNT_ROOT  # /mnt/{namespace}_{volume name}
 from aleph.vm.storage_budget import parse_budget
 from aleph.vm.storage_pools import StoragePool, get_pools, iter_namespace_dirs
 from aleph.vm.supervisor_interface.abc import Supervisor
@@ -62,9 +63,6 @@ from aleph.vm.utils import create_task_log_exceptions
 
 logger = logging.getLogger(__name__)
 
-# Where create_devmapper mounts a volume while resizing it (storage.py mounts
-# /mnt/{namespace}_{volume name}).
-MOUNT_ROOT = Path("/mnt")
 STAGING_KINDS = ("vprogram", "snp-instance")
 
 # Namespace to the number of creates in flight for it. A count rather than

--- a/src/aleph/vm/agent/vm/retire.py
+++ b/src/aleph/vm/agent/vm/retire.py
@@ -30,10 +30,15 @@ from aleph_message.models import ItemHash
 
 from aleph.vm.agent.metrics import delete_records_for_vm
 from aleph.vm.agent.vm.backup import purge_vm_backups
-from aleph.vm.agent.vm.purge import purge_vm_side_dirs, purge_vm_storage
+from aleph.vm.agent.vm.purge import (
+    _checked_namespace,
+    purge_vm_side_dirs,
+    purge_vm_storage,
+)
 from aleph.vm.agent.vm.reclaimable import depends_on_from_content, mark_reclaimable
 from aleph.vm.agent.vm_registry import AgentVmRecord, AgentVmRegistry
 from aleph.vm.conf import settings
+from aleph.vm.storage import remove_devmapper
 from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.supervisor_interface.errors import VmNotFoundError
 from aleph.vm.supervisor_interface.types import VmId
@@ -63,6 +68,31 @@ def set_after_gone_hook(hook: AfterGoneHook | None) -> None:
     """
     global _after_gone  # noqa: PLW0603
     _after_gone = hook
+
+
+async def teardown_vm_devices(namespace: str, record: AgentVmRecord | None) -> None:
+    """Remove the device-mapper snapshots and loop devices of a VM's
+    parent-backed volumes.
+
+    The agent creates them (``storage.create_devmapper``) and nothing else
+    removes them, so this is the only inverse. Best effort: a failure is
+    logged and the volume file stays behind, where the reconciler's dm guard
+    leaves it for the next pass rather than unlinking a file a loop device
+    still pins.
+    """
+    if record is None:
+        return
+    namespace = _checked_namespace(namespace)
+    for volume in getattr(record.message, "volumes", None) or []:
+        # An instance rootfs is a qcow2 overlay, not a dm snapshot, and it is
+        # not in `volumes` anyway; only a volume with a parent went through
+        # create_devmapper.
+        if getattr(volume, "parent", None) is None or not getattr(volume, "name", None):
+            continue
+        try:
+            await remove_devmapper(namespace, volume.name)
+        except Exception:
+            logger.exception("Device teardown of %s/%s failed", namespace, volume.name)
 
 
 async def retire_vm(
@@ -98,6 +128,10 @@ async def retire_vm(
     record = registry.get(item_hash)
     registry.forget(item_hash)
     await delete_records_for_vm(str(vm_hash))
+    # Before the storage pass: a volume file held by a live dm target cannot
+    # be unlinked usefully, and the marker written for a kept volume would
+    # describe a size the loop device still pins.
+    await teardown_vm_devices(str(vm_hash), record)
     try:
         await asyncio.to_thread(_release_storage, str(vm_hash), reason, record)
     except Exception:

--- a/src/aleph/vm/agent/vm/retire.py
+++ b/src/aleph/vm/agent/vm/retire.py
@@ -76,13 +76,24 @@ async def teardown_vm_devices(namespace: str, record: AgentVmRecord | None) -> N
 
     The agent creates them (``storage.create_devmapper``) and nothing else
     removes them, so this is the only inverse. Best effort: a failure is
-    logged and the volume file stays behind, where the reconciler's dm guard
-    leaves it for the next pass rather than unlinking a file a loop device
-    still pins.
+    logged and never aborts the retire, which still drops the records and
+    releases the rest of the storage. The volume file then stays behind,
+    pinned by its loop device, and the purge's dm guard refuses to unlink it
+    (that would free nothing and would not reset the volume either, since
+    ``create_devmapper`` reuses a live device). Nothing retries the teardown
+    once the record is gone: such a device waits for an operator.
     """
     if record is None:
         return
-    namespace = _checked_namespace(namespace)
+    try:
+        namespace = _checked_namespace(namespace)
+    except ValueError:
+        # Unreachable from the callers, which pass an ItemHash, but the
+        # best-effort contract holds for the check too: a teardown that
+        # cannot run must not abort the retire between the forget and the
+        # storage release.
+        logger.exception("Device teardown of %r skipped", namespace)
+        return
     for volume in getattr(record.message, "volumes", None) or []:
         # An instance rootfs is a qcow2 overlay, not a dm snapshot, and it is
         # not in `volumes` anyway; only a volume with a parent went through

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -32,11 +32,17 @@ from aleph_message.models.execution.volume import (
 )
 
 from aleph.vm.conf import settings
-from aleph.vm.storage_pools import volume_path_for
+from aleph.vm.storage_pools import find_existing_volume, volume_path_for
 from aleph.vm.utils import fix_message_validation, run_in_subprocess
 
 logger = logging.getLogger(__name__)
 DEVICE_MAPPER_DIRECTORY = "/dev/mapper"
+# Where create_devmapper mounts a volume to resize its filesystem.
+MOUNT_ROOT = Path("/mnt")
+# What may be composed into a dmsetup device name. create_devmapper builds
+# names out of a VM hash and a volume name straight from the message, so a
+# name outside this set is one dmsetup would have refused to create.
+DEVICE_NAME_PATTERN = re.compile(r"^[\w\-]+$")
 
 # Runtimes and base images can be several hundred MiB and are sometimes served by slow
 # gateways (e.g. IPFS). We must not cap the *total* transfer time, or large-but-steady
@@ -460,13 +466,78 @@ async def create_devmapper(
     )
     await create_mapped_device(mapped_volume_name, snapshot_table_command)
 
-    mount_path = Path(f"/mnt/{mapped_volume_name}")
+    mount_path = MOUNT_ROOT / mapped_volume_name
     mount_path.mkdir(parents=True, exist_ok=True)
     await resize_and_tune_file_system(path_mapped_volume_name, mount_path)
     await chown_to_jailman(path_image_device_name)
     await chown_to_jailman(path_mapped_volume_name_base)
     await chown_to_jailman(path_mapped_volume_name)
     return path_mapped_volume_name
+
+
+async def detach_loop_devices(backing_file: Path) -> list[str]:
+    """Detach every loop device backed by ``backing_file``.
+
+    ``losetup -j`` lines look like ``/dev/loop3: [2049]:12 (/path/to/file)``.
+    A file can be attached more than once (a create that was interrupted
+    between the loop setup and the dmsetup create leaves one behind), so
+    every match is detached, not just the first.
+    """
+    stdout = await run_in_subprocess(["losetup", "-j", str(backing_file)])
+    detached: list[str] = []
+    for line in stdout.decode().splitlines():
+        device = line.split(":", 1)[0].strip()
+        if not device.startswith("/dev/loop"):
+            continue
+        await run_in_subprocess(["losetup", "-d", device])
+        logger.info("Detached loop device %s of %s", device, backing_file)
+        detached.append(device)
+    return detached
+
+
+async def remove_devmapper(namespace: str, volume_name: str) -> None:
+    """The inverse of ``create_devmapper`` for one volume.
+
+    Removes the snapshot device, detaches the loop devices of its backing
+    file, drops the resize mount point, and removes the per-VM base device
+    once no snapshot of this VM is left. The parent image's device and its
+    read-only loop are shared across VMs and are removed by the cache pass
+    when the image is evicted, never here.
+
+    Until this runs, the volume file is pinned by its loop device: unlinking
+    it would free no space and would not reset the volume either, since
+    ``create_devmapper`` returns early while the dm device exists (which is
+    what ``purge._held_by_device_mapper`` guards against).
+    """
+    mapped_name = f"{namespace}_{volume_name}"
+    if not DEVICE_NAME_PATTERN.match(namespace) or not DEVICE_NAME_PATTERN.match(volume_name):
+        logger.error("Refusing to remove an implausible device-mapper name: %r", mapped_name)
+        return
+
+    mapper = Path(DEVICE_MAPPER_DIRECTORY)
+    if (mapper / mapped_name).is_block_device():
+        await run_in_subprocess(["dmsetup", "remove", mapped_name])
+        logger.info("Removed device-mapper target %s", mapped_name)
+
+    backing_file = find_existing_volume(namespace, f"{volume_name}.btrfs")
+    if backing_file is not None:
+        await detach_loop_devices(backing_file)
+
+    mount_path = MOUNT_ROOT / mapped_name
+    if mount_path.is_dir() and not mount_path.is_mount():
+        try:
+            mount_path.rmdir()
+        except OSError:
+            logger.warning("Could not remove %s", mount_path, exc_info=True)
+
+    # The base device is per VM but shared by all of its parent-backed
+    # volumes (create_devmapper builds it once, from the first one), so it
+    # only goes once the last snapshot of this VM is gone.
+    base_name = f"{namespace}_base"
+    siblings = [path for path in mapper.glob(f"{namespace}_*") if path.name != base_name and path.is_block_device()]
+    if not siblings and (mapper / base_name).is_block_device():
+        await run_in_subprocess(["dmsetup", "remove", base_name])
+        logger.info("Removed device-mapper base %s", base_name)
 
 
 async def get_existing_file(ref: str) -> Path:

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -39,10 +39,13 @@ logger = logging.getLogger(__name__)
 DEVICE_MAPPER_DIRECTORY = "/dev/mapper"
 # Where create_devmapper mounts a volume to resize its filesystem.
 MOUNT_ROOT = Path("/mnt")
-# What may be composed into a dmsetup device name. create_devmapper builds
-# names out of a VM hash and a volume name straight from the message, so a
-# name outside this set is one dmsetup would have refused to create.
-DEVICE_NAME_PATTERN = re.compile(r"^[\w\-]+$")
+# A namespace is an item hash, validated here too (agent.vm.purge does the
+# same for its delete paths) because the cost of being wrong is removing
+# another VM's device. ASCII only: a device name is bytes, and \w would match
+# letters that are not.
+NAMESPACE_PATTERN = re.compile(r"^[0-9a-zA-Z]{16,128}$", re.ASCII)
+# DM_NAME_LEN is 128 bytes including the terminating NUL.
+DEVICE_NAME_MAX_BYTES = 127
 
 # Runtimes and base images can be several hundred MiB and are sometimes served by slow
 # gateways (e.g. IPFS). We must not cap the *total* transfer time, or large-but-steady
@@ -495,6 +498,27 @@ async def detach_loop_devices(backing_file: Path) -> list[str]:
     return detached
 
 
+def device_name_for(namespace: str, volume_name: str) -> str | None:
+    """The dm name ``create_devmapper`` builds, or None if it could not have.
+
+    ``PersistentVolume.name`` is an arbitrary string and nothing on the create
+    path narrows it, so the only names that cannot exist are the ones
+    ``dmsetup create`` itself refuses: empty, containing a ``/``, ``.``, ``..``
+    and anything over the device-mapper name limit. A volume called ``data.1``
+    or ``my data`` has a live device and must be removable; refusing it here
+    would strand its loop device and, through ``purge._held_by_device_mapper``,
+    its disk.
+    """
+    if not NAMESPACE_PATTERN.match(namespace):
+        return None
+    if volume_name in ("", ".", "..") or "/" in volume_name:
+        return None
+    name = f"{namespace}_{volume_name}"
+    if len(name.encode()) > DEVICE_NAME_MAX_BYTES:
+        return None
+    return name
+
+
 async def remove_devmapper(namespace: str, volume_name: str) -> None:
     """The inverse of ``create_devmapper`` for one volume.
 
@@ -509,14 +533,16 @@ async def remove_devmapper(namespace: str, volume_name: str) -> None:
     ``create_devmapper`` returns early while the dm device exists (which is
     what ``purge._held_by_device_mapper`` guards against).
     """
-    mapped_name = f"{namespace}_{volume_name}"
-    if not DEVICE_NAME_PATTERN.match(namespace) or not DEVICE_NAME_PATTERN.match(volume_name):
-        logger.error("Refusing to remove an implausible device-mapper name: %r", mapped_name)
+    mapped_name = device_name_for(namespace, volume_name)
+    if mapped_name is None:
+        logger.error("Refusing to remove an implausible device-mapper name: %r/%r", namespace, volume_name)
         return
 
     mapper = Path(DEVICE_MAPPER_DIRECTORY)
     if (mapper / mapped_name).is_block_device():
-        await run_in_subprocess(["dmsetup", "remove", mapped_name])
+        # --retry: udev and blkid settle on the device for a moment after the
+        # VM exits, and a first "device or resource busy" must not strand it.
+        await run_in_subprocess(["dmsetup", "remove", "--retry", mapped_name])
         logger.info("Removed device-mapper target %s", mapped_name)
 
     backing_file = find_existing_volume(namespace, f"{volume_name}.btrfs")
@@ -536,7 +562,7 @@ async def remove_devmapper(namespace: str, volume_name: str) -> None:
     base_name = f"{namespace}_base"
     siblings = [path for path in mapper.glob(f"{namespace}_*") if path.name != base_name and path.is_block_device()]
     if not siblings and (mapper / base_name).is_block_device():
-        await run_in_subprocess(["dmsetup", "remove", base_name])
+        await run_in_subprocess(["dmsetup", "remove", "--retry", base_name])
         logger.info("Removed device-mapper base %s", base_name)
 
 

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -533,12 +533,32 @@ async def remove_devmapper(namespace: str, volume_name: str) -> None:
     ``create_devmapper`` returns early while the dm device exists (which is
     what ``purge._held_by_device_mapper`` guards against).
     """
+    if not NAMESPACE_PATTERN.match(namespace):
+        logger.error("Refusing device teardown for an implausible VM hash: %r", namespace)
+        return
     mapped_name = device_name_for(namespace, volume_name)
     if mapped_name is None:
-        logger.error("Refusing to remove an implausible device-mapper name: %r/%r", namespace, volume_name)
+        logger.error(
+            "Refusing device teardown of VM %s for a volume name dmsetup could not have created: %r",
+            namespace,
+            volume_name,
+        )
         return
 
     mapper = Path(DEVICE_MAPPER_DIRECTORY)
+    mount_path = MOUNT_ROOT / mapped_name
+    if mount_path.is_mount():
+        # resize_and_tune_file_system mounts the fresh snapshot here to grow
+        # its filesystem and unmounts it on the way out, with nothing to
+        # guarantee the unmount if the agent dies in between. A mount that
+        # outlived it keeps the device busy, so "dmsetup remove --retry"
+        # would fail the same way on every attempt and the teardown could
+        # never succeed. Best effort: if the unmount fails, the removal
+        # below reports the busy device.
+        try:
+            await run_in_subprocess(["umount", str(mount_path)])
+        except Exception:
+            logger.warning("Could not unmount %s before removing its device", mount_path, exc_info=True)
     if (mapper / mapped_name).is_block_device():
         # --retry: udev and blkid settle on the device for a moment after the
         # VM exits, and a first "device or resource busy" must not strand it.
@@ -549,7 +569,6 @@ async def remove_devmapper(namespace: str, volume_name: str) -> None:
     if backing_file is not None:
         await detach_loop_devices(backing_file)
 
-    mount_path = MOUNT_ROOT / mapped_name
     if mount_path.is_dir() and not mount_path.is_mount():
         try:
             mount_path.rmdir()

--- a/tests/supervisor/test_devmapper_teardown.py
+++ b/tests/supervisor/test_devmapper_teardown.py
@@ -1,0 +1,116 @@
+"""remove_devmapper: the inverse of create_devmapper for one volume."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from reclaim_fixtures import VM_HASH, pools, volume  # noqa: F401
+
+import aleph.vm.storage as storage_module
+from aleph.vm.storage import detach_loop_devices, remove_devmapper
+
+real_glob = Path.glob
+
+
+@pytest.fixture
+def commands(mocker):
+    """Record every subprocess call; losetup -j answers with two loop devices."""
+    calls: list[list[str]] = []
+
+    async def fake_run(command, check=True, stdin_input=None):
+        calls.append([str(c) for c in command])
+        if command[:2] == ["losetup", "-j"]:
+            return b"/dev/loop7: []: (/some/file)\n/dev/loop9: []: (/some/file)\n"
+        return b""
+
+    mocker.patch.object(storage_module, "run_in_subprocess", side_effect=fake_run)
+    return calls
+
+
+def _present_devices(monkeypatch, present: set[Path], siblings: list[Path]) -> None:
+    """Pretend ``present`` are the live /dev/mapper block devices."""
+    real_is_block_device = Path.is_block_device
+    monkeypatch.setattr(Path, "is_block_device", lambda self: self in present or real_is_block_device(self))
+    monkeypatch.setattr(
+        Path,
+        "glob",
+        lambda self, pattern: iter(siblings) if str(self) == "/dev/mapper" else real_glob(self, pattern),
+    )
+
+
+@pytest.mark.asyncio
+async def test_detach_loop_devices_detaches_every_loop_of_the_file(commands):
+    detached = await detach_loop_devices(Path("/some/file"))
+
+    assert detached == ["/dev/loop7", "/dev/loop9"]
+    assert ["losetup", "-d", "/dev/loop7"] in commands
+    assert ["losetup", "-d", "/dev/loop9"] in commands
+
+
+@pytest.mark.asyncio
+async def test_remove_devmapper_tears_down_in_order(pools, commands, monkeypatch, tmp_path):  # noqa: F811
+    backing = volume(pools["pool0"], VM_HASH, "data.btrfs")
+    mapped = Path("/dev/mapper") / f"{VM_HASH}_data"
+    base = Path("/dev/mapper") / f"{VM_HASH}_base"
+    _present_devices(monkeypatch, {mapped, base}, [])
+    mount_root = tmp_path / "mnt"
+    (mount_root / f"{VM_HASH}_data").mkdir(parents=True)
+    monkeypatch.setattr(storage_module, "MOUNT_ROOT", mount_root)
+
+    await remove_devmapper(VM_HASH, "data")
+
+    dm_removes = [c for c in commands if c[:2] == ["dmsetup", "remove"]]
+    assert dm_removes == [
+        ["dmsetup", "remove", f"{VM_HASH}_data"],
+        ["dmsetup", "remove", f"{VM_HASH}_base"],
+    ]
+    assert ["losetup", "-j", str(backing)] in commands
+    assert not (mount_root / f"{VM_HASH}_data").exists()
+
+
+@pytest.mark.asyncio
+async def test_remove_devmapper_keeps_base_while_a_sibling_snapshot_exists(pools, commands, monkeypatch):  # noqa: F811
+    volume(pools["pool0"], VM_HASH, "data.btrfs")
+    mapped = Path("/dev/mapper") / f"{VM_HASH}_data"
+    sibling = Path("/dev/mapper") / f"{VM_HASH}_other"
+    base = Path("/dev/mapper") / f"{VM_HASH}_base"
+    _present_devices(monkeypatch, {mapped, sibling, base}, [sibling])
+
+    await remove_devmapper(VM_HASH, "data")
+
+    dm_removes = [c for c in commands if c[:2] == ["dmsetup", "remove"]]
+    assert dm_removes == [["dmsetup", "remove", f"{VM_HASH}_data"]]
+
+
+@pytest.mark.asyncio
+async def test_remove_devmapper_never_touches_the_shared_parent_device(pools, commands, monkeypatch):  # noqa: F811
+    """The parent image's dm device is shared across VMs: only the cache
+    eviction pass may remove it."""
+    volume(pools["pool0"], VM_HASH, "data.btrfs")
+    mapped = Path("/dev/mapper") / f"{VM_HASH}_data"
+    parent = Path("/dev/mapper") / "parent-image-ref"
+    _present_devices(monkeypatch, {mapped, parent}, [])
+
+    await remove_devmapper(VM_HASH, "data")
+
+    assert ["dmsetup", "remove", "parent-image-ref"] not in commands
+
+
+@pytest.mark.asyncio
+async def test_remove_devmapper_is_a_no_op_without_devices(pools, commands):  # noqa: F811
+    await remove_devmapper(VM_HASH, "data")
+
+    assert [c for c in commands if c[0] == "dmsetup"] == []
+
+
+@pytest.mark.asyncio
+async def test_remove_devmapper_refuses_an_implausible_name(commands, monkeypatch):
+    """A name that could never have been created is never composed into a
+    dmsetup argument."""
+    _present_devices(monkeypatch, set(), [])
+
+    await remove_devmapper("../../etc", "data")
+    await remove_devmapper(VM_HASH, "../data")
+
+    assert commands == []

--- a/tests/supervisor/test_devmapper_teardown.py
+++ b/tests/supervisor/test_devmapper_teardown.py
@@ -62,8 +62,8 @@ async def test_remove_devmapper_tears_down_in_order(pools, commands, monkeypatch
 
     dm_removes = [c for c in commands if c[:2] == ["dmsetup", "remove"]]
     assert dm_removes == [
-        ["dmsetup", "remove", f"{VM_HASH}_data"],
-        ["dmsetup", "remove", f"{VM_HASH}_base"],
+        ["dmsetup", "remove", "--retry", f"{VM_HASH}_data"],
+        ["dmsetup", "remove", "--retry", f"{VM_HASH}_base"],
     ]
     assert ["losetup", "-j", str(backing)] in commands
     assert not (mount_root / f"{VM_HASH}_data").exists()
@@ -80,7 +80,7 @@ async def test_remove_devmapper_keeps_base_while_a_sibling_snapshot_exists(pools
     await remove_devmapper(VM_HASH, "data")
 
     dm_removes = [c for c in commands if c[:2] == ["dmsetup", "remove"]]
-    assert dm_removes == [["dmsetup", "remove", f"{VM_HASH}_data"]]
+    assert dm_removes == [["dmsetup", "remove", "--retry", f"{VM_HASH}_data"]]
 
 
 @pytest.mark.asyncio
@@ -94,23 +94,70 @@ async def test_remove_devmapper_never_touches_the_shared_parent_device(pools, co
 
     await remove_devmapper(VM_HASH, "data")
 
-    assert ["dmsetup", "remove", "parent-image-ref"] not in commands
+    assert ["dmsetup", "remove", "--retry", "parent-image-ref"] not in commands
 
 
 @pytest.mark.asyncio
-async def test_remove_devmapper_is_a_no_op_without_devices(pools, commands):  # noqa: F811
+async def test_remove_devmapper_runs_nothing_without_a_device_or_a_file(pools, commands):  # noqa: F811
     await remove_devmapper(VM_HASH, "data")
 
-    assert [c for c in commands if c[0] == "dmsetup"] == []
+    assert commands == []
 
 
 @pytest.mark.asyncio
-async def test_remove_devmapper_refuses_an_implausible_name(commands, monkeypatch):
+async def test_remove_devmapper_detaches_a_stale_loop_without_a_dm_device(pools, commands):  # noqa: F811
+    """A create interrupted between the losetup and the dmsetup create leaves
+    a loop device on the volume file and no dm target above it."""
+    backing = volume(pools["pool0"], VM_HASH, "data.btrfs")
+
+    await remove_devmapper(VM_HASH, "data")
+
+    assert commands == [
+        ["losetup", "-j", str(backing)],
+        ["losetup", "-d", "/dev/loop7"],
+        ["losetup", "-d", "/dev/loop9"],
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("volume_name", ["data.1", "my data"])
+async def test_remove_devmapper_tears_down_an_awkward_but_valid_name(
+    pools,  # noqa: F811
+    commands,
+    monkeypatch,
+    volume_name,
+):
+    """dmsetup only rejects "/", "." and ".."; a volume named "data.1" or
+    "my data" creates fine, so it has to tear down fine too."""
+    backing = volume(pools["pool0"], VM_HASH, f"{volume_name}.btrfs")  # noqa: F811
+    mapped = Path("/dev/mapper") / f"{VM_HASH}_{volume_name}"
+    _present_devices(monkeypatch, {mapped}, [])
+
+    await remove_devmapper(VM_HASH, volume_name)
+
+    assert ["dmsetup", "remove", "--retry", f"{VM_HASH}_{volume_name}"] in commands
+    assert ["losetup", "-j", str(backing)] in commands
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "namespace, volume_name",
+    [
+        ("../../etc", "data"),  # not an item hash
+        (VM_HASH, "a/b"),  # dmsetup rejects "/"
+        (VM_HASH, "."),
+        (VM_HASH, ".."),
+        (VM_HASH, ""),
+        (VM_HASH, "d" * 128),  # over the 127 byte device-mapper name limit
+    ],
+)
+async def test_remove_devmapper_refuses_a_name_dmsetup_could_not_have_created(
+    commands, monkeypatch, namespace, volume_name
+):
     """A name that could never have been created is never composed into a
     dmsetup argument."""
     _present_devices(monkeypatch, set(), [])
 
-    await remove_devmapper("../../etc", "data")
-    await remove_devmapper(VM_HASH, "../data")
+    await remove_devmapper(namespace, volume_name)
 
     assert commands == []

--- a/tests/supervisor/test_devmapper_teardown.py
+++ b/tests/supervisor/test_devmapper_teardown.py
@@ -161,3 +161,44 @@ async def test_remove_devmapper_refuses_a_name_dmsetup_could_not_have_created(
     await remove_devmapper(namespace, volume_name)
 
     assert commands == []
+
+
+@pytest.mark.asyncio
+async def test_remove_devmapper_unmounts_a_leftover_resize_mount_first(pools, mocker, monkeypatch, tmp_path):  # noqa: F811
+    """An agent that died between the resize mount and its umount leaves the
+    snapshot mounted; dmsetup remove would then fail busy on every attempt."""
+    volume(pools["pool0"], VM_HASH, "data.btrfs")
+    mapped = Path("/dev/mapper") / f"{VM_HASH}_data"
+    _present_devices(monkeypatch, {mapped}, [])
+    mount_root = tmp_path / "mnt"
+    mount_path = mount_root / f"{VM_HASH}_data"
+    mount_path.mkdir(parents=True)
+    monkeypatch.setattr(storage_module, "MOUNT_ROOT", mount_root)
+    mounted = {mount_path}
+    monkeypatch.setattr(Path, "is_mount", lambda self: self in mounted)
+    calls: list[list[str]] = []
+
+    async def fake_run(command, check=True, stdin_input=None):
+        calls.append([str(c) for c in command])
+        if command[0] == "umount":
+            mounted.discard(Path(command[1]))
+        return b""
+
+    mocker.patch.object(storage_module, "run_in_subprocess", side_effect=fake_run)
+
+    await remove_devmapper(VM_HASH, "data")
+
+    assert calls[:2] == [["umount", str(mount_path)], ["dmsetup", "remove", "--retry", f"{VM_HASH}_data"]]
+    assert not mount_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_remove_devmapper_does_not_unmount_what_is_not_mounted(pools, commands, monkeypatch, tmp_path):  # noqa: F811
+    volume(pools["pool0"], VM_HASH, "data.btrfs")
+    mapped = Path("/dev/mapper") / f"{VM_HASH}_data"
+    _present_devices(monkeypatch, {mapped}, [])
+    monkeypatch.setattr(storage_module, "MOUNT_ROOT", tmp_path / "mnt")
+
+    await remove_devmapper(VM_HASH, "data")
+
+    assert not any(c[0] == "umount" for c in commands)

--- a/tests/supervisor/test_retire.py
+++ b/tests/supervisor/test_retire.py
@@ -309,3 +309,20 @@ async def test_devices_are_torn_down_after_the_quiesce_and_before_the_storage_pa
     await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
 
     assert order == ["delete_vm", "teardown", "release_storage"]
+
+
+@pytest.mark.asyncio
+async def test_device_teardown_of_an_implausible_hash_is_skipped_not_raised(mocker, caplog):
+    """The namespace check is part of the best-effort contract: it logs and
+    returns like a failed dmsetup, instead of raising out of the retire."""
+    from aleph.vm.agent.vm.retire import teardown_vm_devices
+
+    remove = mocker.patch.object(retire_module, "remove_devmapper", new_callable=AsyncMock)
+    record = MagicMock()
+    _parent_backed_volumes(record)
+
+    with caplog.at_level("ERROR"):
+        await teardown_vm_devices("../../etc", record)
+
+    remove.assert_not_awaited()
+    assert "skipped" in caplog.text

--- a/tests/supervisor/test_retire.py
+++ b/tests/supervisor/test_retire.py
@@ -233,3 +233,57 @@ async def test_a_failing_after_gone_hook_does_not_break_the_retire(env, monkeypa
     # The retire itself completed: the volumes are marked, not lost.
     assert read_marker(env["rootfs"].parent) is not None
     assert "pool on fire" in caplog.text
+
+
+def _parent_backed_volumes(record) -> None:
+    """One parent-backed volume named "data" and one plain volume."""
+    # `name` and `parent` are both MagicMock constructor keywords, so they
+    # have to be assigned after the fact to land on the mock as attributes.
+    parent_backed = MagicMock()
+    parent_backed.name = "data"
+    parent_backed.parent = MagicMock(ref="parent-ref")
+    plain = MagicMock()
+    plain.name = "plain"
+    plain.parent = None
+    record.message.volumes = [parent_backed, plain]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reason", [RetireReason.GONE, RetireReason.ERASE, RetireReason.FAILED_CREATE])
+async def test_purging_reasons_tear_down_parent_backed_volume_devices(env, monkeypatch, mocker, reason):
+    """A parent-backed volume is a loop device under a dm snapshot: its file
+    cannot be reclaimed while those are live."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    remove = mocker.patch.object(retire_module, "remove_devmapper", new_callable=AsyncMock)
+    _parent_backed_volumes(env["registry"].get(ItemHash(VM_HASH)))
+
+    await retire_vm(VM_HASH, reason, supervisor=env["supervisor"], registry=env["registry"])
+
+    remove.assert_awaited_once_with(VM_HASH, "data")
+
+
+@pytest.mark.asyncio
+async def test_recreate_leaves_devices_in_place(env, mocker):
+    remove = mocker.patch.object(retire_module, "remove_devmapper", new_callable=AsyncMock)
+
+    await retire_vm(VM_HASH, RetireReason.RECREATE, supervisor=env["supervisor"])
+
+    remove.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_failing_device_teardown_does_not_abort_the_retire(env, monkeypatch, mocker, caplog):
+    """dmsetup can refuse (device busy); the volume file then stays behind for
+    the next reconcile pass, but the rest of the retire still happens."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    mocker.patch.object(
+        retire_module, "remove_devmapper", new_callable=AsyncMock, side_effect=RuntimeError("device busy")
+    )
+    _parent_backed_volumes(env["registry"].get(ItemHash(VM_HASH)))
+
+    with caplog.at_level("ERROR"):
+        await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
+
+    assert "device busy" in caplog.text
+    assert ItemHash(VM_HASH) not in env["registry"]
+    assert not env["rootfs"].exists()

--- a/tests/supervisor/test_retire.py
+++ b/tests/supervisor/test_retire.py
@@ -287,3 +287,25 @@ async def test_a_failing_device_teardown_does_not_abort_the_retire(env, monkeypa
     assert "device busy" in caplog.text
     assert ItemHash(VM_HASH) not in env["registry"]
     assert not env["rootfs"].exists()
+
+
+@pytest.mark.asyncio
+async def test_devices_are_torn_down_after_the_quiesce_and_before_the_storage_pass(env, monkeypatch, mocker):
+    """The order is the point: the supervisor must have released the VM
+    before its devices go, and the devices must be gone before the storage
+    pass, which cannot usefully unlink a file a loop device still pins."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    order: list[str] = []
+    env["supervisor"].delete_vm.side_effect = lambda *args, **kwargs: order.append("delete_vm")
+    mocker.patch.object(
+        retire_module,
+        "remove_devmapper",
+        new_callable=AsyncMock,
+        side_effect=lambda *args: order.append("teardown"),
+    )
+    mocker.patch.object(retire_module, "_release_storage", side_effect=lambda *args: order.append("release_storage"))
+    _parent_backed_volumes(env["registry"].get(ItemHash(VM_HASH)))
+
+    await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
+
+    assert order == ["delete_vm", "teardown", "release_storage"]

--- a/tests/supervisor/views/test_operator_retire.py
+++ b/tests/supervisor/views/test_operator_retire.py
@@ -486,3 +486,43 @@ async def test_operator_reinstall_non_persistent_recreates(aiohttp_client, mocke
         capacity=app["capacity"],
         persistent=False,
     )
+
+
+@pytest.mark.asyncio
+async def test_operator_reinstall_tears_down_devices_before_purging(aiohttp_client, mocker):
+    """A parent-backed volume's dm snapshot and loop device are torn down
+    right after the stop: the purge cannot unlink a file a loop device pins."""
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    instance_message = await get_message(ref=vm_hash)
+
+    mocker.patch(
+        "aleph.vm.agent.views.authentication.authenticate_jwk",
+        return_value=instance_message.sender,
+    )
+    order: list[str] = []
+    mocker.patch(
+        "aleph.vm.agent.views.operator.teardown_vm_devices",
+        new=AsyncMock(side_effect=lambda *args: order.append("teardown")),
+    )
+    mocker.patch(
+        "aleph.vm.agent.views.operator.purge_vm_volumes",
+        side_effect=lambda *args, **kwargs: order.append("purge") or [],
+    )
+    mocker.patch("aleph.vm.agent.views.operator.recreate_vm_volumes", new=AsyncMock())
+
+    app = setup_webapp(supervisor=_fake_supervisor())
+    app["vm_registry"].record(
+        vm_hash,
+        message=instance_message.content,
+        original=instance_message.content,
+        persistent=True,
+    )
+    app["supervisor"] = _fake_supervisor()
+    client: TestClient = await aiohttp_client(app)
+    response = await client.post(f"/control/machine/{vm_hash}/reinstall")
+
+    assert response.status == 200, await response.text()
+    assert order == ["teardown", "purge"]

--- a/tests/supervisor/views/test_operator_retire.py
+++ b/tests/supervisor/views/test_operator_retire.py
@@ -503,13 +503,18 @@ async def test_operator_reinstall_tears_down_devices_before_purging(aiohttp_clie
         return_value=instance_message.sender,
     )
     order: list[str] = []
+
+    def purge(*args, **kwargs):
+        order.append("purge")
+        return []
+
     mocker.patch(
         "aleph.vm.agent.views.operator.teardown_vm_devices",
         new=AsyncMock(side_effect=lambda *args: order.append("teardown")),
     )
     mocker.patch(
         "aleph.vm.agent.views.operator.purge_vm_volumes",
-        side_effect=lambda *args, **kwargs: order.append("purge") or [],
+        side_effect=purge,
     )
     mocker.patch("aleph.vm.agent.views.operator.recreate_vm_volumes", new=AsyncMock())
 


### PR DESCRIPTION
## Summary

PR C of the 2.1 disk reclamation work (spec Section 5, S9: loop and device-mapper devices were never detached). Stacked on #1156.

- `storage.remove_devmapper(namespace, volume_name)`: the inverse of `create_devmapper`. `dmsetup remove --retry {ns}_{vol}`, `losetup -d` of every loop backed by the volume file (found by `losetup -j`, so a loop over another file is never touched), `rmdir /mnt/{ns}_{vol}`, and `dmsetup remove --retry {ns}_base` only when no other `{ns}_*` snapshot remains. The parent image's `/dev/mapper/{ref}` and its read-only loop are shared across VMs and are never removed here (the cache pass in PR D owns them).
- `retire.teardown_vm_devices`: `retire_vm` tears the devices down after `DeleteVm` returns and before the storage pass, for GONE / ERASE / FAILED_CREATE; RECREATE leaves them for the next create to reuse. Errors are logged, never raised, and never skip the storage release.
- In-place reinstall tears down after `stop_vm`, before the volume purge, so the `.btrfs` file is no longer pinned by a live target (the "still held by device mapper" branch in `purge.py` is now a real error path the reconciler retries).
- Name validation: the namespace keeps the strict item-hash check; the volume name is refused only for what `dmsetup` itself refuses (empty, `/`, `.`, `..`, over 127 bytes), so any name the create path accepted is torn down.
- `MOUNT_ROOT` hoisted into `storage.py` and shared with the reconciler.

## Known follow-ups
- `create_devmapper` builds one `{ns}_base` per namespace from the first parent-backed volume; a VM with two parent-backed volumes of different parents is already wrong on the create side (pre-existing). A volume literally named `base` collides with it. Teardown is correct either way.
- A stray loop over an already-unlinked file cannot be found via `losetup -j`.

## Test plan
- `tests/supervisor`: failing-ID set identical to base (compared by test id against the base commit in a throwaway worktree).
- New `tests/supervisor/test_devmapper_teardown.py` (exact command sequences and order, parent device never touched, `{ns}_base` sibling rule, awkward names, stale loop); `test_retire.py` (per reason, ordering, teardown failure does not abort the retire); `views/test_operator.py` (reinstall order teardown then purge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvDhr5NKq3AY17E1vwV3zk
