### PR TITLE
feat(packaging)!: Rust supervisor daemon and controller by default

### DIFF
--- a/docs/architecture/process-model.md
+++ b/docs/architecture/process-model.md
@@ -87,13 +87,14 @@ never uses it.
 Both a Python supervisor daemon (`src/aleph/vm/supervisor/daemon.py`) and a
 Rust one (`rust/crates/supervisor-daemon`) ship in the same `.deb`. Which one
 runs is an environment variable, `ALEPH_VM_SUPERVISOR_IMPL` (default
-`python`), read by a tiny dispatch script the systemd unit execs:
+`rust` since 2.0), read by a tiny dispatch script the systemd unit execs:
 `packaging/supervisor-launcher` for the daemon and
 `packaging/controller-launcher` for each per-VM controller. Both scripts read
 the same `/etc/aleph-vm/supervisor.env`, so one env change switches the
-daemon and every controller together; an operator typo falls back to
-`python` rather than failing to start. Cutover and rollback are therefore a
-config change, not a packaging event.
+daemon and every controller together; an operator typo falls back to the
+default (`rust`) rather than failing to start. Rollback to the Python daemon
+is therefore a config change (`ALEPH_VM_SUPERVISOR_IMPL=python`), not a
+packaging event.
 
 ### systemd unit topology
 

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -196,8 +196,8 @@ tests.
 - **The integration suite is implementation-agnostic by construction.**
   `tests/integration/conftest.py` selects the daemon via
   `ALEPH_VM_SUPERVISOR_IMPL` and fails loudly on an unrecognized value
-  instead of defaulting to Python, so the CI matrix's rust leg can never
-  silently test the wrong daemon.
+  instead of guessing (its default mirrors the launcher's, `rust`), so
+  neither CI matrix leg can silently test the wrong daemon.
 - **Proto bindings must stay regenerated and committed.**
   `scripts/check_proto_clean.sh`, run in `test-using-pytest.yml`, reruns
   the Python generator and fails the build if `supervisor_pb2.py` or

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -8,8 +8,8 @@ debian-package: debian-package-resources debian-package-code debian-package-rust
 # (rustup picks it up when cargo runs from inside rust/), installed under
 # /opt/aleph-vm/bin/ next to the supervisor-launcher dispatch script.
 # The deb keeps shipping the full Python tree regardless of the
-# ALEPH_VM_SUPERVISOR_IMPL flag (default python); the Rust daemon is inert
-# until an operator flips /etc/aleph-vm/supervisor.env.
+# ALEPH_VM_SUPERVISOR_IMPL flag (default rust); the Python daemon only runs
+# when an operator sets python in /etc/aleph-vm/supervisor.env.
 # Depends on debian-package-code because that target wipes and rebuilds
 # ./aleph-vm/opt/aleph-vm, where the binaries land.
 debian-package-rust: debian-package-code

--- a/packaging/aleph-vm/etc/aleph-vm/supervisor.env
+++ b/packaging/aleph-vm/etc/aleph-vm/supervisor.env
@@ -5,7 +5,7 @@ ALEPH_VM_PAYMENT_RECEIVER_ADDRESS=
 # Two-process split: the agent talks to the supervisor daemon over this socket.
 # Both units read this file; the daemon binds it, the agent dials it.
 ALEPH_VM_SUPERVISOR_GRPC_SOCKET=/var/lib/aleph/vm/supervisor.sock
-# Supervisor implementation: "python" (default) or "rust". Single source of
+# Supervisor implementation: "rust" (default) or "python". Single source of
 # truth: this one flag switches BOTH the supervisor daemon (via
 # /opt/aleph-vm/bin/supervisor-launcher) AND the per-VM controller (via
 # /opt/aleph-vm/bin/controller-launcher). Both implementations ship in the deb
@@ -17,4 +17,4 @@ ALEPH_VM_SUPERVISOR_GRPC_SOCKET=/var/lib/aleph/vm/supervisor.sock
 # cross-impl reattach of a RUNNING VM (e.g. a python daemon reattaching over
 # QMP to a QEMU that a Rust controller launched) is NOT exercised by CI, so
 # flip the impl on a node with running VMs only after cycling them.
-#ALEPH_VM_SUPERVISOR_IMPL=python
+#ALEPH_VM_SUPERVISOR_IMPL=rust

--- a/packaging/aleph-vm/etc/systemd/system/aleph-vm-controller@.service
+++ b/packaging/aleph-vm/etc/systemd/system/aleph-vm-controller@.service
@@ -14,7 +14,7 @@ WorkingDirectory=/opt/aleph-vm
 Environment=PYTHONPATH=/opt/aleph-vm/:$PYTHONPATH
 EnvironmentFile=/etc/aleph-vm/supervisor.env
 # The launcher picks the controller implementation from ALEPH_VM_SUPERVISOR_IMPL
-# (default python), carried by the EnvironmentFile above: the SAME file and flag
+# (default rust), carried by the EnvironmentFile above: the SAME file and flag
 # the supervisor daemon reads, so one env change switches both together.
 ExecStart=/opt/aleph-vm/bin/controller-launcher --config=/var/lib/aleph/vm/%i-controller.json
 Restart=on-failure

--- a/packaging/aleph-vm/etc/systemd/system/aleph-vm-supervisor.service
+++ b/packaging/aleph-vm/etc/systemd/system/aleph-vm-supervisor.service
@@ -12,7 +12,7 @@ Environment=PYTHONPATH=/opt/aleph-vm/:$PYTHONPATH
 Environment=PYTHONDONTWRITEBYTECODE="enabled"
 EnvironmentFile=/etc/aleph-vm/supervisor.env
 # The launcher picks the daemon implementation from ALEPH_VM_SUPERVISOR_IMPL
-# (default python), carried by the EnvironmentFile above.
+# (default rust), carried by the EnvironmentFile above.
 ExecStart=/opt/aleph-vm/bin/supervisor-launcher
 Restart=on-failure
 RestartPreventExitStatus=0 130 143

--- a/packaging/controller-launcher
+++ b/packaging/controller-launcher
@@ -8,8 +8,9 @@
 # reads). One env flag switches BOTH the daemon and the controller, so a node
 # never runs the Rust daemon with the Python controller or vice versa.
 #
-# The deb ships both controllers; cutover is a one-line env change, not a
-# packaging event. "$@" carries the --config=... argument through unchanged.
+# The deb ships both controllers; the Rust controller is the default (2.0),
+# ALEPH_VM_SUPERVISOR_IMPL=python is the one-line rollback, not a packaging
+# event. "$@" carries the --config=... argument through unchanged.
 set -eu
 
 # Target selection is overridable via environment purely so the dispatch can
@@ -19,7 +20,7 @@ set -eu
 : "${ALEPH_VM_CONTROLLER_BIN:=/opt/aleph-vm/bin/aleph-vm-controller}"
 : "${ALEPH_VM_CONTROLLER_PYTHON:=/usr/bin/python3}"
 
-case "${ALEPH_VM_SUPERVISOR_IMPL:-python}" in
+case "${ALEPH_VM_SUPERVISOR_IMPL:-rust}" in
   rust)
     exec "$ALEPH_VM_CONTROLLER_BIN" "$@"
     ;;
