### PR TITLE
fix(agent): 404, not 500, for a /vm/<hash> the network has no message for

### DIFF
--- a/src/aleph/vm/agent/messages.py
+++ b/src/aleph/vm/agent/messages.py
@@ -18,6 +18,12 @@ async def try_get_message(ref: str) -> ExecutableMessage:
     """Get the message or raise an aiohttp HTTP error"""
     try:
         return await get_message(ref)
+    except FileNotFoundError as error:
+        # The API answered but has no message under this hash: never
+        # existed, or forgotten since. A caller's bad reference, not a
+        # node failure, so a 404 rather than the 500 an unhandled error
+        # would produce.
+        raise HTTPNotFound(reason="Hash not found", text=f"Hash not found: {ref}") from error
     except ClientConnectorError as error:
         raise HTTPServiceUnavailable(reason="Aleph Connector unavailable") from error
     except ClientResponseError as error:

--- a/tests/supervisor/views/test_run_code.py
+++ b/tests/supervisor/views/test_run_code.py
@@ -1,12 +1,14 @@
 import pytest
 from aiohttp import ClientResponseError, web
 from aiohttp.test_utils import make_mocked_request
-from aiohttp.web_exceptions import HTTPBadRequest
+from aiohttp.web_exceptions import HTTPBadRequest, HTTPNotFound
 from aleph_message.exceptions import UnknownHashError
 from aleph_message.models import ItemHash
 
+from aleph.vm.agent.supervisor import setup_webapp
 from aleph.vm.agent.views import run_code_from_path
 from aleph.vm.conf import settings
+from aleph.vm.supervisor.local import LocalSupervisor
 
 
 @pytest.mark.asyncio
@@ -44,3 +46,18 @@ async def test_run_code_from_invalid_path(aiohttp_client):
     assert text == f"Invalid message reference: {item_hash}"
     with pytest.raises(ClientResponseError):
         resp.raise_for_status()
+
+
+@pytest.mark.asyncio
+async def test_run_code_unknown_hash_is_404(aiohttp_client, mocker):
+    """A well-formed hash the API has no message for (never existed, or
+    forgotten) is the caller's problem: 404, not an unhandled 500."""
+    item_hash = "5a3081a97c62c8aba7e81005bfda0489dd93ba1601985e3f2dff2d906ff3ea9b"
+    mocker.patch("aleph.vm.storage._fetch_aleph_message", return_value=None)
+
+    app = setup_webapp(supervisor=LocalSupervisor(None))
+    client = await aiohttp_client(app)
+
+    resp = await client.get(f"/vm/{item_hash}/ip/6")
+    assert resp.status == HTTPNotFound.status_code
+    assert await resp.json() == {"error": f"Hash not found: {item_hash}"}


### PR DESCRIPTION
## Summary
- \`storage.get_message\` raises \`FileNotFoundError\` when the API has no message under the requested hash (never existed, or forgotten), but \`try_get_message\` only mapped the older \`ClientResponseError(404)\` to an HTTP 404. The \`FileNotFoundError\` fell through to the unhandled-exception middleware: a 500 plus a full traceback in the journal on every hit.
- Seen on the mainnet SNP test node: something polls \`GET /vm/5a3081a9…/ip/6\` for a forgotten hash every few minutes, each one logging a 15-line traceback.
- Now a \`404 {"error": "Hash not found: <hash>"}\`, same as the connector 404 path.

## Test plan
- [x] new \`test_run_code_unknown_hash_is_404\` (full webapp, \`_fetch_aleph_message\` mocked to \`None\`)
- [x] \`tests/supervisor/views/test_run_code.py\` + \`test_view_errors.py\` pass locally; ruff format / isort clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwF8MmMGqDPX9Y16VwPvUj