### PR TITLE
feat(agent): bounded download caches, in-stream size cap and LRU eviction (2.1, PR D)

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -348,8 +348,10 @@ message. One pass does, in order:
    under `keep`. Liveness is asked again immediately before anything is
    marked, purged or evicted, so a create that commits while the pass walks
    is not mistaken for an orphan.
-2. Delete `*.part` files older than the guard, in the four download caches
-   and in the pools (the downloader streams volumes in place).
+2. Delete `*.part` and `*.tmp` files older than the guard, in the four
+   download caches and in the pools (the downloader streams volumes in
+   place). Every write-then-rename in the agent uses one of the two suffixes,
+   and an interrupted one leaks the same way.
 3. Sweep the side directories keyed by VM hash: the confidential session
    directory, the SNP and V-PROGRAM staging directories, and
    `/mnt/{namespace}_{volume}` mount points. A directory that is still a
@@ -417,9 +419,21 @@ default). The pass evicts least recently used first, mtime being a real
 signal because the downloader touches an entry on every cache hit
 (`_touch_cache_hit`). What it may not touch is the point:
 
-- Entries a **live VM** names, meaning every `runtime`, `code`, `data`,
-  rootfs parent, volume parent and immutable volume `ref` of a message in the
-  agent registry. If live references alone exceed the budget the pass logs an
+- Entries a **live VM** names. `reclaimable.iter_content_refs` is the single
+  enumeration of those, so the two questions asked of a message (what a
+  retained volume depends on, what a live VM still needs) cannot drift apart:
+  `runtime`, `code`, `data`, the rootfs parent, volume parents and immutable
+  volume `ref`s, a V-PROGRAM's `workload.ref` and `workload.hash_tree`, a TEE
+  instance's `trusted_execution.firmware` and `trusted_execution.runtime`, and
+  the VM's own message entry (`<vm_hash>.json`). The confidential ones are not
+  a detail: a V-PROGRAM's workload image and hash tree are attached as the
+  VM's disks straight out of `DATA_CACHE`, so evicting one unlinks a running
+  VM's disk. The runtime bundle tarball is the one ref no message carries
+  (only the manifest names it); it is protected whenever the manifest itself
+  is cached, and is otherwise a re-downloadable artifact, since nothing runs
+  off the tarball (it is verified and extracted into the VM's staging
+  directory at create time).
+  If live references alone exceed the budget the pass logs an
   error and stops: that is a capacity problem admission should have refused,
   and eviction cannot fix it. The referenced set is read from the registry's
   messages, so a pass whose live set holds a hash the registry has no record
@@ -429,6 +443,13 @@ signal because the downloader touches an entry on every cache hit
   retained directories go first (oldest marker first, through
   `purge_vm_storage`), and a parent is evicted only once every retained VM
   that named it is gone and its purge actually removed the disks.
+
+The pass also sweeps what an earlier teardown left behind: a loop device
+still backed by a cache entry that is already unlinked (the kernel shows it as
+` (deleted)` in `/sys/block/loop*/loop/backing_file`). That is the recovery
+path for a teardown that crashed or failed, because once the entry is gone
+nothing else can name the loop that pins its blocks; the same holders check
+applies, so a leaked loop whose device is in use after all is left alone.
 
 Evicting a parent image also removes what `create_devmapper` builds once per
 image rather than once per VM: the `/dev/mapper/<ref>` target and the
@@ -450,6 +471,18 @@ rather than writing bytes that trigger an eviction storm. Directories that
 are not cache roots are none of its business: the downloader streams per-VM
 volumes in place, and those are admitted by the capacity checks and the pool
 budget.
+
+It is deliberately weaker than the pass, because it runs on the event loop
+inside a create. It unlinks unreferenced cache entries and nothing else: it
+never reclaims a retained VM directory (that is an `rmtree`, which belongs in
+the reconciler's worker thread), so what it cannot free it refuses and leaves
+to the next pass. And it evicts nothing at all unless the live set can be
+trusted: a pass publishes the live set only when both halves agree (the
+registry and a supervisor that answered `list_vms`), and admission additionally
+requires that every hash in it has a registry record, since a live VM without a
+message means the referenced set is incomplete. Before the first pass there is
+no live set, so admission evicts nothing and simply admits or refuses on the
+budget as it stands.
 
 ### Settings
 
@@ -549,7 +582,9 @@ pass against an empty registry would call every running VM an orphan.
 - `src/aleph/vm/agent/vm/retire.py`: `retire_vm` and `RetireReason`, the one
   way a VM's storage is released.
 - `src/aleph/vm/agent/vm/reclaimable.py`: the `.reclaimable` marker
-  (`mark_reclaimable`, `adopt`, `iter_reclaimable`, `reclaimable_bytes`).
+  (`mark_reclaimable`, `adopt`, `iter_reclaimable`, `reclaimable_bytes`) and
+  the one enumeration of the cache entries a message names
+  (`iter_content_refs`, `refs_from_content`, `depends_on_from_content`).
 - `src/aleph/vm/agent/vm/cache.py`: the cache budget, LRU eviction
   (`evict_caches`), the download admission hook (`admit_download`) and the
   parent image's device teardown (`remove_parent_device`).

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -342,6 +342,14 @@ registry alone is not enough, because it is refilled at boot from the agent
 DB and that rehydration skips any record with an empty or unparseable
 message. One pass does, in order:
 
+0. Tear down the device-mapper snapshots and loop devices of every namespace
+   `/dev/mapper` still names and no live VM owns
+   (`teardown_namespace_devices`). Before the walk, not inside it: a volume
+   file a dm target still holds cannot be unlinked usefully, so a directory
+   whose devices are still up is refused by step 1 and would be refused
+   again on every later pass. This runs on the event loop (dmsetup has to be
+   awaited) and only when the supervisor answered `list_vms`, since removing
+   the device of a VM that is merely unlisted takes that VM's disk with it.
 1. Walk `{pool}/*/`. Each directory is live (the registry or the supervisor
    knows its hash), reclaimable (a marker is present) or an orphan
    (neither). Orphans are purged under `reap` and marked `reason: orphan`
@@ -363,7 +371,11 @@ message. One pass does, in order:
    evict oldest-first (by `reclaimable_since`) until under
    `VOLUME_RETENTION_BUDGET`. Under `reap` everything marked is given back,
    which is how a node switched from `keep` to `reap` drains.
-5. Bring the four download caches under `CACHE_BUDGET` (see below).
+5. Bring the four download caches under `CACHE_BUDGET` (see below). Skipped
+   entirely, with an ERROR, when the supervisor could not be listed: what a
+   cache holds for a live VM is read from that VM's message, so a live set
+   that is the registry alone cannot answer the question, and evicting on it
+   would unlink a running VM's runtime.
 6. Sweep expired backups.
 
 Nothing a create is still building is touched. Two independent guards say
@@ -415,9 +427,19 @@ cache's `MAX_*_ARCHIVE_SIZE` before it opens the file, and aborts the moment
 the bytes written pass it, so a lying `Content-Length` cannot fill a disk.
 
 Per root: each cache gets `CACHE_BUDGET` (20% of the filesystem it sits on by
-default). The pass evicts least recently used first, mtime being a real
+default), the message cache included. The spec suggested a smaller budget for
+it; it does not have one, and does not need one: its entries are a few
+kilobytes of JSON each, so it never approaches a budget sized for runtime
+images, and one setting is one thing for an operator to reason about. A root's
+usage is its finished entries plus what it owes to downloads that have not
+finished (`in_flight_bytes`): the allocated blocks of `.part` and `.tmp`
+files, and the size any admitted download was promised.
+
+The pass evicts least recently used first, mtime being a real
 signal because the downloader touches an entry on every cache hit
