### PR TITLE
feat(cli): aleph-vm storage status, list, reclaim and reconcile (2.1, PR E)

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -560,12 +560,19 @@ process*:
   applies), reclaim reports that and exits non-zero rather than claiming
   success.
 - `storage reconcile [--dry-run] [--trust-registry]`: run one
-  `reconcile_storage()` pass, printing what it removed (or, under
-  `--dry-run`, what it would remove), then tears down the devices of any
-  evicted runtime cache parent the same way `reconcile_now` /
-  `reconcile_at_startup` do (`remove_parent_device` per evicted ref, then
-  `sweep_leaked_cache_loops`), so an evicted entry never leaves
-  `/dev/mapper/<ref>` and its loop device pinning the deleted inode.
+  `reconcile_storage()` pass with the daemon's two device steps around it,
+  or the CLI would keep refusing what the daemon reclaims. Before the pass,
+  `_teardown_orphan_devices` removes the dm devices of every namespace no
+  live VM owns, so the purge that follows is not refused on a volume file a
+  target still holds; that step needs the supervisor's answer and is skipped
+  under `--dry-run` and when the supervisor is unreachable, `--trust-registry`
+  included (it buys a purge on the registry's word, not a teardown). After
+  the pass, and printing what it removed (or, under `--dry-run`, what it
+  would remove), it tears down the devices of any evicted runtime cache
+  parent the same way `reconcile_now` / `reconcile_at_startup` do
+  (`remove_parent_device` per evicted ref, then `sweep_leaked_cache_loops`),
+  so an evicted entry never leaves `/dev/mapper/<ref>` and its loop device
+  pinning the deleted inode.
 
 `reconcile` and `reclaim` can purge, so they apply the same fail-closed rule
 `reconciler._startup_refusal` applies to the daemon's own startup pass: a

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -551,17 +551,20 @@ process*:
   orphan no pass has reached yet is not a live VM). Read-only, registry
   live set only.
 - `storage reclaim <hash> [--trust-registry]`: purge one reclaimable
-  directory now. Checks the `.reclaimable` marker first, purely locally, so
-  a typo or an unrelated hash fails instantly rather than waiting on a
-  supervisor dial that could only ever confirm what the marker check already
-  knows; a directory with no marker (it may belong to a live VM) is refused
-  the same way. Then refuses a hash the agent registry or the supervisor
-  considers live (see below), and refuses outright, without
-  `--trust-registry`, when the supervisor cannot be asked. Finally, if the
-  purge itself leaves the directory behind (a device-mapper target still
-  holds one of its volumes, the same guard `purge_vm_storage` always
+  directory now. Checks the name and the `.reclaimable` marker first, purely
+  locally, so a typo or an unrelated hash fails instantly rather than
+  waiting on a supervisor dial that could only ever confirm what those
+  checks already know; a name that is not a VM hash (a hand-made marker
+  under `backup_old`) and a directory with no marker (it may belong to a
+  live VM) are refused the same way. Then refuses a hash the agent registry
+  or the supervisor considers live (see below), and refuses outright,
+  without `--trust-registry`, when the supervisor cannot be asked. Finally,
+  if the purge itself leaves the directory behind (a device-mapper target
+  still holds one of its volumes, the same guard `purge_vm_storage` always
   applies), reclaim reports that and exits non-zero rather than claiming
-  success.
+  success. `reclaim` never tears devices down itself: `storage reconcile`
+  is the CLI path that does, for every VM nothing owns, so the refusal
+  points the operator there.
 - `storage reconcile [--dry-run] [--trust-registry]`: run one
   `reconcile_storage()` pass with the daemon's two device steps around it,
   or the CLI would keep refusing what the daemon reclaims. Before the pass,

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -539,7 +539,8 @@ goes first", which is the only promise a node can honestly sell.
 
 Storage is agent-side and readable from the filesystem plus the agent DB, so
 `aleph-vm storage ...` (`src/aleph/vm/agent/storage_cli.py`, dispatched by
-`agent/cli.py` before its own argument parser) needs no running *agent
+`agent/cli.py` before its own argument parser, which points at
+`storage --help` in its own `--help` epilog) needs no running *agent
 process*:
 
 - `storage status`: per pool, live / reclaimable / cache / free bytes
@@ -547,14 +548,24 @@ process*:
 - `storage list [--reclaimable]`: hash, pool, size, reason, age. Read-only,
   registry live set only.
 - `storage reclaim <hash> [--trust-registry]`: purge one reclaimable
-  directory now. Refuses a directory with no `.reclaimable` marker (it may
-  belong to a live VM); an implausible or unrelated hash simply matches
-  nothing on disk, so it is refused the same way. Also refuses a hash the
-  agent registry or the supervisor considers live (see below), and refuses
-  outright, without `--trust-registry`, when the supervisor cannot be asked.
+  directory now. Checks the `.reclaimable` marker first, purely locally, so
+  a typo or an unrelated hash fails instantly rather than waiting on a
+  supervisor dial that could only ever confirm what the marker check already
+  knows; a directory with no marker (it may belong to a live VM) is refused
+  the same way. Then refuses a hash the agent registry or the supervisor
+  considers live (see below), and refuses outright, without
+  `--trust-registry`, when the supervisor cannot be asked. Finally, if the
+  purge itself leaves the directory behind (a device-mapper target still
+  holds one of its volumes, the same guard `purge_vm_storage` always
+  applies), reclaim reports that and exits non-zero rather than claiming
+  success.
 - `storage reconcile [--dry-run] [--trust-registry]`: run one
   `reconcile_storage()` pass, printing what it removed (or, under
-  `--dry-run`, what it would remove).
+  `--dry-run`, what it would remove), then tears down the devices of any
+  evicted runtime cache parent the same way `reconcile_now` /
+  `reconcile_at_startup` do (`remove_parent_device` per evicted ref, then
+  `sweep_leaked_cache_loops`), so an evicted entry never leaves
+  `/dev/mapper/<ref>` and its loop device pinning the deleted inode.
 
 `reconcile` and `reclaim` can purge, so they apply the same fail-closed rule
 `reconciler._startup_refusal` applies to the daemon's own startup pass: a
@@ -566,11 +577,24 @@ supervisor over the same gRPC socket the agent uses
 (`settings.SUPERVISOR_GRPC_SOCKET`, a few seconds' timeout) and union its
 `list_vms()` answer into the live set (`reconciler.supervisor_hashes`, the
 same id-to-hash mapping the daemon pass uses). When the supervisor cannot be
-reached: `reconcile` runs as a dry run and prints a warning explaining why,
-unless `--trust-registry` says to purge on the registry alone (`--dry-run`
-always wins, with or without the flag); `reclaim` refuses outright unless
-`--trust-registry` is given. `status` and `list` are read-only and never
-dial the supervisor.
+reached and an explicit `--dry-run` was not requested, `reconcile` still
+runs as a dry run (a preview, nothing removed) but treats this as an error:
+it prints a warning to stderr (`"registry-only"`, not `"trusted"`: the
+report on stdout stays parseable, uninterrupted by the warning) and exits
+`2`, unless `--trust-registry` says to purge on the registry alone. An
+explicit `--dry-run` always stays exit `0`, whether or not the supervisor
+answered: nothing was silently downgraded, the caller asked for a preview
+and got one. `reclaim` refuses outright unless `--trust-registry` is given.
+`status` and `list` are read-only and never dial the supervisor.
+
+Neither command can see a create the daemon is in the middle of:
+`reconciler.is_creating()` is in-process state of the running agent, so a
+CLI invocation (a separate process) never sees it. A create that has
+outlived `VOLUME_CREATE_GUARD` and has not yet landed in the registry or in
+`list_vms` looks exactly like an orphan to a real `reconcile` run from the
+CLI, which can then remove it out from under the daemon. `reconcile --help`
+says so; the daemon's own pass (startup, periodic, at-GONE) is preferred
+whenever the daemon is up, and this command is mainly for when it is not.
 
 ### First start on an existing node
 

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -539,24 +539,38 @@ goes first", which is the only promise a node can honestly sell.
 
 Storage is agent-side and readable from the filesystem plus the agent DB, so
 `aleph-vm storage ...` (`src/aleph/vm/agent/storage_cli.py`, dispatched by
-`agent/cli.py` before its own argument parser) needs no running daemon:
+`agent/cli.py` before its own argument parser) needs no running *agent
+process*:
 
 - `storage status`: per pool, live / reclaimable / cache / free bytes
-  against the budgets.
-- `storage list [--reclaimable]`: hash, pool, size, reason, age.
-- `storage reclaim <hash>`: purge one reclaimable directory now. Refuses a
-  directory with no `.reclaimable` marker (it may belong to a live VM) and,
-  since it only ever matches a directory that already exists on disk, an
-  implausible or unrelated hash simply matches nothing.
-- `storage reconcile [--dry-run]`: run one `reconcile_storage()` pass,
-  printing what it removed (or, under `--dry-run`, what it would remove).
+  against the budgets. Read-only, registry live set only.
+- `storage list [--reclaimable]`: hash, pool, size, reason, age. Read-only,
+  registry live set only.
+- `storage reclaim <hash> [--trust-registry]`: purge one reclaimable
+  directory now. Refuses a directory with no `.reclaimable` marker (it may
+  belong to a live VM); an implausible or unrelated hash simply matches
+  nothing on disk, so it is refused the same way. Also refuses a hash the
+  agent registry or the supervisor considers live (see below), and refuses
+  outright, without `--trust-registry`, when the supervisor cannot be asked.
+- `storage reconcile [--dry-run] [--trust-registry]`: run one
+  `reconcile_storage()` pass, printing what it removed (or, under
+  `--dry-run`, what it would remove).
 