@@ -27,8 +28,8 @@ case "${ALEPH_VM_SUPERVISOR_IMPL:-python}" in
     exec "$ALEPH_VM_CONTROLLER_PYTHON" -m aleph.vm.supervisor.controllers "$@"
     ;;
   *)
-    # An operator typo must not brick the node: log and run the default.
-    echo "controller-launcher: unknown ALEPH_VM_SUPERVISOR_IMPL='${ALEPH_VM_SUPERVISOR_IMPL}', falling back to python" >&2
-    exec "$ALEPH_VM_CONTROLLER_PYTHON" -m aleph.vm.supervisor.controllers "$@"
+    # An operator typo must not brick the node: log and run the default (rust).
+    echo "controller-launcher: unknown ALEPH_VM_SUPERVISOR_IMPL='${ALEPH_VM_SUPERVISOR_IMPL}', falling back to rust" >&2
+    exec "$ALEPH_VM_CONTROLLER_BIN" "$@"
     ;;
 esac

--- a/packaging/supervisor-launcher
+++ b/packaging/supervisor-launcher
@@ -4,8 +4,9 @@
 #
 # aleph-vm-supervisor.service execs this script; the implementation is
 # selected by ALEPH_VM_SUPERVISOR_IMPL from /etc/aleph-vm/supervisor.env
-# (loaded by the unit's EnvironmentFile). The deb ships both daemons;
-# cutover is a one-line env change, not a packaging event.
+# (loaded by the unit's EnvironmentFile). The deb ships both daemons; the
+# Rust daemon is the default (2.0), ALEPH_VM_SUPERVISOR_IMPL=python is the
+# one-line rollback to the Python daemon, not a packaging event.
 set -eu
 
 # Target selection is overridable via environment purely so the dispatch can
@@ -15,7 +16,7 @@ set -eu
 : "${ALEPH_VM_SUPERVISOR_BIN:=/opt/aleph-vm/bin/aleph-vm-supervisor}"
 : "${ALEPH_VM_SUPERVISOR_PYTHON:=python3}"
 
-case "${ALEPH_VM_SUPERVISOR_IMPL:-python}" in
+case "${ALEPH_VM_SUPERVISOR_IMPL:-rust}" in
   rust)
     exec "$ALEPH_VM_SUPERVISOR_BIN" "$@"
     ;;
@@ -23,8 +24,8 @@ case "${ALEPH_VM_SUPERVISOR_IMPL:-python}" in
     exec "$ALEPH_VM_SUPERVISOR_PYTHON" -m aleph.vm.supervisor "$@"
     ;;
   *)