-(`_touch_cache_hit`). What it may not touch is the point:
+(`_touch_cache_hit`, called by `download_file` for the caches it serves and
+by `get_runtime_path` / `get_rootfs_base_path`, which short-circuit a hit
+before reaching it). What it may not touch is the point:
 
 - Entries a **live VM** names. `reclaimable.iter_content_refs` is the single
   enumeration of those, so the two questions asked of a message (what a
@@ -464,10 +486,17 @@ left alone: its devices belong to that create now.
 
 Admission is the same question one download ahead: `storage`'s cache
 admission hook (registered by the agent on `set_cache_admission`) runs inside
-`download_file_in_chunks` once `Content-Length` is known and before the file
-is opened. It evicts what it can, and raises `InsufficientResourcesError`
+`download_file_in_chunks` once the size is known and before the file is
+opened. It evicts what it can, and raises `InsufficientResourcesError`
 (mapped to 503 on the create path) when the download still would not fit,
-rather than writing bytes that trigger an eviction storm. Directories that
+rather than writing bytes that trigger an eviction storm. A response with no
+`Content-Length` is admitted for the worst case it is allowed to send, its
+`MAX_*_ARCHIVE_SIZE` cap, and refused when that does not fit: the alternative
+is a download charged for nothing at all. What is admitted is then charged to
+the download's `.part` path (`reserve_download`) until `download_file`
+releases it, so a second create arriving while the first is still writing
+sees the room the first was promised rather than only the bytes it has
+managed to write. Directories that
 are not cache roots are none of its business: the downloader streams per-VM
 volumes in place, and those are admitted by the capacity checks and the pool
 budget.

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -361,7 +361,8 @@ message. One pass does, in order:
    evict oldest-first (by `reclaimable_since`) until under
    `VOLUME_RETENTION_BUDGET`. Under `reap` everything marked is given back,
    which is how a node switched from `keep` to `reap` drains.
-5. Sweep expired backups.
+5. Bring the four download caches under `CACHE_BUDGET` (see below).
+6. Sweep expired backups.
 
 Nothing a create is still building is touched. Two independent guards say
 so: a hash registered in the in-process "creating" set (every create path in
@@ -399,6 +400,56 @@ the whole transfer and records the imported VM in the registry (and the agent
 DB) once `CreateVm` returns. A namespace under the guard is skipped whole,
 `.part` files included: the directory mtime does not advance while a file
 inside it grows, so age is no evidence that a transfer has stopped.
+
+### The download caches
+
+The runtime, code, data and message caches are flat directories keyed by item
+hash and shared by every VM naming the same hash, and nothing used to remove
+anything from them. Two things now bound them
+(`src/aleph/vm/agent/vm/cache.py`).
+
+In the stream: `download_file_in_chunks` refuses a `Content-Length` above the
+cache's `MAX_*_ARCHIVE_SIZE` before it opens the file, and aborts the moment
+the bytes written pass it, so a lying `Content-Length` cannot fill a disk.
+
+Per root: each cache gets `CACHE_BUDGET` (20% of the filesystem it sits on by
+default). The pass evicts least recently used first, mtime being a real
+signal because the downloader touches an entry on every cache hit
+(`_touch_cache_hit`). What it may not touch is the point:
+
+- Entries a **live VM** names, meaning every `runtime`, `code`, `data`,
+  rootfs parent, volume parent and immutable volume `ref` of a message in the
+  agent registry. If live references alone exceed the budget the pass logs an
+  error and stops: that is a capacity problem admission should have refused,
+  and eviction cannot fix it. The referenced set is read from the registry's
+  messages, so a pass whose live set holds a hash the registry has no record
+  for skips the cache pass entirely rather than guess.
+- Entries a `.reclaimable` marker names in `depends_on`, the parent images
+  retained overlays are built on. Over budget with only those left, the
+  retained directories go first (oldest marker first, through
+  `purge_vm_storage`), and a parent is evicted only once every retained VM
+  that named it is gone and its purge actually removed the disks.
+
+Evicting a parent image also removes what `create_devmapper` builds once per
+image rather than once per VM: the `/dev/mapper/<ref>` target and the
+read-only loop device under it. A parent whose device still has holders (a
+VM's `<ns>_base` device is stacked on it) is not evicted at all, and an
+unanswerable question counts as held. The teardown runs on the event loop
+after the pass (`reconcile_now`), because the entry is already unlinked by
+then; `losetup -j` can no longer find the loop that pins its blocks, so the
+loop devices are found through sysfs, which keeps the backing path with a
+` (deleted)` suffix. An image a create downloaded again in the meantime is
+left alone: its devices belong to that create now.
+
+Admission is the same question one download ahead: `storage`'s cache
+admission hook (registered by the agent on `set_cache_admission`) runs inside
+`download_file_in_chunks` once `Content-Length` is known and before the file
+is opened. It evicts what it can, and raises `InsufficientResourcesError`
+(mapped to 503 on the create path) when the download still would not fit,
+rather than writing bytes that trigger an eviction storm. Directories that
+are not cache roots are none of its business: the downloader streams per-VM
+volumes in place, and those are admitted by the capacity checks and the pool
+budget.
 
 ### Settings
 
@@ -452,6 +503,10 @@ pass against an empty registry would call every running VM an orphan.
   and a placement that does not fit evicts them (oldest first) before it is
   refused (`src/aleph/vm/agent/capacity.py`,
   `src/aleph/vm/agent/resources.py`, `src/aleph/vm/storage_pools.py`).
+- A cache entry a live VM's message names is never evicted, and a parent
+  image whose device-mapper device still has holders is never evicted; both
+  questions fail closed when they cannot be answered
+  (`src/aleph/vm/agent/vm/cache.py`).
 - Every agent-side deletion goes through `retire_vm` with an explicit
   reason; nothing else under `src/aleph/vm/agent/` calls
   `supervisor.delete_vm` (`src/aleph/vm/agent/vm/retire.py`).
@@ -495,6 +550,9 @@ pass against an empty registry would call every running VM an orphan.
   way a VM's storage is released.
 - `src/aleph/vm/agent/vm/reclaimable.py`: the `.reclaimable` marker
   (`mark_reclaimable`, `adopt`, `iter_reclaimable`, `reclaimable_bytes`).
+- `src/aleph/vm/agent/vm/cache.py`: the cache budget, LRU eviction
+  (`evict_caches`), the download admission hook (`admit_download`) and the
+  parent image's device teardown (`remove_parent_device`).
 - `src/aleph/vm/agent/vm/reconciler.py`: `reconcile_storage`, the create
   guard (`creating`), the evictor (`make_room`) and the startup/periodic
   hooks the agent registers in `src/aleph/vm/agent/supervisor.py`.

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -490,9 +490,16 @@ admission hook (registered by the agent on `set_cache_admission`) runs inside
 opened. It evicts what it can, and raises `InsufficientResourcesError`
 (mapped to 503 on the create path) when the download still would not fit,
 rather than writing bytes that trigger an eviction storm. A response with no
-`Content-Length` is admitted for the worst case it is allowed to send, its
-`MAX_*_ARCHIVE_SIZE` cap, and refused when that does not fit: the alternative
-is a download charged for nothing at all. What is admitted is then charged to
+`Content-Length` is a different question, and the hook is told the two
+figures separately (`content_length`, `max_bytes`) so it can tell them apart.
+A cap is not a measurement: `MAX_RUNTIME_ARCHIVE_SIZE` is 100 GiB, the
+ceiling for a runtime image and equally the ceiling for a few kilobytes of
+manifest, so charging it as a size would evict a whole cache root for a
+download that never needed the room. An unknown-length download therefore
+never evicts, is refused only when the root is already over its budget, and
+is charged `min(cap, budget)`: bounded, so a stream of them still runs the
+root over budget and the next one is refused, and never more than the budget
+itself. What is admitted is then charged to
 the download's `.part` path (`reserve_download`) until `download_file`
 releases it, so a second create arriving while the first is still writing
 sees the room the first was promised rather than only the bytes it has

--- a/docs/architecture/vm-lifecycle.md
+++ b/docs/architecture/vm-lifecycle.md
@@ -136,7 +136,9 @@ Admission happens in two layers that never overlap in what they check:
   own early registry record (recorded before the spec build, to make
   owner-auth answerable during a slow confidential download) is excluded
   from the committed memory/vCPU sums via `exclude_vm_hash`, or a create
-  would count its own request against itself. GPU admission is a separate
+  would count its own request against itself. Cache downloads are admitted
+  separately, against `CACHE_BUDGET`, inside the downloader itself (see
+  [storage.md](storage.md)). GPU admission is a separate
   reservation ledger (`CapacityManager.holds`, keyed by concrete `pci_host`)
   with a short-lived hold/resolve two-step: `reserve_gpus` (used by the same
   dry-run endpoint) holds a card for a user for `RESERVATION_TTL_SECONDS`,
@@ -423,8 +425,13 @@ path); `purge_vm_storage` removes those directories, the confidential
 session directory and the SNP/V-PROGRAM staging directory. A `.btrfs`
 volume whose device-mapper target is still present is refused with an
 error rather than unlinked (the loop device would pin the inode and
-`create_devmapper` would skip the rebuild), until dm teardown on stop
-exists.
+`create_devmapper` would skip the rebuild). That refusal is a backstop
+rather than a dead end: `retire_vm` tears the VM's dm snapshots and loop
+devices down before the storage pass (`teardown_vm_devices`, from the
+message's volumes, or `teardown_namespace_devices` off `/dev/mapper` when
+no record is left), and the reconciler does the same for every namespace
+no live VM owns before its walk, so a refused directory is reclaimed on
+the pass after its devices go.
 
 What `DeleteVm` does: stop the VM (tearing down its network state exactly
 as `StopVm` would, and releasing every handle the daemon holds on the VM's

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -706,7 +706,8 @@ async def create_vm_execution_or_raise_http_error(
             text="This CRN cannot host the requested workload at this time.",
         ) from error
     except FileTooLargeError as error:
-        raise HTTPInternalServerError(reason=error.args[0]) from error
+        # An oversized resource is the message's fault, not the node's.
+        raise HTTPBadRequest(reason=error.args[0]) from error
     except VmStartupError as error:
         # Created but never reached RUNNING (terminal status or start timeout):
         # a distinct, expected outcome, not the generic "unhandled error".
@@ -756,7 +757,8 @@ def _raise_http_for_program_error(error: Exception, vm_hash: ItemHash) -> None:
             text="This CRN cannot host the requested workload at this time.",
         ) from error
     if isinstance(error, FileTooLargeError):
-        raise HTTPInternalServerError(reason=str(error) or "File too large") from error
+        # An oversized resource is the message's fault, not the node's.
+        raise HTTPBadRequest(reason=str(error) or "File too large") from error
     if isinstance(error, VmStartupError):
         # Created but never reached RUNNING (terminal status or start timeout):
         # a distinct, expected outcome, not the generic "unhandled error".

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -522,7 +522,7 @@ def run():
     # And the third hook of the same kind: a download about to start asks the
     # cache budget for room, so a create that would blow it is refused before
     # the bytes land rather than after (spec section 4).
-    storage.set_cache_admission(lambda root, size: admit_download(app["vm_registry"], root, size))
+    storage.set_cache_admission(lambda tmp_path, size: admit_download(app["vm_registry"], tmp_path, size))
     app.on_startup.append(start_node_hash_discovery)
     app.on_cleanup.append(stop_node_hash_discovery)
 

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -522,7 +522,11 @@ def run():
     # And the third hook of the same kind: a download about to start asks the
     # cache budget for room, so a create that would blow it is refused before
     # the bytes land rather than after (spec section 4).
-    storage.set_cache_admission(lambda tmp_path, size: admit_download(app["vm_registry"], tmp_path, size))
+    storage.set_cache_admission(
+        lambda tmp_path, content_length, max_bytes: admit_download(
+            app["vm_registry"], tmp_path, content_length, max_bytes
+        )
+    )
     app.on_startup.append(start_node_hash_discovery)
     app.on_cleanup.append(stop_node_hash_discovery)
 

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -521,7 +521,7 @@ def run():
     set_after_gone_hook(lambda: reconcile_now(app))
     # And the third hook of the same kind: a download about to start asks the
     # cache budget for room, so a create that would blow it is refused before
-    # the bytes land rather than after (spec section 4).
+    # the bytes land rather than after.
     storage.set_cache_admission(
         lambda tmp_path, content_length, max_bytes: admit_download(
             app["vm_registry"], tmp_path, content_length, max_bytes

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -15,13 +15,14 @@ from aiohttp import hdrs, web
 from aiohttp.web_exceptions import HTTPException
 from aiohttp_cors import ResourceOptions, setup
 
-from aleph.vm import storage_pools
+from aleph.vm import storage, storage_pools
 from aleph.vm.agent.capacity import CapacityManager
 from aleph.vm.agent.expiry import ExpiryManager
 from aleph.vm.agent.migration.reaper import reap_orphan_migration_files
 from aleph.vm.agent.update_watcher import UpdateWatcher
 from aleph.vm.agent.vcpu_probe import get_snp_launch_capability
 from aleph.vm.agent.vm.backup import BackupManager
+from aleph.vm.agent.vm.cache import admit_download
 from aleph.vm.agent.vm.program_client import ProgramGuestClient
 from aleph.vm.agent.vm.reconciler import (
     known_live_hashes,
@@ -518,6 +519,10 @@ def run():
         lambda pool, needed: make_room(pool, needed, live=known_live_hashes(app["vm_registry"])),
     )
     set_after_gone_hook(lambda: reconcile_now(app))
+    # And the third hook of the same kind: a download about to start asks the
+    # cache budget for room, so a create that would blow it is refused before
+    # the bytes land rather than after (spec section 4).
+    storage.set_cache_admission(lambda root, size: admit_download(app["vm_registry"], root, size))
     app.on_startup.append(start_node_hash_discovery)
     app.on_cleanup.append(stop_node_hash_discovery)
 

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -34,18 +34,22 @@ last, and the next create simply re-downloads what was taken.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import shutil
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Collection, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
 from aleph.vm.agent.vm.purge import _ITEM_HASH_PATTERN, purge_vm_storage
 from aleph.vm.agent.vm.reclaimable import (
+    MANIFEST_REF_KINDS,
     ReclaimableMarker,
     file_size_bytes,
+    iter_content_refs,
     iter_reclaimable,
+    refs_from_content,
 )
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
@@ -58,6 +62,9 @@ from aleph.vm.utils import create_task_log_exceptions, run_in_subprocess
 logger = logging.getLogger(__name__)
 
 MIB = 1024 * 1024
+# A runtime manifest is a few kilobytes of JSON; anything larger in the data
+# cache is a payload, not a manifest, and is not read.
+MANIFEST_MAX_BYTES = 64 * 1024
 # Where the kernel lists the loop devices and what backs them. Read rather
 # than `losetup -j` when the backing file is already unlinked: sysfs keeps
 # the path (with a " (deleted)" suffix), losetup cannot stat it any more.
@@ -67,6 +74,24 @@ DELETED_SUFFIX = " (deleted)"
 # Suffixes of files that are not cache entries: a download in flight
 # (download_file) and a message being written (storage.get_message).
 IN_FLIGHT_SUFFIXES = (".part", ".tmp")
+
+
+# The reconciler's most recent live set. The admission hook runs on the create
+# path, off any pass, and cannot ask the supervisor what it is running; the
+# pass can, so it leaves its answer here. Session state, deliberately: an
+# agent that has not reconciled yet has no live set, and admission treats
+# that as "do not evict" rather than as "nothing is live".
+_live_snapshot: frozenset[str] | None = None
+
+
+def record_live_snapshot(live: Collection[str]) -> None:
+    """Publish the live set a pass established, for the admission hook."""
+    global _live_snapshot  # noqa: PLW0603
+    _live_snapshot = frozenset(str(namespace) for namespace in live)
+
+
+def live_snapshot() -> frozenset[str] | None:
+    return _live_snapshot
 
 
 @dataclass(frozen=True)
@@ -129,31 +154,55 @@ def _entry_refs(path: Path) -> set[str]:
     return {path.name, path.stem}
 
 
-def _record_refs(content) -> set[str]:
-    """Every cache entry one message names: runtime, code, data, the rootfs
-    parent, volume parents and immutable volume refs."""
-    refs: set[str] = set()
-    for attribute in ("runtime", "code", "data"):
-        obj = getattr(content, attribute, None)
-        if obj is not None and getattr(obj, "ref", None):
-            refs.add(str(obj.ref))
-    rootfs = getattr(content, "rootfs", None)
-    if rootfs is not None and getattr(rootfs, "parent", None):
-        refs.add(str(rootfs.parent.ref))
-    for volume in getattr(content, "volumes", None) or []:
-        parent = getattr(volume, "parent", None)
-        if parent is not None and getattr(parent, "ref", None):
-            refs.add(str(parent.ref))
-        if getattr(volume, "ref", None):
-            refs.add(str(volume.ref))
+def _manifest_bundle_ref(ref: str) -> str | None:
+    """The bundle tarball a locally cached runtime manifest names, or None.
+
+    A V-PROGRAM and a confidential instance pin their runtime by the hash of
+    a small JSON manifest, and the tarball it points at is a ref no message
+    carries: it is knowable only from the manifest. So it is protected when
+    the manifest is here to read, and treated as a re-downloadable artifact
+    when it is not (nothing runs off the tarball itself, which is verified
+    and extracted into the VM's staging directory at create time).
+
+    Bounded on purpose: only DATA_CACHE (where both manifests are fetched to)
+    and only a small file, so this never reads a runtime image looking for
+    JSON.
+    """
+    if not settings.DATA_CACHE or not _safe_ref(ref):
+        return None
+    path = Path(settings.DATA_CACHE) / ref
+    try:
+        if not path.is_file() or path.stat().st_size > MANIFEST_MAX_BYTES:
+            return None
+        manifest = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+    bundle = manifest.get("bundle") if isinstance(manifest, dict) else None
+    bundle_ref = bundle.get("ref") if isinstance(bundle, dict) else None
+    return str(bundle_ref) if bundle_ref else None
+
+
+def _record_refs(content, vm_hash: object) -> set[str]:
+    """Every cache entry one live record names.
+
+    ``reclaimable.iter_content_refs`` is the enumeration; this adds what only
+    the filesystem knows, the bundle tarball named by a cached manifest.
+    """
+    refs = refs_from_content(content, vm_hash=str(vm_hash) if vm_hash else None)
+    for kind, ref in iter_content_refs(content):
+        if kind not in MANIFEST_REF_KINDS:
+            continue
+        bundle_ref = _manifest_bundle_ref(ref)
+        if bundle_ref:
+            refs.add(bundle_ref)
     return refs
 
 
 def live_refs(registry: AgentVmRegistry) -> set[str]:
     """The refs live records name: never evictable, whatever the budget."""
     refs: set[str] = set()
-    for _vm_hash, record in list(registry.items()):
-        refs |= _record_refs(record.message)
+    for vm_hash, record in list(registry.items()):
+        refs |= _record_refs(record.message, vm_hash)
     return refs
 
 
@@ -382,6 +431,7 @@ def evict_caches(
     needed: dict[Path, int] | None = None,
     dry_run: bool = False,
     is_live: Callable[[str], bool] | None = None,
+    reclaim_retained: bool = True,
 ) -> list[Path]:
     """Bring every cache root under ``CACHE_BUDGET``; return what was evicted.
 
@@ -391,6 +441,11 @@ def evict_caches(
     ``is_live`` decides whether a reclaimable directory may be reclaimed to
     free its parent image; it defaults to the registry alone, which is what a
     caller holding no supervisor handle can offer.
+
+    ``reclaim_retained`` is the second phase, purging retained VM directories
+    to free the parent images they pin. Admission turns it off: it runs on the
+    event loop inside a download, where an rmtree of a retained VM's disks
+    does not belong. What it cannot free there, the next pass frees.
     """
     needed = needed or {}
     evicted: list[Path] = []
@@ -418,12 +473,21 @@ def evict_caches(
         # root changes what this one is allowed to touch.
         markers = _markers()
         _evict_unreferenced(state, entries, state.live_only | _marker_refs(markers))
-        if state.over_budget:
+        if state.over_budget and reclaim_retained:
             _reclaim_pinning_dirs(state, entries, markers)
-        if state.over_budget:
+        if not state.over_budget:
+            continue
+        if reclaim_retained:
             logger.error(
                 "Cache %s is %d bytes over its %d byte budget but only live references remain; "
                 "admission should have refused this load",
+                root,
+                state.usage - budget,
+                budget,
+            )
+        else:
+            logger.info(
+                "Cache %s is %d bytes over its %d byte budget; what is left is pinned, leaving it to the pass",
                 root,
                 state.usage - budget,
                 budget,
@@ -534,22 +598,60 @@ def _still_pinned(ref: str, markers: list[tuple[Path, ReclaimableMarker]], recla
     return any(ref in marker.depends_on and directory.name not in reclaimed for directory, marker in markers)
 
 
+def _may_evict_for_admission(registry: AgentVmRegistry) -> bool:
+    """Whether admission is allowed to evict anything at all.
+
+    The same precondition the pass applies (``reconciler._enforce_cache_budget``):
+    what a cache holds for a live VM is read from that VM's message, so a live
+    VM without a registry record makes the referenced set incomplete, and
+    evicting on an incomplete set unlinks a running VM's disk. Admission is
+    the riskier of the two, since it runs on the create path with no
+    supervisor answer of its own, so it refuses on the same doubt and on one
+    more: no pass has run yet, so there is no live set to check against.
+    """
+    snapshot = live_snapshot()
+    if snapshot is None:
+        logger.warning("No storage reconcile has run yet; admitting downloads without evicting")
+        return False
+    unknown = sorted(namespace for namespace in snapshot if namespace not in registry)
+    if unknown:
+        logger.error(
+            "Not evicting for a download: %d live VM(s) have no registry record (%s), so what they reference is "
+            "unknown and the caches stay unbounded until this is resolved",
+            len(unknown),
+            ", ".join(unknown[:3]),
+        )
+        return False
+    return True
+
+
 def admit_download(registry: AgentVmRegistry, root: Path, size_bytes: int) -> None:
     """Refuse, before a byte is written, a download the cache cannot hold.
 
     Registered on ``storage.set_cache_admission`` so it runs inside
     ``download_file_in_chunks`` once ``Content-Length`` is known. Evicting
     first is the point: the budget is a cap on what is kept, not on what may
-    be fetched, and only a load that stays over the budget with nothing
-    evictable left is refused (spec section 4). A directory that is not a
-    cache root is not this budget's business: the downloader also streams
-    per-VM volumes in place, and those are admitted by the capacity checks
-    and the pool budget.
+    be fetched, and only a load that stays over the budget with nothing safely
+    evictable left is refused (spec section 4).
+
+    Two things it deliberately does not do. It does not reclaim retained VM
+    directories (``reclaim_retained=False``): that is an rmtree, and this runs
+    on the event loop inside a download. And it does not evict at all when the
+    live set cannot be trusted; the download is then admitted or refused on
+    the budget as it stands.
+
+    A directory that is not a cache root is not this budget's business: the
+    downloader also streams per-VM volumes in place, and those are admitted by
+    the capacity checks and the pool budget.
     """
     root = Path(root)
     if root not in cache_roots():
+        logger.debug("Not a download cache, so not subject to CACHE_BUDGET: %s", root)
         return
-    release_parent_devices(evict_caches(registry, needed={root: size_bytes}))
+    if _may_evict_for_admission(registry):
+        release_parent_devices(
+            evict_caches(registry, needed={root: size_bytes}, reclaim_retained=False),
+        )
     try:
         budget = cache_budget_bytes(root)
     except OSError:
@@ -565,3 +667,54 @@ def admit_download(registry: AgentVmRegistry, root: Path, size_bytes: int) -> No
         required={"disk_mib": size_bytes // MIB},
         available={"disk_mib": free // MIB},
     )
+
+
+def _deleted_cache_backings() -> list[tuple[str, Path]]:
+    """``(loop device, cache entry)`` for every loop device still backed by a
+    cache entry that is already unlinked."""
+    roots = cache_roots()
+    leaked: list[tuple[str, Path]] = []
+    try:
+        backing_files = sorted(SYS_BLOCK.glob("loop*/loop/backing_file"))
+    except OSError:
+        return leaked
+    for backing_file in backing_files:
+        try:
+            backing = backing_file.read_text().strip()
+        except OSError:
+            continue
+        if not backing.endswith(DELETED_SUFFIX):
+            continue
+        path = Path(backing.removesuffix(DELETED_SUFFIX))
+        if path.parent in roots:
+            leaked.append((f"/dev/{backing_file.parent.parent.name}", path))
+    return leaked
+
+
+async def sweep_leaked_cache_loops() -> list[str]:
+    """Detach the loop devices of cache entries that are already gone.
+
+    The recovery path for a teardown that never happened or failed: the
+    eviction unlinks the entry and only then removes its devices, so a crash,
+    a restart or a failing ``dmsetup`` in between leaves a loop device holding
+    the inode of a file nobody can name any more. Its blocks are not free, and
+    no later pass would find it, because the entry it belonged to is no longer
+    in the cache. The kernel still knows, so ask it.
+
+    Fail closed the same way the eviction does: a leaked loop whose
+    ``/dev/mapper/<ref>`` target still has holders is in use after all and is
+    left alone.
+    """
+    detached: list[str] = []
+    for loop_device, path in _deleted_cache_backings():
+        ref = path.name
+        device = Path(DEVICE_MAPPER_DIRECTORY) / ref
+        if _is_block_device(device):
+            if not parent_device_is_free(ref):
+                continue
+            await run_in_subprocess(["dmsetup", "remove", "--retry", ref])
+            logger.info("Removed the leaked device of the evicted cache entry %s", ref)
+        await run_in_subprocess(["losetup", "-d", loop_device])
+        logger.info("Detached the leaked loop device %s of the evicted cache entry %s", loop_device, path)
+        detached.append(loop_device)
+    return detached

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -54,7 +54,12 @@ from aleph.vm.agent.vm.reclaimable import (
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 from aleph.vm.resources import InsufficientResourcesError
-from aleph.vm.storage import DEVICE_MAPPER_DIRECTORY, DEVICE_NAME_MAX_BYTES
+from aleph.vm.storage import (
+    DEVICE_MAPPER_DIRECTORY,
+    DEVICE_NAME_MAX_BYTES,
+    reserve_download,
+    reserved_downloads,
+)
 from aleph.vm.storage_budget import parse_budget
 from aleph.vm.storage_pools import iter_namespace_dirs
 from aleph.vm.utils import create_task_log_exceptions, run_in_subprocess
@@ -143,6 +148,40 @@ def cache_entries(root: Path) -> list[CacheEntry]:
         entries.append(CacheEntry(path=path, size_bytes=size, mtime=mtime))
     entries.sort(key=lambda entry: entry.mtime)
     return entries
+
+
+def in_flight_bytes(root: Path) -> int:
+    """What ``root`` owes to downloads that have not finished.
+
+    Two overlapping things, counted once. A ``.part`` or ``.tmp`` file holds
+    real blocks the moment it is written, and it is not a cache entry, so
+    ``cache_entries`` skips it and nothing else would charge for it. And a
+    download admission has already approved holds room that does not exist on
+    disk yet: without it two creates arriving together are both told there is
+    space only one of them can have. For a reservation still being written the
+    bigger of the two is the honest figure, never their sum.
+    """
+    reserved = reserved_downloads()
+    total = 0
+    counted: set[Path] = set()
+    for path, size_bytes in reserved.items():
+        if path.parent != root:
+            continue
+        total += max(size_bytes, file_size_bytes(path))
+        counted.add(path)
+    try:
+        children = list(root.iterdir())
+    except OSError:
+        return total
+    for path in children:
+        if path.suffix not in IN_FLIGHT_SUFFIXES or path in counted:
+            continue
+        total += file_size_bytes(path)
+    return total
+
+
+def _root_usage(root: Path, entries: list[CacheEntry]) -> int:
+    return sum(entry.size_bytes for entry in entries) + in_flight_bytes(root)
 
 
 def _entry_refs(path: Path) -> set[str]:
@@ -461,7 +500,7 @@ def evict_caches(
         state = _RootBudget(
             root=root,
             budget=budget,
-            usage=sum(entry.size_bytes for entry in entries) + needed.get(root, 0),
+            usage=_root_usage(root, entries) + needed.get(root, 0),
             evicted=evicted,
             live_only=live_only,
             is_live=is_live,
@@ -625,14 +664,19 @@ def _may_evict_for_admission(registry: AgentVmRegistry) -> bool:
     return True
 
 
-def admit_download(registry: AgentVmRegistry, root: Path, size_bytes: int) -> None:
+def admit_download(registry: AgentVmRegistry, tmp_path: Path, size_bytes: int) -> None:
     """Refuse, before a byte is written, a download the cache cannot hold.
 
     Registered on ``storage.set_cache_admission`` so it runs inside
-    ``download_file_in_chunks`` once ``Content-Length`` is known. Evicting
-    first is the point: the budget is a cap on what is kept, not on what may
-    be fetched, and only a load that stays over the budget with nothing safely
-    evictable left is refused (spec section 4).
+    ``download_file_in_chunks`` once ``Content-Length`` is known (or, when the
+    server does not say, once its cap is). Evicting first is the point: the
+    budget is a cap on what is kept, not on what may be fetched, and only a
+    load that stays over the budget with nothing safely evictable left is
+    refused (spec section 4).
+
+    An admitted download is then charged to its ``.part`` path until
+    ``download_file`` releases it, so the next admission sees the room this
+    one was promised and not just the bytes it has managed to write.
 
     Two things it deliberately does not do. It does not reclaim retained VM
     directories (``reclaim_retained=False``): that is an rmtree, and this runs
@@ -644,7 +688,8 @@ def admit_download(registry: AgentVmRegistry, root: Path, size_bytes: int) -> No
     downloader also streams per-VM volumes in place, and those are admitted by
     the capacity checks and the pool budget.
     """
-    root = Path(root)
+    tmp_path = Path(tmp_path)
+    root = tmp_path.parent
     if root not in cache_roots():
         logger.debug("Not a download cache, so not subject to CACHE_BUDGET: %s", root)
         return
@@ -656,9 +701,11 @@ def admit_download(registry: AgentVmRegistry, root: Path, size_bytes: int) -> No
         budget = cache_budget_bytes(root)
     except OSError:
         logger.warning("Cache directory %s is not accessible; admitting the download", root, exc_info=True)
+        reserve_download(tmp_path, size_bytes)
         return
-    usage = sum(entry.size_bytes for entry in cache_entries(root)) + size_bytes
+    usage = _root_usage(root, cache_entries(root)) + size_bytes
     if usage <= budget:
+        reserve_download(tmp_path, size_bytes)
         return
     free = max(budget - (usage - size_bytes), 0)
     msg = f"Cache {root} cannot hold a {size_bytes} byte download within CACHE_BUDGET"

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -245,6 +245,18 @@ def live_refs(registry: AgentVmRegistry) -> set[str]:
     return refs
 
 
+def _is_creating(namespace: str) -> bool:
+    """Whether a create currently holds this namespace.
+
+    Imported late on purpose: the reconciler imports this module, so this
+    module cannot import it back at load time. The set is asked at call time
+    anyway, which is the only moment its answer is worth anything.
+    """
+    from aleph.vm.agent.vm.reconciler import is_creating
+
+    return is_creating(namespace)
+
+
 def _markers() -> list[tuple[Path, ReclaimableMarker]]:
     """The reclaimable directories, oldest marker first, implausibly named
     ones dropped (they can never be handed to ``purge_vm_storage``)."""
@@ -597,6 +609,12 @@ def _reclaim_for_parents(
         return False
     if state.is_live(namespace):
         logger.warning("Not reclaiming %s for its parent images: a live VM owns it", namespace)
+        return False
+    if _is_creating(namespace):
+        # A re-create adopted the directory after the markers were listed:
+        # ``creating`` clears the marker, but this list is older than that,
+        # and the VM has no registry record yet for ``is_live`` to find.
+        logger.warning("Not reclaiming %s for its parent images: a create is using it", namespace)
         return False
     if not state.dry_run:
         purge_vm_storage(namespace)

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -682,19 +682,29 @@ def _may_evict_for_admission(registry: AgentVmRegistry) -> bool:
     return True
 
 
-def admit_download(registry: AgentVmRegistry, tmp_path: Path, size_bytes: int) -> None:
+def admit_download(
+    registry: AgentVmRegistry,
+    tmp_path: Path,
+    content_length: int | None,
+    max_bytes: int | None = None,
+) -> None:
     """Refuse, before a byte is written, a download the cache cannot hold.
 
     Registered on ``storage.set_cache_admission`` so it runs inside
-    ``download_file_in_chunks`` once ``Content-Length`` is known (or, when the
-    server does not say, once its cap is). Evicting first is the point: the
-    budget is a cap on what is kept, not on what may be fetched, and only a
-    load that stays over the budget with nothing safely evictable left is
-    refused (spec section 4).
+    ``download_file_in_chunks`` as soon as the response headers are in.
+    Evicting first is the point: the budget is a cap on what is kept, not on
+    what may be fetched, and only a load that stays over the budget with
+    nothing safely evictable left is refused (spec section 4).
 
     An admitted download is then charged to its ``.part`` path until
     ``download_file`` releases it, so the next admission sees the room this
     one was promised and not just the bytes it has managed to write.
+
+    ``content_length`` is None when the server sent none (a chunked-encoding
+    response), and that is a different question, answered by
+    ``_admit_unknown_length``: ``max_bytes`` is then all that bounds the body,
+    and it is a ceiling on every download of that kind rather than a
+    measurement of this one.
 
     Two things it deliberately does not do. It does not reclaim retained VM
     directories (``reclaim_retained=False``): that is an rmtree, and this runs
@@ -711,27 +721,60 @@ def admit_download(registry: AgentVmRegistry, tmp_path: Path, size_bytes: int) -
     if root not in cache_roots():
         logger.debug("Not a download cache, so not subject to CACHE_BUDGET: %s", root)
         return
-    if _may_evict_for_admission(registry):
-        release_parent_devices(
-            evict_caches(registry, needed={root: size_bytes}, reclaim_retained=False),
-        )
     try:
         budget = cache_budget_bytes(root)
     except OSError:
         logger.warning("Cache directory %s is not accessible; admitting the download", root, exc_info=True)
-        reserve_download(tmp_path, size_bytes)
+        if content_length is not None:
+            reserve_download(tmp_path, content_length)
         return
-    usage = _root_usage(root, cache_entries(root)) + size_bytes
+    if content_length is None:
+        _admit_unknown_length(tmp_path, root, budget, max_bytes)
+        return
+    if _may_evict_for_admission(registry):
+        release_parent_devices(
+            evict_caches(registry, needed={root: content_length}, reclaim_retained=False),
+        )
+    usage = _root_usage(root, cache_entries(root)) + content_length
     if usage <= budget:
-        reserve_download(tmp_path, size_bytes)
+        reserve_download(tmp_path, content_length)
         return
-    free = max(budget - (usage - size_bytes), 0)
-    msg = f"Cache {root} cannot hold a {size_bytes} byte download within CACHE_BUDGET"
+    free = max(budget - (usage - content_length), 0)
+    msg = f"Cache {root} cannot hold a {content_length} byte download within CACHE_BUDGET"
     raise InsufficientResourcesError(
         msg,
-        required={"disk_mib": size_bytes // MIB},
+        required={"disk_mib": content_length // MIB},
         available={"disk_mib": free // MIB},
     )
+
+
+def _admit_unknown_length(tmp_path: Path, root: Path, budget: int, max_bytes: int | None) -> None:
+    """Admit a download whose size the server did not state.
+
+    All that is known is the cap the caller is downloading under, and a cap is
+    not a measurement: ``MAX_RUNTIME_ARCHIVE_SIZE`` is 100 GiB, which is the
+    ceiling for a runtime image and equally the ceiling for the few kilobytes
+    of a manifest. Treating it as a size made every chunked-encoding response
+    ask for 100 GiB of room, which on any cache disk under half a terabyte
+    meant evicting the entire unreferenced cache and then refusing the
+    download anyway.
+
+    So: never evict for a figure that is only a ceiling, and refuse only what
+    a root that is already over its budget cannot start at all. What is
+    charged is ``min(cap, budget)``, enough that a handful of concurrent
+    unknown-length downloads still run the root over its budget and the next
+    one is refused, and never more than the budget itself.
+    """
+    usage = _root_usage(root, cache_entries(root))
+    if usage > budget:
+        msg = f"Cache {root} is already over CACHE_BUDGET; not starting a download of unknown length"
+        raise InsufficientResourcesError(
+            msg,
+            required={"disk_mib": (usage - budget) // MIB},
+            available={"disk_mib": 0},
+        )
+    charge = min(max_bytes, budget) if max_bytes is not None else budget
+    reserve_download(tmp_path, charge)
 
 
 def _deleted_cache_backings() -> list[tuple[str, Path]]:

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -1,0 +1,567 @@
+"""Bounded download caches: a budget per cache root, LRU eviction of the
+entries no live VM and no retained disk still needs.
+
+The four caches (runtime, code, data, message) are flat directories keyed by
+item hash, shared by every VM that names the same hash. Nothing used to
+remove anything from them: a node accumulated every runtime, every program
+archive and every parent image it had ever been asked for until the disk was
+full. Each root now gets ``CACHE_BUDGET`` and the reconciler evicts what is
+over it, least recently used first (the downloader touches an entry's mtime
+on every cache hit, so "recently used" is a real signal and not just
+"recently downloaded").
+
+Two things are never evicted. An entry a live VM names is off limits, since
+its VM is running on it right now; if live references alone exceed the
+budget, this logs and stops, because that is a capacity problem admission
+should have refused, not something eviction can fix. An entry a
+``.reclaimable`` marker names in ``depends_on`` is a parent image a retained
+overlay is built on: reclaiming the overlay comes first, and only then does
+its parent become evictable (spec section 4).
+
+A parent image also has a shared read-only loop device and a
+``/dev/mapper/<ref>`` device on top of it, built once by
+``storage.create_devmapper`` for every VM using that image. Unlinking the
+file while those exist frees nothing (the loop pins the inode), so the
+device teardown belongs here, with the eviction (spec section 5), and an
+image whose device still has holders is not evicted at all.
+
+Residual race, accepted: a create that has downloaded a cache entry but has
+not recorded its VM yet holds no reference this module can see. The mtime
+touch makes such an entry the most recently used one, so LRU reaches it
+last, and the next create simply re-downloads what was taken.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from aleph.vm.agent.vm.purge import _ITEM_HASH_PATTERN, purge_vm_storage
+from aleph.vm.agent.vm.reclaimable import (
+    ReclaimableMarker,
+    file_size_bytes,
+    iter_reclaimable,
+)
+from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.conf import settings
+from aleph.vm.resources import InsufficientResourcesError
+from aleph.vm.storage import DEVICE_MAPPER_DIRECTORY, DEVICE_NAME_MAX_BYTES
+from aleph.vm.storage_budget import parse_budget
+from aleph.vm.storage_pools import iter_namespace_dirs
+from aleph.vm.utils import create_task_log_exceptions, run_in_subprocess
+
+logger = logging.getLogger(__name__)
+
+MIB = 1024 * 1024
+# Where the kernel lists the loop devices and what backs them. Read rather
+# than `losetup -j` when the backing file is already unlinked: sysfs keeps
+# the path (with a " (deleted)" suffix), losetup cannot stat it any more.
+SYS_BLOCK = Path("/sys/block")
+SYS_DEV_BLOCK = Path("/sys/dev/block")
+DELETED_SUFFIX = " (deleted)"
+# Suffixes of files that are not cache entries: a download in flight
+# (download_file) and a message being written (storage.get_message).
+IN_FLIGHT_SUFFIXES = (".part", ".tmp")
+
+
+@dataclass(frozen=True)
+class CacheEntry:
+    path: Path
+    size_bytes: int
+    mtime: float
+
+
+def cache_roots() -> list[Path]:
+    """The download caches that exist, deduplicated."""
+    roots: list[Path] = []
+    for setting in (settings.RUNTIME_CACHE, settings.CODE_CACHE, settings.DATA_CACHE, settings.MESSAGE_CACHE):
+        if not setting:
+            continue
+        root = Path(setting)
+        if root.is_dir() and root not in roots:
+            roots.append(root)
+    return roots
+
+
+def _runtime_cache() -> Path | None:
+    return Path(settings.RUNTIME_CACHE) if settings.RUNTIME_CACHE else None
+
+
+def cache_entries(root: Path) -> list[CacheEntry]:
+    """The regular files directly inside ``root``, oldest mtime first.
+
+    Sizes come from ``file_size_bytes`` (allocated blocks), the same
+    definition the volume budgets use, and a symlink is not an entry: what it
+    points at is not this cache's space.
+    """
+    entries: list[CacheEntry] = []
+    try:
+        children = list(root.iterdir())
+    except OSError:
+        logger.warning("Cache directory %s is not readable", root, exc_info=True)
+        return entries
+    for path in children:
+        if path.suffix in IN_FLIGHT_SUFFIXES:
+            continue
+        size = file_size_bytes(path)  # 0 for a symlink, a directory or a vanished file
+        if not path.is_file() or path.is_symlink():
+            continue
+        try:
+            mtime = path.lstat().st_mtime
+        except OSError:
+            continue
+        entries.append(CacheEntry(path=path, size_bytes=size, mtime=mtime))
+    entries.sort(key=lambda entry: entry.mtime)
+    return entries
+
+
+def _entry_refs(path: Path) -> set[str]:
+    """The item hashes an entry's file name can stand for.
+
+    The three binary caches key an entry by the hash itself; the message
+    cache appends ``.json`` to it (``storage.get_message``).
+    """
+    return {path.name, path.stem}
+
+
+def _record_refs(content) -> set[str]:
+    """Every cache entry one message names: runtime, code, data, the rootfs
+    parent, volume parents and immutable volume refs."""
+    refs: set[str] = set()
+    for attribute in ("runtime", "code", "data"):
+        obj = getattr(content, attribute, None)
+        if obj is not None and getattr(obj, "ref", None):
+            refs.add(str(obj.ref))
+    rootfs = getattr(content, "rootfs", None)
+    if rootfs is not None and getattr(rootfs, "parent", None):
+        refs.add(str(rootfs.parent.ref))
+    for volume in getattr(content, "volumes", None) or []:
+        parent = getattr(volume, "parent", None)
+        if parent is not None and getattr(parent, "ref", None):
+            refs.add(str(parent.ref))
+        if getattr(volume, "ref", None):
+            refs.add(str(volume.ref))
+    return refs
+
+
+def live_refs(registry: AgentVmRegistry) -> set[str]:
+    """The refs live records name: never evictable, whatever the budget."""
+    refs: set[str] = set()
+    for _vm_hash, record in list(registry.items()):
+        refs |= _record_refs(record.message)
+    return refs
+
+
+def _markers() -> list[tuple[Path, ReclaimableMarker]]:
+    """The reclaimable directories, oldest marker first, implausibly named
+    ones dropped (they can never be handed to ``purge_vm_storage``)."""
+    entries = [(directory, marker) for directory, marker in iter_reclaimable() if _plausible(directory.name)]
+    entries.sort(key=lambda item: item[1].reclaimable_since)
+    return entries
+
+
+def _plausible(name: str) -> bool:
+    return bool(_ITEM_HASH_PATTERN.match(name))
+
+
+def _marker_refs(markers: Iterable[tuple[Path, ReclaimableMarker]]) -> set[str]:
+    return {ref for _directory, marker in markers for ref in marker.depends_on}
+
+
+def referenced_hashes(registry: AgentVmRegistry) -> set[str]:
+    """Live refs plus what the ``.reclaimable`` markers pin."""
+    return live_refs(registry) | _marker_refs(_markers())
+
+
+def cache_budget_bytes(root: Path) -> int:
+    return parse_budget(settings.CACHE_BUDGET, shutil.disk_usage(str(root)).total)
+
+
+def _safe_ref(ref: str) -> bool:
+    """Whether ``ref`` can be handed to dmsetup as a device name.
+
+    A cache entry's name is a path component, so it can hold no ``/`` and be
+    neither ``.`` nor ``..``; this says so anyway, and refuses a name that a
+    subprocess would read as an option.
+    """
+    if not ref or ref in (".", "..") or "/" in ref or ref.startswith("-"):
+        return False
+    return len(ref.encode()) <= DEVICE_NAME_MAX_BYTES
+
+
+def _is_block_device(path: Path) -> bool:
+    try:
+        return path.is_block_device()
+    except OSError:
+        return False
+
+
+def parent_device_is_free(ref: str) -> bool:
+    """Whether the parent image's shared device can go with the image.
+
+    ``create_devmapper`` stacks one ``<namespace>_base`` device per VM on top
+    of ``/dev/mapper/<ref>``; the kernel lists those in the device's
+    ``holders`` directory. Fail closed: an unanswerable question (no sysfs
+    entry, an unreadable directory) counts as held, because evicting an image
+    a running VM's snapshot is built on takes that VM's disk with it.
+    """
+    if not _safe_ref(ref):
+        return False
+    device = Path(DEVICE_MAPPER_DIRECTORY) / ref
+    if not _is_block_device(device):
+        return True
+    try:
+        rdev = device.stat().st_rdev
+        holders = [path.name for path in (SYS_DEV_BLOCK / f"{os.major(rdev)}:{os.minor(rdev)}" / "holders").iterdir()]
+    except OSError:
+        logger.warning("Cannot tell whether the parent device %s is still in use; keeping it", ref, exc_info=True)
+        return False
+    if holders:
+        logger.info("Parent device %s is still held by %s", ref, ", ".join(sorted(holders)))
+        return False
+    return True
+
+
+def parent_refs_of(evicted: list[Path]) -> list[str]:
+    """The runtime-cache refs among ``evicted``: the images whose shared
+    device and loop device the caller has to remove."""
+    runtime = _runtime_cache()
+    if runtime is None:
+        return []
+    return [path.name for path in evicted if path.parent == runtime]
+
+
+def _loop_devices_backing(path: Path) -> list[str]:
+    """The loop devices backed by ``path``, found through sysfs.
+
+    ``storage.detach_loop_devices`` asks ``losetup -j``, which has to stat
+    the backing file; an evicted cache entry is already unlinked, and the
+    loop that still pins its blocks is exactly the one that has to go. sysfs
+    keeps the path, marked " (deleted)".
+    """
+    devices: list[str] = []
+    try:
+        backing_files = sorted(SYS_BLOCK.glob("loop*/loop/backing_file"))
+    except OSError:
+        return devices
+    for backing_file in backing_files:
+        try:
+            backing = backing_file.read_text().strip()
+        except OSError:
+            continue
+        if backing.removesuffix(DELETED_SUFFIX) == str(path):
+            devices.append(f"/dev/{backing_file.parent.parent.name}")
+    return devices
+
+
+async def remove_parent_device(ref: str) -> None:
+    """Remove the shared read-only device of an evicted parent image.
+
+    The inverse of what ``create_devmapper`` builds once per image rather
+    than once per VM: the ``/dev/mapper/<ref>`` linear target and the
+    read-only loop device under it. ``remove_devmapper`` deliberately leaves
+    both alone, because they are shared; the cache pass owns them, and calls
+    this only for an image it has just evicted (so no ``<ns>_base`` device
+    was stacked on it, see ``parent_device_is_free``).
+    """
+    if not _safe_ref(ref):
+        logger.error("Refusing to remove an implausible parent device name: %r", ref)
+        return
+    runtime = _runtime_cache()
+    cache_path = runtime / ref if runtime is not None else None
+    if cache_path is not None and cache_path.exists():
+        # A create downloaded the image again between the eviction and this
+        # teardown: the devices are that create's now, and removing them
+        # would break the VM it is building.
+        logger.info("Not removing the devices of %s: the image is back in the cache", ref)
+        return
+    device = Path(DEVICE_MAPPER_DIRECTORY) / ref
+    if _is_block_device(device):
+        await run_in_subprocess(["dmsetup", "remove", "--retry", ref])
+        logger.info("Removed the shared device of the evicted parent image %s", ref)
+    if cache_path is None:
+        return
+    for loop_device in _loop_devices_backing(cache_path):
+        await run_in_subprocess(["losetup", "-d", loop_device])
+        logger.info("Detached loop device %s of the evicted parent image %s", loop_device, ref)
+
+
+async def remove_parent_devices(refs: list[str]) -> None:
+    """``remove_parent_device`` for each ref, one failure never stopping the
+    others: a device left behind costs disk, not correctness."""
+    for ref in refs:
+        try:
+            await remove_parent_device(ref)
+        except Exception:
+            logger.exception("Removing the device of the evicted parent image %s failed", ref)
+
+
+def release_parent_devices(evicted: list[Path]) -> None:
+    """Schedule the device teardown of the parent images among ``evicted``.
+
+    For the synchronous callers that run on the event loop (the download
+    admission hook): the teardown is a subprocess away and cannot be awaited
+    from here. Nothing else picks these up later, since the entry itself is
+    already gone by the time the next pass walks the cache.
+    """
+    refs = parent_refs_of(evicted)
+    if not refs:
+        return
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        logger.warning("No event loop to remove the devices of %s on", ", ".join(refs))
+        return
+    create_task_log_exceptions(remove_parent_devices(refs), name="remove parent devices")
+
+
+def _may_evict(entry: CacheEntry) -> bool:
+    """Whether this entry's file can be unlinked right now.
+
+    Only parent images have devices on top of them, and only they can be
+    refused here.
+    """
+    runtime = _runtime_cache()
+    if runtime is None or entry.path.parent != runtime:
+        return True
+    if parent_device_is_free(entry.path.name):
+        return True
+    logger.warning("Not evicting %s: its device-mapper device is still held", entry.path)
+    return False
+
+
+def _evict_entry(entry: CacheEntry, evicted: list[Path], *, dry_run: bool) -> bool:
+    if dry_run:
+        evicted.append(entry.path)
+        return True
+    try:
+        entry.path.unlink()
+    except FileNotFoundError:
+        logger.debug("Cache entry %s was already gone", entry.path)
+        return False
+    except OSError:
+        logger.warning("Failed to evict %s", entry.path, exc_info=True)
+        return False
+    logger.info("Evicted cache entry %s (%d bytes)", entry.path, entry.size_bytes)
+    evicted.append(entry.path)
+    return True
+
+
+@dataclass
+class _RootBudget:
+    """One cache root's arithmetic, carried through the two eviction phases."""
+
+    root: Path
+    budget: int
+    usage: int
+    evicted: list[Path]
+    live_only: set[str]
+    is_live: Callable[[str], bool]
+    dry_run: bool
+
+    @property
+    def over_budget(self) -> bool:
+        return self.usage > self.budget
+
+    def take(self, entry: CacheEntry) -> bool:
+        """Evict one entry and discount what it was holding."""
+        if not _evict_entry(entry, self.evicted, dry_run=self.dry_run):
+            return False
+        self.usage -= entry.size_bytes
+        return True
+
+
+def evict_caches(
+    registry: AgentVmRegistry,
+    *,
+    needed: dict[Path, int] | None = None,
+    dry_run: bool = False,
+    is_live: Callable[[str], bool] | None = None,
+) -> list[Path]:
+    """Bring every cache root under ``CACHE_BUDGET``; return what was evicted.
+
+    ``needed`` is what a download about to start would add to a root, so
+    admission asks the same question a pass does, one download ahead of it.
+
+    ``is_live`` decides whether a reclaimable directory may be reclaimed to
+    free its parent image; it defaults to the registry alone, which is what a
+    caller holding no supervisor handle can offer.
+    """
+    needed = needed or {}
+    evicted: list[Path] = []
+    is_live = is_live or (lambda namespace: namespace in registry)
+    live_only = live_refs(registry)
+    for root in cache_roots():
+        try:
+            budget = cache_budget_bytes(root)
+        except OSError:
+            logger.warning("Cache directory %s is not accessible; not applying its budget", root, exc_info=True)
+            continue
+        entries = cache_entries(root)
+        state = _RootBudget(
+            root=root,
+            budget=budget,
+            usage=sum(entry.size_bytes for entry in entries) + needed.get(root, 0),
+            evicted=evicted,
+            live_only=live_only,
+            is_live=is_live,
+            dry_run=dry_run,
+        )
+        if not state.over_budget:
+            continue
+        # Re-read the markers per root: what was reclaimed for the previous
+        # root changes what this one is allowed to touch.
+        markers = _markers()
+        _evict_unreferenced(state, entries, state.live_only | _marker_refs(markers))
+        if state.over_budget:
+            _reclaim_pinning_dirs(state, entries, markers)
+        if state.over_budget:
+            logger.error(
+                "Cache %s is %d bytes over its %d byte budget but only live references remain; "
+                "admission should have refused this load",
+                root,
+                state.usage - budget,
+                budget,
+            )
+    return evicted
+
+
+def _evict_unreferenced(state: _RootBudget, entries: list[CacheEntry], referenced: set[str]) -> None:
+    """Least recently used first, skipping anything anyone still names."""
+    for entry in entries:
+        if not state.over_budget:
+            return
+        if _entry_refs(entry.path) & referenced:
+            continue
+        if _may_evict(entry):
+            state.take(entry)
+
+
+def _reclaim_pinning_dirs(
+    state: _RootBudget,
+    entries: list[CacheEntry],
+    markers: list[tuple[Path, ReclaimableMarker]],
+) -> None:
+    """Give back retained disks so their parent images become evictable.
+
+    Only the entries a ``.reclaimable`` marker pins are reachable here: a live
+    VM's entries were skipped above and stay skipped. The directories go
+    oldest marker first, the same order the retention budget uses, and a
+    parent image is evicted only once every retained VM that named it is gone.
+    """
+    pinned = _pinned_entries(state, entries)
+    reclaimed: set[str] = set()
+    for directory, marker in markers:
+        if not state.over_budget:
+            return
+        if not _reclaim_for_parents(state, directory, marker, pinned, reclaimed):
+            continue
+        _evict_freed_parents(state, marker, markers, pinned, reclaimed)
+
+
+def _pinned_entries(state: _RootBudget, entries: list[CacheEntry]) -> dict[str, CacheEntry]:
+    """The still-present entries by every ref they answer to, live ones left
+    out: those are never evictable, so nothing is reclaimed to free them."""
+    gone = set(state.evicted)
+    pinned: dict[str, CacheEntry] = {}
+    for entry in entries:
+        if entry.path in gone:
+            continue
+        for ref in _entry_refs(entry.path) - state.live_only:
+            pinned.setdefault(ref, entry)
+    return pinned
+
+
+def _reclaim_for_parents(
+    state: _RootBudget,
+    directory: Path,
+    marker: ReclaimableMarker,
+    pinned: dict[str, CacheEntry],
+    reclaimed: set[str],
+) -> bool:
+    """Purge one retained VM because it pins a parent image; False if it does
+    not pin one, must not be touched, or kept its disks."""
+    namespace = directory.name
+    if namespace in reclaimed:
+        # A VM spanning two pools is purged whole on the first marker.
+        return False
+    if not any(ref in pinned for ref in marker.depends_on):
+        return False
+    if state.is_live(namespace):
+        logger.warning("Not reclaiming %s for its parent images: a live VM owns it", namespace)
+        return False
+    if not state.dry_run:
+        purge_vm_storage(namespace)
+        if any(True for _ in iter_namespace_dirs(namespace)):
+            # purge_vm_storage refuses a directory a device-mapper target
+            # still holds: those volumes still need their parent image, so
+            # the parent stays too.
+            logger.warning("Not evicting the parent images of %s: its purge left directories behind", namespace)
+            return False
+    reclaimed.add(namespace)
+    logger.info("Reclaimed the retained volumes of %s to free its parent images", namespace)
+    return True
+
+
+def _evict_freed_parents(
+    state: _RootBudget,
+    marker: ReclaimableMarker,
+    markers: list[tuple[Path, ReclaimableMarker]],
+    pinned: dict[str, CacheEntry],
+    reclaimed: set[str],
+) -> None:
+    """Evict the parent images the VM just reclaimed was the last to need."""
+    for ref in marker.depends_on:
+        entry = pinned.get(ref)
+        if entry is None:
+            continue
+        if _still_pinned(ref, markers, reclaimed):
+            logger.debug("Keeping the parent image %s: another retained VM still depends on it", ref)
+            continue
+        if not _may_evict(entry) or not state.take(entry):
+            continue
+        for name in [name for name, pinned_entry in pinned.items() if pinned_entry is entry]:
+            pinned.pop(name)
+
+
+def _still_pinned(ref: str, markers: list[tuple[Path, ReclaimableMarker]], reclaimed: set[str]) -> bool:
+    """Whether a retained VM other than the ones just reclaimed needs ``ref``."""
+    return any(ref in marker.depends_on and directory.name not in reclaimed for directory, marker in markers)
+
+
+def admit_download(registry: AgentVmRegistry, root: Path, size_bytes: int) -> None:
+    """Refuse, before a byte is written, a download the cache cannot hold.
+
+    Registered on ``storage.set_cache_admission`` so it runs inside
+    ``download_file_in_chunks`` once ``Content-Length`` is known. Evicting
+    first is the point: the budget is a cap on what is kept, not on what may
+    be fetched, and only a load that stays over the budget with nothing
+    evictable left is refused (spec section 4). A directory that is not a
+    cache root is not this budget's business: the downloader also streams
+    per-VM volumes in place, and those are admitted by the capacity checks
+    and the pool budget.
+    """
+    root = Path(root)
+    if root not in cache_roots():
+        return
+    release_parent_devices(evict_caches(registry, needed={root: size_bytes}))
+    try:
+        budget = cache_budget_bytes(root)
+    except OSError:
+        logger.warning("Cache directory %s is not accessible; admitting the download", root, exc_info=True)
+        return
+    usage = sum(entry.size_bytes for entry in cache_entries(root)) + size_bytes
+    if usage <= budget:
+        return
+    free = max(budget - (usage - size_bytes), 0)
+    msg = f"Cache {root} cannot hold a {size_bytes} byte download within CACHE_BUDGET"
+    raise InsufficientResourcesError(
+        msg,
+        required={"disk_mib": size_bytes // MIB},
+        available={"disk_mib": free // MIB},
+    )

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -16,13 +16,13 @@ budget, this logs and stops, because that is a capacity problem admission
 should have refused, not something eviction can fix. An entry a
 ``.reclaimable`` marker names in ``depends_on`` is a parent image a retained
 overlay is built on: reclaiming the overlay comes first, and only then does
-its parent become evictable (spec section 4).
+its parent become evictable.
 
 A parent image also has a shared read-only loop device and a
 ``/dev/mapper/<ref>`` device on top of it, built once by
 ``storage.create_devmapper`` for every VM using that image. Unlinking the
 file while those exist frees nothing (the loop pins the inode), so the
-device teardown belongs here, with the eviction (spec section 5), and an
+device teardown belongs here, with the eviction, and an
 image whose device still has holders is not evicted at all.
 
 Residual race, accepted: a create that has downloaded a cache entry but has
@@ -694,7 +694,7 @@ def admit_download(
     ``download_file_in_chunks`` as soon as the response headers are in.
     Evicting first is the point: the budget is a cap on what is kept, not on
     what may be fetched, and only a load that stays over the budget with
-    nothing safely evictable left is refused (spec section 4).
+    nothing safely evictable left is refused.
 
     An admitted download is then charged to its ``.part`` path until
     ``download_file`` releases it, so the next admission sees the room this

--- a/src/aleph/vm/agent/vm/purge.py
+++ b/src/aleph/vm/agent/vm/purge.py
@@ -134,10 +134,13 @@ def purge_vm_volumes(
     ):
         if _held_by_device_mapper(namespace, volume):
             # A parent-backed volume (create_devmapper) is a loop device
-            # under a dm snapshot, and nothing tears those down on stop yet.
-            # Unlinking the file would neither free its blocks (the loop
-            # device pins the inode) nor reset the volume (create_devmapper
-            # returns early while the dm device exists). Fail loud instead.
+            # under a dm snapshot. The teardown runs before this (retire_vm's
+            # teardown_vm_devices, or the reconciler's orphan device pass), so
+            # a target still standing here means that teardown failed or was
+            # skipped. Unlinking the file would then neither free its blocks
+            # (the loop device pins the inode) nor reset the volume
+            # (create_devmapper returns early while the dm device exists).
+            # Fail loud and leave it for the next pass instead.
             logger.error(
                 "Not deleting %s: its device-mapper target is still present; remove it first",
                 volume,

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -22,7 +22,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
-from aleph_message.models import ExecutableContent, InstanceContent
+from aleph_message.models import ExecutableContent
 
 from aleph.vm.agent.vm.purge import _checked_namespace
 from aleph.vm.storage_pools import get_pools, iter_namespace_dirs
@@ -183,16 +183,95 @@ def clear_marker(namespace_dir: Path) -> bool:
     return True
 
 
+# The kinds ``iter_content_refs`` labels a parent image with: what a per-VM
+# volume is built on, and so what a retained volume keeps needing.
+PARENT_REF_KINDS = frozenset({"rootfs_parent", "volume_parent"})
+# The kinds that name a runtime manifest, whose bundle tarball is a ref only
+# the manifest itself knows (see agent.vm.cache).
+MANIFEST_REF_KINDS = frozenset({"runtime", "tee_runtime"})
+
+
+def _ref_of(obj: object) -> str | None:
+    ref = getattr(obj, "ref", None) if obj is not None else None
+    return str(ref) if ref else None
+
+
+def _iter_volume_refs(content: ExecutableContent) -> Iterator[tuple[str, str]]:
+    """The rootfs parent image, and each volume's parent image or own ref."""
+    rootfs = getattr(content, "rootfs", None)
+    ref = _ref_of(getattr(rootfs, "parent", None)) if rootfs is not None else None
+    if ref:
+        yield "rootfs_parent", ref
+    for volume in getattr(content, "volumes", None) or []:
+        parent_ref = _ref_of(getattr(volume, "parent", None))
+        if parent_ref:
+            yield "volume_parent", parent_ref
+        volume_ref = _ref_of(volume)
+        if volume_ref:
+            yield "volume", volume_ref
+
+
+def _iter_measured_refs(content: ExecutableContent) -> Iterator[tuple[str, str]]:
+    """What the confidential content types name: a V-PROGRAM's workload image
+    and hash tree (both attached as disks), and a TEE instance's firmware and
+    runtime manifest."""
+    workload = getattr(content, "workload", None)
+    if workload is not None:
+        ref = _ref_of(workload)
+        if ref:
+            yield "workload", ref
+        hash_tree = getattr(workload, "hash_tree", None)
+        if hash_tree:
+            yield "workload_hash_tree", str(hash_tree)
+    environment = getattr(content, "environment", None)
+    trusted_execution = getattr(environment, "trusted_execution", None) if environment is not None else None
+    if trusted_execution is None:
+        return
+    for kind, attribute in (("tee_firmware", "firmware"), ("tee_runtime", "runtime")):
+        value = getattr(trusted_execution, attribute, None)
+        if value:
+            yield kind, str(value)
+
+
+def iter_content_refs(content: ExecutableContent) -> Iterator[tuple[str, str]]:
+    """Every item hash a message names, as ``(kind, ref)`` pairs.
+
+    The single enumeration of what a VM needs out of the download caches, so
+    the two questions asked of it cannot drift apart: what a retained volume
+    depends on (``depends_on_from_content``, the parent images) and what may
+    never be evicted while the VM is alive (``refs_from_content``, all of it).
+    Getting the second one short is how a running VM's disk gets unlinked:
+    a V-PROGRAM's workload image and its hash tree are attached straight out
+    of DATA_CACHE, and so are a confidential instance's firmware and runtime
+    manifest.
+
+    Read with ``getattr``: one enumeration covers program, instance,
+    V-PROGRAM and confidential content, and a field a content type does not
+    have is simply not there.
+    """
+    for kind in ("runtime", "code", "data"):
+        ref = _ref_of(getattr(content, kind, None))
+        if ref:
+            yield kind, ref
+    yield from _iter_volume_refs(content)
+    yield from _iter_measured_refs(content)
+
+
+def refs_from_content(content: ExecutableContent, *, vm_hash: str | None = None) -> set[str]:
+    """Every cache entry a message names, the VM's own message included.
+
+    ``vm_hash`` is the VM's item hash: the message cache holds it as
+    ``<vm_hash>.json`` and a live VM's message is not a spare copy.
+    """
+    refs = {ref for _kind, ref in iter_content_refs(content)}
+    if vm_hash:
+        refs.add(str(vm_hash))
+    return refs
+
+
 def depends_on_from_content(content: ExecutableContent) -> tuple[str, ...]:
     """The cache entries (parent images) a VM's per-VM volumes are built on."""
-    refs: list[str] = []
-    if isinstance(content, InstanceContent) and content.rootfs and content.rootfs.parent:
-        refs.append(str(content.rootfs.parent.ref))
-    for vol in content.volumes or []:
-        parent = getattr(vol, "parent", None)
-        if parent is not None:
-            refs.append(str(parent.ref))
-    return tuple(dict.fromkeys(refs))
+    return tuple(dict.fromkeys(ref for kind, ref in iter_content_refs(content) if kind in PARENT_REF_KINDS))
 
 
 def mark_reclaimable(

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -10,6 +10,14 @@ plausible item hash.
 the registry is refilled at boot from the agent DB alone, so it can be empty
 or incomplete while VMs are running, and the startup pass refuses to purge
 anything when that union cannot be established (see ``_startup_refusal``).
+A live set the supervisor could not confirm also stops the cache pass (see
+``_enforce_cache_budget``) and the device teardown below.
+
+Two parts of a pass run on the event loop rather than in the walk's worker
+thread, because both shell out to dmsetup: ``_teardown_orphan_devices``
+before it (a volume a dm target still holds cannot be reclaimed, so the
+devices go first) and ``_release_cache_devices`` after it (the devices of
+the parent images the cache pass evicted).
 
 Loop-triggered passes are serialized, not coalesced: a sweep that retires N
 VMs GONE under ``keep`` queues N passes behind the lock, each re-reading the
@@ -63,8 +71,9 @@ from aleph.vm.agent.vm.reclaimable import (
 from aleph.vm.agent.vm.retire import teardown_namespace_devices
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
-from aleph.vm.storage import MOUNT_ROOT  # /mnt/{namespace}_{volume name}
-from aleph.vm.storage import DEVICE_MAPPER_DIRECTORY
+
+# MOUNT_ROOT is /mnt, where a volume's mount point is {namespace}_{volume name}.
+from aleph.vm.storage import DEVICE_MAPPER_DIRECTORY, MOUNT_ROOT
 from aleph.vm.storage_budget import parse_budget
 from aleph.vm.storage_pools import StoragePool, get_pools, iter_namespace_dirs
 from aleph.vm.supervisor_interface.abc import Supervisor

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -43,6 +43,7 @@ from aleph_message.exceptions import UnknownHashError
 from aleph_message.models import ItemHash
 
 from aleph.vm.agent.vm.backup import sweep_expired_backups
+from aleph.vm.agent.vm.cache import evict_caches, parent_refs_of, remove_parent_device
 from aleph.vm.agent.vm.purge import _ITEM_HASH_PATTERN, purge_vm_storage
 from aleph.vm.agent.vm.reclaimable import (
     ReclaimableMarker,
@@ -77,6 +78,7 @@ class ReconcileReport:
     purged_orphans: list[str] = field(default_factory=list)
     marked_orphans: list[str] = field(default_factory=list)
     evicted: list[str] = field(default_factory=list)
+    cache_evicted: list[Path] = field(default_factory=list)
     parts_removed: int = 0
     side_dirs_removed: int = 0
     backups_removed: int = 0
@@ -86,6 +88,7 @@ class ReconcileReport:
         return (
             f"orphans purged={len(self.purged_orphans)} marked={len(self.marked_orphans)}, "
             f"evicted={len(self.evicted)}, parts={self.parts_removed}, side dirs={self.side_dirs_removed}, "
+            f"cache entries={len(self.cache_evicted)}, "
             f"backups={self.backups_removed}, freed={self.bytes_freed} bytes"
         )
 
@@ -282,7 +285,7 @@ def reconcile_storage(
     is_live: Callable[[str], bool] | None = None,
 ) -> ReconcileReport:
     """One reconciliation pass: namespaces, .part files, side directories,
-    the retention budget, then the backups.
+    the retention budget, the download caches, then the backups.
 
     ``live`` is the set of hashes a live VM owns. Pass it when the caller
     runs this off the event loop (see ``live_hashes``); it defaults to
@@ -303,6 +306,7 @@ def reconcile_storage(
     _sweep_parts(now, guard, report, dry_run=dry_run)
     _sweep_side_dirs(live, now, guard, report, dry_run=dry_run, is_live=is_live)
     _enforce_retention_budget(report, dry_run=dry_run, is_live=is_live)
+    _enforce_cache_budget(registry, live, report, dry_run=dry_run, is_live=is_live)
     if not dry_run:
         report.backups_removed = sweep_expired_backups(now)
     logger.info("Storage reconcile%s: %s", " (dry run)" if dry_run else "", report.summary())
@@ -655,6 +659,36 @@ def _enforce_retention_budget(
                 total -= marker.size_bytes
 
 
+def _enforce_cache_budget(
+    registry: AgentVmRegistry,
+    live: Collection[str],
+    report: ReconcileReport,
+    *,
+    dry_run: bool,
+    is_live: Callable[[str], bool],
+) -> None:
+    """Bring the download caches under CACHE_BUDGET.
+
+    Which cache entries are in use is read from the registry's messages, and
+    from there alone: a hash is not enough, the message is what names the
+    runtime, the code and the parent images. So a live VM the registry does
+    not know makes the referenced set incomplete, and this pass refuses to
+    run rather than evict the runtime of a VM that is running on it. That is
+    the same fail-closed rule the startup pass applies to purging, for the
+    same reason: the registry is rehydrated from the agent DB and can be
+    empty or partial while the supervisor still runs VMs.
+    """
+    unknown = sorted(namespace for namespace in live if namespace not in registry)
+    if unknown:
+        logger.warning(
+            "Skipping the cache pass: %d live VM(s) have no registry record (%s), so what they reference is unknown",
+            len(unknown),
+            ", ".join(unknown[:3]),
+        )
+        return
+    report.cache_evicted = evict_caches(registry, dry_run=dry_run, is_live=is_live)
+
+
 def make_room(pool: StoragePool, needed_bytes: int, *, live: Collection[str] | None = None) -> int:
     """Evict reclaimable directories on ``pool``, oldest first, until a
     ``needed_bytes`` create fits on it. Returns the bytes freed on ``pool``.
@@ -739,7 +773,23 @@ async def reconcile_now(app: web.Application, *, dry_run: bool = False) -> Recon
     registry = app["vm_registry"]
     async with _pass_lock(app):
         live, _running = await _live_set(app)
-        return await _pass(registry, live, dry_run=dry_run)
+        report = await _pass(registry, live, dry_run=dry_run)
+    await _remove_evicted_parent_devices(report)
+    return report
+
+
+async def _remove_evicted_parent_devices(report: ReconcileReport) -> None:
+    """Tear down the shared devices of the parent images the pass evicted.
+
+    The pass itself runs in a worker thread and dmsetup has to be awaited, so
+    this is the loop side of the cache pass: nothing else will pick these up,
+    since the cache entry they belong to is already gone.
+    """
+    for ref in parent_refs_of(report.cache_evicted):
+        try:
+            await remove_parent_device(ref)
+        except Exception:
+            logger.exception("Removing the device of the evicted parent image %s failed", ref)
 
 
 async def _pass(registry: AgentVmRegistry, live: set[str], *, dry_run: bool) -> ReconcileReport:
@@ -820,8 +870,10 @@ async def reconcile_at_startup(app: web.Application) -> None:
             live, running = await _live_set(app)
             refusal = _startup_refusal(registry, running)
             _log_startup_preview(await _pass(registry, live, dry_run=True), refusal=refusal)
-            if refusal is None:
-                await _pass(registry, live, dry_run=False)
+            if refusal is not None:
+                return
+            report = await _pass(registry, live, dry_run=False)
+        await _remove_evicted_parent_devices(report)
     except Exception:
         # Housekeeping never blocks the boot: an on_startup hook that raises
         # stops the agent, and a full or read-only pool is exactly what this

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -617,8 +617,8 @@ def _evict(
     is_live: Callable[[str], bool] | None = None,
 ) -> int:
     if is_live is not None and is_live(namespace):
-        # A stale marker on a live VM, or a create that adopted the directory
-        # since this pass started listing it.
+        # A stale marker on a live VM, or a create that committed since this
+        # pass started listing it.
         logger.warning("Not evicting %s: a live VM owns it despite its reclaimable marker", namespace)
         return 0
     if is_creating(namespace):

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -43,7 +43,13 @@ from aleph_message.exceptions import UnknownHashError
 from aleph_message.models import ItemHash
 
 from aleph.vm.agent.vm.backup import sweep_expired_backups
-from aleph.vm.agent.vm.cache import evict_caches, parent_refs_of, remove_parent_device
+from aleph.vm.agent.vm.cache import (
+    evict_caches,
+    parent_refs_of,
+    record_live_snapshot,
+    remove_parent_device,
+    sweep_leaked_cache_loops,
+)
 from aleph.vm.agent.vm.purge import _ITEM_HASH_PATTERN, purge_vm_storage
 from aleph.vm.agent.vm.reclaimable import (
     ReclaimableMarker,
@@ -204,6 +210,11 @@ async def _live_set(app: web.Application) -> tuple[set[str], int | None]:
     The returned count is ``None`` when the supervisor could not be asked,
     which is not the same answer as "it runs nothing" (see
     ``_startup_refusal``).
+
+    A live set both halves agree on is published for the admission hook,
+    which runs on the create path and cannot ask the supervisor itself (see
+    ``cache.admit_download``). A half-known one is not: admission would then
+    evict against a set that may be missing a running VM.
     """
     registry_live = live_hashes(app["vm_registry"])
     supervisor = app.get("supervisor")
@@ -217,7 +228,9 @@ async def _live_set(app: web.Application) -> tuple[set[str], int | None]:
         logger.warning("Could not list the supervisor's VMs (%s); the live set is the agent registry alone", error)
         return registry_live, None
     _last_supervisor_hashes = running
-    return registry_live | running, len(running)
+    live = registry_live | running
+    record_live_snapshot(live)
+    return live, len(running)
 
 
 # What the supervisor listed at the last pass, for the one caller that cannot
@@ -442,9 +455,15 @@ def _part_roots() -> Iterator[Path]:
 
 
 def _sweep_parts(now: datetime, guard: timedelta, report: ReconcileReport, *, dry_run: bool) -> None:
+    """Remove the half-written files of a download or a write that stopped.
+
+    ``.tmp`` goes with ``.part``: every write-then-rename in the agent uses
+    one (``storage.get_message``, ``create_ext4``, the marker writer), and an
+    interrupted one leaks exactly the same way.
+    """
     for root in _part_roots():
         try:
-            parts = list(root.glob("*.part"))
+            parts = [path for pattern in ("*.part", "*.tmp") for path in root.glob(pattern)]
         except OSError:
             continue
         for part in parts:
@@ -680,8 +699,9 @@ def _enforce_cache_budget(
     """
     unknown = sorted(namespace for namespace in live if namespace not in registry)
     if unknown:
-        logger.warning(
-            "Skipping the cache pass: %d live VM(s) have no registry record (%s), so what they reference is unknown",
+        logger.error(
+            "Skipping the cache pass: %d live VM(s) have no registry record (%s), so what they reference is "
+            "unknown and the caches are unbounded until this is resolved",
             len(unknown),
             ", ".join(unknown[:3]),
         )
@@ -774,22 +794,29 @@ async def reconcile_now(app: web.Application, *, dry_run: bool = False) -> Recon
     async with _pass_lock(app):
         live, _running = await _live_set(app)
         report = await _pass(registry, live, dry_run=dry_run)
-    await _remove_evicted_parent_devices(report)
+    await _release_cache_devices(report, dry_run=dry_run)
     return report
 
 
-async def _remove_evicted_parent_devices(report: ReconcileReport) -> None:
-    """Tear down the shared devices of the parent images the pass evicted.
+async def _release_cache_devices(report: ReconcileReport, *, dry_run: bool) -> None:
+    """Tear down the devices of the parent images the pass evicted, then sweep
+    the ones an earlier teardown left behind.
 
     The pass itself runs in a worker thread and dmsetup has to be awaited, so
-    this is the loop side of the cache pass: nothing else will pick these up,
-    since the cache entry they belong to is already gone.
+    this is the loop side of the cache pass. A dry run reaches none of it: it
+    evicted nothing, and the sweep removes devices.
     """
+    if dry_run:
+        return
     for ref in parent_refs_of(report.cache_evicted):
         try:
             await remove_parent_device(ref)
         except Exception:
             logger.exception("Removing the device of the evicted parent image %s failed", ref)
+    try:
+        await sweep_leaked_cache_loops()
+    except Exception:
+        logger.exception("Sweeping the loop devices of evicted cache entries failed")
 
 
 async def _pass(registry: AgentVmRegistry, live: set[str], *, dry_run: bool) -> ReconcileReport:
@@ -873,7 +900,7 @@ async def reconcile_at_startup(app: web.Application) -> None:
             if refusal is not None:
                 return
             report = await _pass(registry, live, dry_run=False)
-        await _remove_evicted_parent_devices(report)
+        await _release_cache_devices(report, dry_run=False)
     except Exception:
         # Housekeeping never blocks the boot: an on_startup hook that raises
         # stops the agent, and a full or read-only pool is exactly what this

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -296,6 +296,7 @@ def reconcile_storage(
     dry_run: bool = False,
     live: Collection[str] | None = None,
     is_live: Callable[[str], bool] | None = None,
+    live_known: bool = True,
 ) -> ReconcileReport:
     """One reconciliation pass: namespaces, .part files, side directories,
     the retention budget, the download caches, then the backups.
@@ -309,6 +310,11 @@ def reconcile_storage(
     an orphan (see ``registry_is_live``). It defaults to the ``live``
     snapshot alone, which is what a caller holding no loop reference can
     offer.
+
+    ``live_known`` is False when ``live`` is the agent registry alone because
+    the supervisor could not be asked. The cache pass is skipped then (see
+    ``_enforce_cache_budget``); everything else still runs on the registry's
+    own answer plus the create guard.
     """
     now = now or datetime.now(tz=timezone.utc)
     guard = timedelta(seconds=settings.VOLUME_CREATE_GUARD)
@@ -319,7 +325,7 @@ def reconcile_storage(
     _sweep_parts(now, guard, report, dry_run=dry_run)
     _sweep_side_dirs(live, now, guard, report, dry_run=dry_run, is_live=is_live)
     _enforce_retention_budget(report, dry_run=dry_run, is_live=is_live)
-    _enforce_cache_budget(registry, live, report, dry_run=dry_run, is_live=is_live)
+    _enforce_cache_budget(registry, live, report, dry_run=dry_run, is_live=is_live, live_known=live_known)
     if not dry_run:
         report.backups_removed = sweep_expired_backups(now)
     logger.info("Storage reconcile%s: %s", " (dry run)" if dry_run else "", report.summary())
@@ -685,6 +691,7 @@ def _enforce_cache_budget(
     *,
     dry_run: bool,
     is_live: Callable[[str], bool],
+    live_known: bool = True,
 ) -> None:
     """Bring the download caches under CACHE_BUDGET.
 
@@ -696,7 +703,19 @@ def _enforce_cache_budget(
     the same fail-closed rule the startup pass applies to purging, for the
     same reason: the registry is rehydrated from the agent DB and can be
     empty or partial while the supervisor still runs VMs.
+
+    ``live_known`` is the harder version of the same doubt: the supervisor
+    could not be listed at all, so ``live`` is the registry alone and the
+    check below has nothing to compare against. Every VM the registry has
+    forgotten would then read as "not live and not referenced", which is
+    exactly the set this pass unlinks.
     """
+    if not live_known:
+        logger.error(
+            "Skipping the cache pass: the supervisor could not be listed, so the VMs it runs are unknown, "
+            "what they reference is unknown with them, and the caches are unbounded until this is resolved"
+        )
+        return
     unknown = sorted(namespace for namespace in live if namespace not in registry)
     if unknown:
         logger.error(
@@ -792,8 +811,8 @@ async def reconcile_now(app: web.Application, *, dry_run: bool = False) -> Recon
     """
     registry = app["vm_registry"]
     async with _pass_lock(app):
-        live, _running = await _live_set(app)
-        report = await _pass(registry, live, dry_run=dry_run)
+        live, running = await _live_set(app)
+        report = await _pass(registry, live, dry_run=dry_run, live_known=running is not None)
     await _release_cache_devices(report, dry_run=dry_run)
     return report
 
@@ -819,7 +838,9 @@ async def _release_cache_devices(report: ReconcileReport, *, dry_run: bool) -> N
         logger.exception("Sweeping the loop devices of evicted cache entries failed")
 
 
-async def _pass(registry: AgentVmRegistry, live: set[str], *, dry_run: bool) -> ReconcileReport:
+async def _pass(
+    registry: AgentVmRegistry, live: set[str], *, dry_run: bool, live_known: bool = True
+) -> ReconcileReport:
     """One walk in a worker thread, against a live set already established."""
     return await asyncio.to_thread(
         reconcile_storage,
@@ -827,6 +848,7 @@ async def _pass(registry: AgentVmRegistry, live: set[str], *, dry_run: bool) -> 
         dry_run=dry_run,
         live=live,
         is_live=registry_is_live(registry, live),
+        live_known=live_known,
     )
 
 
@@ -896,10 +918,11 @@ async def reconcile_at_startup(app: web.Application) -> None:
         async with _pass_lock(app):
             live, running = await _live_set(app)
             refusal = _startup_refusal(registry, running)
-            _log_startup_preview(await _pass(registry, live, dry_run=True), refusal=refusal)
+            live_known = running is not None
+            _log_startup_preview(await _pass(registry, live, dry_run=True, live_known=live_known), refusal=refusal)
             if refusal is not None:
                 return
-            report = await _pass(registry, live, dry_run=False)
+            report = await _pass(registry, live, dry_run=False, live_known=live_known)
         await _release_cache_devices(report, dry_run=False)
     except Exception:
         # Housekeeping never blocks the boot: an on_startup hook that raises

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -60,9 +60,11 @@ from aleph.vm.agent.vm.reclaimable import (
     mark_reclaimable,
     read_marker,
 )
+from aleph.vm.agent.vm.retire import teardown_namespace_devices
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 from aleph.vm.storage import MOUNT_ROOT  # /mnt/{namespace}_{volume name}
+from aleph.vm.storage import DEVICE_MAPPER_DIRECTORY
 from aleph.vm.storage_budget import parse_budget
 from aleph.vm.storage_pools import StoragePool, get_pools, iter_namespace_dirs
 from aleph.vm.supervisor_interface.abc import Supervisor
@@ -812,9 +814,58 @@ async def reconcile_now(app: web.Application, *, dry_run: bool = False) -> Recon
     registry = app["vm_registry"]
     async with _pass_lock(app):
         live, running = await _live_set(app)
+        if not dry_run and running is not None:
+            await _teardown_orphan_devices(live)
         report = await _pass(registry, live, dry_run=dry_run, live_known=running is not None)
     await _release_cache_devices(report, dry_run=dry_run)
     return report
+
+
+def orphan_device_namespaces(live: Collection[str]) -> list[str]:
+    """The VM hashes device-mapper still holds devices for and nothing owns.
+
+    The inverse of the naming ``create_devmapper`` uses,
+    ``<namespace>_<volume name>``, read straight out of /dev/mapper. Anything
+    that is not a plausible item hash is not a VM device and is not this
+    pass's business.
+    """
+    namespaces: set[str] = set()
+    try:
+        devices = list(Path(DEVICE_MAPPER_DIRECTORY).glob("*_*"))
+    except OSError:
+        logger.warning("Could not list %s", DEVICE_MAPPER_DIRECTORY, exc_info=True)
+        return []
+    for device in devices:
+        namespace = device.name.split("_", 1)[0]
+        if not _plausible(namespace) or namespace in live or is_creating(namespace):
+            continue
+        namespaces.add(namespace)
+    return sorted(namespaces)
+
+
+async def _teardown_orphan_devices(live: Collection[str]) -> list[str]:
+    """Tear down the devices of the VMs the walk is about to find unowned.
+
+    ``retire_vm`` is the normal inverse of ``create_devmapper``, and it reads
+    the volumes to remove from the VM's message. Two paths have no message: a
+    create that failed before its registry commit, and a GONE for a VM the
+    registry never knew. What they leave is a dm target holding a volume file,
+    which ``purge_vm_storage`` then refuses to unlink on every pass, forever.
+
+    So it runs before the walk, not inside it: the purge that follows can only
+    reclaim a directory whose devices are already gone. On the event loop for
+    the same reason the cache pass's teardown is, dmsetup has to be awaited,
+    and only when the live set is trustworthy: removing the device of a VM
+    that is merely unlisted takes that VM's disk with it.
+    """
+    namespaces = orphan_device_namespaces(live)
+    for namespace in namespaces:
+        logger.warning("Tearing down the device-mapper devices of %s: no live VM owns them", namespace)
+        try:
+            await teardown_namespace_devices(namespace)
+        except Exception:
+            logger.exception("Device teardown of the orphan %s failed", namespace)
+    return namespaces
 
 
 async def _release_cache_devices(report: ReconcileReport, *, dry_run: bool) -> None:
@@ -922,6 +973,7 @@ async def reconcile_at_startup(app: web.Application) -> None:
             _log_startup_preview(await _pass(registry, live, dry_run=True, live_known=live_known), refusal=refusal)
             if refusal is not None:
                 return
+            await _teardown_orphan_devices(live)
             report = await _pass(registry, live, dry_run=False, live_known=live_known)
         await _release_cache_devices(report, dry_run=False)
     except Exception:

--- a/src/aleph/vm/agent/vm/retire.py
+++ b/src/aleph/vm/agent/vm/retire.py
@@ -25,6 +25,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from enum import Enum
+from pathlib import Path
 
 from aleph_message.models import ItemHash
 
@@ -38,7 +39,7 @@ from aleph.vm.agent.vm.purge import (
 from aleph.vm.agent.vm.reclaimable import depends_on_from_content, mark_reclaimable
 from aleph.vm.agent.vm_registry import AgentVmRecord, AgentVmRegistry
 from aleph.vm.conf import settings
-from aleph.vm.storage import remove_devmapper
+from aleph.vm.storage import DEVICE_MAPPER_DIRECTORY, remove_devmapper
 from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.supervisor_interface.errors import VmNotFoundError
 from aleph.vm.supervisor_interface.types import VmId
@@ -70,6 +71,39 @@ def set_after_gone_hook(hook: AfterGoneHook | None) -> None:
     _after_gone = hook
 
 
+async def teardown_namespace_devices(namespace: str) -> None:
+    """Remove a VM's device-mapper snapshots without knowing its volumes.
+
+    The inverse of ``storage.device_name_for``: ``create_devmapper`` names a
+    snapshot ``<namespace>_<volume name>``, so when no message is left to
+    enumerate the volumes from, /dev/mapper is the only thing that still
+    remembers what this VM built. Two paths arrive here with no record: a
+    create that failed before the registry commit (FAILED_CREATE is raised
+    from the create path, where the record is written only after ``create_vm``
+    returns) and a GONE for a VM the registry never knew. Without this their
+    volume files stay held by a dm target, and ``purge_vm_storage`` refuses
+    such a directory on every pass, forever.
+
+    ``<namespace>_base`` is skipped: ``remove_devmapper`` removes it itself,
+    after the last snapshot of this VM is gone.
+    """
+    namespace = _checked_namespace(namespace)
+    mapper = Path(DEVICE_MAPPER_DIRECTORY)
+    try:
+        devices = sorted(mapper.glob(f"{namespace}_*"))
+    except OSError:
+        logger.warning("Could not list the device-mapper devices of %s", namespace, exc_info=True)
+        return
+    for device in devices:
+        volume_name = device.name[len(namespace) + 1 :]
+        if not volume_name or volume_name == "base":
+            continue
+        try:
+            await remove_devmapper(namespace, volume_name)
+        except Exception:
+            logger.exception("Device teardown of %s/%s failed", namespace, volume_name)
+
+
 async def teardown_vm_devices(namespace: str, record: AgentVmRecord | None) -> None:
     """Remove the device-mapper snapshots and loop devices of a VM's
     parent-backed volumes.
@@ -80,10 +114,13 @@ async def teardown_vm_devices(namespace: str, record: AgentVmRecord | None) -> N
     releases the rest of the storage. The volume file then stays behind,
     pinned by its loop device, and the purge's dm guard refuses to unlink it
     (that would free nothing and would not reset the volume either, since
-    ``create_devmapper`` reuses a live device). Nothing retries the teardown
-    once the record is gone: such a device waits for an operator.
+    ``create_devmapper`` reuses a live device). Once the record is gone the
+    retry is the reconciler's orphan device pass, which tears down the
+    devices of every namespace no live VM owns before its walk.
     """
     if record is None:
+        # No message to read the volumes from: ask device-mapper instead.
+        await teardown_namespace_devices(namespace)
         return
     try:
         namespace = _checked_namespace(namespace)

--- a/src/aleph/vm/agent/vm/retire.py
+++ b/src/aleph/vm/agent/vm/retire.py
@@ -39,7 +39,11 @@ from aleph.vm.agent.vm.purge import (
 from aleph.vm.agent.vm.reclaimable import depends_on_from_content, mark_reclaimable
 from aleph.vm.agent.vm_registry import AgentVmRecord, AgentVmRegistry
 from aleph.vm.conf import settings
-from aleph.vm.storage import DEVICE_MAPPER_DIRECTORY, remove_devmapper
+from aleph.vm.storage import (
+    DEVICE_MAPPER_DIRECTORY,
+    remove_base_device,
+    remove_devmapper,
+)
 from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.supervisor_interface.errors import VmNotFoundError
 from aleph.vm.supervisor_interface.types import VmId
@@ -84,8 +88,10 @@ async def teardown_namespace_devices(namespace: str) -> None:
     volume files stay held by a dm target, and ``purge_vm_storage`` refuses
     such a directory on every pass, forever.
 
-    ``<namespace>_base`` is skipped: ``remove_devmapper`` removes it itself,
-    after the last snapshot of this VM is gone.
+    ``<namespace>_base`` is not removed in the loop: ``remove_devmapper``
+    removes it itself, after the last snapshot of this VM is gone. A base with
+    no snapshot at all (a create that died between the two ``dmsetup create``
+    calls) is the one case that never reaches, so it is removed at the end.
     """
     namespace = _checked_namespace(namespace)
     mapper = Path(DEVICE_MAPPER_DIRECTORY)
@@ -102,6 +108,10 @@ async def teardown_namespace_devices(namespace: str) -> None:
             await remove_devmapper(namespace, volume_name)
         except Exception:
             logger.exception("Device teardown of %s/%s failed", namespace, volume_name)
+    try:
+        await remove_base_device(namespace)
+    except Exception:
+        logger.exception("Device teardown of the base of %s failed", namespace)
 
 
 async def teardown_vm_devices(namespace: str, record: AgentVmRecord | None) -> None:
@@ -120,7 +130,14 @@ async def teardown_vm_devices(namespace: str, record: AgentVmRecord | None) -> N
     """
     if record is None:
         # No message to read the volumes from: ask device-mapper instead.
-        await teardown_namespace_devices(namespace)
+        # Best effort like the rest of this function, and here that includes
+        # the namespace check itself: an implausible hash raises, and a
+        # teardown that cannot run must not abort the retire that would have
+        # dropped the records and the rest of the storage.
+        try:
+            await teardown_namespace_devices(namespace)
+        except Exception:
+            logger.exception("Device teardown of %s failed", namespace)
         return
     try:
         namespace = _checked_namespace(namespace)

--- a/src/aleph/vm/backup/staging.py
+++ b/src/aleph/vm/backup/staging.py
@@ -34,5 +34,5 @@ async def download_volume_by_ref(
 
     dest_path = destination / f"{item_hash}.qcow2"
     url = await _get_content_url(item_hash)
-    await download_file(url, dest_path)
+    await download_file(url, dest_path, max_bytes=settings.MAX_RUNTIME_ARCHIVE_SIZE)
     return dest_path

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -88,7 +88,14 @@ async def file_downloaded_by_another_task(final_path: Path) -> None:
 # against, and the agent cannot make the downloader import it. It is handed
 # the ``.part`` path, not its directory: the room a download was admitted for
 # is charged to that path until the download ends.
-CacheAdmission = Callable[[Path, int], None]
+#
+# ``(tmp_path, content_length, max_bytes)``, and the middle one is None when
+# the server did not say. The two are not interchangeable: a Content-Length
+# is a measurement of this download, a cap is a ceiling on every download of
+# that kind, and admission has to treat them differently (see
+# ``cache.admit_download``). Deciding that here, by handing over one number,
+# is what made a chunked-encoding response ask for the whole runtime cap.
+CacheAdmission = Callable[[Path, int | None, int | None], None]
 _cache_admission: CacheAdmission | None = None
 
 # Downloads that have been admitted and are still being written, by ``.part``
@@ -135,17 +142,14 @@ async def download_file_in_chunks(url: str, tmp_path: Path, *, max_bytes: int | 
             msg = f"{url} is {resp.content_length} bytes, above the {max_bytes} byte limit"
             raise FileTooLargeError(msg)
 
-        # A response without a Content-Length is admitted for the worst case
-        # it is allowed to send: the cap it is being downloaded under. The
-        # alternative is a download that writes an unbounded number of bytes
-        # into a budget nobody ever charged.
-        admitted = resp.content_length if resp.content_length is not None else max_bytes
-        if _cache_admission is not None and admitted is not None:
+        if _cache_admission is not None:
             # Before the open: a refused download must leave nothing behind,
             # and it may evict, so the room it is admitted against is the
             # room it will actually find. What it was admitted for stays
-            # charged to the .part until download_file releases it.
-            _cache_admission(tmp_path, admitted)
+            # charged to the .part until download_file releases it. Both
+            # figures go over, whether the server measured the body or only
+            # this call's cap bounds it.
+            _cache_admission(tmp_path, resp.content_length, max_bytes)
 
         with open(tmp_path, "wb") as cache_file:
             counter = 0

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from shutil import make_archive
 from subprocess import CalledProcessError
@@ -80,6 +81,20 @@ async def file_downloaded_by_another_task(final_path: Path) -> None:
         await asyncio.sleep(0.1)
 
 
+# What the caches admit, set by the agent (agent.vm.cache.admit_download):
+# the download caches are budgeted, and a download that cannot fit is refused
+# before a byte is written rather than after the disk is full. A module hook
+# because storage.py knows nothing of the VM registry the budget is computed
+# against, and the agent cannot make the downloader import it.
+CacheAdmission = Callable[[Path, int], None]
+_cache_admission: CacheAdmission | None = None
+
+
+def set_cache_admission(fn: CacheAdmission | None) -> None:
+    global _cache_admission
+    _cache_admission = fn
+
+
 async def download_file_in_chunks(url: str, tmp_path: Path, *, max_bytes: int | None = None) -> None:
     # No total timeout: a 500+ MiB image over a slow gateway is a legitimate multi-minute
     # download. sock_read makes the request fail fast only if the transfer truly stalls.
@@ -95,6 +110,12 @@ async def download_file_in_chunks(url: str, tmp_path: Path, *, max_bytes: int | 
         if max_bytes is not None and resp.content_length is not None and resp.content_length > max_bytes:
             msg = f"{url} is {resp.content_length} bytes, above the {max_bytes} byte limit"
             raise FileTooLargeError(msg)
+
+        if _cache_admission is not None and resp.content_length is not None:
+            # Before the open: a refused download must leave nothing behind,
+            # and it may evict, so the room it is admitted against is the
+            # room it will actually find.
+            _cache_admission(tmp_path.parent, resp.content_length)
 
         with open(tmp_path, "wb") as cache_file:
             counter = 0
@@ -117,24 +138,33 @@ async def download_file_in_chunks(url: str, tmp_path: Path, *, max_bytes: int | 
         sys.stdout.flush()
 
 
-def _touch_cache_hit(local_path: Path) -> None:
-    """Bump the mtime of a cache hit for the LRU signal.
+def _touch_cache_hit(local_path: Path) -> bool:
+    """Bump the mtime of a cache hit for the LRU signal; False if it is gone.
 
     A cache hit served by a user without ownership or write access
     (chown_to_jailman ran on the original download) must still be returned:
-    the mtime touch is an LRU nicety, not a precondition.
+    the mtime touch is an LRU nicety, not a precondition. A file that
+    vanished is the opposite case and the caller has to know: the cache pass
+    evicts entries, and it can take this one between the is_file() check and
+    this touch.
     """
     try:
         os.utime(local_path, None)
+    except FileNotFoundError:
+        return False
     except OSError as error:
         logger.warning(f"Could not update mtime of cached file {local_path}: {error}")
+    return True
 
 
 async def download_file(url: str, local_path: Path, *, max_bytes: int | None = None) -> None:
     if local_path.is_file():
-        logger.debug(f"File already exists: {local_path}")
-        _touch_cache_hit(local_path)
-        return
+        if _touch_cache_hit(local_path) and local_path.is_file():
+            logger.debug(f"File already exists: {local_path}")
+            return
+        # Evicted while it was being served: fall through and fetch it again
+        # rather than hand back a path that is no longer there.
+        logger.info(f"Cached file {local_path} vanished while it was being read; downloading it again")
 
     # Avoid partial downloads and incomplete files by only moving the file when it's complete.
     tmp_path = Path(f"{local_path}.part")

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -85,14 +85,38 @@ async def file_downloaded_by_another_task(final_path: Path) -> None:
 # the download caches are budgeted, and a download that cannot fit is refused
 # before a byte is written rather than after the disk is full. A module hook
 # because storage.py knows nothing of the VM registry the budget is computed
-# against, and the agent cannot make the downloader import it.
+# against, and the agent cannot make the downloader import it. It is handed
+# the ``.part`` path, not its directory: the room a download was admitted for
+# is charged to that path until the download ends.
 CacheAdmission = Callable[[Path, int], None]
 _cache_admission: CacheAdmission | None = None
+
+# Downloads that have been admitted and are still being written, by ``.part``
+# path. Nothing on disk says how big one is going to be, so an in-flight
+# download would otherwise be invisible to the next admission, and two
+# concurrent creates would both be told there is room only one of them can
+# have. Kept here rather than in the agent's cache module because this is
+# where the download ends, in ``download_file``'s finally.
+_reserved_downloads: dict[Path, int] = {}
 
 
 def set_cache_admission(fn: CacheAdmission | None) -> None:
     global _cache_admission
     _cache_admission = fn
+
+
+def reserve_download(tmp_path: Path, size_bytes: int) -> None:
+    """Charge ``size_bytes`` to ``tmp_path`` until the download ends."""
+    _reserved_downloads[Path(tmp_path)] = size_bytes
+
+
+def release_download(tmp_path: Path) -> None:
+    _reserved_downloads.pop(Path(tmp_path), None)
+
+
+def reserved_downloads() -> dict[Path, int]:
+    """What admission has charged for and not yet seen written."""
+    return dict(_reserved_downloads)
 
 
 async def download_file_in_chunks(url: str, tmp_path: Path, *, max_bytes: int | None = None) -> None:
@@ -111,11 +135,17 @@ async def download_file_in_chunks(url: str, tmp_path: Path, *, max_bytes: int | 
             msg = f"{url} is {resp.content_length} bytes, above the {max_bytes} byte limit"
             raise FileTooLargeError(msg)
 
-        if _cache_admission is not None and resp.content_length is not None:
+        # A response without a Content-Length is admitted for the worst case
+        # it is allowed to send: the cap it is being downloaded under. The
+        # alternative is a download that writes an unbounded number of bytes
+        # into a budget nobody ever charged.
+        admitted = resp.content_length if resp.content_length is not None else max_bytes
+        if _cache_admission is not None and admitted is not None:
             # Before the open: a refused download must leave nothing behind,
             # and it may evict, so the room it is admitted against is the
-            # room it will actually find.
-            _cache_admission(tmp_path.parent, resp.content_length)
+            # room it will actually find. What it was admitted for stays
+            # charged to the .part until download_file releases it.
+            _cache_admission(tmp_path, admitted)
 
         with open(tmp_path, "wb") as cache_file:
             counter = 0
@@ -212,8 +242,11 @@ async def download_file(url: str, local_path: Path, *, max_bytes: int | None = N
                 logger.warning(f"Download of {url} failed, aborting...")
                 raise error
         finally:
-            # Only clean up the .part file if this task created it
+            # Only clean up the .part file if this task created it, and with
+            # it the room admission charged to that path: the bytes are either
+            # a cache entry now or gone.
             if owns_tmp:
+                release_download(tmp_path)
                 tmp_path.unlink(missing_ok=True)
 
 

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -8,6 +8,7 @@ In the future, it should connect to an Aleph node and retrieve the code from the
 import asyncio
 import json
 import logging
+import os
 import re
 import sys
 from pathlib import Path
@@ -33,6 +34,7 @@ from aleph_message.models.execution.volume import (
 
 from aleph.vm.conf import settings
 from aleph.vm.storage_pools import find_existing_volume, volume_path_for
+from aleph.vm.supervisor_interface.errors import FileTooLargeError
 from aleph.vm.utils import fix_message_validation, run_in_subprocess
 
 logger = logging.getLogger(__name__)
@@ -78,7 +80,7 @@ async def file_downloaded_by_another_task(final_path: Path) -> None:
         await asyncio.sleep(0.1)
 
 
-async def download_file_in_chunks(url: str, tmp_path: Path) -> None:
+async def download_file_in_chunks(url: str, tmp_path: Path, *, max_bytes: int | None = None) -> None:
     # No total timeout: a 500+ MiB image over a slow gateway is a legitimate multi-minute
     # download. sock_read makes the request fail fast only if the transfer truly stalls.
     timeout = aiohttp.ClientTimeout(
@@ -90,12 +92,21 @@ async def download_file_in_chunks(url: str, tmp_path: Path) -> None:
         resp = await session.get(url)
         resp.raise_for_status()
 
+        if max_bytes is not None and resp.content_length is not None and resp.content_length > max_bytes:
+            msg = f"{url} is {resp.content_length} bytes, above the {max_bytes} byte limit"
+            raise FileTooLargeError(msg)
+
         with open(tmp_path, "wb") as cache_file:
             counter = 0
+            written = 0
             while True:
                 chunk = await resp.content.read(65536)
                 if not chunk:
                     break
+                written += len(chunk)
+                if max_bytes is not None and written > max_bytes:
+                    msg = f"{url} exceeded the {max_bytes} byte limit while downloading"
+                    raise FileTooLargeError(msg)
                 cache_file.write(chunk)
                 counter += 1
                 if not (counter % 20):
@@ -106,10 +117,10 @@ async def download_file_in_chunks(url: str, tmp_path: Path) -> None:
         sys.stdout.flush()
 
 
-async def download_file(url: str, local_path: Path) -> None:
-    # TODO: Limit max size of download to the message specification
+async def download_file(url: str, local_path: Path, *, max_bytes: int | None = None) -> None:
     if local_path.is_file():
         logger.debug(f"File already exists: {local_path}")
+        os.utime(local_path, None)
         return
 
     # Avoid partial downloads and incomplete files by only moving the file when it's complete.
@@ -125,7 +136,7 @@ async def download_file(url: str, local_path: Path) -> None:
             tmp_path.touch(exist_ok=False)
             owns_tmp = True
 
-            await download_file_in_chunks(url, tmp_path)
+            await download_file_in_chunks(url, tmp_path, max_bytes=max_bytes)
             tmp_path.rename(local_path)
             logger.debug(f"Download complete, moved {tmp_path} -> {local_path}")
             return
@@ -269,7 +280,7 @@ async def get_code_path(ref: str) -> Path:
 
     cache_path = Path(settings.CODE_CACHE) / ref
     url = await _get_content_url(ref)
-    await download_file(url, cache_path)
+    await download_file(url, cache_path, max_bytes=settings.MAX_PROGRAM_ARCHIVE_SIZE)
     return cache_path
 
 
@@ -281,7 +292,7 @@ async def get_data_path(ref: str) -> Path:
 
     cache_path = Path(settings.DATA_CACHE) / ref
     url = await _get_content_url(ref)
-    await download_file(url, cache_path)
+    await download_file(url, cache_path, max_bytes=settings.MAX_DATA_ARCHIVE_SIZE)
     return cache_path
 
 
@@ -304,7 +315,7 @@ async def get_runtime_path(ref: str) -> Path:
 
     if not cache_path.is_file():
         url = await _get_content_url(ref)
-        await download_file(url, cache_path)
+        await download_file(url, cache_path, max_bytes=settings.MAX_RUNTIME_ARCHIVE_SIZE)
 
     await check_squashfs_integrity(cache_path)
     await chown_to_jailman(cache_path)
@@ -320,7 +331,7 @@ async def get_rootfs_base_path(ref: ItemHash) -> Path:
     cache_path = Path(settings.RUNTIME_CACHE) / ref
     if not cache_path.is_file():
         url = await _get_content_url(ref)
-        await download_file(url, cache_path)
+        await download_file(url, cache_path, max_bytes=settings.MAX_RUNTIME_ARCHIVE_SIZE)
     await chown_to_jailman(cache_path)
     return cache_path
 

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -389,7 +389,12 @@ async def get_runtime_path(ref: str) -> Path:
 
     cache_path = Path(settings.RUNTIME_CACHE) / ref
 
-    if not cache_path.is_file():
+    # The touch is what makes the runtime cache's LRU a use signal rather than
+    # download order (download_file does it for a hit it serves itself, but a
+    # hit never reaches it: asking for the URL of an image already on disk is
+    # a message lookup for nothing). A touch that finds the entry gone means
+    # the cache pass took it between the two calls: download it again.
+    if not cache_path.is_file() or not _touch_cache_hit(cache_path):
         url = await _get_content_url(ref)
         await download_file(url, cache_path, max_bytes=settings.MAX_RUNTIME_ARCHIVE_SIZE)
 
@@ -405,7 +410,9 @@ async def get_rootfs_base_path(ref: ItemHash) -> Path:
         return Path(settings.FAKE_INSTANCE_BASE)
 
     cache_path = Path(settings.RUNTIME_CACHE) / ref
-    if not cache_path.is_file():
+    # Same as get_runtime_path: a cache hit is touched here, since it never
+    # reaches download_file's own touch.
+    if not cache_path.is_file() or not _touch_cache_hit(cache_path):
         url = await _get_content_url(ref)
         await download_file(url, cache_path, max_bytes=settings.MAX_RUNTIME_ARCHIVE_SIZE)
     await chown_to_jailman(cache_path)

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -645,7 +645,13 @@ async def get_existing_file(ref: str) -> Path:
 
     cache_path = Path(settings.DATA_CACHE) / ref
     url = await _get_content_url(ref)
-    await download_file(url, cache_path, max_bytes=settings.MAX_DATA_ARCHIVE_SIZE)
+    # Not MAX_DATA_ARCHIVE_SIZE: that setting has only ever gated a program's
+    # `data` archive (get_data_path), and this function serves immutable
+    # volumes, the SNP and V-PROGRAM runtime bundle tarballs and a V-PROGRAM's
+    # workload image plus its hash tree. None of those was ever bounded by 10
+    # MB and all of them are routinely far larger, so the image cap is the
+    # only one that fits.
+    await download_file(url, cache_path, max_bytes=settings.MAX_RUNTIME_ARCHIVE_SIZE)
     await chown_to_jailman(cache_path)
     return cache_path
 

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -683,6 +683,30 @@ async def remove_devmapper(namespace: str, volume_name: str) -> None:
         logger.info("Removed device-mapper base %s", base_name)
 
 
+async def remove_base_device(namespace: str) -> None:
+    """Remove ``<namespace>_base`` when no snapshot of this VM is left.
+
+    ``create_devmapper`` builds the base device before the snapshot stacked on
+    it, so a create that died between the two leaves a base device with
+    nothing above it. ``remove_devmapper`` removes the base as the last step
+    of removing a snapshot, which is exactly the step that never runs in that
+    case, and the base holds the parent image's device, and through it the
+    runtime cache entry, for good (``cache.parent_device_is_free`` sees a
+    holder and keeps the image).
+    """
+    if not NAMESPACE_PATTERN.match(namespace):
+        logger.error("Refusing to remove an implausible device-mapper base: %r", namespace)
+        return
+    mapper = Path(DEVICE_MAPPER_DIRECTORY)
+    base_name = f"{namespace}_base"
+    siblings = [path for path in mapper.glob(f"{namespace}_*") if path.name != base_name and path.is_block_device()]
+    if siblings:
+        return
+    if (mapper / base_name).is_block_device():
+        await run_in_subprocess(["dmsetup", "remove", "--retry", base_name])
+        logger.info("Removed the orphan device-mapper base %s", base_name)
+
+
 async def get_existing_file(ref: str) -> Path:
     if settings.FAKE_DATA_PROGRAM and settings.FAKE_DATA_VOLUME:
         return Path(settings.FAKE_DATA_VOLUME)

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -117,10 +117,23 @@ async def download_file_in_chunks(url: str, tmp_path: Path, *, max_bytes: int | 
         sys.stdout.flush()
 
 
+def _touch_cache_hit(local_path: Path) -> None:
+    """Bump the mtime of a cache hit for the LRU signal.
+
+    A cache hit served by a user without ownership or write access
+    (chown_to_jailman ran on the original download) must still be returned:
+    the mtime touch is an LRU nicety, not a precondition.
+    """
+    try:
+        os.utime(local_path, None)
+    except OSError as error:
+        logger.warning(f"Could not update mtime of cached file {local_path}: {error}")
+
+
 async def download_file(url: str, local_path: Path, *, max_bytes: int | None = None) -> None:
     if local_path.is_file():
         logger.debug(f"File already exists: {local_path}")
-        os.utime(local_path, None)
+        _touch_cache_hit(local_path)
         return
 
     # Avoid partial downloads and incomplete files by only moving the file when it's complete.
@@ -602,7 +615,7 @@ async def get_existing_file(ref: str) -> Path:
 
     cache_path = Path(settings.DATA_CACHE) / ref
     url = await _get_content_url(ref)
-    await download_file(url, cache_path)
+    await download_file(url, cache_path, max_bytes=settings.MAX_DATA_ARCHIVE_SIZE)
     await chown_to_jailman(cache_path)
     return cache_path
 

--- a/tests/supervisor/test_cache_eviction.py
+++ b/tests/supervisor/test_cache_eviction.py
@@ -12,6 +12,7 @@ from aleph_message.models import ItemHash
 from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
 
 import aleph.vm.agent.vm.cache as cache_module
+import aleph.vm.agent.vm.reconciler as reconciler_module
 import aleph.vm.storage as storage_module
 from aleph.vm.agent.vm.cache import (
     admit_download,
@@ -537,3 +538,17 @@ async def test_the_sweep_ignores_deleted_files_outside_the_caches(pools, monkeyp
 
     assert await cache_module.sweep_leaked_cache_loops() == []
     assert commands == []
+
+
+def test_a_retained_dir_a_create_is_using_is_not_reclaimed_for_its_parent(pools, monkeypatch):
+    """Same race as the retention budget's: the markers were listed before the
+    create adopted the directory, and the VM has no registry record yet."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    parent = _entry(pools["runtime"], "parent", size=4096)
+    adopted = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", ("parent",), now=NOW)
+    monkeypatch.setattr(reconciler_module, "_creating", {VM_HASH})
+
+    assert evict_caches(registry) == []
+    assert parent.exists() and adopted.exists()

--- a/tests/supervisor/test_cache_eviction.py
+++ b/tests/supervisor/test_cache_eviction.py
@@ -552,3 +552,80 @@ def test_a_retained_dir_a_create_is_using_is_not_reclaimed_for_its_parent(pools,
 
     assert evict_caches(registry) == []
     assert parent.exists() and adopted.exists()
+
+
+def _fake_device(monkeypatch, tmp_path, ref="parent", *, present=True):
+    """A /dev/mapper and a /sys/dev/block the test owns.
+
+    ``_is_block_device`` answers on existence: a regular file stands in for a
+    device node, which no test can create, and a path that is not there is
+    still not there.
+    """
+    mapper = tmp_path / "mapper"
+    mapper.mkdir(exist_ok=True)
+    sysfs = tmp_path / "sys-dev-block"
+    sysfs.mkdir(exist_ok=True)
+    monkeypatch.setattr(cache_module, "DEVICE_MAPPER_DIRECTORY", str(mapper))
+    monkeypatch.setattr(cache_module, "SYS_DEV_BLOCK", sysfs)
+    monkeypatch.setattr(cache_module, "_is_block_device", lambda path: path.exists())
+    device = mapper / ref
+    if present:
+        device.write_bytes(b"")
+    return device, sysfs
+
+
+def _holders_of(sysfs, device):
+    """Where the kernel would list what is stacked on ``device``."""
+    rdev = device.stat().st_rdev
+    return sysfs / f"{os.major(rdev)}:{os.minor(rdev)}" / "holders"
+
+
+def test_a_parent_device_with_no_holders_is_free(monkeypatch, tmp_path):
+    device, sysfs = _fake_device(monkeypatch, tmp_path)
+    _holders_of(sysfs, device).mkdir(parents=True)
+
+    assert cache_module.parent_device_is_free("parent") is True
+
+
+def test_a_parent_device_a_vm_is_stacked_on_is_not_free(monkeypatch, tmp_path, caplog):
+    """create_devmapper stacks one <namespace>_base per VM on the image."""
+    caplog.set_level(logging.INFO)
+    device, sysfs = _fake_device(monkeypatch, tmp_path)
+    holders = _holders_of(sysfs, device)
+    holders.mkdir(parents=True)
+    (holders / "dm-3").mkdir()
+
+    assert cache_module.parent_device_is_free("parent") is False
+    assert "dm-3" in caplog.text
+
+
+def test_a_ref_with_no_device_at_all_is_free(monkeypatch, tmp_path):
+    """Nothing is stacked on a device that does not exist."""
+    _fake_device(monkeypatch, tmp_path, present=False)
+
+    assert cache_module.parent_device_is_free("parent") is True
+
+
+def test_a_device_sysfs_does_not_know_is_not_free(monkeypatch, tmp_path, caplog):
+    """Fail closed: the question could not be answered, and the cost of
+    guessing wrong is a running VM's disk."""
+    _fake_device(monkeypatch, tmp_path)
+
+    assert cache_module.parent_device_is_free("parent") is False
+    assert "still in use" in caplog.text
+
+
+def test_an_unreadable_holders_directory_is_not_free(monkeypatch, tmp_path):
+    device, sysfs = _fake_device(monkeypatch, tmp_path)
+    holders = _holders_of(sysfs, device)
+    holders.parent.mkdir(parents=True)
+    holders.write_bytes(b"not a directory")
+
+    assert cache_module.parent_device_is_free("parent") is False
+
+
+def test_an_implausible_ref_is_never_free(monkeypatch, tmp_path):
+    _fake_device(monkeypatch, tmp_path, present=False)
+
+    assert cache_module.parent_device_is_free("../escape") is False
+    assert cache_module.parent_device_is_free("-o") is False

--- a/tests/supervisor/test_cache_eviction.py
+++ b/tests/supervisor/test_cache_eviction.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import logging
 import os
 import time
 from datetime import datetime, timezone
@@ -26,6 +28,13 @@ NOW = datetime(2026, 8, 24, tzinfo=timezone.utc)
 OLDER = datetime(2026, 8, 23, tzinfo=timezone.utc)
 
 
+@pytest.fixture(autouse=True)
+def _no_live_snapshot(monkeypatch):
+    """The reconciler's live-set snapshot is module state: no test inherits
+    another's."""
+    monkeypatch.setattr(cache_module, "_live_snapshot", None)
+
+
 def _entry(root, name, size=4096, age=0):
     path = root / name
     path.write_bytes(b"x" * size)
@@ -41,17 +50,22 @@ def _program_record(registry, vm_hash, *, runtime="rt", code="code", data=None):
     content.data = MagicMock(ref=data) if data else None
     content.rootfs = None
     content.volumes = []
+    content.workload = None
+    content.environment = None
     registry.record(ItemHash(vm_hash), message=content, original=content)
     return content
 
 
 def test_referenced_hashes_cover_records_and_markers(pools):
     registry = AgentVmRegistry()
-    _program_record(registry, "ab" * 32, runtime="rt1", code="c1", data="d1")
+    vm_hash = "ab" * 32
+    _program_record(registry, vm_hash, runtime="rt1", code="c1", data="d1")
     volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
     mark_reclaimable(VM_HASH, "gone", ("parent1",), now=NOW)
 
-    assert referenced_hashes(registry) == {"rt1", "c1", "d1", "parent1"}
+    # The VM's own message entry is a reference too: the message cache holds
+    # it as <vm_hash>.json.
+    assert referenced_hashes(registry) == {"rt1", "c1", "d1", "parent1", vm_hash}
 
 
 def test_referenced_hashes_cover_instance_parents_and_immutable_volumes(pools):
@@ -68,9 +82,73 @@ def test_referenced_hashes_cover_instance_parents_and_immutable_volumes(pools):
     immutable = MagicMock(ref="immutable")
     immutable.parent = None
     content.volumes = [parent_backed, immutable]
-    registry.record(ItemHash("ab" * 32), message=content, original=content)
+    content.workload = None
+    content.environment = None
+    vm_hash = "ab" * 32
+    registry.record(ItemHash(vm_hash), message=content, original=content)
 
-    assert referenced_hashes(registry) == {"base", "vparent", "immutable"}
+    assert referenced_hashes(registry) == {"base", "vparent", "immutable", vm_hash}
+
+
+def _vprogram_record(registry, vm_hash, **fields):
+    content = MagicMock()
+    content.runtime = MagicMock(ref=fields.get("runtime", "manifest"))
+    content.code = None
+    content.data = None
+    content.rootfs = None
+    content.volumes = []
+    content.workload = MagicMock(ref=fields.get("workload", "workload"), hash_tree=fields.get("hash_tree", "hashtree"))
+    content.environment = MagicMock()
+    content.environment.trusted_execution = fields.get("trusted_execution")
+    registry.record(ItemHash(vm_hash), message=content, original=content)
+    return content
+
+
+def test_a_live_vprograms_workload_disks_are_never_evicted(pools, monkeypatch):
+    """Both are attached as the VM's disks straight out of DATA_CACHE."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    _vprogram_record(registry, "ab" * 32)
+    workload = _entry(pools["data"], "workload", size=4096)
+    hash_tree = _entry(pools["data"], "hashtree", size=4096)
+
+    assert evict_caches(registry) == []
+    assert workload.exists() and hash_tree.exists()
+
+
+def test_a_confidential_instances_firmware_and_runtime_are_never_evicted(pools, monkeypatch):
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    _vprogram_record(registry, "ab" * 32, trusted_execution=MagicMock(firmware="fw", runtime="tee-rt"))
+    firmware = _entry(pools["data"], "fw", size=4096)
+    runtime = _entry(pools["data"], "tee-rt", size=4096)
+
+    assert evict_caches(registry) == []
+    assert firmware.exists() and runtime.exists()
+
+
+def test_the_bundle_a_locally_cached_manifest_names_is_kept(pools, monkeypatch):
+    """The tarball ref is only knowable from the manifest, so it is protected
+    whenever the manifest itself is in the cache."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    _vprogram_record(registry, "ab" * 32, workload="w", hash_tree="h")
+    (pools["data"] / "manifest").write_text(json.dumps({"bundle": {"ref": "tarball"}}))
+    tarball = _entry(pools["data"], "tarball", size=4096)
+
+    assert evict_caches(registry) == []
+    assert tarball.exists()
+
+
+def test_a_live_vms_own_message_entry_is_kept(pools, monkeypatch):
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    vm_hash = "ab" * 32
+    _program_record(registry, vm_hash)
+    message = _entry(pools["message"], f"{vm_hash}.json", size=4096)
+
+    assert evict_caches(registry) == []
+    assert message.exists()
 
 
 def test_cache_entries_skip_parts_and_sort_oldest_first(pools):
@@ -223,11 +301,54 @@ def test_parent_refs_of_only_names_runtime_entries(pools):
 def test_admit_download_evicts_to_make_room(pools, monkeypatch):
     monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
     registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
     old = _entry(pools["code"], "old", size=4096, age=1000)
 
     admit_download(registry, pools["code"], 8000)
 
     assert not old.exists()
+
+
+def test_admit_download_never_reclaims_retained_disks(pools, monkeypatch):
+    """Phase 2 purges VM directories, which on the admission path would mean
+    an rmtree on the event loop: admission evicts cache files or refuses."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    parent = _entry(pools["runtime"], "parent", size=4096)
+    retained = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", ("parent",), now=NOW)
+
+    with pytest.raises(InsufficientResourcesError):
+        admit_download(registry, pools["runtime"], 512)
+
+    assert parent.exists() and retained.exists()
+
+
+def test_admit_download_evicts_nothing_when_a_live_vm_has_no_record(pools, monkeypatch, caplog):
+    """The same fail-closed rule the pass applies: without every live VM's
+    message, what the caches hold for them is unknown."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot({VM_HASH})
+    old = _entry(pools["code"], "old", size=4096, age=1000)
+
+    with pytest.raises(InsufficientResourcesError):
+        admit_download(registry, pools["code"], 8000)
+
+    assert old.exists()
+    assert "no registry record" in caplog.text
+
+
+def test_admit_download_evicts_nothing_before_the_first_pass(pools, monkeypatch):
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    registry = AgentVmRegistry()
+    old = _entry(pools["code"], "old", size=4096, age=1000)
+
+    with pytest.raises(InsufficientResourcesError):
+        admit_download(registry, pools["code"], 8000)
+
+    assert old.exists()
 
 
 def test_admit_download_refuses_what_the_budget_cannot_hold(pools, monkeypatch):
@@ -238,15 +359,18 @@ def test_admit_download_refuses_what_the_budget_cannot_hold(pools, monkeypatch):
         admit_download(registry, pools["code"], 9000)
 
 
-def test_admit_download_ignores_a_directory_that_is_not_a_cache(pools, monkeypatch):
+def test_admit_download_ignores_a_directory_that_is_not_a_cache(pools, monkeypatch, caplog):
     """The downloader streams per-VM volumes in place; those are admitted by
     the capacity checks and the pool budget, not by CACHE_BUDGET."""
+    caplog.set_level(logging.DEBUG)
     monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
     registry = AgentVmRegistry()
     directory = pools["pool0"] / VM_HASH
     directory.mkdir()
 
     admit_download(registry, directory, 10 * 1024**3)
+
+    assert str(directory) in caplog.text
 
 
 def _record_calls(monkeypatch, *, loop_of=None):
@@ -313,4 +437,37 @@ async def test_remove_parent_device_refuses_an_implausible_ref(pools, monkeypatc
 
     await cache_module.remove_parent_device("../escape")
 
+    assert commands == []
+
+
+@pytest.mark.asyncio
+async def test_the_sweep_detaches_a_loop_left_over_a_deleted_cache_entry(pools, monkeypatch):
+    """The recovery path for a teardown that failed: the entry is gone, so
+    only the kernel still knows which loop pins its blocks."""
+    commands = _record_calls(monkeypatch, loop_of=pools["runtime"] / "gone")
+    monkeypatch.setattr(cache_module, "_is_block_device", lambda path: True)
+    monkeypatch.setattr(cache_module, "parent_device_is_free", lambda ref: True)
+
+    assert await cache_module.sweep_leaked_cache_loops() == ["/dev/loop7"]
+    assert commands == [["dmsetup", "remove", "--retry", "gone"], ["losetup", "-d", "/dev/loop7"]]
+
+
+@pytest.mark.asyncio
+async def test_the_sweep_leaves_a_loop_whose_device_is_still_held(pools, monkeypatch):
+    commands = _record_calls(monkeypatch, loop_of=pools["runtime"] / "gone")
+    monkeypatch.setattr(cache_module, "_is_block_device", lambda path: True)
+    monkeypatch.setattr(cache_module, "parent_device_is_free", lambda ref: False)
+
+    assert await cache_module.sweep_leaked_cache_loops() == []
+    assert commands == []
+
+
+@pytest.mark.asyncio
+async def test_the_sweep_ignores_deleted_files_outside_the_caches(pools, monkeypatch):
+    """A VM volume's loop device is remove_devmapper's business, not this
+    sweep's."""
+    commands = _record_calls(monkeypatch, loop_of=pools["pool0"] / "rootfs.btrfs")
+    monkeypatch.setattr(cache_module, "_is_block_device", lambda path: True)
+
+    assert await cache_module.sweep_leaked_cache_loops() == []
     assert commands == []

--- a/tests/supervisor/test_cache_eviction.py
+++ b/tests/supervisor/test_cache_eviction.py
@@ -12,6 +12,7 @@ from aleph_message.models import ItemHash
 from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
 
 import aleph.vm.agent.vm.cache as cache_module
+import aleph.vm.storage as storage_module
 from aleph.vm.agent.vm.cache import (
     admit_download,
     cache_entries,
@@ -33,6 +34,12 @@ def _no_live_snapshot(monkeypatch):
     """The reconciler's live-set snapshot is module state: no test inherits
     another's."""
     monkeypatch.setattr(cache_module, "_live_snapshot", None)
+
+
+@pytest.fixture(autouse=True)
+def _no_reserved_downloads(monkeypatch):
+    """So is the set of downloads admission has already charged for."""
+    monkeypatch.setattr(storage_module, "_reserved_downloads", {})
 
 
 def _entry(root, name, size=4096, age=0):
@@ -304,7 +311,7 @@ def test_admit_download_evicts_to_make_room(pools, monkeypatch):
     cache_module.record_live_snapshot(set())
     old = _entry(pools["code"], "old", size=4096, age=1000)
 
-    admit_download(registry, pools["code"], 8000)
+    admit_download(registry, pools["code"] / "new.part", 8000)
 
     assert not old.exists()
 
@@ -320,7 +327,7 @@ def test_admit_download_never_reclaims_retained_disks(pools, monkeypatch):
     mark_reclaimable(VM_HASH, "gone", ("parent",), now=NOW)
 
     with pytest.raises(InsufficientResourcesError):
-        admit_download(registry, pools["runtime"], 512)
+        admit_download(registry, pools["runtime"] / "new.part", 512)
 
     assert parent.exists() and retained.exists()
 
@@ -334,7 +341,7 @@ def test_admit_download_evicts_nothing_when_a_live_vm_has_no_record(pools, monke
     old = _entry(pools["code"], "old", size=4096, age=1000)
 
     with pytest.raises(InsufficientResourcesError):
-        admit_download(registry, pools["code"], 8000)
+        admit_download(registry, pools["code"] / "new.part", 8000)
 
     assert old.exists()
     assert "no registry record" in caplog.text
@@ -346,7 +353,7 @@ def test_admit_download_evicts_nothing_before_the_first_pass(pools, monkeypatch)
     old = _entry(pools["code"], "old", size=4096, age=1000)
 
     with pytest.raises(InsufficientResourcesError):
-        admit_download(registry, pools["code"], 8000)
+        admit_download(registry, pools["code"] / "new.part", 8000)
 
     assert old.exists()
 
@@ -356,7 +363,66 @@ def test_admit_download_refuses_what_the_budget_cannot_hold(pools, monkeypatch):
     registry = AgentVmRegistry()
 
     with pytest.raises(InsufficientResourcesError):
-        admit_download(registry, pools["code"], 9000)
+        admit_download(registry, pools["code"] / "a.part", 9000)
+
+
+def test_two_concurrent_downloads_cannot_both_fit_in_room_for_one(pools, monkeypatch):
+    """Admission used to see only what was already on disk, and a ``.part`` is
+    not a cache entry: two creates arriving together were both told there was
+    room for a download only one of them could have."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    first = pools["code"] / "a.part"
+    first.touch()
+
+    admit_download(registry, first, 8000)
+
+    second = pools["code"] / "b.part"
+    second.touch()
+    with pytest.raises(InsufficientResourcesError):
+        admit_download(registry, second, 8000)
+
+
+def test_a_finished_download_releases_the_room_it_held(pools, monkeypatch):
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    first = pools["code"] / "a.part"
+    first.touch()
+    admit_download(registry, first, 8000)
+
+    storage_module.release_download(first)
+    first.unlink()
+
+    admit_download(registry, pools["code"] / "b.part", 8000)
+
+
+def test_the_bytes_of_an_unadmitted_part_file_are_counted_too(pools, monkeypatch):
+    """A ``.part`` from a crashed download holds real blocks until the
+    reconciler's guard expires; admission may not hand the same blocks out."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    orphan = pools["code"] / "crashed.part"
+    orphan.write_bytes(b"x" * 8000)
+
+    with pytest.raises(InsufficientResourcesError):
+        admit_download(registry, pools["code"] / "b.part", 4096)
+
+
+def test_a_reservation_is_not_counted_twice_while_its_part_grows(pools, monkeypatch):
+    """The reservation and the bytes already written are the same room."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "16384")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    part = pools["code"] / "a.part"
+    part.touch()
+    admit_download(registry, part, 8192)
+    part.write_bytes(b"x" * 8192)
+
+    # 8 KiB reserved, 8 KiB of it written: 8 KiB of the 16 KiB budget is left.
+    admit_download(registry, pools["code"] / "b.part", 4096)
 
 
 def test_admit_download_ignores_a_directory_that_is_not_a_cache(pools, monkeypatch, caplog):
@@ -368,7 +434,7 @@ def test_admit_download_ignores_a_directory_that_is_not_a_cache(pools, monkeypat
     directory = pools["pool0"] / VM_HASH
     directory.mkdir()
 
-    admit_download(registry, directory, 10 * 1024**3)
+    admit_download(registry, directory / "rootfs.qcow2.part", 10 * 1024**3)
 
     assert str(directory) in caplog.text
 

--- a/tests/supervisor/test_cache_eviction.py
+++ b/tests/supervisor/test_cache_eviction.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from aleph_message.models import ItemHash
+from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
+
+import aleph.vm.agent.vm.cache as cache_module
+from aleph.vm.agent.vm.cache import (
+    admit_download,
+    cache_entries,
+    evict_caches,
+    parent_refs_of,
+    referenced_hashes,
+)
+from aleph.vm.agent.vm.reclaimable import mark_reclaimable
+from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.conf import settings
+from aleph.vm.resources import InsufficientResourcesError
+
+NOW = datetime(2026, 8, 24, tzinfo=timezone.utc)
+OLDER = datetime(2026, 8, 23, tzinfo=timezone.utc)
+
+
+def _entry(root, name, size=4096, age=0):
+    path = root / name
+    path.write_bytes(b"x" * size)
+    stamp = time.time() - age
+    os.utime(path, (stamp, stamp))
+    return path
+
+
+def _program_record(registry, vm_hash, *, runtime="rt", code="code", data=None):
+    content = MagicMock()
+    content.runtime = MagicMock(ref=runtime)
+    content.code = MagicMock(ref=code)
+    content.data = MagicMock(ref=data) if data else None
+    content.rootfs = None
+    content.volumes = []
+    registry.record(ItemHash(vm_hash), message=content, original=content)
+    return content
+
+
+def test_referenced_hashes_cover_records_and_markers(pools):
+    registry = AgentVmRegistry()
+    _program_record(registry, "ab" * 32, runtime="rt1", code="c1", data="d1")
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", ("parent1",), now=NOW)
+
+    assert referenced_hashes(registry) == {"rt1", "c1", "d1", "parent1"}
+
+
+def test_referenced_hashes_cover_instance_parents_and_immutable_volumes(pools):
+    registry = AgentVmRegistry()
+    content = MagicMock()
+    content.runtime = None
+    content.code = None
+    content.data = None
+    # ``parent`` is a Mock constructor argument, so it has to be assigned.
+    content.rootfs = MagicMock()
+    content.rootfs.parent = MagicMock(ref="base")
+    parent_backed = MagicMock(ref=None)
+    parent_backed.parent = MagicMock(ref="vparent")
+    immutable = MagicMock(ref="immutable")
+    immutable.parent = None
+    content.volumes = [parent_backed, immutable]
+    registry.record(ItemHash("ab" * 32), message=content, original=content)
+
+    assert referenced_hashes(registry) == {"base", "vparent", "immutable"}
+
+
+def test_cache_entries_skip_parts_and_sort_oldest_first(pools):
+    new = _entry(pools["runtime"], "new", age=10)
+    old = _entry(pools["runtime"], "old", age=1000)
+    _entry(pools["runtime"], "x.part")
+
+    assert [e.path for e in cache_entries(pools["runtime"])] == [old, new]
+
+
+def test_evicts_unreferenced_lru_until_under_budget(pools, monkeypatch):
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    registry = AgentVmRegistry()
+    _program_record(registry, "ab" * 32, runtime="live")
+    live = _entry(pools["runtime"], "live", age=5000)
+    oldest = _entry(pools["runtime"], "oldest", age=3000)
+    newer = _entry(pools["runtime"], "newer", age=100)
+
+    evicted = evict_caches(registry)
+
+    assert evicted == [oldest]
+    assert live.exists() and newer.exists()
+
+
+def test_never_evicts_a_live_reference_even_over_budget(pools, monkeypatch, caplog):
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    _program_record(registry, "ab" * 32, runtime="live")
+    live = _entry(pools["runtime"], "live", size=4096)
+
+    assert evict_caches(registry) == []
+    assert live.exists()
+    assert "live references" in caplog.text
+
+
+def test_a_message_cache_entry_of_a_live_vm_is_kept(pools, monkeypatch):
+    """The message cache keys entries ``<ref>.json``, so the referenced set
+    has to be matched against the stem too."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    _program_record(registry, "ab" * 32, runtime="live")
+    kept = _entry(pools["message"], "live.json", size=4096)
+
+    assert evict_caches(registry) == []
+    assert kept.exists()
+
+
+def test_reclaimable_dependents_go_before_their_parent(pools, monkeypatch):
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    parent = _entry(pools["runtime"], "parent", size=4096)
+    retained = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", ("parent",), now=NOW)
+
+    evicted = evict_caches(registry)
+
+    assert evicted == [parent]
+    assert not retained.exists()
+    assert parent_refs_of(evicted) == ["parent"]
+
+
+def test_a_parent_a_vm_that_is_live_again_needs_is_kept(pools, monkeypatch):
+    """Reclaiming one dependent does not free a parent a second directory
+    still names, and a stale marker on a live VM is never reclaimed for it."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    parent = _entry(pools["runtime"], "parent", size=4096)
+    reclaimable = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    live = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", ("parent",), now=OLDER)
+    mark_reclaimable(OTHER_HASH, "gone", ("parent",), now=NOW)
+    _program_record(registry, OTHER_HASH)
+
+    assert evict_caches(registry) == []
+    assert parent.exists() and live.exists()
+    assert not reclaimable.exists()
+
+
+def test_every_dependent_goes_before_the_parent_they_share(pools, monkeypatch):
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    parent = _entry(pools["runtime"], "parent", size=4096)
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", ("parent",), now=OLDER)
+    mark_reclaimable(OTHER_HASH, "gone", ("parent",), now=NOW)
+
+    assert evict_caches(registry) == [parent]
+    assert not (pools["pool0"] / VM_HASH).exists()
+    assert not (pools["pool0"] / OTHER_HASH).exists()
+
+
+def test_a_parent_is_kept_when_its_dependents_purge_leaves_disks_behind(pools, monkeypatch):
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    parent = _entry(pools["runtime"], "parent", size=4096)
+    retained = volume(pools["pool0"], VM_HASH, "rootfs.btrfs")
+    mark_reclaimable(VM_HASH, "gone", ("parent",), now=NOW)
+    # What purge_vm_storage does when a device-mapper target still holds the
+    # volume: it logs and leaves the directory in place.
+    monkeypatch.setattr(cache_module, "purge_vm_storage", lambda namespace: 0)
+
+    assert evict_caches(registry) == []
+    assert parent.exists() and retained.exists()
+
+
+def test_needed_bytes_are_counted_against_the_budget(pools, monkeypatch):
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    registry = AgentVmRegistry()
+    a = _entry(pools["code"], "a", size=4096, age=100)
+
+    assert evict_caches(registry, needed={pools["code"]: 8000}) == [a]
+
+
+def test_dry_run_reports_without_deleting(pools, monkeypatch):
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    a = _entry(pools["data"], "a", size=4096)
+
+    assert evict_caches(registry, dry_run=True) == [a]
+    assert a.exists()
+
+
+def test_dry_run_does_not_purge_a_reclaimable_dependent(pools, monkeypatch):
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    parent = _entry(pools["runtime"], "parent", size=4096)
+    retained = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", ("parent",), now=NOW)
+
+    assert evict_caches(registry, dry_run=True) == [parent]
+    assert parent.exists() and retained.exists()
+
+
+def test_a_parent_whose_device_is_still_held_is_not_evicted(pools, monkeypatch, caplog):
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    parent = _entry(pools["runtime"], "parent", size=4096)
+    monkeypatch.setattr(cache_module, "parent_device_is_free", lambda ref: False)
+
+    assert evict_caches(registry) == []
+    assert parent.exists()
+    assert "device" in caplog.text
+
+
+def test_parent_refs_of_only_names_runtime_entries(pools):
+    assert parent_refs_of([pools["runtime"] / "a", pools["code"] / "b"]) == ["a"]
+
+
+def test_admit_download_evicts_to_make_room(pools, monkeypatch):
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    registry = AgentVmRegistry()
+    old = _entry(pools["code"], "old", size=4096, age=1000)
+
+    admit_download(registry, pools["code"], 8000)
+
+    assert not old.exists()
+
+
+def test_admit_download_refuses_what_the_budget_cannot_hold(pools, monkeypatch):
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    registry = AgentVmRegistry()
+
+    with pytest.raises(InsufficientResourcesError):
+        admit_download(registry, pools["code"], 9000)
+
+
+def test_admit_download_ignores_a_directory_that_is_not_a_cache(pools, monkeypatch):
+    """The downloader streams per-VM volumes in place; those are admitted by
+    the capacity checks and the pool budget, not by CACHE_BUDGET."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    directory = pools["pool0"] / VM_HASH
+    directory.mkdir()
+
+    admit_download(registry, directory, 10 * 1024**3)
+
+
+def _record_calls(monkeypatch, *, loop_of=None):
+    """Record the commands remove_parent_device runs, with a fake sysfs whose
+    only loop device is backed by ``loop_of`` (already unlinked)."""
+    commands: list[list[str]] = []
+
+    async def fake_run(command, **kwargs):
+        commands.append(command)
+        return b""
+
+    monkeypatch.setattr(cache_module, "run_in_subprocess", fake_run)
+    if loop_of is not None:
+        sys_block = loop_of.parent / "sys-block"
+        backing_file = sys_block / "loop7" / "loop" / "backing_file"
+        backing_file.parent.mkdir(parents=True)
+        backing_file.write_text(f"{loop_of} (deleted)\n")
+        (sys_block / "loop8" / "loop").mkdir(parents=True)
+        (sys_block / "loop8" / "loop" / "backing_file").write_text("/some/other/file\n")
+        monkeypatch.setattr(cache_module, "SYS_BLOCK", sys_block)
+    return commands
+
+
+@pytest.mark.asyncio
+async def test_remove_parent_device_removes_the_device_and_its_loop(pools, monkeypatch):
+    """The eviction unlinks the image before this runs, so `losetup -j` can no
+    longer find the loop device that pins its blocks: sysfs still can."""
+    commands = _record_calls(monkeypatch, loop_of=pools["runtime"] / "parent")
+    monkeypatch.setattr(cache_module, "_is_block_device", lambda path: True)
+
+    await cache_module.remove_parent_device("parent")
+
+    assert commands == [["dmsetup", "remove", "--retry", "parent"], ["losetup", "-d", "/dev/loop7"]]
+
+
+@pytest.mark.asyncio
+async def test_remove_parent_device_detaches_the_loop_of_a_ref_with_no_device(pools, monkeypatch):
+    """An interrupted create can leave a read-only loop device with no dm
+    target on top: the evicted file's blocks stay pinned until it is detached."""
+    commands = _record_calls(monkeypatch, loop_of=pools["runtime"] / "parent")
+    monkeypatch.setattr(cache_module, "_is_block_device", lambda path: False)
+
+    await cache_module.remove_parent_device("parent")
+
+    assert commands == [["losetup", "-d", "/dev/loop7"]]
+
+
+@pytest.mark.asyncio
+async def test_remove_parent_device_leaves_an_image_that_came_back_alone(pools, monkeypatch):
+    """Downloaded again between the eviction and this teardown: the devices
+    belong to the create that fetched it, not to the eviction."""
+    commands = _record_calls(monkeypatch, loop_of=pools["runtime"] / "parent")
+    (pools["runtime"] / "parent").write_bytes(b"image")
+    monkeypatch.setattr(cache_module, "_is_block_device", lambda path: True)
+
+    await cache_module.remove_parent_device("parent")
+
+    assert commands == []
+
+
+@pytest.mark.asyncio
+async def test_remove_parent_device_refuses_an_implausible_ref(pools, monkeypatch):
+    commands = _record_calls(monkeypatch)
+
+    await cache_module.remove_parent_device("../escape")
+
+    assert commands == []

--- a/tests/supervisor/test_cache_eviction.py
+++ b/tests/supervisor/test_cache_eviction.py
@@ -629,3 +629,62 @@ def test_an_implausible_ref_is_never_free(monkeypatch, tmp_path):
 
     assert cache_module.parent_device_is_free("../escape") is False
     assert cache_module.parent_device_is_free("-o") is False
+
+
+def test_an_unknown_length_download_evicts_nothing(pools, monkeypatch):
+    """A cap is not a measurement. MAX_RUNTIME_ARCHIVE_SIZE is 100 GiB, and
+    charging that for a chunked response wiped every unreferenced entry in the
+    root before refusing the download anyway."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    old = _entry(pools["runtime"], "old", size=4096, age=1000)
+
+    admit_download(registry, pools["runtime"] / "new.part", None, 100 * 1024**3)
+
+    assert old.exists()
+    assert storage_module.reserved_downloads() == {pools["runtime"] / "new.part": 8192}
+
+
+def test_an_unknown_length_download_is_refused_on_a_root_over_budget(pools, monkeypatch):
+    """The one thing it still refuses, and it evicts nothing on the way out."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    old = _entry(pools["runtime"], "old", size=4096, age=1000)
+
+    with pytest.raises(InsufficientResourcesError):
+        admit_download(registry, pools["runtime"] / "new.part", None, 999)
+
+    assert old.exists()
+    assert storage_module.reserved_downloads() == {}
+
+
+def test_two_unknown_length_downloads_are_both_charged_the_capped_figure(pools, monkeypatch):
+    """Bounded, so a stream of them still runs the root over its budget and
+    the next one is refused, but never charged more than the budget itself."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    first = pools["runtime"] / "a.part"
+    second = pools["runtime"] / "b.part"
+
+    admit_download(registry, first, None, 4096)
+    admit_download(registry, second, None, 100 * 1024**3)
+
+    assert storage_module.reserved_downloads() == {first: 4096, second: 8192}
+    with pytest.raises(InsufficientResourcesError):
+        admit_download(registry, pools["runtime"] / "c.part", None, 4096)
+
+
+def test_a_measured_download_still_evicts_to_make_room(pools, monkeypatch):
+    """The Content-Length path is unchanged: that figure is this download's
+    size, so the budget may be made to fit it."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    old = _entry(pools["code"], "old", size=4096, age=1000)
+
+    admit_download(registry, pools["code"] / "new.part", 8000)
+
+    assert not old.exists()

--- a/tests/supervisor/test_cache_eviction.py
+++ b/tests/supervisor/test_cache_eviction.py
@@ -548,7 +548,7 @@ def test_a_retained_dir_a_create_is_using_is_not_reclaimed_for_its_parent(pools,
     parent = _entry(pools["runtime"], "parent", size=4096)
     adopted = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
     mark_reclaimable(VM_HASH, "gone", ("parent",), now=NOW)
-    monkeypatch.setattr(reconciler_module, "_creating", {VM_HASH})
+    monkeypatch.setattr(reconciler_module, "_creating", {VM_HASH: 1})
 
     assert evict_caches(registry) == []
     assert parent.exists() and adopted.exists()

--- a/tests/supervisor/test_devmapper_teardown.py
+++ b/tests/supervisor/test_devmapper_teardown.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 from fnmatch import fnmatch
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
 
 import aleph.vm.storage as storage_module
-from aleph.vm.agent.vm.retire import teardown_namespace_devices
+from aleph.vm.agent.vm.retire import teardown_namespace_devices, teardown_vm_devices
 from aleph.vm.storage import (
     DEVICE_MAPPER_DIRECTORY,
     detach_loop_devices,
@@ -298,3 +299,38 @@ async def test_a_failing_snapshot_removal_does_not_stop_the_others(pools, live_m
     await teardown_namespace_devices(VM_HASH)
 
     assert calls == ["data", "rootfs"]
+
+
+@pytest.mark.asyncio
+async def test_teardown_namespace_devices_removes_a_lone_base(pools, live_mapper):  # noqa: F811
+    """create_devmapper builds the base before the snapshot on top of it, so a
+    create that died between the two leaves a base holding the parent image,
+    and with it the runtime cache entry, for good."""
+    live_mapper["present"].add(f"{VM_HASH}_base")
+
+    await teardown_namespace_devices(VM_HASH)
+
+    assert live_mapper["commands"] == [["dmsetup", "remove", "--retry", f"{VM_HASH}_base"]]
+    assert live_mapper["present"] == set()
+
+
+@pytest.mark.asyncio
+async def test_a_base_is_kept_while_a_snapshot_of_its_vm_survives(pools, live_mapper, mocker):  # noqa: F811
+    """A snapshot whose removal failed still needs its base."""
+    live_mapper["present"].update({f"{VM_HASH}_data", f"{VM_HASH}_base"})
+    mocker.patch("aleph.vm.agent.vm.retire.remove_devmapper", side_effect=AsyncMock())
+
+    await teardown_namespace_devices(VM_HASH)
+
+    assert live_mapper["present"] == {f"{VM_HASH}_data", f"{VM_HASH}_base"}
+
+
+@pytest.mark.asyncio
+async def test_teardown_vm_devices_without_a_record_never_raises(live_mapper, caplog):
+    """The record-less branch runs from retire_vm, which must still drop the
+    records and the storage when the teardown cannot even start."""
+    with caplog.at_level("ERROR"):
+        await teardown_vm_devices("../../etc", None)
+
+    assert live_mapper["commands"] == []
+    assert "Device teardown" in caplog.text

--- a/tests/supervisor/test_devmapper_teardown.py
+++ b/tests/supervisor/test_devmapper_teardown.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+from fnmatch import fnmatch
 from pathlib import Path
 
 import pytest
-from reclaim_fixtures import VM_HASH, pools, volume  # noqa: F401
+from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
 
 import aleph.vm.storage as storage_module
-from aleph.vm.storage import detach_loop_devices, remove_devmapper
+from aleph.vm.agent.vm.retire import teardown_namespace_devices
+from aleph.vm.storage import (
+    DEVICE_MAPPER_DIRECTORY,
+    detach_loop_devices,
+    remove_devmapper,
+)
 
 real_glob = Path.glob
 
@@ -202,3 +208,93 @@ async def test_remove_devmapper_does_not_unmount_what_is_not_mounted(pools, comm
     await remove_devmapper(VM_HASH, "data")
 
     assert not any(c[0] == "umount" for c in commands)
+
+
+@pytest.fixture
+def live_mapper(mocker, monkeypatch):
+    """A /dev/mapper whose contents `dmsetup remove` actually changes.
+
+    The teardown decides what to remove from what is there and
+    ``remove_devmapper`` decides whether the base device may go from what is
+    left, so a static listing would not exercise either.
+    """
+    present: set[str] = set()
+    commands: list[list[str]] = []
+    mapper = Path(DEVICE_MAPPER_DIRECTORY)
+
+    async def fake_run(command, check=True, stdin_input=None):
+        command = [str(argument) for argument in command]
+        commands.append(command)
+        if command[:3] == ["dmsetup", "remove", "--retry"]:
+            present.discard(command[3])
+        return b""
+
+    real_is_block_device = Path.is_block_device
+    monkeypatch.setattr(storage_module, "run_in_subprocess", fake_run)
+    monkeypatch.setattr(
+        Path,
+        "is_block_device",
+        lambda self: self.name in present if self.parent == mapper else real_is_block_device(self),
+    )
+    monkeypatch.setattr(
+        Path,
+        "glob",
+        lambda self, pattern: (
+            iter([mapper / name for name in sorted(present) if fnmatch(name, pattern)])
+            if self == mapper
+            else real_glob(self, pattern)
+        ),
+    )
+    return {"present": present, "commands": commands}
+
+
+@pytest.mark.asyncio
+async def test_teardown_namespace_devices_removes_every_snapshot_then_the_base(pools, live_mapper):  # noqa: F811
+    """The record-less inverse: a create that failed before its registry
+    commit leaves these behind and no message names the volumes any more."""
+    volume(pools["pool0"], VM_HASH, "rootfs.btrfs")
+    volume(pools["pool0"], VM_HASH, "data.btrfs")
+    live_mapper["present"].update({f"{VM_HASH}_rootfs", f"{VM_HASH}_data", f"{VM_HASH}_base"})
+
+    await teardown_namespace_devices(VM_HASH)
+
+    removed = [command[3] for command in live_mapper["commands"] if command[:2] == ["dmsetup", "remove"]]
+    assert removed == [f"{VM_HASH}_data", f"{VM_HASH}_rootfs", f"{VM_HASH}_base"]
+    assert live_mapper["present"] == set()
+
+
+@pytest.mark.asyncio
+async def test_teardown_namespace_devices_never_touches_another_vm(pools, live_mapper):  # noqa: F811
+    live_mapper["present"].update({f"{VM_HASH}_rootfs", f"{OTHER_HASH}_rootfs", f"{OTHER_HASH}_base"})
+
+    await teardown_namespace_devices(VM_HASH)
+
+    assert live_mapper["present"] == {f"{OTHER_HASH}_rootfs", f"{OTHER_HASH}_base"}
+
+
+@pytest.mark.asyncio
+async def test_teardown_namespace_devices_refuses_an_implausible_namespace(live_mapper):
+    with pytest.raises(ValueError):
+        await teardown_namespace_devices("../../etc")
+
+    assert live_mapper["commands"] == []
+
+
+@pytest.mark.asyncio
+async def test_a_failing_snapshot_removal_does_not_stop_the_others(pools, live_mapper, mocker):  # noqa: F811
+    """Best effort, one volume at a time: a dm target that refuses to go must
+    not strand the volumes that would have."""
+    live_mapper["present"].update({f"{VM_HASH}_data", f"{VM_HASH}_rootfs"})
+    calls: list[str] = []
+
+    async def refuse_one(namespace, volume_name):
+        calls.append(volume_name)
+        if volume_name == "data":
+            msg = "device busy"
+            raise RuntimeError(msg)
+
+    mocker.patch("aleph.vm.agent.vm.retire.remove_devmapper", side_effect=refuse_one)
+
+    await teardown_namespace_devices(VM_HASH)
+
+    assert calls == ["data", "rootfs"]

--- a/tests/supervisor/test_pr2_neutral_modules.py
+++ b/tests/supervisor/test_pr2_neutral_modules.py
@@ -120,6 +120,8 @@ def test_get_backup_directory_explicit(monkeypatch, tmp_path):
 
 @pytest.mark.asyncio
 async def test_download_volume_by_ref(monkeypatch, tmp_path):
+    from aleph.vm.conf import settings
+
     monkeypatch.setattr(
         "aleph.vm.storage._get_content_url",
         AsyncMock(return_value="http://example/volume"),
@@ -130,7 +132,7 @@ async def test_download_volume_by_ref(monkeypatch, tmp_path):
     dest = await backup_staging.download_volume_by_ref("abc123", tmp_path)
 
     assert dest == tmp_path / "abc123.qcow2"
-    download_file.assert_awaited_once_with("http://example/volume", dest)
+    download_file.assert_awaited_once_with("http://example/volume", dest, max_bytes=settings.MAX_RUNTIME_ARCHIVE_SIZE)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/supervisor/test_reclaimable.py
+++ b/tests/supervisor/test_reclaimable.py
@@ -5,7 +5,11 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
-from aleph_message.models import InstanceContent, ProgramContent
+from aleph_message.models import (
+    InstanceContent,
+    ProgramContent,
+    VerifiableProgramContent,
+)
 from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
 
 from aleph.vm.agent.vm.reclaimable import (
@@ -19,6 +23,7 @@ from aleph.vm.agent.vm.reclaimable import (
     mark_reclaimable,
     read_marker,
     reclaimable_bytes,
+    refs_from_content,
     write_marker,
 )
 from aleph.vm.storage import get_message
@@ -342,3 +347,41 @@ def test_the_cache_is_invalidated_after_the_publish_too(pools, monkeypatch):  # 
 
     assert seen_mid_write == [0]
     assert reclaimable_bytes() == 4096
+
+
+def test_refs_from_content_covers_a_vprogram_workload(mocker):
+    """A V-PROGRAM's workload image and hash tree are attached as the VM's
+    disks straight from DATA_CACHE, so they are refs like any other."""
+    content = mocker.MagicMock(spec=VerifiableProgramContent)
+    content.runtime = mocker.MagicMock(ref="manifest")
+    content.volumes = []
+    content.workload = mocker.MagicMock(ref="workload", hash_tree="hashtree")
+    content.environment = mocker.MagicMock(trusted_execution=None)
+
+    assert refs_from_content(content, vm_hash="vmhash") == {"manifest", "workload", "hashtree", "vmhash"}
+
+
+def test_refs_from_content_covers_trusted_execution(mocker):
+    content = mocker.MagicMock(spec=InstanceContent)
+    content.rootfs = mocker.MagicMock()
+    content.rootfs.parent = mocker.MagicMock(ref="base")
+    content.volumes = []
+    content.environment = mocker.MagicMock()
+    content.environment.trusted_execution = mocker.MagicMock(firmware="firmware", runtime="tee-runtime")
+
+    assert refs_from_content(content) == {"base", "firmware", "tee-runtime"}
+
+
+def test_depends_on_is_the_parent_subset_of_the_same_enumeration(mocker):
+    """One traversal, two questions: the marker pins the parent images its
+    volumes are built on, not everything the message names."""
+    content = mocker.MagicMock(spec=VerifiableProgramContent)
+    content.runtime = mocker.MagicMock(ref="manifest")
+    parent_backed = mocker.MagicMock(ref=None)
+    parent_backed.parent = mocker.MagicMock(ref="parent")
+    content.volumes = [parent_backed]
+    content.workload = mocker.MagicMock(ref="workload", hash_tree="hashtree")
+    content.environment = mocker.MagicMock(trusted_execution=None)
+
+    assert depends_on_from_content(content) == ("parent",)
+    assert set(depends_on_from_content(content)) <= refs_from_content(content)

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -12,6 +12,7 @@ import pytest
 from aleph_message.models import ItemHash
 from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
 
+import aleph.vm.agent.vm.cache as cache_module
 import aleph.vm.agent.vm.reconciler as reconciler_module
 from aleph.vm.agent.vm.reclaimable import mark_reclaimable, read_marker
 from aleph.vm.agent.vm.reconciler import (
@@ -69,6 +70,12 @@ def _supervisor(*vm_ids: str, fails: bool = False):
 
 def _app(registry, supervisor=None):
     return {"vm_registry": registry, "supervisor": supervisor if supervisor is not None else _supervisor()}
+
+
+@pytest.fixture(autouse=True)
+def _no_live_snapshot(monkeypatch):
+    """The live-set snapshot the admission hook reads is module state."""
+    monkeypatch.setattr(cache_module, "_live_snapshot", None)
 
 
 @pytest.fixture(autouse=True)
@@ -760,7 +767,7 @@ def test_the_cache_pass_is_skipped_when_a_live_vm_has_no_record(pools, registry,
 
     assert report.cache_evicted == []
     assert stale.exists()
-    assert "cache pass" in caplog.text
+    assert any(record.levelname == "ERROR" and "cache pass" in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -774,3 +781,54 @@ async def test_reconcile_now_removes_the_devices_of_evicted_parents(pools, regis
 
     assert [path.name for path in report.cache_evicted] == ["stale"]
     assert removed == ["stale"]
+
+
+def test_old_tmp_files_are_removed_alongside_the_parts(pools, registry):  # noqa: F811
+    """get_message writes <ref>.json.tmp before renaming, create_ext4 and the
+    marker writer do the same: an interrupted one leaks exactly like a .part."""
+    old_tmp = pools["message"] / "abc.json.tmp"
+    old_tmp.write_bytes(b"x")
+    _age(old_tmp, 10_000)
+    young_tmp = pools["code"] / "def.tmp"
+    young_tmp.write_bytes(b"x")
+    _age(young_tmp, 10)
+
+    report = reconcile_storage(registry, now=NOW)
+
+    assert not old_tmp.exists()
+    assert young_tmp.exists()
+    assert report.parts_removed == 1
+
+
+@pytest.mark.asyncio
+async def test_the_pass_records_the_live_set_for_the_admission_hook(pools, registry):  # noqa: F811
+    await reconcile_now(_app(registry, _supervisor(VM_HASH)))
+
+    assert cache_module.live_snapshot() == frozenset({LIVE, VM_HASH})
+
+
+@pytest.mark.asyncio
+async def test_a_half_known_live_set_is_never_published(pools, registry):  # noqa: F811
+    """Admission evicts against this set; a set missing whatever the
+    supervisor would have listed is not one it may use."""
+    await reconcile_now(_app(registry, _supervisor(fails=True)))
+
+    assert cache_module.live_snapshot() is None
+
+
+@pytest.mark.asyncio
+async def test_a_dry_run_never_touches_a_device(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    stale = pools["runtime"] / "stale"
+    stale.write_bytes(b"x" * 4096)
+    removed: list[str] = []
+    monkeypatch.setattr(reconciler_module, "remove_parent_device", AsyncMock(side_effect=removed.append))
+    swept = AsyncMock(return_value=[])
+    monkeypatch.setattr(reconciler_module, "sweep_leaked_cache_loops", swept)
+
+    report = await reconcile_now(_app(registry), dry_run=True)
+
+    assert [path.name for path in report.cache_evicted] == ["stale"]
+    assert stale.exists()
+    assert removed == []
+    swept.assert_not_awaited()

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -771,6 +771,37 @@ def test_the_cache_pass_is_skipped_when_a_live_vm_has_no_record(pools, registry,
 
 
 @pytest.mark.asyncio
+async def test_the_cache_pass_is_skipped_when_the_supervisor_cannot_be_listed(pools, registry, monkeypatch, caplog):  # noqa: F811
+    """No answer from list_vms leaves the live set as the registry alone, and
+    the cache pass reads what is referenced from the registry's messages: a VM
+    the registry does not know would then look like nothing at all, and its
+    runtime would be evicted under it. Same doubt, same refusal as the startup
+    pass and the admission hook."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    stale = pools["runtime"] / "stale"
+    stale.write_bytes(b"x" * 4096)
+
+    report = await reconcile_now(_app(registry, _supervisor(fails=True)))
+
+    assert report.cache_evicted == []
+    assert stale.exists()
+    assert any(record.levelname == "ERROR" and "unbounded" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_the_rest_of_the_pass_still_runs_without_the_supervisor(pools, registry, monkeypatch):  # noqa: F811
+    """Only the cache pass depends on the messages of every live VM; the
+    namespace pass has the registry's own answer plus the create guard."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    old = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    _age(old.parent, 10_000)
+
+    report = await reconcile_now(_app(registry, _supervisor(fails=True)))
+
+    assert report.purged_orphans == [VM_HASH]
+
+
+@pytest.mark.asyncio
 async def test_reconcile_now_removes_the_devices_of_evicted_parents(pools, registry, monkeypatch):  # noqa: F811
     monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
     (pools["runtime"] / "stale").write_bytes(b"x" * 4096)

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -955,7 +955,7 @@ def test_make_room_never_evicts_a_directory_a_create_is_using(pools, monkeypatch
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
     retained = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
     mark_reclaimable(VM_HASH, "gone", now=NOW - timedelta(days=2))
-    monkeypatch.setattr(reconciler_module, "_creating", {VM_HASH})
+    monkeypatch.setattr(reconciler_module, "_creating", {VM_HASH: 1})
     _fake_disk_usage(monkeypatch, 0)
 
     freed = make_room(get_pools()[0], needed_bytes=8192)

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -89,6 +89,14 @@ def _mount_root(tmp_path, monkeypatch):
     monkeypatch.setattr(reconciler_module, "MOUNT_ROOT", tmp_path / "unused-mnt")
 
 
+@pytest.fixture(autouse=True)
+def _no_device_mapper(tmp_path, monkeypatch):
+    """Nor its real /dev/mapper: the orphan device pass reads it."""
+    empty = tmp_path / "empty-mapper"
+    empty.mkdir()
+    monkeypatch.setattr(reconciler_module, "DEVICE_MAPPER_DIRECTORY", str(empty))
+
+
 def test_live_dirs_are_left_alone(pools, registry):  # noqa: F811
     live = volume(pools["pool0"], LIVE, "rootfs.qcow2")
     _age(live.parent, 10_000)
@@ -863,3 +871,81 @@ async def test_a_dry_run_never_touches_a_device(pools, registry, monkeypatch):  
     assert stale.exists()
     assert removed == []
     swept.assert_not_awaited()
+
+
+def _fake_mapper(monkeypatch, tmp_path, *names: str) -> Path:
+    """A /dev/mapper holding ``names``, for the pass to read."""
+    mapper = tmp_path / "mapper"
+    mapper.mkdir(exist_ok=True)
+    for name in names:
+        (mapper / name).touch()
+    monkeypatch.setattr(reconciler_module, "DEVICE_MAPPER_DIRECTORY", str(mapper))
+    return mapper
+
+
+@pytest.mark.asyncio
+async def test_the_pass_tears_down_the_devices_of_a_vm_nothing_owns(pools, registry, monkeypatch, tmp_path):  # noqa: F811
+    """A create that failed before its registry commit leaves a dm snapshot
+    holding the volume file. purge_vm_storage refuses such a directory, so
+    without a teardown the orphan is refused on every pass, forever."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    _age(volume(pools["pool0"], VM_HASH, "rootfs.btrfs").parent, 10_000)
+    _fake_mapper(monkeypatch, tmp_path, f"{VM_HASH}_rootfs", f"{LIVE}_rootfs", "control", "lost+found_1")
+    torn: list[str] = []
+    monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
+
+    await reconcile_now(_app(registry, _supervisor()))
+
+    assert torn == [VM_HASH]
+
+
+@pytest.mark.asyncio
+async def test_a_create_in_flight_keeps_its_devices(pools, registry, monkeypatch, tmp_path):  # noqa: F811
+    _fake_mapper(monkeypatch, tmp_path, f"{VM_HASH}_rootfs")
+    torn: list[str] = []
+    monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
+
+    with creating(VM_HASH):
+        await reconcile_now(_app(registry, _supervisor()))
+
+    assert torn == []
+
+
+@pytest.mark.asyncio
+async def test_no_device_is_torn_down_when_the_supervisor_cannot_be_listed(pools, registry, monkeypatch, tmp_path):  # noqa: F811
+    """A VM the supervisor would have listed is live; removing its dm device
+    takes its disk with it."""
+    _fake_mapper(monkeypatch, tmp_path, f"{VM_HASH}_rootfs")
+    torn: list[str] = []
+    monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
+
+    await reconcile_now(_app(registry, _supervisor(fails=True)))
+    await reconcile_at_startup(_app(registry, _supervisor(fails=True)))
+
+    assert torn == []
+
+
+@pytest.mark.asyncio
+async def test_a_dry_run_tears_down_no_device(pools, registry, monkeypatch, tmp_path):  # noqa: F811
+    _fake_mapper(monkeypatch, tmp_path, f"{VM_HASH}_rootfs")
+    torn: list[str] = []
+    monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
+
+    await reconcile_now(_app(registry, _supervisor()), dry_run=True)
+
+    assert torn == []
+
+
+@pytest.mark.asyncio
+async def test_a_failing_device_teardown_does_not_stop_the_pass(pools, registry, monkeypatch, tmp_path):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    old = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2")
+    _age(old.parent, 10_000)
+    _fake_mapper(monkeypatch, tmp_path, f"{VM_HASH}_rootfs")
+    monkeypatch.setattr(
+        reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=RuntimeError("device busy"))
+    )
+
+    report = await reconcile_now(_app(registry, _supervisor()))
+
+    assert report.purged_orphans == [OTHER_HASH]

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -951,21 +951,6 @@ async def test_a_failing_device_teardown_does_not_stop_the_pass(pools, registry,
     assert report.purged_orphans == [OTHER_HASH]
 
 
-def test_evict_never_touches_a_directory_a_create_is_using(pools, caplog):  # noqa: F811
-    """A re-create adopts a retained directory and clears its marker, but a
-    pass that listed the markers first still carries it, and the VM has no
-    registry record yet for the live check to find."""
-    retained = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
-    report = reconciler_module.ReconcileReport()
-
-    with creating(VM_HASH):
-        freed = reconciler_module._evict(VM_HASH, report, dry_run=False)
-
-    assert freed == 0
-    assert retained.exists()
-    assert report.evicted == []
-
-
 def test_make_room_never_evicts_a_directory_a_create_is_using(pools, monkeypatch):  # noqa: F811
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
     retained = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -949,3 +949,31 @@ async def test_a_failing_device_teardown_does_not_stop_the_pass(pools, registry,
     report = await reconcile_now(_app(registry, _supervisor()))
 
     assert report.purged_orphans == [OTHER_HASH]
+
+
+def test_evict_never_touches_a_directory_a_create_is_using(pools, caplog):  # noqa: F811
+    """A re-create adopts a retained directory and clears its marker, but a
+    pass that listed the markers first still carries it, and the VM has no
+    registry record yet for the live check to find."""
+    retained = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
+    report = reconciler_module.ReconcileReport()
+
+    with creating(VM_HASH):
+        freed = reconciler_module._evict(VM_HASH, report, dry_run=False)
+
+    assert freed == 0
+    assert retained.exists()
+    assert report.evicted == []
+
+
+def test_make_room_never_evicts_a_directory_a_create_is_using(pools, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    retained = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
+    mark_reclaimable(VM_HASH, "gone", now=NOW - timedelta(days=2))
+    monkeypatch.setattr(reconciler_module, "_creating", {VM_HASH})
+    _fake_disk_usage(monkeypatch, 0)
+
+    freed = make_room(get_pools()[0], needed_bytes=8192)
+
+    assert freed == 0
+    assert retained.exists()

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -735,3 +735,42 @@ async def test_a_failing_startup_pass_does_not_stop_the_boot(pools, registry, mo
     await reconcile_at_startup(_app(registry))
 
     assert "Startup storage reconcile failed" in caplog.text
+
+
+def test_reconcile_runs_the_cache_pass(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    stale = pools["runtime"] / "stale"
+    stale.write_bytes(b"x" * 4096)
+
+    report = reconcile_storage(registry, now=NOW)
+
+    assert report.cache_evicted == [stale]
+    assert not stale.exists()
+
+
+def test_the_cache_pass_is_skipped_when_a_live_vm_has_no_record(pools, registry, monkeypatch, caplog):  # noqa: F811
+    """Cache references are read from the registry's messages alone, so a VM
+    the supervisor runs but the registry does not know makes the referenced
+    set incomplete. Fail closed rather than evict a running VM's runtime."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    stale = pools["runtime"] / "stale"
+    stale.write_bytes(b"x" * 4096)
+
+    report = reconcile_storage(registry, now=NOW, live={LIVE, VM_HASH})
+
+    assert report.cache_evicted == []
+    assert stale.exists()
+    assert "cache pass" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_reconcile_now_removes_the_devices_of_evicted_parents(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    (pools["runtime"] / "stale").write_bytes(b"x" * 4096)
+    removed: list[str] = []
+    monkeypatch.setattr(reconciler_module, "remove_parent_device", AsyncMock(side_effect=removed.append))
+
+    report = await reconcile_now(_app(registry))
+
+    assert [path.name for path in report.cache_evicted] == ["stale"]
+    assert removed == ["stale"]

--- a/tests/supervisor/test_retire.py
+++ b/tests/supervisor/test_retire.py
@@ -326,3 +326,30 @@ async def test_device_teardown_of_an_implausible_hash_is_skipped_not_raised(mock
 
     remove.assert_not_awaited()
     assert "skipped" in caplog.text
+
+
+async def test_a_retire_without_a_record_asks_device_mapper_instead(env, monkeypatch, mocker):
+    """FAILED_CREATE fires before the registry commit and a GONE can name a VM
+    the registry never knew: there is no message to read the volumes from, and
+    a dm target left standing makes purge_vm_storage refuse the directory for
+    good."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    fallback = mocker.patch.object(retire_module, "teardown_namespace_devices", new_callable=AsyncMock)
+    env["registry"].forget(ItemHash(VM_HASH))
+
+    await retire_vm(VM_HASH, RetireReason.FAILED_CREATE, supervisor=env["supervisor"], registry=env["registry"])
+
+    fallback.assert_awaited_once_with(VM_HASH)
+
+
+@pytest.mark.asyncio
+async def test_a_retire_with_a_record_reads_the_volumes_from_the_message(env, monkeypatch, mocker):
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    fallback = mocker.patch.object(retire_module, "teardown_namespace_devices", new_callable=AsyncMock)
+    remove = mocker.patch.object(retire_module, "remove_devmapper", new_callable=AsyncMock)
+    _parent_backed_volumes(env["registry"].get(ItemHash(VM_HASH)))
+
+    await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
+
+    fallback.assert_not_awaited()
+    remove.assert_awaited_once_with(VM_HASH, "data")

--- a/tests/supervisor/test_storage.py
+++ b/tests/supervisor/test_storage.py
@@ -178,7 +178,7 @@ async def test_download_file_retries_on_timeout(tmp_path):
     local_path = tmp_path / "runtime"
     calls = {"n": 0}
 
-    async def _flaky(_url, _target_path):
+    async def _flaky(_url, _target_path, max_bytes=None):
         calls["n"] += 1
         if calls["n"] < 3:
             raise TimeoutError
@@ -196,7 +196,7 @@ async def test_download_file_aborts_after_exhausting_retries_on_timeout(tmp_path
     """If every attempt times out, the error propagates after the retries are exhausted."""
     local_path = tmp_path / "runtime"
 
-    async def _always_timeout(_url, _target_path):
+    async def _always_timeout(_url, _target_path, max_bytes=None):
         raise TimeoutError
 
     with patch("aleph.vm.storage.download_file_in_chunks", side_effect=_always_timeout):

--- a/tests/supervisor/test_storage_download_cap.py
+++ b/tests/supervisor/test_storage_download_cap.py
@@ -188,25 +188,25 @@ async def test_cache_admission_hook_runs_before_writing(tmp_path):
     import aleph.vm.storage as storage_module
 
     seen = []
-    storage_module.set_cache_admission(lambda root, size: seen.append((root, size)))
+    storage_module.set_cache_admission(lambda path, length, cap: seen.append((path, length, cap)))
     session, _ = _session([b"x" * 4], content_length=4)
     try:
         with patch("aleph.vm.storage.aiohttp.ClientSession", return_value=session):
             await download_file_in_chunks("http://x/f", tmp_path / "f.part")
     finally:
         storage_module.set_cache_admission(None)
-    assert seen == [(tmp_path / "f.part", 4)]
+    assert seen == [(tmp_path / "f.part", 4, None)]
 
 
 @pytest.mark.asyncio
-async def test_a_download_without_a_content_length_is_admitted_against_its_cap(tmp_path):
-    """A server that does not say how big the body is gets admitted for the
-    worst case it is allowed to send: the alternative is a download that
-    writes an unbounded number of bytes into a budget nobody charged."""
+async def test_a_download_without_a_content_length_reports_its_cap_as_a_cap(tmp_path):
+    """The hook is told what the server said and what bounds it, separately.
+    Collapsing the two here is what made a chunked response ask the cache for
+    the whole MAX_RUNTIME_ARCHIVE_SIZE."""
     import aleph.vm.storage as storage_module
 
     seen = []
-    storage_module.set_cache_admission(lambda path, size: seen.append((path, size)))
+    storage_module.set_cache_admission(lambda path, length, cap: seen.append((path, length, cap)))
     session, _ = _session([b"x" * 4], content_length=None)
     try:
         with patch("aleph.vm.storage.aiohttp.ClientSession", return_value=session):
@@ -214,7 +214,7 @@ async def test_a_download_without_a_content_length_is_admitted_against_its_cap(t
     finally:
         storage_module.set_cache_admission(None)
         storage_module.release_download(tmp_path / "f.part")
-    assert seen == [(tmp_path / "f.part", 999)]
+    assert seen == [(tmp_path / "f.part", None, 999)]
 
 
 @pytest.mark.asyncio
@@ -242,7 +242,7 @@ async def test_a_refusing_cache_admission_writes_nothing(tmp_path):
     import aleph.vm.storage as storage_module
     from aleph.vm.resources import InsufficientResourcesError
 
-    def refuse(root, size):
+    def refuse(path, length, cap):
         raise InsufficientResourcesError("no room", required={}, available={})
 
     storage_module.set_cache_admission(refuse)

--- a/tests/supervisor/test_storage_download_cap.py
+++ b/tests/supervisor/test_storage_download_cap.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import os
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aleph.vm.storage import download_file, download_file_in_chunks
+from aleph.vm.supervisor_interface.errors import FileTooLargeError
+
+
+def _session(chunks: list[bytes], content_length: int | None):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.content_length = content_length
+    reads = iter(chunks + [b""])
+    resp.content.read = AsyncMock(side_effect=lambda n: next(reads))
+    session = MagicMock()
+    session.get = AsyncMock(return_value=resp)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session, resp
+
+
+@pytest.mark.asyncio
+async def test_content_length_above_the_cap_is_refused_before_writing(tmp_path):
+    session, resp = _session([b"x" * 10], content_length=10)
+    with patch("aleph.vm.storage.aiohttp.ClientSession", return_value=session):
+        with pytest.raises(FileTooLargeError):
+            await download_file_in_chunks("http://x/f", tmp_path / "f.part", max_bytes=5)
+    resp.content.read.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stream_past_the_cap_is_aborted(tmp_path):
+    session, _ = _session([b"x" * 4, b"x" * 4], content_length=None)
+    part = tmp_path / "f.part"
+    with patch("aleph.vm.storage.aiohttp.ClientSession", return_value=session):
+        with pytest.raises(FileTooLargeError):
+            await download_file_in_chunks("http://x/f", part, max_bytes=5)
+
+
+@pytest.mark.asyncio
+async def test_download_file_unlinks_the_part_and_does_not_retry(tmp_path):
+    attempts = []
+
+    async def too_large(url, tmp_path_, max_bytes=None):
+        attempts.append(1)
+        tmp_path_.write_bytes(b"partial")
+        raise FileTooLargeError("too big")
+
+    with patch("aleph.vm.storage.download_file_in_chunks", side_effect=too_large):
+        with pytest.raises(FileTooLargeError):
+            await download_file("http://x/f", tmp_path / "f", max_bytes=5)
+    assert attempts == [1]
+    assert not (tmp_path / "f.part").exists()
+    assert not (tmp_path / "f").exists()
+
+
+@pytest.mark.asyncio
+async def test_existing_file_is_touched_on_hit(tmp_path):
+    target = tmp_path / "f"
+    target.write_bytes(b"cached")
+    old = time.time() - 100_000
+    os.utime(target, (old, old))
+
+    await download_file("http://x/f", target)
+
+    assert target.stat().st_mtime > old + 50_000
+
+
+@pytest.mark.asyncio
+async def test_getters_pass_their_caps(mocker, tmp_path):
+    import aleph.vm.storage as storage_module
+    from aleph.vm.conf import settings
+
+    mocker.patch.object(settings, "CODE_CACHE", tmp_path / "code")
+    mocker.patch.object(settings, "DATA_CACHE", tmp_path / "data")
+    mocker.patch.object(settings, "RUNTIME_CACHE", tmp_path / "runtime")
+    mocker.patch.object(settings, "FAKE_DATA_PROGRAM", None)
+    mocker.patch.object(storage_module, "_get_content_url", AsyncMock(return_value="http://x/f"))
+    mocker.patch.object(storage_module, "check_squashfs_integrity", AsyncMock())
+    mocker.patch.object(storage_module, "chown_to_jailman", AsyncMock())
+    download = mocker.patch.object(storage_module, "download_file", AsyncMock())
+
+    await storage_module.get_code_path("ref")
+    await storage_module.get_data_path("ref")
+    await storage_module.get_runtime_path("ref")
+    await storage_module.get_rootfs_base_path("ref")
+
+    caps = [call.kwargs["max_bytes"] for call in download.await_args_list]
+    assert caps == [
+        settings.MAX_PROGRAM_ARCHIVE_SIZE,
+        settings.MAX_DATA_ARCHIVE_SIZE,
+        settings.MAX_RUNTIME_ARCHIVE_SIZE,
+        settings.MAX_RUNTIME_ARCHIVE_SIZE,
+    ]

--- a/tests/supervisor/test_storage_download_cap.py
+++ b/tests/supervisor/test_storage_download_cap.py
@@ -86,7 +86,11 @@ async def test_existing_file_touch_failure_does_not_fail_the_cache_hit(tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_get_existing_file_passes_the_data_cap(mocker, tmp_path):
+async def test_get_existing_file_passes_the_runtime_cap(mocker, tmp_path):
+    """MAX_DATA_ARCHIVE_SIZE only ever gated a program's `data` archive.
+    get_existing_file serves immutable volumes, the SNP and V-PROGRAM runtime
+    bundles and a V-PROGRAM's workload image, none of which was ever bounded
+    by 10 MB and all of which are routinely larger."""
     import aleph.vm.storage as storage_module
     from aleph.vm.conf import settings
 
@@ -98,7 +102,57 @@ async def test_get_existing_file_passes_the_data_cap(mocker, tmp_path):
 
     await storage_module.get_existing_file("ref")
 
-    download.assert_awaited_once_with("http://x/f", tmp_path / "data" / "ref", max_bytes=settings.MAX_DATA_ARCHIVE_SIZE)
+    download.assert_awaited_once_with(
+        "http://x/f", tmp_path / "data" / "ref", max_bytes=settings.MAX_RUNTIME_ARCHIVE_SIZE
+    )
+
+
+def _existing_file_env(mocker, tmp_path):
+    import aleph.vm.storage as storage_module
+    from aleph.vm.conf import settings
+
+    cache = tmp_path / "data"
+    cache.mkdir()
+    mocker.patch.object(settings, "DATA_CACHE", cache)
+    mocker.patch.object(settings, "FAKE_DATA_PROGRAM", None)
+    mocker.patch.object(storage_module, "_get_content_url", AsyncMock(return_value="http://x/f"))
+    mocker.patch.object(storage_module, "chown_to_jailman", AsyncMock())
+    return cache
+
+
+@pytest.mark.asyncio
+async def test_get_existing_file_streams_a_volume_larger_than_the_data_cap(mocker, tmp_path):
+    """End to end through download_file's retry and cleanup wrapper: a 12 MB
+    immutable volume used to be refused with a 400 by the 10 MB data cap."""
+    import aleph.vm.storage as storage_module
+
+    cache = _existing_file_env(mocker, tmp_path)
+    megabyte = b"x" * (1024 * 1024)
+    session, _ = _session([megabyte] * 12, content_length=12 * 1024 * 1024)
+
+    with patch("aleph.vm.storage.aiohttp.ClientSession", return_value=session):
+        path = await storage_module.get_existing_file("ref")
+
+    assert path == cache / "ref"
+    assert path.stat().st_size == 12 * 1024 * 1024
+    assert not (cache / "ref.part").exists()
+
+
+@pytest.mark.asyncio
+async def test_get_existing_file_above_the_runtime_cap_leaves_no_part(mocker, tmp_path):
+    import aleph.vm.storage as storage_module
+    from aleph.vm.conf import settings
+
+    cache = _existing_file_env(mocker, tmp_path)
+    session, resp = _session([b"x"], content_length=settings.MAX_RUNTIME_ARCHIVE_SIZE + 1)
+
+    with patch("aleph.vm.storage.aiohttp.ClientSession", return_value=session):
+        with pytest.raises(FileTooLargeError):
+            await storage_module.get_existing_file("ref")
+
+    resp.content.read.assert_not_called()
+    assert not (cache / "ref.part").exists()
+    assert not (cache / "ref").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_storage_download_cap.py
+++ b/tests/supervisor/test_storage_download_cap.py
@@ -71,6 +71,37 @@ async def test_existing_file_is_touched_on_hit(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_existing_file_touch_failure_does_not_fail_the_cache_hit(tmp_path):
+    """A cache hit served by a non-owning, non-jailman user can't utime the
+    cached file (chown_to_jailman ran after the original download); that must
+    not turn a perfectly usable cache hit into a failure."""
+    target = tmp_path / "f"
+    target.write_bytes(b"cached")
+
+    with patch("aleph.vm.storage.os.utime", side_effect=PermissionError("no permission")):
+        await download_file("http://x/f", target)
+
+    assert target.is_file()
+    assert target.read_bytes() == b"cached"
+
+
+@pytest.mark.asyncio
+async def test_get_existing_file_passes_the_data_cap(mocker, tmp_path):
+    import aleph.vm.storage as storage_module
+    from aleph.vm.conf import settings
+
+    mocker.patch.object(settings, "DATA_CACHE", tmp_path / "data")
+    mocker.patch.object(settings, "FAKE_DATA_PROGRAM", None)
+    mocker.patch.object(storage_module, "_get_content_url", AsyncMock(return_value="http://x/f"))
+    mocker.patch.object(storage_module, "chown_to_jailman", AsyncMock())
+    download = mocker.patch.object(storage_module, "download_file", AsyncMock())
+
+    await storage_module.get_existing_file("ref")
+
+    download.assert_awaited_once_with("http://x/f", tmp_path / "data" / "ref", max_bytes=settings.MAX_DATA_ARCHIVE_SIZE)
+
+
+@pytest.mark.asyncio
 async def test_getters_pass_their_caps(mocker, tmp_path):
     import aleph.vm.storage as storage_module
     from aleph.vm.conf import settings

--- a/tests/supervisor/test_storage_download_cap.py
+++ b/tests/supervisor/test_storage_download_cap.py
@@ -127,3 +127,55 @@ async def test_getters_pass_their_caps(mocker, tmp_path):
         settings.MAX_RUNTIME_ARCHIVE_SIZE,
         settings.MAX_RUNTIME_ARCHIVE_SIZE,
     ]
+
+
+@pytest.mark.asyncio
+async def test_cache_admission_hook_runs_before_writing(tmp_path):
+    import aleph.vm.storage as storage_module
+
+    seen = []
+    storage_module.set_cache_admission(lambda root, size: seen.append((root, size)))
+    session, _ = _session([b"x" * 4], content_length=4)
+    try:
+        with patch("aleph.vm.storage.aiohttp.ClientSession", return_value=session):
+            await download_file_in_chunks("http://x/f", tmp_path / "f.part")
+    finally:
+        storage_module.set_cache_admission(None)
+    assert seen == [(tmp_path, 4)]
+
+
+@pytest.mark.asyncio
+async def test_a_refusing_cache_admission_writes_nothing(tmp_path):
+    import aleph.vm.storage as storage_module
+    from aleph.vm.resources import InsufficientResourcesError
+
+    def refuse(root, size):
+        raise InsufficientResourcesError("no room", required={}, available={})
+
+    storage_module.set_cache_admission(refuse)
+    session, resp = _session([b"x" * 4], content_length=4)
+    try:
+        with patch("aleph.vm.storage.aiohttp.ClientSession", return_value=session):
+            with pytest.raises(InsufficientResourcesError):
+                await download_file_in_chunks("http://x/f", tmp_path / "f.part")
+    finally:
+        storage_module.set_cache_admission(None)
+    resp.content.read.assert_not_called()
+    assert not (tmp_path / "f.part").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_cache_hit_evicted_mid_touch_falls_through_to_the_download(tmp_path):
+    """The cache pass can unlink an entry between the is_file() check and the
+    mtime touch: reporting that as a hit would hand back a path that is gone."""
+    target = tmp_path / "f"
+    target.write_bytes(b"cached")
+
+    async def fake_download(url, part, max_bytes=None):
+        part.write_bytes(b"fresh")
+
+    with patch("aleph.vm.storage.os.utime", side_effect=FileNotFoundError("gone")):
+        with patch("aleph.vm.storage.download_file_in_chunks", side_effect=fake_download):
+            await download_file("http://x/f", target)
+
+    assert target.read_bytes() == b"fresh"

--- a/tests/supervisor/test_storage_download_cap.py
+++ b/tests/supervisor/test_storage_download_cap.py
@@ -272,3 +272,62 @@ async def test_a_cache_hit_evicted_mid_touch_falls_through_to_the_download(tmp_p
             await download_file("http://x/f", target)
 
     assert target.read_bytes() == b"fresh"
+
+
+def _runtime_cache_env(mocker, tmp_path):
+    import aleph.vm.storage as storage_module
+    from aleph.vm.conf import settings
+
+    cache = tmp_path / "runtime"
+    cache.mkdir()
+    entry = cache / "ref"
+    entry.write_bytes(b"image")
+    old = time.time() - 100_000
+    os.utime(entry, (old, old))
+    mocker.patch.object(settings, "RUNTIME_CACHE", cache)
+    mocker.patch.object(settings, "FAKE_DATA_PROGRAM", None)
+    mocker.patch.object(settings, "USE_FAKE_INSTANCE_BASE", False)
+    mocker.patch.object(storage_module, "check_squashfs_integrity", AsyncMock())
+    mocker.patch.object(storage_module, "chown_to_jailman", AsyncMock())
+    return entry, old, mocker.patch.object(storage_module, "_get_content_url", AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_a_runtime_cache_hit_is_touched(mocker, tmp_path):
+    """The runtime cache is the largest one, and its entries are the ones a
+    hundred VMs boot from: without the touch its LRU is download order, and
+    the entry every VM on the node uses looks like the oldest thing there."""
+    import aleph.vm.storage as storage_module
+
+    entry, old, url = _runtime_cache_env(mocker, tmp_path)
+
+    assert await storage_module.get_runtime_path("ref") == entry
+
+    assert entry.stat().st_mtime > old + 50_000
+    # A hit is a hit: no message lookup, no download.
+    url.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_an_instance_base_cache_hit_is_touched(mocker, tmp_path):
+    import aleph.vm.storage as storage_module
+
+    entry, old, url = _runtime_cache_env(mocker, tmp_path)
+
+    assert await storage_module.get_rootfs_base_path("ref") == entry
+
+    assert entry.stat().st_mtime > old + 50_000
+    url.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_runtime_entry_evicted_mid_touch_is_downloaded_again(mocker, tmp_path):
+    import aleph.vm.storage as storage_module
+
+    entry, _old, url = _runtime_cache_env(mocker, tmp_path)
+    url.return_value = "http://x/f"
+    download = mocker.patch.object(storage_module, "download_file", AsyncMock())
+    with patch("aleph.vm.storage.os.utime", side_effect=FileNotFoundError("gone")):
+        await storage_module.get_runtime_path("ref")
+
+    download.assert_awaited_once()

--- a/tests/supervisor/test_storage_download_cap.py
+++ b/tests/supervisor/test_storage_download_cap.py
@@ -195,7 +195,46 @@ async def test_cache_admission_hook_runs_before_writing(tmp_path):
             await download_file_in_chunks("http://x/f", tmp_path / "f.part")
     finally:
         storage_module.set_cache_admission(None)
-    assert seen == [(tmp_path, 4)]
+    assert seen == [(tmp_path / "f.part", 4)]
+
+
+@pytest.mark.asyncio
+async def test_a_download_without_a_content_length_is_admitted_against_its_cap(tmp_path):
+    """A server that does not say how big the body is gets admitted for the
+    worst case it is allowed to send: the alternative is a download that
+    writes an unbounded number of bytes into a budget nobody charged."""
+    import aleph.vm.storage as storage_module
+
+    seen = []
+    storage_module.set_cache_admission(lambda path, size: seen.append((path, size)))
+    session, _ = _session([b"x" * 4], content_length=None)
+    try:
+        with patch("aleph.vm.storage.aiohttp.ClientSession", return_value=session):
+            await download_file_in_chunks("http://x/f", tmp_path / "f.part", max_bytes=999)
+    finally:
+        storage_module.set_cache_admission(None)
+        storage_module.release_download(tmp_path / "f.part")
+    assert seen == [(tmp_path / "f.part", 999)]
+
+
+@pytest.mark.asyncio
+async def test_an_admitted_download_is_reserved_until_the_part_is_gone(tmp_path):
+    """What admission promised has to stay charged while it is being written,
+    or the next create admits the same room a second time."""
+    import aleph.vm.storage as storage_module
+
+    reserved_mid_download = {}
+
+    async def fake_chunks(url, part, max_bytes=None):
+        # What download_file_in_chunks does once the admission hook returns.
+        storage_module.reserve_download(part, max_bytes)
+        reserved_mid_download.update(storage_module.reserved_downloads())
+
+    with patch("aleph.vm.storage.download_file_in_chunks", side_effect=fake_chunks):
+        await download_file("http://x/f", tmp_path / "f", max_bytes=999)
+
+    assert reserved_mid_download == {tmp_path / "f.part": 999}
+    assert storage_module.reserved_downloads() == {}
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_supervisor_run_routing.py
+++ b/tests/supervisor/test_supervisor_run_routing.py
@@ -881,3 +881,42 @@ def test_program_error_mapper_maps_startup_failure():
     with pytest.raises(HTTPInternalServerError) as excinfo:
         run_module._raise_http_for_program_error(run_module.VmStartupError("never reached RUNNING"), ItemHash(_HASH))
     assert excinfo.value.reason == "VM failed to start"
+
+
+def test_program_error_mapper_maps_file_too_large_to_bad_request():
+    """An oversized resource is the message's fault, not the node's: it must
+    surface as a 400, the same bucket as ResourceDownloadError, not a 500."""
+    from aiohttp.web_exceptions import HTTPBadRequest
+
+    from aleph.vm.supervisor_interface.errors import FileTooLargeError
+
+    with pytest.raises(HTTPBadRequest) as excinfo:
+        run_module._raise_http_for_program_error(FileTooLargeError("f is too big"), ItemHash(_HASH))
+    assert excinfo.value.reason == "f is too big"
+
+
+@pytest.mark.asyncio
+async def test_create_execution_maps_file_too_large_to_bad_request(monkeypatch):
+    """The instance/v-program create path gives FileTooLargeError the same
+    400 treatment as the on-demand program mapper."""
+    from aiohttp.web_exceptions import HTTPBadRequest
+
+    from aleph.vm.supervisor_interface.errors import FileTooLargeError
+
+    content = _make_qemu_instance_message(hypervisor=HypervisorType.qemu)
+    message = MagicMock(content=content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
+    )
+    monkeypatch.setattr(run_module, "build_create_vm_spec", AsyncMock(side_effect=FileTooLargeError("f is too big")))
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+
+    with pytest.raises(HTTPBadRequest) as excinfo:
+        await run_module.create_vm_execution_or_raise_http_error(
+            _HASH,
+            supervisor=_fake_supervisor(),
+            registry=AgentVmRegistry(),
+            capacity=_fake_capacity(),
+            persistent=True,
+        )
+    assert excinfo.value.reason == "f is too big"


### PR DESCRIPTION
## Summary

PR D of the 2.1 disk reclamation work (spec Section 4, S4 unbounded caches and S5 no download size cap; the parent-device half of Section 5). Stacked on #1160.

- **Size enforced in the stream.** `download_file_in_chunks(url, tmp, *, max_bytes)` rejects an oversize `Content-Length` before opening the file and aborts, unlinking the `.part`, the moment the byte count passes the limit. Same limits as before (`MAX_PROGRAM_ARCHIVE_SIZE`, `MAX_DATA_ARCHIVE_SIZE`, new `MAX_RUNTIME_ARCHIVE_SIZE`), now applied to every `download_file` caller: the four cache getters, immutable volume refs and restore staging. `FileTooLargeError` is a 400 on the create path. A cache hit touches the entry's mtime (the LRU signal) and falls through to a download if the file vanished under it.
- **Bounded caches.** `CACHE_BUDGET` (default 20% of the filesystem) per cache root. The reconciler's cache pass computes the referenced set (every item hash a live VM's message names: runtime, code, data, rootfs parent, volume parents and refs, V-PROGRAM workload and hash tree, confidential firmware and runtime, the VM's own message; plus every `.reclaimable` marker's `depends_on`) through one shared enumeration in `reclaimable.py`, then evicts unreferenced entries LRU; if still over budget with only retained-VM-referenced entries left it reclaims those retained directories oldest-first and then their entries; entries a live VM references are never evicted (log and stop). Evicting a parent image removes its shared `/dev/mapper/<ref>` and read-only loop only when nothing stacks on it (sysfs holders), and a sweep recovers loops left over a deleted cache file.
- **Admission.** `storage.set_cache_admission` runs before a download writes: it may evict unreferenced LRU entries only, never retained VMs, never anything while the live set is not trusted (registry and `list_vms` disagree), and refuses with `InsufficientResourcesError` (503) otherwise.

## Known limitations
- If the supervisor never answers `list_vms`, admission never evicts and downloads are refused once a cache reaches its budget (fail-closed).
- Per-root percentage budgets stack when several caches share one filesystem (spec-mandated shape).
- Admission's directory walks run on the event loop (bounded: a few stats per entry).

## Test plan
- `tests/supervisor`: failing-ID set identical to base across both tasks.
- New: `test_storage_download_cap.py`, `test_cache_eviction.py`; extended `test_reconciler.py`, `test_reclaimable.py`, `test_storage.py`, run-routing error mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvDhr5NKq3AY17E1vwV3zk