-The live set these commands act against is the agent registry alone
-(rehydrated from the agent DB on startup, `rehydrate_registry`): there is no
-daemon to ask `list_vms`, so this cannot cross-check against a supervisor's
-answer the way the startup pass does (`reconciler._startup_refusal`). An
-operator invoking this by hand already knows what is running; the CLI does
-not add a `--trust-registry` gate on top of the registry it already trusts.
+`reconcile` and `reclaim` can purge, so they apply the same fail-closed rule
+`reconciler._startup_refusal` applies to the daemon's own startup pass: a
+live set built from the registry alone purges the disks of VMs the
+supervisor still runs, since a fresh or partly-lost agent DB rehydrates into
+an incomplete registry (this was PR A's Critical 1). A CLI process holding
+only the registry is exactly that state, so both commands dial the
+supervisor over the same gRPC socket the agent uses
+(`settings.SUPERVISOR_GRPC_SOCKET`, a few seconds' timeout) and union its
+`list_vms()` answer into the live set (`reconciler.supervisor_hashes`, the
+same id-to-hash mapping the daemon pass uses). When the supervisor cannot be
+reached: `reconcile` runs as a dry run and prints a warning explaining why,
+unless `--trust-registry` says to purge on the registry alone (`--dry-run`
+always wins, with or without the flag); `reclaim` refuses outright unless
+`--trust-registry` is given. `status` and `list` are read-only and never
+dial the supervisor.
 
 ### First start on an existing node
 

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -545,8 +545,11 @@ process*:
 
 - `storage status`: per pool, live / reclaimable / cache / free bytes
   against the budgets. Read-only, registry live set only.
-- `storage list [--reclaimable]`: hash, pool, size, reason, age. Read-only,
-  registry live set only.
+- `storage list [--reclaimable]`: hash, pool, size, reason, age. The reason
+  is the marker's for a reclaimable directory; an unmarked directory reads
+  `live` when the registry knows its hash and `unmarked` otherwise (an
+  orphan no pass has reached yet is not a live VM). Read-only, registry
+  live set only.
 - `storage reclaim <hash> [--trust-registry]`: purge one reclaimable
   directory now. Checks the `.reclaimable` marker first, purely locally, so
   a typo or an unrelated hash fails instantly rather than waiting on a
@@ -588,7 +591,9 @@ reached and an explicit `--dry-run` was not requested, `reconcile` still
 runs as a dry run (a preview, nothing removed) but treats this as an error:
 it prints a warning to stderr (`"registry-only"`, not `"trusted"`: the
 report on stdout stays parseable, uninterrupted by the warning) and exits
-`2`, unless `--trust-registry` says to purge on the registry alone. An
+`3` (not `2`, which argparse uses for a usage error, so a wrapper script
+can tell the two apart), unless `--trust-registry` says to purge on the
+registry alone. An
 explicit `--dry-run` always stays exit `0`, whether or not the supervisor
 answered: nothing was silently downgraded, the caller asked for a preview
 and got one. `reclaim` refuses outright unless `--trust-registry` is given.

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -535,6 +535,29 @@ and an attacker does not need to stop paying to create them (create, forget,
 repeat). It means "kept as long as the budget and live demand allow, oldest
 goes first", which is the only promise a node can honestly sell.
 
+### CLI
+
+Storage is agent-side and readable from the filesystem plus the agent DB, so
+`aleph-vm storage ...` (`src/aleph/vm/agent/storage_cli.py`, dispatched by
+`agent/cli.py` before its own argument parser) needs no running daemon:
+
+- `storage status`: per pool, live / reclaimable / cache / free bytes
+  against the budgets.
+- `storage list [--reclaimable]`: hash, pool, size, reason, age.
+- `storage reclaim <hash>`: purge one reclaimable directory now. Refuses a
+  directory with no `.reclaimable` marker (it may belong to a live VM) and,
+  since it only ever matches a directory that already exists on disk, an
+  implausible or unrelated hash simply matches nothing.
+- `storage reconcile [--dry-run]`: run one `reconcile_storage()` pass,
+  printing what it removed (or, under `--dry-run`, what it would remove).
+
+The live set these commands act against is the agent registry alone
+(rehydrated from the agent DB on startup, `rehydrate_registry`): there is no
+daemon to ask `list_vms`, so this cannot cross-check against a supervisor's
+answer the way the startup pass does (`reconciler._startup_refusal`). An
+operator invoking this by hand already knows what is running; the CLI does
+not add a `--trust-registry` gate on top of the registry it already trusts.
+
 ### First start on an existing node
 
 The first pass on an upgraded node finds every directory leaked by the bugs

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -596,12 +596,22 @@ and got one. `reclaim` refuses outright unless `--trust-registry` is given.
 
 Neither command can see a create the daemon is in the middle of:
 `reconciler.is_creating()` is in-process state of the running agent, so a
-CLI invocation (a separate process) never sees it. A create that has
-outlived `VOLUME_CREATE_GUARD` and has not yet landed in the registry or in
-`list_vms` looks exactly like an orphan to a real `reconcile` run from the
-CLI, which can then remove it out from under the daemon. `reconcile --help`
-says so; the daemon's own pass (startup, periodic, at-GONE) is preferred
-whenever the daemon is up, and this command is mainly for when it is not.
+CLI invocation (a separate process) never sees it. What protects such a
+create from the CLI is the age of its directory alone: the directory purge
+and the orphan-device teardown (`orphan_device_namespaces`) both skip a
+namespace whose directory is younger than `VOLUME_CREATE_GUARD`. The
+registry record reaches the DB only once the VM runs and `list_vms`
+answers only once `create_vm` returned, so a create that has outlived the
+guard before either happened looks exactly like an orphan to a real
+`reconcile` run from the CLI, which can then remove its directory and its
+devices out from under the daemon. A CLI pass also holds no lock against
+the daemon's own passes (`_pass_lock` is in-process too) and can run
+concurrently with one; that is benign, since purges are idempotent and
+tolerate a directory that vanished mid-pass and markers are written
+exclusively, but it is one more reason to prefer the daemon's pass.
+`reconcile --help` says so; the daemon's own pass (startup, periodic,
+at-GONE) is preferred whenever the daemon is up, and this command is mainly
+for when it is not.
 
 ### First start on an existing node
 

--- a/src/aleph/vm/agent/cli.py
+++ b/src/aleph/vm/agent/cli.py
@@ -22,7 +22,11 @@ logger = logging.getLogger(__name__)
 
 
 def parse_args(args):
-    parser = argparse.ArgumentParser(prog="aleph-vm", description="Aleph.im compute node agent")
+    parser = argparse.ArgumentParser(
+        prog="aleph-vm",
+        description="Aleph.im compute node agent",
+        epilog="Run 'aleph-vm storage --help' for VM storage reclamation (status, list, reclaim, reconcile).",
+    )
     parser.add_argument(
         "--system-logs",
         action="store_true",

--- a/src/aleph/vm/agent/cli.py
+++ b/src/aleph/vm/agent/cli.py
@@ -151,6 +151,11 @@ async def run_async_db_migrations():
 
 
 def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "storage":
+        from aleph.vm.agent import storage_cli
+
+        sys.exit(storage_cli.main(sys.argv[2:]))
+
     args = parse_args(sys.argv[1:])
 
     log_format = (

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -10,9 +10,19 @@ exactly that state, so ``reconcile`` and ``reclaim`` ask the supervisor
 daemon over the same gRPC socket the agent dials (``GrpcSupervisor``,
 ``settings.SUPERVISOR_GRPC_SOCKET``), with a short timeout, and union its
 answer into the live set. When the daemon cannot be reached, both commands
-fail closed: ``reconcile`` runs dry and warns, ``reclaim`` refuses, unless
-``--trust-registry`` says to proceed on the registry alone. ``status`` and
-``list`` are read-only and never touch the supervisor.
+fail closed: ``reconcile`` runs dry, warns on stderr and exits non-zero,
+``reclaim`` refuses, unless ``--trust-registry`` says to proceed on the
+registry alone. ``status`` and ``list`` are read-only and never touch the
+supervisor.
+
+What this process still cannot see, even with the supervisor reachable: a
+create the daemon is in the middle of. ``reconciler.is_creating()`` is an
+in-process set the running agent populates for the duration of a create; a
+CLI invocation is a separate process and never sees it, so a create that has
+outlived ``VOLUME_CREATE_GUARD`` and has not yet landed in the registry or
+in ``list_vms`` looks exactly like an orphan to a real ``reconcile`` here.
+The daemon's own pass (startup, periodic, at-GONE) is always preferred when
+the daemon is up; this command exists mainly for when it is not.
 """
 
 from __future__ import annotations
@@ -36,6 +46,8 @@ from aleph.vm.agent.vm.reclaimable import (
     reclaimable_bytes,
 )
 from aleph.vm.agent.vm.reconciler import (
+    _release_cache_devices,
+    _still_on_disk,
     live_hashes,
     reconcile_storage,
     supervisor_hashes,
@@ -51,11 +63,20 @@ from aleph.vm.supervisor_interface.abc import Supervisor
 # sit through a 30 second RPC deadline just to learn the daemon is down.
 SUPERVISOR_CONNECT_TIMEOUT_SECS = 3.0
 
+# Exit code for a reconcile that silently downgraded to a dry run because the
+# supervisor could not be asked and --trust-registry was not given. Distinct
+# from an explicit --dry-run, which is a success (exit 0): nothing was
+# downgraded, the caller asked for a preview and got one.
+DEGRADED_EXIT_CODE = 2
+
 logger = logging.getLogger(__name__)
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(prog="aleph-vm storage", description="VM storage reclamation")
+    parser = argparse.ArgumentParser(
+        prog="aleph-vm storage",
+        description="VM storage reclamation: status, list, reclaim, reconcile.",
+    )
     sub = parser.add_subparsers(dest="command", required=True)
     sub.add_parser("status", help="per-pool and per-cache usage against the budgets")
     list_parser = sub.add_parser("list", help="VM directories on every pool")
@@ -67,7 +88,19 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="purge using the registry alone when the supervisor cannot be asked whether the hash is running",
     )
-    reconcile_parser = sub.add_parser("reconcile", help="run one reconciler pass")
+    reconcile_parser = sub.add_parser(
+        "reconcile",
+        help="run one reconciler pass",
+        description=(
+            "Run one reconciler pass against the agent registry (unioned with the supervisor's "
+            "list_vms() when it can be reached). This process cannot see a create the daemon is "
+            "currently in the middle of: is_creating() is in-process state of the running agent, "
+            "so a create that has outlived VOLUME_CREATE_GUARD and is not yet in the registry or "
+            "list_vms looks like an orphan here and a real pass can remove it. Prefer the daemon's "
+            "own pass (it runs at startup, periodically, and after every GONE) when the daemon is "
+            "up; use this command mainly when it is not."
+        ),
+    )
     reconcile_parser.add_argument("--dry-run", action="store_true")
     reconcile_parser.add_argument(
         "--trust-registry",
@@ -86,7 +119,8 @@ def _human(size: int) -> str:
         if value < _UNIT_STEP or unit == "TiB":
             return f"{value:.1f} {unit}" if unit != "B" else f"{int(value)} B"
         value /= _UNIT_STEP
-    return f"{value:.1f} TiB"
+    msg = "unreachable: the loop above always returns on its last unit (TiB)"
+    raise AssertionError(msg)
 
 
 def _age(since: datetime) -> str:
@@ -185,6 +219,15 @@ def _list(out: TextIO, *, reclaimable_only: bool) -> int:
 
 
 def _reclaim(registry: AgentVmRegistry, vm_hash: str, out: TextIO, *, trust_registry: bool) -> int:
+    # Cheapest, purely local check first: a typo or an unrelated hash fails
+    # instantly instead of waiting out a supervisor dial that can only ever
+    # confirm what this check already knows.
+    marked = [directory for directory, _marker in iter_reclaimable() if directory.name == vm_hash]
+    if not marked:
+        out.write(
+            f"{vm_hash} is not reclaimable (no .reclaimable marker); refusing to purge a directory a VM may own\n"
+        )
+        return 1
     if vm_hash in live_hashes(registry):
         out.write(f"{vm_hash} is a live VM in the agent registry; refusing to purge it\n")
         return 1
@@ -199,24 +242,24 @@ def _reclaim(registry: AgentVmRegistry, vm_hash: str, out: TextIO, *, trust_regi
             "Pass --trust-registry to purge using the registry alone\n"
         )
         return 1
-    marked = [directory for directory, _marker in iter_reclaimable() if directory.name == vm_hash]
-    if not marked:
+    deleted = purge_vm_storage(vm_hash)
+    if _still_on_disk(vm_hash):
         out.write(
-            f"{vm_hash} is not reclaimable (no .reclaimable marker); refusing to purge a directory a VM may own\n"
+            f"Purge of {vm_hash} left directories behind: a device-mapper target still holds its volumes; "
+            "retry once it is torn down\n"
         )
         return 1
-    deleted = purge_vm_storage(vm_hash)
     out.write(f"Purged {vm_hash}: {deleted} volume file(s)\n")
     return 0
 
 
 def _reconcile(registry: AgentVmRegistry, out: TextIO, *, dry_run: bool, trust_registry: bool) -> int:
     live, reachable = _cli_live_set(registry)
-    effective_dry_run = dry_run
-    if not reachable and not trust_registry:
-        effective_dry_run = True
-        out.write(
-            "Warning: supervisor unreachable; showing what a trusted pass would purge; "
+    downgraded = not reachable and not trust_registry
+    effective_dry_run = dry_run or downgraded
+    if downgraded:
+        sys.stderr.write(
+            "Warning: supervisor unreachable; showing what a registry-only pass would purge; "
             "pass --trust-registry to purge using the registry alone\n"
         )
     report = reconcile_storage(registry, dry_run=effective_dry_run, live=live)
@@ -226,7 +269,12 @@ def _reconcile(registry: AgentVmRegistry, out: TextIO, *, dry_run: bool, trust_r
         out.write(f"  {'would purge' if effective_dry_run else 'purged'} {name}\n")
     for name in report.marked_orphans:
         out.write(f"  {'would mark' if effective_dry_run else 'marked'} {name}\n")
-    return 0
+    # Mirrors reconcile_now/reconcile_at_startup: tear down the devices of
+    # evicted parent images, then sweep whatever an earlier teardown left
+    # behind. _release_cache_devices no-ops under a dry run on its own, so
+    # calling it unconditionally here matches the daemon's own passes.
+    asyncio.run(_release_cache_devices(report, dry_run=effective_dry_run))
+    return DEGRADED_EXIT_CODE if downgraded and not dry_run else 0
 
 
 def run(args: argparse.Namespace, registry: AgentVmRegistry, out: TextIO) -> int:

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -1,22 +1,25 @@
 """``aleph-vm storage``: show and drive reclamation from the node shell.
 
 Storage is agent-side and, by design, readable from the filesystem plus the
-agent DB, so these commands need no running daemon. They run the same code
-the reconciler runs.
-
-The live set these commands act against is the agent registry alone
-(rehydrated from the agent DB, ``rehydrate_registry``): there is no daemon to
-ask ``list_vms``, so unlike the startup pass (``reconciler._startup_refusal``)
-this cannot cross-check against a supervisor's answer. An operator invoking
-this by hand already knows whether the daemon is up; running it against a
-stopped daemon (the normal case, since the daemon holds no lock these
-commands need) is exactly the documented use.
+agent DB, so these commands need no *agent process* running. They run the
+same code the reconciler runs, including the same safety rule: a live set
+built from the registry alone purges the disks of VMs the supervisor still
+runs (that was PR A's Critical 1, guarded on the daemon side by
+``reconciler._startup_refusal``). A CLI process holding only the registry is
+exactly that state, so ``reconcile`` and ``reclaim`` ask the supervisor
+daemon over the same gRPC socket the agent dials (``GrpcSupervisor``,
+``settings.SUPERVISOR_GRPC_SOCKET``), with a short timeout, and union its
+answer into the live set. When the daemon cannot be reached, both commands
+fail closed: ``reconcile`` runs dry and warns, ``reclaim`` refuses, unless
+``--trust-registry`` says to proceed on the registry alone. ``status`` and
+``list`` are read-only and never touch the supervisor.
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
+import logging
 import shutil
 import sys
 from datetime import datetime, timezone
@@ -32,11 +35,23 @@ from aleph.vm.agent.vm.reclaimable import (
     read_marker,
     reclaimable_bytes,
 )
-from aleph.vm.agent.vm.reconciler import live_hashes, reconcile_storage
+from aleph.vm.agent.vm.reconciler import (
+    live_hashes,
+    reconcile_storage,
+    supervisor_hashes,
+)
 from aleph.vm.agent.vm_registry import AgentVmRegistry, rehydrate_registry
 from aleph.vm.conf import settings
 from aleph.vm.storage_budget import parse_budget
 from aleph.vm.storage_pools import iter_namespace_dirs
+from aleph.vm.supervisor_interface.abc import Supervisor
+
+# How long to wait for the supervisor to answer before treating it as
+# unreachable. Short on purpose: an operator running this by hand should not
+# sit through a 30 second RPC deadline just to learn the daemon is down.
+SUPERVISOR_CONNECT_TIMEOUT_SECS = 3.0
+
+logger = logging.getLogger(__name__)
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -47,8 +62,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     list_parser.add_argument("--reclaimable", action="store_true", help="only directories no VM owns")
     reclaim_parser = sub.add_parser("reclaim", help="purge one reclaimable VM directory now")
     reclaim_parser.add_argument("vm_hash")
+    reclaim_parser.add_argument(
+        "--trust-registry",
+        action="store_true",
+        help="purge using the registry alone when the supervisor cannot be asked whether the hash is running",
+    )
     reconcile_parser = sub.add_parser("reconcile", help="run one reconciler pass")
     reconcile_parser.add_argument("--dry-run", action="store_true")
+    reconcile_parser.add_argument(
+        "--trust-registry",
+        action="store_true",
+        help="purge using the registry alone when the supervisor cannot be asked which VMs it runs",
+    )
     return parser.parse_args(argv)
 
 
@@ -69,6 +94,52 @@ def _age(since: datetime) -> str:
     days, rem = divmod(int(delta.total_seconds()), 86400)
     hours = rem // 3600
     return f"{days}d {hours}h"
+
+
+def _open_supervisor() -> Supervisor:
+    """The agent's handle on the supervisor daemon, over the same gRPC socket
+    the web app dials. A thin wrapper so tests can substitute a fake handle
+    instead of a real gRPC channel."""
+    from aleph.vm.supervisor_interface.client import GrpcSupervisor
+
+    return GrpcSupervisor(settings.SUPERVISOR_GRPC_SOCKET)
+
+
+async def _supervisor_running_hashes(timeout: float = SUPERVISOR_CONNECT_TIMEOUT_SECS) -> set[str] | None:
+    """The item hashes the supervisor lists as running, or None when it could
+    not be asked (unreachable, timed out, or answered with an error).
+
+    Reuses ``reconciler.supervisor_hashes`` for the id-to-hash mapping, so a
+    CLI pass and a daemon pass never disagree on what counts as a plausible
+    VM id.
+    """
+    supervisor = _open_supervisor()
+    try:
+        return await asyncio.wait_for(supervisor_hashes(supervisor), timeout=timeout)
+    except Exception:
+        return None
+    finally:
+        close = getattr(supervisor, "close", None)
+        if close is not None:
+            try:
+                await close()
+            except Exception:
+                logger.debug("Failed to close the supervisor handle", exc_info=True)
+
+
+def _cli_live_set(registry: AgentVmRegistry) -> tuple[set[str], bool]:
+    """(live hashes, whether the supervisor could be asked).
+
+    The registry alone is never enough here: it is the same fail-closed
+    reasoning ``reconciler._startup_refusal`` applies to the daemon's own
+    startup pass, applied to a CLI process that by construction never has
+    more than the registry unless it asks the daemon itself.
+    """
+    running = asyncio.run(_supervisor_running_hashes())
+    live = live_hashes(registry)
+    if running is None:
+        return live, False
+    return live | running, True
 
 
 def _status(registry: AgentVmRegistry, out: TextIO) -> int:
@@ -113,7 +184,21 @@ def _list(out: TextIO, *, reclaimable_only: bool) -> int:
     return 0
 
 
-def _reclaim(vm_hash: str, out: TextIO) -> int:
+def _reclaim(registry: AgentVmRegistry, vm_hash: str, out: TextIO, *, trust_registry: bool) -> int:
+    if vm_hash in live_hashes(registry):
+        out.write(f"{vm_hash} is a live VM in the agent registry; refusing to purge it\n")
+        return 1
+    running = asyncio.run(_supervisor_running_hashes())
+    if running is not None:
+        if vm_hash in running:
+            out.write(f"{vm_hash} is running (the supervisor lists it); refusing to purge it\n")
+            return 1
+    elif not trust_registry:
+        out.write(
+            f"Supervisor unreachable; cannot confirm {vm_hash} is not running. "
+            "Pass --trust-registry to purge using the registry alone\n"
+        )
+        return 1
     marked = [directory for directory, _marker in iter_reclaimable() if directory.name == vm_hash]
     if not marked:
         out.write(
@@ -125,14 +210,22 @@ def _reclaim(vm_hash: str, out: TextIO) -> int:
     return 0
 
 
-def _reconcile(registry: AgentVmRegistry, out: TextIO, *, dry_run: bool) -> int:
-    report = reconcile_storage(registry, dry_run=dry_run)
-    prefix = "Dry run: " if dry_run else "Reconciled: "
+def _reconcile(registry: AgentVmRegistry, out: TextIO, *, dry_run: bool, trust_registry: bool) -> int:
+    live, reachable = _cli_live_set(registry)
+    effective_dry_run = dry_run
+    if not reachable and not trust_registry:
+        effective_dry_run = True
+        out.write(
+            "Warning: supervisor unreachable; showing what a trusted pass would purge; "
+            "pass --trust-registry to purge using the registry alone\n"
+        )
+    report = reconcile_storage(registry, dry_run=effective_dry_run, live=live)
+    prefix = "Dry run: " if effective_dry_run else "Reconciled: "
     out.write(prefix + report.summary() + "\n")
     for name in report.purged_orphans + report.evicted:
-        out.write(f"  {'would purge' if dry_run else 'purged'} {name}\n")
+        out.write(f"  {'would purge' if effective_dry_run else 'purged'} {name}\n")
     for name in report.marked_orphans:
-        out.write(f"  {'would mark' if dry_run else 'marked'} {name}\n")
+        out.write(f"  {'would mark' if effective_dry_run else 'marked'} {name}\n")
     return 0
 
 
@@ -142,9 +235,9 @@ def run(args: argparse.Namespace, registry: AgentVmRegistry, out: TextIO) -> int
     if args.command == "list":
         return _list(out, reclaimable_only=args.reclaimable)
     if args.command == "reclaim":
-        return _reclaim(args.vm_hash, out)
+        return _reclaim(registry, args.vm_hash, out, trust_registry=args.trust_registry)
     if args.command == "reconcile":
-        return _reconcile(registry, out, dry_run=args.dry_run)
+        return _reconcile(registry, out, dry_run=args.dry_run, trust_registry=args.trust_registry)
     return 2
 
 

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -1,0 +1,163 @@
+"""``aleph-vm storage``: show and drive reclamation from the node shell.
+
+Storage is agent-side and, by design, readable from the filesystem plus the
+agent DB, so these commands need no running daemon. They run the same code
+the reconciler runs.
+
+The live set these commands act against is the agent registry alone
+(rehydrated from the agent DB, ``rehydrate_registry``): there is no daemon to
+ask ``list_vms``, so unlike the startup pass (``reconciler._startup_refusal``)
+this cannot cross-check against a supervisor's answer. An operator invoking
+this by hand already knows whether the daemon is up; running it against a
+stopped daemon (the normal case, since the daemon holds no lock these
+commands need) is exactly the documented use.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import shutil
+import sys
+from datetime import datetime, timezone
+from typing import TextIO
+
+from aleph.vm import storage_pools
+from aleph.vm.agent import metrics
+from aleph.vm.agent.vm.cache import cache_budget_bytes, cache_entries, cache_roots
+from aleph.vm.agent.vm.purge import purge_vm_storage
+from aleph.vm.agent.vm.reclaimable import (
+    directory_size_bytes,
+    iter_reclaimable,
+    read_marker,
+    reclaimable_bytes,
+)
+from aleph.vm.agent.vm.reconciler import live_hashes, reconcile_storage
+from aleph.vm.agent.vm_registry import AgentVmRegistry, rehydrate_registry
+from aleph.vm.conf import settings
+from aleph.vm.storage_budget import parse_budget
+from aleph.vm.storage_pools import iter_namespace_dirs
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="aleph-vm storage", description="VM storage reclamation")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("status", help="per-pool and per-cache usage against the budgets")
+    list_parser = sub.add_parser("list", help="VM directories on every pool")
+    list_parser.add_argument("--reclaimable", action="store_true", help="only directories no VM owns")
+    reclaim_parser = sub.add_parser("reclaim", help="purge one reclaimable VM directory now")
+    reclaim_parser.add_argument("vm_hash")
+    reconcile_parser = sub.add_parser("reconcile", help="run one reconciler pass")
+    reconcile_parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+_UNIT_STEP = 1024
+
+
+def _human(size: int) -> str:
+    value = float(size)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < _UNIT_STEP or unit == "TiB":
+            return f"{value:.1f} {unit}" if unit != "B" else f"{int(value)} B"
+        value /= _UNIT_STEP
+    return f"{value:.1f} TiB"
+
+
+def _age(since: datetime) -> str:
+    delta = datetime.now(tz=timezone.utc) - since
+    days, rem = divmod(int(delta.total_seconds()), 86400)
+    hours = rem // 3600
+    return f"{days}d {hours}h"
+
+
+def _status(registry: AgentVmRegistry, out: TextIO) -> int:
+    live = live_hashes(registry)
+    out.write("POOL\tLIVE\tRECLAIMABLE\tBUDGET\tFREE\n")
+    for pool in storage_pools.get_pools():
+        live_bytes = sum(
+            directory_size_bytes(directory)
+            for directory in iter_namespace_dirs()
+            if directory.parent == pool.path and directory.name in live
+        )
+        try:
+            usage = shutil.disk_usage(str(pool.path))
+            total, free = usage.total, usage.free
+        except OSError:
+            total = free = 0
+        budget = 0 if settings.VOLUME_RETENTION == "reap" else parse_budget(settings.VOLUME_RETENTION_BUDGET, total)
+        out.write(
+            f"{pool.path}\t{_human(live_bytes)}\t{_human(reclaimable_bytes(pool.path))}\t"
+            f"{_human(budget)}\t{_human(free)}\n"
+        )
+    out.write("CACHE\tUSED\tBUDGET\n")
+    for root in cache_roots():
+        used = sum(entry.size_bytes for entry in cache_entries(root))
+        try:
+            budget = cache_budget_bytes(root)
+        except OSError:
+            budget = 0
+        out.write(f"{root}\t{_human(used)}\t{_human(budget)}\n")
+    return 0
+
+
+def _list(out: TextIO, *, reclaimable_only: bool) -> int:
+    out.write("HASH\tPOOL\tSIZE\tREASON\tAGE\n")
+    for directory in iter_namespace_dirs():
+        marker = read_marker(directory)
+        if reclaimable_only and marker is None:
+            continue
+        reason = marker.reason if marker else "live"
+        age = _age(marker.reclaimable_since) if marker else "-"
+        out.write(f"{directory.name}\t{directory.parent}\t{_human(directory_size_bytes(directory))}\t{reason}\t{age}\n")
+    return 0
+
+
+def _reclaim(vm_hash: str, out: TextIO) -> int:
+    marked = [directory for directory, _marker in iter_reclaimable() if directory.name == vm_hash]
+    if not marked:
+        out.write(
+            f"{vm_hash} is not reclaimable (no .reclaimable marker); refusing to purge a directory a VM may own\n"
+        )
+        return 1
+    deleted = purge_vm_storage(vm_hash)
+    out.write(f"Purged {vm_hash}: {deleted} volume file(s)\n")
+    return 0
+
+
+def _reconcile(registry: AgentVmRegistry, out: TextIO, *, dry_run: bool) -> int:
+    report = reconcile_storage(registry, dry_run=dry_run)
+    prefix = "Dry run: " if dry_run else "Reconciled: "
+    out.write(prefix + report.summary() + "\n")
+    for name in report.purged_orphans + report.evicted:
+        out.write(f"  {'would purge' if dry_run else 'purged'} {name}\n")
+    for name in report.marked_orphans:
+        out.write(f"  {'would mark' if dry_run else 'marked'} {name}\n")
+    return 0
+
+
+def run(args: argparse.Namespace, registry: AgentVmRegistry, out: TextIO) -> int:
+    if args.command == "status":
+        return _status(registry, out)
+    if args.command == "list":
+        return _list(out, reclaimable_only=args.reclaimable)
+    if args.command == "reclaim":
+        return _reclaim(args.vm_hash, out)
+    if args.command == "reconcile":
+        return _reconcile(registry, out, dry_run=args.dry_run)
+    return 2
+
+
+async def _load_registry() -> AgentVmRegistry:
+    metrics.setup_engine()
+    registry = AgentVmRegistry()
+    await rehydrate_registry(registry)
+    return registry
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    settings.setup()
+    storage_pools.setup_pools()
+    registry = asyncio.run(_load_registry())
+    return run(args, registry, sys.stdout)

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -262,7 +262,7 @@ def _reconcile(registry: AgentVmRegistry, out: TextIO, *, dry_run: bool, trust_r
             "Warning: supervisor unreachable; showing what a registry-only pass would purge; "
             "pass --trust-registry to purge using the registry alone\n"
         )
-    report = reconcile_storage(registry, dry_run=effective_dry_run, live=live)
+    report = reconcile_storage(registry, dry_run=effective_dry_run, live=live, live_known=reachable)
     prefix = "Dry run: " if effective_dry_run else "Reconciled: "
     out.write(prefix + report.summary() + "\n")
     for name in report.purged_orphans + report.evicted:

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -48,6 +48,7 @@ from aleph.vm.agent.vm.reclaimable import (
 from aleph.vm.agent.vm.reconciler import (
     _release_cache_devices,
     _still_on_disk,
+    _teardown_orphan_devices,
     live_hashes,
     reconcile_storage,
     supervisor_hashes,
@@ -262,6 +263,14 @@ def _reconcile(registry: AgentVmRegistry, out: TextIO, *, dry_run: bool, trust_r
             "Warning: supervisor unreachable; showing what a registry-only pass would purge; "
             "pass --trust-registry to purge using the registry alone\n"
         )
+    # Mirrors reconcile_now: the devices of every namespace nothing owns go
+    # before the walk, or the purge that follows refuses those directories
+    # (a dm target still holds their volume files) exactly as the daemon's
+    # passes used to. Only when the supervisor answered, since removing the
+    # device of a VM that is merely unlisted takes that VM's disk with it:
+    # --trust-registry buys a purge on the registry's word, not a teardown.
+    if not effective_dry_run and reachable:
+        asyncio.run(_teardown_orphan_devices(live))
     report = reconcile_storage(registry, dry_run=effective_dry_run, live=live, live_known=reachable)
     prefix = "Dry run: " if effective_dry_run else "Reconciled: "
     out.write(prefix + report.summary() + "\n")

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -18,11 +18,18 @@ supervisor.
 What this process still cannot see, even with the supervisor reachable: a
 create the daemon is in the middle of. ``reconciler.is_creating()`` is an
 in-process set the running agent populates for the duration of a create; a
-CLI invocation is a separate process and never sees it, so a create that has
-outlived ``VOLUME_CREATE_GUARD`` and has not yet landed in the registry or
-in ``list_vms`` looks exactly like an orphan to a real ``reconcile`` here.
-The daemon's own pass (startup, periodic, at-GONE) is always preferred when
-the daemon is up; this command exists mainly for when it is not.
+CLI invocation is a separate process and never sees it. What protects such
+a create here is only the age of its directory: the directory purge and the
+orphan-device teardown both leave a namespace whose directory is younger
+than ``VOLUME_CREATE_GUARD`` alone, so a create that has outlived the guard
+and has not yet landed in the registry DB or in ``list_vms`` looks exactly
+like an orphan to a real ``reconcile`` here, directory and devices alike.
+A CLI pass also shares no lock with the daemon's own passes and can run
+concurrently with one; that is benign (purges are idempotent and tolerate a
+directory that vanished under them, markers are written exclusively), but
+it is one more reason the daemon's own pass (startup, periodic, at-GONE) is
+always preferred when the daemon is up; this command exists mainly for when
+it is not.
 """
 
 from __future__ import annotations
@@ -96,10 +103,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "Run one reconciler pass against the agent registry (unioned with the supervisor's "
             "list_vms() when it can be reached). This process cannot see a create the daemon is "
             "currently in the middle of: is_creating() is in-process state of the running agent, "
-            "so a create that has outlived VOLUME_CREATE_GUARD and is not yet in the registry or "
-            "list_vms looks like an orphan here and a real pass can remove it. Prefer the daemon's "
-            "own pass (it runs at startup, periodically, and after every GONE) when the daemon is "
-            "up; use this command mainly when it is not."
+            "and only the age of the directory protects such a create here, so a create that has "
+            "outlived VOLUME_CREATE_GUARD and is not yet in the registry DB or list_vms looks like "
+            "an orphan and a real pass can remove its directory and its devices. Prefer the "
+            "daemon's own pass (it runs at startup, periodically, and after every GONE) when the "
+            "daemon is up; use this command mainly when it is not."
         ),
     )
     reconcile_parser.add_argument("--dry-run", action="store_true")

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -74,8 +74,10 @@ SUPERVISOR_CONNECT_TIMEOUT_SECS = 3.0
 # Exit code for a reconcile that silently downgraded to a dry run because the
 # supervisor could not be asked and --trust-registry was not given. Distinct
 # from an explicit --dry-run, which is a success (exit 0): nothing was
-# downgraded, the caller asked for a preview and got one.
-DEGRADED_EXIT_CODE = 2
+# downgraded, the caller asked for a preview and got one. Not 2, which
+# argparse uses for a usage error: a wrapper script must be able to tell a
+# degraded pass from a bad argument without parsing stderr.
+DEGRADED_EXIT_CODE = 3
 
 logger = logging.getLogger(__name__)
 
@@ -215,13 +217,22 @@ def _status(registry: AgentVmRegistry, out: TextIO) -> int:
     return 0
 
 
-def _list(out: TextIO, *, reclaimable_only: bool) -> int:
+def _list(registry: AgentVmRegistry, out: TextIO, *, reclaimable_only: bool) -> int:
+    # REASON is the marker's reason for a reclaimable directory. An unmarked
+    # directory is "live" only when the registry knows its hash; otherwise
+    # it is "unmarked", which is what an operator triaging by hand needs to
+    # see: an orphan no pass has reached yet must not read as a live VM.
+    # Registry only, like status: list never dials the supervisor.
+    live = live_hashes(registry)
     out.write("HASH\tPOOL\tSIZE\tREASON\tAGE\n")
     for directory in iter_namespace_dirs():
         marker = read_marker(directory)
         if reclaimable_only and marker is None:
             continue
-        reason = marker.reason if marker else "live"
+        if marker:
+            reason = marker.reason
+        else:
+            reason = "live" if directory.name in live else "unmarked"
         age = _age(marker.reclaimable_since) if marker else "-"
         out.write(f"{directory.name}\t{directory.parent}\t{_human(directory_size_bytes(directory))}\t{reason}\t{age}\n")
     return 0
@@ -298,7 +309,7 @@ def run(args: argparse.Namespace, registry: AgentVmRegistry, out: TextIO) -> int
     if args.command == "status":
         return _status(registry, out)
     if args.command == "list":
-        return _list(out, reclaimable_only=args.reclaimable)
+        return _list(registry, out, reclaimable_only=args.reclaimable)
     if args.command == "reclaim":
         return _reclaim(registry, args.vm_hash, out, trust_registry=args.trust_registry)
     if args.command == "reconcile":

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -53,6 +53,7 @@ from aleph.vm.agent.vm.reclaimable import (
     reclaimable_bytes,
 )
 from aleph.vm.agent.vm.reconciler import (
+    _plausible,
     _release_cache_devices,
     _still_on_disk,
     _teardown_orphan_devices,
@@ -238,35 +239,44 @@ def _list(registry: AgentVmRegistry, out: TextIO, *, reclaimable_only: bool) -> 
     return 0
 
 
-def _reclaim(registry: AgentVmRegistry, vm_hash: str, out: TextIO, *, trust_registry: bool) -> int:
-    # Cheapest, purely local check first: a typo or an unrelated hash fails
-    # instantly instead of waiting out a supervisor dial that can only ever
-    # confirm what this check already knows.
-    marked = [directory for directory, _marker in iter_reclaimable() if directory.name == vm_hash]
-    if not marked:
-        out.write(
-            f"{vm_hash} is not reclaimable (no .reclaimable marker); refusing to purge a directory a VM may own\n"
-        )
-        return 1
+def _reclaim_refusal(registry: AgentVmRegistry, vm_hash: str, *, trust_registry: bool) -> str | None:
+    """Why reclaim must not purge this hash, or None when it may.
+
+    Cheapest, purely local checks first: a typo or an unrelated hash fails
+    instantly instead of waiting out a supervisor dial that can only ever
+    confirm what these checks already know. The name check mirrors the
+    daemon's walk: a hand-made marker under a directory nobody named after a
+    VM must be refused here, not tripped over as a ValueError inside
+    purge_vm_storage after every other check passed.
+    """
+    if not _plausible(vm_hash):
+        return f"{vm_hash!r} is not a VM hash; refusing to purge a directory not named after a VM"
+    if not any(directory.name == vm_hash for directory, _marker in iter_reclaimable()):
+        return f"{vm_hash} is not reclaimable (no .reclaimable marker); refusing to purge a directory a VM may own"
     if vm_hash in live_hashes(registry):
-        out.write(f"{vm_hash} is a live VM in the agent registry; refusing to purge it\n")
-        return 1
+        return f"{vm_hash} is a live VM in the agent registry; refusing to purge it"
     running = asyncio.run(_supervisor_running_hashes())
     if running is not None:
         if vm_hash in running:
-            out.write(f"{vm_hash} is running (the supervisor lists it); refusing to purge it\n")
-            return 1
+            return f"{vm_hash} is running (the supervisor lists it); refusing to purge it"
     elif not trust_registry:
-        out.write(
+        return (
             f"Supervisor unreachable; cannot confirm {vm_hash} is not running. "
-            "Pass --trust-registry to purge using the registry alone\n"
+            "Pass --trust-registry to purge using the registry alone"
         )
+    return None
+
+
+def _reclaim(registry: AgentVmRegistry, vm_hash: str, out: TextIO, *, trust_registry: bool) -> int:
+    refusal = _reclaim_refusal(registry, vm_hash, trust_registry=trust_registry)
+    if refusal is not None:
+        out.write(refusal + "\n")
         return 1
     deleted = purge_vm_storage(vm_hash)
     if _still_on_disk(vm_hash):
         out.write(
-            f"Purge of {vm_hash} left directories behind: a device-mapper target still holds its volumes; "
-            "retry once it is torn down\n"
+            f"Purge of {vm_hash} left directories behind: a device-mapper target still holds its volumes. "
+            "Run 'storage reconcile' to tear down the devices of every VM nothing owns, then retry\n"
         )
         return 1
     out.write(f"Purged {vm_hash}: {deleted} volume file(s)\n")

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -837,7 +837,18 @@ def orphan_device_namespaces(live: Collection[str]) -> list[str]:
     ``<namespace>_<volume name>``, read straight out of /dev/mapper. Anything
     that is not a plausible item hash is not a VM device and is not this
     pass's business.
+
+    A namespace whose directory is younger than VOLUME_CREATE_GUARD keeps its
+    devices, the same guard the directory purge applies. A create has its
+    devices before it has a record anything outside the creating process
+    can see: the registry record reaches the DB only once the VM runs, and
+    ``list_vms`` answers only once ``create_vm`` returned, so a pass run from
+    another process (the storage CLI) would otherwise take the devices of a
+    VM mid-build and boot it on nothing. The guard is not a substitute for
+    ``is_creating`` in-process, only the same floor for the other one.
     """
+    now = datetime.now(tz=timezone.utc)
+    guard = timedelta(seconds=settings.VOLUME_CREATE_GUARD)
     namespaces: set[str] = set()
     try:
         devices = list(Path(DEVICE_MAPPER_DIRECTORY).glob("*_*"))
@@ -848,8 +859,23 @@ def orphan_device_namespaces(live: Collection[str]) -> list[str]:
         namespace = device.name.split("_", 1)[0]
         if not _plausible(namespace) or namespace in live or is_creating(namespace):
             continue
+        if _within_create_guard(namespace, now, guard):
+            continue
         namespaces.add(namespace)
     return sorted(namespaces)
+
+
+def _within_create_guard(namespace: str, now: datetime, guard: timedelta) -> bool:
+    """Whether any directory of the namespace is young enough to be a create
+    in flight. A namespace with no directory at all is not: its devices are
+    what a create left behind, not what one is building on."""
+    for directory in iter_namespace_dirs(namespace):
+        try:
+            if now - _mtime(directory) < guard:
+                return True
+        except OSError:
+            continue
+    return False
 
 
 async def _teardown_orphan_devices(live: Collection[str]) -> list[str]:

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -927,7 +927,11 @@ async def test_a_young_directory_keeps_its_devices_without_the_in_process_guard(
     assert torn == []
     assert young.exists()
 
-    _age(young, 10_000)
+    # Aged against the clock, not NOW: orphan_device_namespaces reads the
+    # clock itself (reconcile_now threads no `now`), and the young case above
+    # already relies on the directory's real mtime being recent.
+    stamp = time.time() - 10_000
+    os.utime(young, (stamp, stamp))
     await reconcile_now(_app(registry, _supervisor()))
     assert torn == [VM_HASH]
 

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -912,6 +912,27 @@ async def test_a_create_in_flight_keeps_its_devices(pools, registry, monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_a_young_directory_keeps_its_devices_without_the_in_process_guard(pools, registry, monkeypatch, tmp_path):  # noqa: F811
+    """What a pass from another process sees of a create in flight: no
+    creating() entry, no registry record yet, no list_vms answer, only a
+    directory younger than VOLUME_CREATE_GUARD. The devices get the same
+    guard the directory purge gives the directory."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    young = volume(pools["pool0"], VM_HASH, "rootfs.btrfs").parent
+    _fake_mapper(monkeypatch, tmp_path, f"{VM_HASH}_rootfs")
+    torn: list[str] = []
+    monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
+
+    await reconcile_now(_app(registry, _supervisor()))
+    assert torn == []
+    assert young.exists()
+
+    _age(young, 10_000)
+    await reconcile_now(_app(registry, _supervisor()))
+    assert torn == [VM_HASH]
+
+
+@pytest.mark.asyncio
 async def test_no_device_is_torn_down_when_the_supervisor_cannot_be_listed(pools, registry, monkeypatch, tmp_path):  # noqa: F811
     """A VM the supervisor would have listed is live; removing its dm device
     takes its disk with it."""

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -255,6 +255,30 @@ def test_reconcile_trust_registry_purges_when_supervisor_unreachable(pools, regi
     assert other.exists()
 
 
+def test_reconcile_passes_live_known_false_when_supervisor_unreachable(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(fails=True))
+    fake_report = reconciler_module.ReconcileReport()
+    spy = MagicMock(return_value=fake_report)
+    monkeypatch.setattr(cli, "reconcile_storage", spy)
+
+    code, out = _run(["reconcile", "--trust-registry"], registry)
+
+    assert code == 0
+    assert spy.call_args.kwargs["live_known"] is False
+
+
+def test_reconcile_passes_live_known_true_when_supervisor_reachable(pools, registry, monkeypatch):  # noqa: F811
+    # The autouse fixture already installs a reachable fake supervisor.
+    fake_report = reconciler_module.ReconcileReport()
+    spy = MagicMock(return_value=fake_report)
+    monkeypatch.setattr(cli, "reconcile_storage", spy)
+
+    code, out = _run(["reconcile"], registry)
+
+    assert code == 0
+    assert spy.call_args.kwargs["live_known"] is True
+
+
 def test_reconcile_tears_down_devices_of_evicted_cache_parents(pools, registry, monkeypatch):  # noqa: F811
     monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
     stale = pools["runtime"] / "stale"

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -4,7 +4,8 @@ import io
 import os
 import time
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aleph_message.models import ItemHash
@@ -30,6 +31,22 @@ def registry():
 @pytest.fixture(autouse=True)
 def _no_backups(mocker):
     mocker.patch("aleph.vm.agent.vm.reconciler.sweep_expired_backups", return_value=0)
+
+
+def _fake_supervisor(*vm_ids: str, fails: bool = False):
+    """A supervisor handle that lists ``vm_ids``, or cannot be asked at all
+    (an unreachable daemon: a connection error, a timeout, any of it)."""
+    if fails:
+        return SimpleNamespace(list_vms=AsyncMock(side_effect=RuntimeError("no answer")))
+    return SimpleNamespace(list_vms=AsyncMock(return_value=[SimpleNamespace(vm_id=vm_id) for vm_id in vm_ids]))
+
+
+@pytest.fixture(autouse=True)
+def _supervisor_reachable(monkeypatch):
+    """By default the supervisor is reachable and lists nothing running: the
+    tests that care about a different answer override ``_open_supervisor``
+    themselves."""
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor())
 
 
 def _run(argv: list[str], registry) -> tuple[int, str]:
@@ -65,17 +82,54 @@ def test_list_shows_every_vm_dir_and_reclaimable_filters(pools, registry):  # no
 
 
 def test_reclaim_purges_a_reclaimable_dir_only(pools, registry):  # noqa: F811
-    live = volume(pools["pool0"], LIVE, "rootfs.qcow2")
     gone = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    unmarked = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2")
     mark_reclaimable(VM_HASH, "gone", now=NOW)
 
     code, out = _run(["reclaim", VM_HASH], registry)
     assert code == 0 and "Purged" in out
     assert not gone.exists()
 
-    code, out = _run(["reclaim", LIVE], registry)
+    # OTHER_HASH is on disk, unmarked, unknown to the registry and to the
+    # (fake, reachable) supervisor: reclaim refuses it for lack of a marker,
+    # not because anything claims to own it.
+    code, out = _run(["reclaim", OTHER_HASH], registry)
     assert code == 1 and "not reclaimable" in out
+    assert unmarked.exists()
+
+
+def test_reclaim_refuses_a_live_registry_hash(pools, registry):  # noqa: F811
+    live = volume(pools["pool0"], LIVE, "rootfs.qcow2")
+
+    code, out = _run(["reclaim", LIVE], registry)
+
+    assert code == 1 and "live" in out
     assert live.exists()
+
+
+def test_reclaim_refuses_a_hash_the_supervisor_lists_as_running(pools, registry, monkeypatch):  # noqa: F811
+    gone = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(VM_HASH))
+
+    code, out = _run(["reclaim", VM_HASH], registry)
+
+    assert code == 1 and "running" in out
+    assert gone.exists()
+
+
+def test_reclaim_refuses_unless_trust_registry_when_supervisor_unreachable(pools, registry, monkeypatch):  # noqa: F811
+    gone = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(fails=True))
+
+    code, out = _run(["reclaim", VM_HASH], registry)
+    assert code == 1 and "unreachable" in out
+    assert gone.exists()
+
+    code, out = _run(["reclaim", "--trust-registry", VM_HASH], registry)
+    assert code == 0 and "Purged" in out
+    assert not gone.exists()
 
 
 def test_reconcile_dry_run_reports_without_changing(pools, registry, monkeypatch):  # noqa: F811
@@ -89,8 +143,55 @@ def test_reconcile_dry_run_reports_without_changing(pools, registry, monkeypatch
     assert code == 0 and "Dry run" in out and "purged=1" in out
     assert orphan.exists()
 
+    # The fake supervisor (installed by the autouse fixture) is reachable and
+    # lists nothing running, so a real pass is allowed to purge.
     code, out = _run(["reconcile"], registry)
     assert code == 0 and not orphan.exists()
+
+
+def test_reconcile_leaves_a_supervisor_known_vm_the_registry_does_not(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    unknown = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2")
+    stamp = time.time() - 10_000
+    os.utime(unknown.parent, (stamp, stamp))
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(OTHER_HASH))
+
+    code, out = _run(["reconcile"], registry)
+
+    assert code == 0
+    assert unknown.exists()
+
+
+def test_reconcile_dry_runs_and_warns_when_supervisor_unreachable(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    orphan = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    stamp = time.time() - 10_000
+    os.utime(orphan.parent, (stamp, stamp))
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(fails=True))
+
+    code, out = _run(["reconcile"], registry)
+
+    assert code == 0 and "unreachable" in out and "Dry run" in out
+    assert orphan.exists()
+
+
+def test_reconcile_trust_registry_purges_when_supervisor_unreachable(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    orphan = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    stamp = time.time() - 10_000
+    os.utime(orphan.parent, (stamp, stamp))
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(fails=True))
+
+    code, out = _run(["reconcile", "--trust-registry"], registry)
+
+    assert code == 0 and not orphan.exists()
+
+    # --dry-run still wins even with --trust-registry.
+    other = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2")
+    os.utime(other.parent, (time.time() - 10_000, time.time() - 10_000))
+    code, out = _run(["reconcile", "--dry-run", "--trust-registry"], registry)
+    assert code == 0 and "Dry run" in out
+    assert other.exists()
 
 
 def test_cli_main_dispatches_storage_subcommand(mocker):

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import io
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from aleph_message.models import ItemHash
+from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
+
+import aleph.vm.agent.storage_cli as cli
+from aleph.vm.agent.vm.reclaimable import mark_reclaimable
+from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.conf import settings
+
+LIVE = "dead" * 16
+NOW = datetime(2026, 8, 24, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def registry():
+    reg = AgentVmRegistry()
+    content = MagicMock(volumes=[], rootfs=None)
+    reg.record(ItemHash(LIVE), message=content, original=content, persistent=True)
+    return reg
+
+
+@pytest.fixture(autouse=True)
+def _no_backups(mocker):
+    mocker.patch("aleph.vm.agent.vm.reconciler.sweep_expired_backups", return_value=0)
+
+
+def _run(argv: list[str], registry) -> tuple[int, str]:
+    out = io.StringIO()
+    code = cli.run(cli.parse_args(argv), registry, out)
+    return code, out.getvalue()
+
+
+def test_status_lists_pools_and_caches(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    volume(pools["pool0"], LIVE, "rootfs.qcow2", size=4096)
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=4096)
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+
+    code, out = _run(["status"], registry)
+
+    assert code == 0
+    assert "POOL" in out and str(pools["pool0"]) in out and str(pools["pool1"]) in out
+    assert "CACHE" in out and str(pools["runtime"]) in out
+
+
+def test_list_shows_every_vm_dir_and_reclaimable_filters(pools, registry):  # noqa: F811
+    volume(pools["pool0"], LIVE, "rootfs.qcow2")
+    volume(pools["pool1"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "orphan", now=NOW - timedelta(days=3))
+
+    code, out = _run(["list"], registry)
+    assert code == 0
+    assert LIVE in out and VM_HASH in out
+
+    code, out = _run(["list", "--reclaimable"], registry)
+    assert LIVE not in out and VM_HASH in out and "orphan" in out
+
+
+def test_reclaim_purges_a_reclaimable_dir_only(pools, registry):  # noqa: F811
+    live = volume(pools["pool0"], LIVE, "rootfs.qcow2")
+    gone = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+
+    code, out = _run(["reclaim", VM_HASH], registry)
+    assert code == 0 and "Purged" in out
+    assert not gone.exists()
+
+    code, out = _run(["reclaim", LIVE], registry)
+    assert code == 1 and "not reclaimable" in out
+    assert live.exists()
+
+
+def test_reconcile_dry_run_reports_without_changing(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    orphan = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    stamp = time.time() - 10_000
+    os.utime(orphan.parent, (stamp, stamp))
+
+    code, out = _run(["reconcile", "--dry-run"], registry)
+
+    assert code == 0 and "Dry run" in out and "purged=1" in out
+    assert orphan.exists()
+
+    code, out = _run(["reconcile"], registry)
+    assert code == 0 and not orphan.exists()
+
+
+def test_cli_main_dispatches_storage_subcommand(mocker):
+    from aleph.vm.agent import cli as agent_cli
+
+    storage_main = mocker.patch("aleph.vm.agent.storage_cli.main", return_value=7)
+    mocker.patch("sys.argv", ["aleph-vm", "storage", "status"])
+    with pytest.raises(SystemExit) as exit_info:
+        agent_cli.main()
+    assert exit_info.value.code == 7
+    storage_main.assert_called_once_with(["status"])

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -122,7 +122,12 @@ def test_reclaim_checks_the_marker_before_dialing_the_supervisor(pools, registry
     """A typo'd or unrelated hash is refused by the purely local marker check
     alone: nothing here should wait out a supervisor dial first."""
     dialed = []
-    monkeypatch.setattr(cli, "_open_supervisor", lambda: dialed.append(True) or _fake_supervisor())
+
+    def open_supervisor():
+        dialed.append(True)
+        return _fake_supervisor()
+
+    monkeypatch.setattr(cli, "_open_supervisor", open_supervisor)
 
     code, out = _run(["reclaim", "not-a-real-hash"], registry)
 

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -91,11 +91,15 @@ def test_status_lists_pools_and_caches(pools, registry, monkeypatch):  # noqa: F
 def test_list_shows_every_vm_dir_and_reclaimable_filters(pools, registry):  # noqa: F811
     volume(pools["pool0"], LIVE, "rootfs.qcow2")
     volume(pools["pool1"], VM_HASH, "rootfs.qcow2")
+    volume(pools["pool1"], OTHER_HASH, "rootfs.qcow2")
     mark_reclaimable(VM_HASH, "orphan", now=NOW - timedelta(days=3))
 
     code, out = _run(["list"], registry)
     assert code == 0
-    assert LIVE in out and VM_HASH in out
+    rows = {line.split("\t")[0]: line.split("\t")[3] for line in out.splitlines()[1:]}
+    # An unmarked directory is "live" only on the registry's word; an
+    # unmarked orphan no pass has reached yet must not read as a live VM.
+    assert rows == {LIVE: "live", VM_HASH: "orphan", OTHER_HASH: "unmarked"}
 
     code, out = _run(["list", "--reclaimable"], registry)
     assert LIVE not in out and VM_HASH in out and "orphan" in out

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -4,6 +4,7 @@ import io
 import os
 import time
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -12,6 +13,7 @@ from aleph_message.models import ItemHash
 from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
 
 import aleph.vm.agent.storage_cli as cli
+import aleph.vm.agent.vm.reconciler as reconciler_module
 from aleph.vm.agent.vm.reclaimable import mark_reclaimable
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
@@ -98,12 +100,39 @@ def test_reclaim_purges_a_reclaimable_dir_only(pools, registry):  # noqa: F811
     assert unmarked.exists()
 
 
-def test_reclaim_refuses_a_live_registry_hash(pools, registry):  # noqa: F811
+def test_reclaim_checks_the_marker_before_dialing_the_supervisor(pools, registry, monkeypatch):  # noqa: F811, ARG001
+    """A typo'd or unrelated hash is refused by the purely local marker check
+    alone: nothing here should wait out a supervisor dial first."""
+    dialed = []
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: dialed.append(True) or _fake_supervisor())
+
+    code, out = _run(["reclaim", "not-a-real-hash"], registry)
+
+    assert code == 1 and "not reclaimable" in out
+    assert dialed == []
+
+
+def test_reclaim_refuses_an_unmarked_live_directory(pools, registry):  # noqa: F811
+    """A live VM's directory ordinarily carries no marker, so the marker
+    check alone already refuses it."""
     live = volume(pools["pool0"], LIVE, "rootfs.qcow2")
 
     code, out = _run(["reclaim", LIVE], registry)
 
-    assert code == 1 and "live" in out
+    assert code == 1 and "not reclaimable" in out
+    assert live.exists()
+
+
+def test_reclaim_refuses_a_marked_but_still_live_registry_hash(pools, registry):  # noqa: F811
+    """A stale marker on a directory the registry still calls live (not yet
+    cleared by a reconcile pass): the registry check catches it once the
+    marker check has passed."""
+    live = volume(pools["pool0"], LIVE, "rootfs.qcow2")
+    mark_reclaimable(LIVE, "orphan", now=NOW)
+
+    code, out = _run(["reclaim", LIVE], registry)
+
+    assert code == 1 and "live VM in the agent registry" in out
     assert live.exists()
 
 
@@ -130,6 +159,20 @@ def test_reclaim_refuses_unless_trust_registry_when_supervisor_unreachable(pools
     code, out = _run(["reclaim", "--trust-registry", VM_HASH], registry)
     assert code == 0 and "Purged" in out
     assert not gone.exists()
+
+
+def test_reclaim_refuses_when_the_purge_leaves_a_dm_held_directory(pools, registry, monkeypatch):  # noqa: F811
+    held = volume(pools["pool0"], VM_HASH, "data.btrfs")
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+    dm_path = Path("/dev/mapper") / f"{VM_HASH}_data"
+    real_is_block_device = Path.is_block_device
+    monkeypatch.setattr(Path, "is_block_device", lambda self: self == dm_path or real_is_block_device(self))
+
+    code, out = _run(["reclaim", VM_HASH], registry)
+
+    assert code == 1
+    assert "device-mapper" in out
+    assert held.exists()
 
 
 def test_reconcile_dry_run_reports_without_changing(pools, registry, monkeypatch):  # noqa: F811
@@ -162,7 +205,7 @@ def test_reconcile_leaves_a_supervisor_known_vm_the_registry_does_not(pools, reg
     assert unknown.exists()
 
 
-def test_reconcile_dry_runs_and_warns_when_supervisor_unreachable(pools, registry, monkeypatch):  # noqa: F811
+def test_reconcile_unreachable_exits_nonzero_and_warns_on_stderr(pools, registry, monkeypatch, capsys):  # noqa: F811
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
     orphan = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
     stamp = time.time() - 10_000
@@ -171,7 +214,25 @@ def test_reconcile_dry_runs_and_warns_when_supervisor_unreachable(pools, registr
 
     code, out = _run(["reconcile"], registry)
 
-    assert code == 0 and "unreachable" in out and "Dry run" in out
+    assert code == cli.DEGRADED_EXIT_CODE
+    assert "Dry run" in out
+    assert "unreachable" not in out  # the warning must not land in the parseable report
+    err = capsys.readouterr().err
+    assert "unreachable" in err and "registry-only" in err
+    assert orphan.exists()
+
+
+def test_reconcile_explicit_dry_run_stays_exit_zero_when_unreachable(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    orphan = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    stamp = time.time() - 10_000
+    os.utime(orphan.parent, (stamp, stamp))
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(fails=True))
+
+    code, out = _run(["reconcile", "--dry-run"], registry)
+
+    assert code == 0
+    assert "Dry run" in out
     assert orphan.exists()
 
 
@@ -192,6 +253,34 @@ def test_reconcile_trust_registry_purges_when_supervisor_unreachable(pools, regi
     code, out = _run(["reconcile", "--dry-run", "--trust-registry"], registry)
     assert code == 0 and "Dry run" in out
     assert other.exists()
+
+
+def test_reconcile_tears_down_devices_of_evicted_cache_parents(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    stale = pools["runtime"] / "stale"
+    stale.write_bytes(b"x" * 4096)
+    removed: list[str] = []
+    monkeypatch.setattr(reconciler_module, "remove_parent_device", AsyncMock(side_effect=removed.append))
+
+    code, out = _run(["reconcile"], registry)
+
+    assert code == 0
+    assert not stale.exists()
+    assert removed == ["stale"]
+
+
+def test_reconcile_dry_run_never_touches_cache_parent_devices(pools, registry, monkeypatch):  # noqa: F811
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    stale = pools["runtime"] / "stale"
+    stale.write_bytes(b"x" * 4096)
+    removed: list[str] = []
+    monkeypatch.setattr(reconciler_module, "remove_parent_device", AsyncMock(side_effect=removed.append))
+
+    code, out = _run(["reconcile", "--dry-run"], registry)
+
+    assert code == 0
+    assert stale.exists()
+    assert removed == []
 
 
 def test_cli_main_dispatches_storage_subcommand(mocker):

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -402,3 +402,18 @@ def test_reconcile_leaves_orphan_devices_when_the_supervisor_is_unreachable(pool
 
     assert code == 0
     assert torn == []
+
+
+def test_a_degraded_reconcile_leaves_orphan_devices_too(pools, registry, monkeypatch, tmp_path):  # noqa: F811
+    """Without --trust-registry an unreachable supervisor downgrades the pass
+    to a dry run, and a dry run tears nothing down: the device skip holds on
+    both counts, not only through the --trust-registry branch."""
+    _fake_mapper(monkeypatch, tmp_path, f"{VM_HASH}_rootfs")
+    torn: list[str] = []
+    monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(fails=True))
+
+    code, _out = _run(["reconcile"], registry)
+
+    assert code == cli.DEGRADED_EXIT_CODE
+    assert torn == []

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -14,7 +14,11 @@ from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
 
 import aleph.vm.agent.storage_cli as cli
 import aleph.vm.agent.vm.reconciler as reconciler_module
-from aleph.vm.agent.vm.reclaimable import mark_reclaimable
+from aleph.vm.agent.vm.reclaimable import (
+    ReclaimableMarker,
+    mark_reclaimable,
+    write_marker,
+)
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 
@@ -134,9 +138,25 @@ def test_reclaim_checks_the_marker_before_dialing_the_supervisor(pools, registry
     monkeypatch.setattr(cli, "_open_supervisor", open_supervisor)
 
     code, out = _run(["reclaim", "not-a-real-hash"], registry)
+    assert code == 1 and "not a VM hash" in out
 
+    code, out = _run(["reclaim", "f" * 64], registry)
     assert code == 1 and "not reclaimable" in out
+
     assert dialed == []
+
+
+def test_reclaim_refuses_a_marked_directory_not_named_after_a_vm(pools, registry):  # noqa: F811
+    """A hand-made marker under a directory nobody named after a VM: the
+    daemon's walk drops such names, and reclaim must refuse them cleanly
+    rather than trip over purge_vm_storage's own hash guard."""
+    kept = volume(pools["pool0"], "backup_old", "rootfs.qcow2")
+    write_marker(kept.parent, ReclaimableMarker(reclaimable_since=NOW, reason="gone", size_bytes=0))
+
+    code, out = _run(["reclaim", "backup_old"], registry)
+
+    assert code == 1 and "not a VM hash" in out
+    assert kept.exists()
 
 
 def test_reclaim_refuses_an_unmarked_live_directory(pools, registry):  # noqa: F811

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -35,6 +35,24 @@ def _no_backups(mocker):
     mocker.patch("aleph.vm.agent.vm.reconciler.sweep_expired_backups", return_value=0)
 
 
+@pytest.fixture(autouse=True)
+def _no_device_mapper(tmp_path, monkeypatch):
+    """Never let a test read the host's real /dev/mapper: the reconcile the
+    CLI runs tears down the devices of every namespace nothing owns."""
+    empty = tmp_path / "empty-mapper"
+    empty.mkdir()
+    monkeypatch.setattr(reconciler_module, "DEVICE_MAPPER_DIRECTORY", str(empty))
+
+
+def _fake_mapper(monkeypatch, tmp_path, *names: str) -> Path:
+    mapper = tmp_path / "mapper"
+    mapper.mkdir(exist_ok=True)
+    for name in names:
+        (mapper / name).touch()
+    monkeypatch.setattr(reconciler_module, "DEVICE_MAPPER_DIRECTORY", str(mapper))
+    return mapper
+
+
 def _fake_supervisor(*vm_ids: str, fails: bool = False):
     """A supervisor handle that lists ``vm_ids``, or cannot be asked at all
     (an unreachable daemon: a connection error, a timeout, any of it)."""
@@ -316,3 +334,42 @@ def test_cli_main_dispatches_storage_subcommand(mocker):
         agent_cli.main()
     assert exit_info.value.code == 7
     storage_main.assert_called_once_with(["status"])
+
+
+def test_reconcile_tears_down_the_devices_of_an_orphan_namespace(pools, registry, monkeypatch, tmp_path):  # noqa: F811
+    """Same parity as the cache devices: without this the CLI keeps refusing
+    the dm-held directories the daemon's own pass now reclaims."""
+    _fake_mapper(monkeypatch, tmp_path, f"{VM_HASH}_rootfs", f"{LIVE}_rootfs")
+    torn: list[str] = []
+    monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
+
+    code, _out = _run(["reconcile"], registry)
+
+    assert code == 0
+    assert torn == [VM_HASH]
+
+
+def test_reconcile_dry_run_never_touches_orphan_devices(pools, registry, monkeypatch, tmp_path):  # noqa: F811
+    _fake_mapper(monkeypatch, tmp_path, f"{VM_HASH}_rootfs")
+    torn: list[str] = []
+    monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
+
+    code, _out = _run(["reconcile", "--dry-run"], registry)
+
+    assert code == 0
+    assert torn == []
+
+
+def test_reconcile_leaves_orphan_devices_when_the_supervisor_is_unreachable(pools, registry, monkeypatch, tmp_path):  # noqa: F811
+    """--trust-registry buys a purge on the registry's word, not a teardown:
+    a VM the registry has forgotten but the daemon still runs would lose its
+    disk with its device."""
+    _fake_mapper(monkeypatch, tmp_path, f"{VM_HASH}_rootfs")
+    torn: list[str] = []
+    monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(fails=True))
+
+    code, _out = _run(["reconcile", "--trust-registry"], registry)
+
+    assert code == 0
+    assert torn == []


### PR DESCRIPTION
## Summary

PR E of the 2.1 disk reclamation work (spec Section 6, operator CLI). Stacked on #1161. Last PR of the stack.

`aleph-vm storage ...`, runnable without the agent daemon (filesystem plus the agent DB):

- `status`: per pool live / reclaimable / budget / free bytes, then per cache root used / budget.
- `list [--reclaimable]`: hash, pool, size, reason, age.
- `reclaim <hash>`: purges one directory carrying a `.reclaimable` marker; refuses an unmarked or live hash; exits non-zero if the purge was refused (device-mapper hold).
- `reconcile [--dry-run] [--trust-registry]`: one reconciler pass (same passes and the same cache-device teardown as the daemon's), printing what it removed or would remove.

Fail-closed rule, same as the daemon: `reconcile` and `reclaim` build the live set from the registry union the supervisor's `list_vms()` when the supervisor is reachable (3 s connect timeout); when it is not, `reconcile` runs dry with a warning on stderr and exit code 2 unless `--trust-registry` is passed, and `reclaim` refuses. `status` and `list` never dial the supervisor.

## Known limitation
- The daemon's in-flight-create guard (`creating()`) is process-local; from the CLI only the age of the directory protects a create in flight, for its directory and its devices alike (the orphan-device scan now applies `VOLUME_CREATE_GUARD` too). A real `reconcile` while the daemon is creating a VM that has outlived the guard and is not yet in the registry DB or `list_vms` can remove that create. Stated in `reconcile --help` and the docs; the daemon's own pass is preferred when it is up.
- A CLI pass shares no lock with the daemon's passes; running both at once is benign (idempotent purges, exclusive marker writes).
- Exit code `3` marks a reconcile that downgraded to a dry run; `2` stays argparse's usage error.

## Test plan
- `tests/supervisor`: failing-ID set identical to base.
- New `tests/supervisor/test_storage_cli.py` (24 tests: real temp pools and markers, fake supervisor for all three reachability states, dry-run inertness, exit codes, device teardown seams).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvDhr5NKq3AY17E1vwV3zk