-    # An operator typo must not brick the node: log and run the default.
-    echo "supervisor-launcher: unknown ALEPH_VM_SUPERVISOR_IMPL='${ALEPH_VM_SUPERVISOR_IMPL}', falling back to python" >&2
-    exec "$ALEPH_VM_SUPERVISOR_PYTHON" -m aleph.vm.supervisor "$@"
+    # An operator typo must not brick the node: log and run the default (rust).
+    echo "supervisor-launcher: unknown ALEPH_VM_SUPERVISOR_IMPL='${ALEPH_VM_SUPERVISOR_IMPL}', falling back to rust" >&2
+    exec "$ALEPH_VM_SUPERVISOR_BIN" "$@"
     ;;
 esac

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -67,13 +67,14 @@ HAS_KVM = os.access("/dev/kvm", os.R_OK | os.W_OK)
 # Which supervisor daemon the suite drives: the same selector the packaged
 # launcher reads (design doc section 5). The tests themselves are
 # implementation-agnostic; only the spawn differs. Unknown values fail
-# loudly at collection: silently falling back to python would run the CI
-# matrix's rust leg against the wrong daemon.
-SUPERVISOR_IMPL = os.environ.get("ALEPH_VM_SUPERVISOR_IMPL", "python")
+# loudly at collection: silently picking one daemon would run a CI matrix
+# leg against the wrong implementation. The default mirrors the launcher's
+# (rust since 2.0).
+SUPERVISOR_IMPL = os.environ.get("ALEPH_VM_SUPERVISOR_IMPL", "rust")
 if SUPERVISOR_IMPL not in ("python", "rust"):
     msg = (
         f"unknown ALEPH_VM_SUPERVISOR_IMPL={SUPERVISOR_IMPL!r}: "
-        "expected 'python' or 'rust' (refusing to silently test the python daemon)"
+        "expected 'python' or 'rust' (refusing to silently pick a daemon)"
     )
     raise RuntimeError(msg)
 RUST_DAEMON_BINARY = Path(

--- a/tests/test_controller_launcher.py
+++ b/tests/test_controller_launcher.py
@@ -1,8 +1,8 @@
 """Dispatch tests for packaging/controller-launcher.
 
 The launcher is the exact artifact that flips the production cutover, and it
-is on the critical path for the DEFAULT python install too (the systemd unit
-execs the launcher, not python directly). These tests EXEC the real script
+is on the critical path for the DEFAULT (rust) install too (the systemd unit
+execs the launcher, not the binary directly). These tests EXEC the real script
 (not a reimplementation) so a dispatch regression cannot ship green.
 
 The launcher hardcodes /opt/aleph-vm paths in production. To exercise it
@@ -27,14 +27,14 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 LAUNCHER = REPO_ROOT / "packaging" / "controller-launcher"
 
 # The four operator-visible cases the case-statement must cover, and the
-# target each one selects. "python" is both the explicit value and the
-# default for "unset" and any unknown value (an operator typo must not brick
-# the node): the launcher never routes an unknown impl to the Rust binary.
+# target each one selects. "rust" is both the explicit value and the default
+# for "unset" and any unknown value (an operator typo must not brick the
+# node): the Python controller only ever runs when asked for by name.
 _CASES = [
     pytest.param("rust", "rust", id="rust->rust"),
     pytest.param("python", "python", id="python->python"),
-    pytest.param(None, "python", id="unset->python"),
-    pytest.param("bogus", "python", id="bogus->python"),
+    pytest.param(None, "rust", id="unset->rust"),
+    pytest.param("bogus", "rust", id="bogus->rust"),
 ]
 
 


### PR DESCRIPTION
## What

`ALEPH_VM_SUPERVISOR_IMPL` defaults to `rust` in `packaging/supervisor-launcher` and `packaging/controller-launcher`. An unknown value keeps its "log and run the default" semantics, so it lands on Rust as well; the Python daemon and controller only run when an operator sets `ALEPH_VM_SUPERVISOR_IMPL=python` explicitly, which stays the one-line rollback. The deb still ships both implementations; this is the 2.0 cutover without the code removal (that is #1170, held back).

Also: the integration conftest default follows the launcher (`rust`), the launcher dispatch tests pin the new table (`unset -> rust`, `bogus -> rust`), and the packaged `supervisor.env`, unit comments, Makefile note and `process-model.md` say so.

## Effect on CI

The droplet e2e jobs install the deb with a `supervisor.env` that does not set the flag, so from this PR on they exercise the Rust daemon and controller. The pytest integration matrix sets the flag explicitly and keeps both legs.

## Verification

- `tests/test_controller_launcher.py`: 5 passed with the new dispatch table (the tests exec the real script).
- `ruff format` clean; shellcheck runs in CI (`code-quality-shell`).
- On the testnets, aleph-testnets#37 runs the whole suite with `ALEPH_VM_SUPERVISOR_IMPL=rust` on every CRN: run 2 was 28/31 with the three failures being harness drift (CLI 0.17.0 name argument, upgrade test leaking into pr-tests), run 3 in progress.
