### PR TITLE
feat(agent): build a plan from a push and answer it immediately

### DIFF
--- a/src/aleph/vm/agent/allocation/plan.py
+++ b/src/aleph/vm/agent/allocation/plan.py
@@ -7,26 +7,10 @@ down VMs that were migrated elsewhere during the downtime.
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
 
 from aleph_message.models import ItemHash
 
 from aleph.vm.agent.allocation.verify import VerifiedMessage
-
-
-class AllocationState(str, Enum):
-    """Agent-side phases, which all precede the supervisor knowing the VM.
-
-    Deliberately NOT a mirror of VmStatus: once create_vm returns, VmStatus is
-    the answer and this state stops existing. Two disjoint fields cannot drift,
-    whereas a merged enum would need maintaining in lockstep forever.
-    """
-
-    PLANNED = "planned"
-    RESOLVING = "resolving"
-    DOWNLOADING = "downloading"
-    SUBMITTING = "submitting"
-    FAILED = "failed"
 
 
 @dataclass
@@ -45,23 +29,6 @@ class AllocationPlan:
 
 
 @dataclass
-class FailureRecord:
-    """Why a planned VM is not running, and when we will try again.
-
-    Kept in the reconciler and NOT in AgentVmRegistry on purpose: the registry
-    is what CapacityManager sums committed resources over, and a VM that failed
-    to start must not count as committed.
-    """
-
-    code: str
-    message: str
-    attempts: int
-    first_failed_at: datetime
-    last_failed_at: datetime
-    next_retry_at: datetime
-
-
-@dataclass
 class PlanVerdict:
     """The immediate answer returned to the scheduler."""
 
@@ -69,5 +36,5 @@ class PlanVerdict:
     pending: list[ItemHash] = field(default_factory=list)
     unchanged: list[ItemHash] = field(default_factory=list)
     removing: list[ItemHash] = field(default_factory=list)
-    rejected: dict[ItemHash, dict] = field(default_factory=dict)
+    rejected: dict[str, dict] = field(default_factory=dict)
     retained: dict[ItemHash, str] = field(default_factory=dict)

--- a/src/aleph/vm/agent/allocation/plan.py
+++ b/src/aleph/vm/agent/allocation/plan.py
@@ -1,0 +1,73 @@
+"""What the scheduler asked for, and how far the agent got with it.
+
+The plan is held in memory only. After a restart the agent has no plan, and a
+reconciler with no plan deletes nothing: acting on a stale plan risks tearing
+down VMs that were migrated elsewhere during the downtime.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+
+from aleph_message.models import ItemHash
+
+from aleph.vm.agent.allocation.verify import VerifiedMessage
+
+
+class AllocationState(str, Enum):
+    """Agent-side phases, which all precede the supervisor knowing the VM.
+
+    Deliberately NOT a mirror of VmStatus: once create_vm returns, VmStatus is
+    the answer and this state stops existing. Two disjoint fields cannot drift,
+    whereas a merged enum would need maintaining in lockstep forever.
+    """
+
+    PLANNED = "planned"
+    RESOLVING = "resolving"
+    DOWNLOADING = "downloading"
+    SUBMITTING = "submitting"
+    FAILED = "failed"
+
+
+@dataclass
+class PlannedVm:
+    """One entry of the plan. State lives in the reconciler, not here: one owner."""
+
+    vm_hash: ItemHash
+    verified: VerifiedMessage | None = None
+
+
+@dataclass(frozen=True)
+class AllocationPlan:
+    plan_id: str
+    received_at: datetime
+    entries: dict[ItemHash, PlannedVm]
+
+
+@dataclass
+class FailureRecord:
+    """Why a planned VM is not running, and when we will try again.
+
+    Kept in the reconciler and NOT in AgentVmRegistry on purpose: the registry
+    is what CapacityManager sums committed resources over, and a VM that failed
+    to start must not count as committed.
+    """
+
+    code: str
+    message: str
+    attempts: int
+    first_failed_at: datetime
+    last_failed_at: datetime
+    next_retry_at: datetime
+
+
+@dataclass
+class PlanVerdict:
+    """The immediate answer returned to the scheduler."""
+
+    accepted: list[ItemHash] = field(default_factory=list)
+    pending: list[ItemHash] = field(default_factory=list)
+    unchanged: list[ItemHash] = field(default_factory=list)
+    removing: list[ItemHash] = field(default_factory=list)
+    rejected: dict[ItemHash, dict] = field(default_factory=dict)
+    retained: dict[ItemHash, str] = field(default_factory=dict)

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -1,0 +1,133 @@
+"""Turning a request body into a plan, and a plan into an immediate answer.
+
+Everything here is pure and await-free by design: the handler must not yield to
+the event loop between reading the supervisor's view and swapping the desired
+state, or a concurrent push could invalidate the verdict it just returned.
+"""
+
+import logging
+from datetime import datetime
+from hashlib import sha256
+
+from aleph_message.models import (
+    ExecutableContent,
+    InstanceContent,
+    ItemHash,
+    VerifiableProgramContent,
+)
+
+from aleph.vm.agent.allocation.plan import AllocationPlan, PlannedVm, PlanVerdict
+from aleph.vm.agent.allocation.teardown import is_removable_by_allocation
+from aleph.vm.agent.allocation.verify import VerificationOutcome, verify_entry
+from aleph.vm.agent.capacity import requirements_from_message
+from aleph.vm.supervisor_interface.types import ConfidentialMode, VmInfo, VmStatus
+
+logger = logging.getLogger(__name__)
+
+# A VM the supervisor is already working on does not need re-creating.
+LIVE_STATUSES = (VmStatus.RUNNING, VmStatus.BOOTING, VmStatus.DEFINED)
+
+
+def compute_plan_id(hashes: list[str]) -> str:
+    """A stable identity for a plan, for correlation in logs and responses.
+
+    Order-independent, so the scheduler re-pushing the same set in a different
+    order is visibly the same plan.
+    """
+    return "sha256:" + sha256("\n".join(sorted(hashes)).encode()).hexdigest()
+
+
+def build_plan(body: dict, *, now: datetime) -> tuple[AllocationPlan, dict[ItemHash, dict]]:
+    """Verify every entry and assemble the plan.
+
+    Rejected entries are returned separately: they are answered in the response
+    and never enter the plan, so nothing downstream can act on them.
+    """
+    entries: dict[ItemHash, PlannedVm] = {}
+    rejected: dict[ItemHash, dict] = {}
+    for entry in body.get("vms", []):
+        vm_hash = ItemHash(entry["item_hash"])
+        outcome, verified, reason = verify_entry(entry)
+        if outcome is VerificationOutcome.REJECTED:
+            rejected[vm_hash] = {"code": "invalid_message", "message": reason}
+            continue
+        entries[vm_hash] = PlannedVm(vm_hash=vm_hash, verified=verified)
+    plan_id = compute_plan_id([str(h) for h in entries] + [str(h) for h in rejected])
+    return AllocationPlan(plan_id=plan_id, received_at=now, entries=entries), rejected
+
+
+def _retention_reason(record, info: VmInfo) -> str:
+    """Why an allocation push is not allowed to stop this VM."""
+    if record.uses_payment_stream:
+        return "payment_stream"
+    if record.uses_payment_credit:
+        return "payment_credit"
+    if info.gpus:
+        return "gpu"
+    if info.confidential_mode is not ConfidentialMode.NONE:
+        return "confidential"
+    return "operator_policy"
+
+
+def _targets_another_node(content: ExecutableContent, node_hash: str | None) -> bool:
+    """Whether the message pins itself to a CRN that is not us."""
+    requirements = getattr(content, "requirements", None)
+    node = getattr(requirements, "node", None) if requirements else None
+    required = getattr(node, "node_hash", None) if node else None
+    if not required:
+        return False
+    return node_hash is None or str(required) != str(node_hash)
+
+
+def compute_verdict(
+    plan: AllocationPlan,
+    *,
+    infos: list[VmInfo],
+    registry,
+    capacity,
+    node_hash: str | None = None,
+) -> PlanVerdict:
+    """The immediate answer: what we take, what we drop, what we refuse."""
+    verdict = PlanVerdict()
+    by_hash = {ItemHash(info.vm_id): info for info in infos}
+
+    for vm_hash, info in by_hash.items():
+        record = registry.get(vm_hash)
+        if vm_hash in plan.entries:
+            if info.status in LIVE_STATUSES or info.awaiting_confidential_init:
+                verdict.unchanged.append(vm_hash)
+            continue
+        if record is None or info.status is not VmStatus.RUNNING:
+            continue
+        if is_removable_by_allocation(record, info):
+            verdict.removing.append(vm_hash)
+        else:
+            verdict.retained[vm_hash] = _retention_reason(record, info)
+
+    candidates = []
+    for vm_hash, planned in plan.entries.items():
+        if vm_hash in verdict.unchanged:
+            continue
+        if planned.verified is None:
+            verdict.pending.append(vm_hash)
+            continue
+        content = planned.verified.message.content
+        if _targets_another_node(content, node_hash):
+            logger.info("Refusing %s: allocated to another node", vm_hash)
+            verdict.rejected[vm_hash] = {
+                "code": "node_mismatch",
+                "message": "this instance is allocated to a different node",
+            }
+            continue
+        # A v-program belongs in the instance memory bucket but is not an
+        # InstanceContent, the same distinction _admit makes in run.py.
+        is_instance = isinstance(content, (InstanceContent, VerifiableProgramContent))
+        candidates.append((vm_hash, requirements_from_message(content), is_instance))
+
+    for admission in capacity.simulate(candidates, releasing=frozenset(verdict.removing)):
+        if admission.accepted:
+            verdict.accepted.append(admission.vm_hash)
+        else:
+            verdict.rejected[admission.vm_hash] = {"code": admission.code, "message": admission.detail}
+
+    return verdict

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -8,6 +8,7 @@ state, or a concurrent push could invalidate the verdict it just returned.
 import logging
 from datetime import datetime
 from hashlib import sha256
+from typing import Protocol
 
 from aleph_message.models import (
     ExecutableContent,
@@ -19,10 +20,33 @@ from aleph_message.models import (
 from aleph.vm.agent.allocation.plan import AllocationPlan, PlannedVm, PlanVerdict
 from aleph.vm.agent.allocation.teardown import is_removable_by_allocation
 from aleph.vm.agent.allocation.verify import VerificationOutcome, verify_entry
-from aleph.vm.agent.capacity import requirements_from_message
+from aleph.vm.agent.capacity import (
+    AdmissionVerdict,
+    ResourceRequirements,
+    requirements_from_message,
+)
+from aleph.vm.agent.vm_registry import AgentVmRecord
 from aleph.vm.supervisor_interface.types import ConfidentialMode, VmInfo, VmStatus
 
 logger = logging.getLogger(__name__)
+
+
+class _Registry(Protocol):
+    """The slice of AgentVmRegistry this module needs."""
+
+    def get(self, vm_hash: ItemHash) -> AgentVmRecord | None: ...
+
+
+class _Capacity(Protocol):
+    """The slice of CapacityManager this module needs."""
+
+    def simulate(
+        self,
+        candidates: list[tuple[ItemHash, ResourceRequirements, bool]],
+        *,
+        releasing: frozenset[ItemHash] = ...,
+    ) -> list[AdmissionVerdict]: ...
+
 
 # A VM the supervisor is already working on does not need re-creating.
 LIVE_STATUSES = (VmStatus.RUNNING, VmStatus.BOOTING, VmStatus.DEFINED)
@@ -37,16 +61,25 @@ def compute_plan_id(hashes: list[str]) -> str:
     return "sha256:" + sha256("\n".join(sorted(hashes)).encode()).hexdigest()
 
 
-def build_plan(body: dict, *, now: datetime) -> tuple[AllocationPlan, dict[ItemHash, dict]]:
+def build_plan(body: dict, *, now: datetime) -> tuple[AllocationPlan, dict[str, dict]]:
     """Verify every entry and assemble the plan.
 
     Rejected entries are returned separately: they are answered in the response
     and never enter the plan, so nothing downstream can act on them.
     """
     entries: dict[ItemHash, PlannedVm] = {}
-    rejected: dict[ItemHash, dict] = {}
+    rejected: dict[str, dict] = {}
     for entry in body.get("vms", []):
-        vm_hash = ItemHash(entry["item_hash"])
+        # This is the validation boundary for a body the scheduler controls, so
+        # a bad entry is data to reject, never an exception: one unusable hash
+        # must not take down the whole push.
+        raw_hash = entry.get("item_hash") if isinstance(entry, dict) else None
+        try:
+            vm_hash = ItemHash(str(raw_hash))
+        except Exception:
+            logger.warning("Refusing plan entry with an unusable item_hash: %r", raw_hash)
+            rejected[str(raw_hash)] = {"code": "invalid_message", "message": "unusable item_hash"}
+            continue
         outcome, verified, reason = verify_entry(entry)
         if outcome is VerificationOutcome.REJECTED:
             rejected[vm_hash] = {"code": "invalid_message", "message": reason}
@@ -56,8 +89,10 @@ def build_plan(body: dict, *, now: datetime) -> tuple[AllocationPlan, dict[ItemH
     return AllocationPlan(plan_id=plan_id, received_at=now, entries=entries), rejected
 
 
-def _retention_reason(record, info: VmInfo) -> str:
+def _retention_reason(record: AgentVmRecord, info: VmInfo) -> str:
     """Why an allocation push is not allowed to stop this VM."""
+    if not record.persistent:
+        return "non_persistent"
     if record.uses_payment_stream:
         return "payment_stream"
     if record.uses_payment_credit:
@@ -69,33 +104,40 @@ def _retention_reason(record, info: VmInfo) -> str:
     return "operator_policy"
 
 
-def _targets_another_node(content: ExecutableContent, node_hash: str | None) -> bool:
-    """Whether the message pins itself to a CRN that is not us."""
+def _required_node_hash(content: ExecutableContent) -> str | None:
+    """The CRN this message pins itself to, if it pins one."""
     requirements = getattr(content, "requirements", None)
     node = getattr(requirements, "node", None) if requirements else None
     required = getattr(node, "node_hash", None) if node else None
-    if not required:
-        return False
-    return node_hash is None or str(required) != str(node_hash)
+    return str(required) if required else None
 
 
 def compute_verdict(
     plan: AllocationPlan,
     *,
     infos: list[VmInfo],
-    registry,
-    capacity,
+    registry: _Registry,
+    capacity: _Capacity,
     node_hash: str | None = None,
 ) -> PlanVerdict:
     """The immediate answer: what we take, what we drop, what we refuse."""
     verdict = PlanVerdict()
     by_hash = {ItemHash(info.vm_id): info for info in infos}
+    unchanged: set[ItemHash] = set()
+    # Planned VMs the supervisor holds in a dead state are about to be created
+    # again. Their registry records still count as committed, so admission has
+    # to discount them or a recreate is judged against its own resources; the
+    # enforced path does the same thing with check_capacity's exclude_vm_hash.
+    recreating: set[ItemHash] = set()
 
     for vm_hash, info in by_hash.items():
         record = registry.get(vm_hash)
         if vm_hash in plan.entries:
             if info.status in LIVE_STATUSES or info.awaiting_confidential_init:
+                unchanged.add(vm_hash)
                 verdict.unchanged.append(vm_hash)
+            elif record is not None:
+                recreating.add(vm_hash)
             continue
         if record is None or info.status is not VmStatus.RUNNING:
             continue
@@ -106,13 +148,24 @@ def compute_verdict(
 
     candidates = []
     for vm_hash, planned in plan.entries.items():
-        if vm_hash in verdict.unchanged:
+        if vm_hash in unchanged:
             continue
         if planned.verified is None:
             verdict.pending.append(vm_hash)
             continue
         content = planned.verified.message.content
-        if _targets_another_node(content, node_hash):
+        required_node = _required_node_hash(content)
+        if required_node and node_hash is None:
+            # Not knowing our own hash yet is not the same answer as "you asked
+            # for a different CRN": the legacy path returns 503 here so the
+            # scheduler retries rather than treating it as settled.
+            logger.info("Cannot place %s: this node has not discovered its own hash", vm_hash)
+            verdict.rejected[vm_hash] = {
+                "code": "node_hash_unknown",
+                "message": "this node has not discovered its own hash yet",
+            }
+            continue
+        if required_node and required_node != str(node_hash):
             logger.info("Refusing %s: allocated to another node", vm_hash)
             verdict.rejected[vm_hash] = {
                 "code": "node_mismatch",
@@ -124,7 +177,7 @@ def compute_verdict(
         is_instance = isinstance(content, (InstanceContent, VerifiableProgramContent))
         candidates.append((vm_hash, requirements_from_message(content), is_instance))
 
-    for admission in capacity.simulate(candidates, releasing=frozenset(verdict.removing)):
+    for admission in capacity.simulate(candidates, releasing=frozenset(verdict.removing) | recreating):
         if admission.accepted:
             verdict.accepted.append(admission.vm_hash)
         else:

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -71,10 +71,21 @@ def build_plan(body: dict, *, now: datetime) -> tuple[AllocationPlan, dict[str, 
 
     Rejected entries are returned separately: they are answered in the response
     and never enter the plan, so nothing downstream can act on them.
+
+    A bad entry is data to reject, but a body we cannot read raises. An empty
+    plan is a real instruction, the one that stops everything this node runs,
+    so a shape we cannot make sense of must never be read as one: ``vms: 5``
+    and ``vms: null`` used to raise a bare TypeError here, and ``vms: "abc"``
+    was quietly walked character by character into a plan of nothing at all.
+    The list has to be there and be a list; the handler answers 400.
     """
+    vms = body.get("vms") if isinstance(body, dict) else None
+    if not isinstance(vms, list):
+        msg = "plan body has no 'vms' list"
+        raise ValueError(msg)
     entries: dict[ItemHash, PlannedVm] = {}
     rejected: dict[str, dict] = {}
-    for entry in body.get("vms", []):
+    for entry in vms:
         # This is the validation boundary for a body the scheduler controls, so
         # a bad entry is data to reject, never an exception: one unusable hash
         # must not take down the whole push.

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -148,7 +148,15 @@ def compute_verdict(
     capacity: _Capacity,
     node_hash: str | None = None,
 ) -> PlanVerdict:
-    """The immediate answer: what we take, what we drop, what we refuse."""
+    """The immediate answer: what we take, what we drop, what we refuse.
+
+    No GPU inventory reaches simulate from here, so a candidate asking for a
+    card is refused rather than admitted on memory alone. Reading the host's
+    cards is an async call on the supervisor and this stays await-free, for
+    the reason at the top of the module, so that read belongs to the handler
+    that will make this answer authoritative and has yet to be written. Until
+    it is, no plan can place a GPU VM.
+    """
     verdict = PlanVerdict()
     by_hash = {ItemHash(info.vm_id): info for info in infos}
     unchanged: set[ItemHash] = set()

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from hashlib import sha256
 from typing import Protocol
 
+from aleph_message.exceptions import UnknownHashError
 from aleph_message.models import ExecutableContent, ItemHash
 
 from aleph.vm.agent.allocation.plan import AllocationPlan, PlannedVm, PlanVerdict
@@ -140,6 +141,24 @@ def _required_node_hash(content: ExecutableContent) -> str | None:
     return str(required) if required else None
 
 
+def _by_hash(infos: list[VmInfo]) -> dict[ItemHash, VmInfo]:
+    """The supervisor's VMs, keyed by item hash.
+
+    An id that is not one is dropped rather than raised on, the way
+    supervisor_hashes and check_payment drop theirs: it cannot name a VM this
+    plan lists, and letting it through would take down a whole push over a VM
+    the push says nothing about. build_plan holds the entries it reads to the
+    same rule.
+    """
+    by_hash: dict[ItemHash, VmInfo] = {}
+    for info in infos:
+        try:
+            by_hash[ItemHash(str(info.vm_id))] = info
+        except (UnknownHashError, ValueError):
+            logger.warning("The supervisor lists a VM whose id is not an item hash: %r", info.vm_id)
+    return by_hash
+
+
 def compute_verdict(
     plan: AllocationPlan,
     *,
@@ -158,7 +177,7 @@ def compute_verdict(
     it is, no plan can place a GPU VM.
     """
     verdict = PlanVerdict()
-    by_hash = {ItemHash(info.vm_id): info for info in infos}
+    by_hash = _by_hash(infos)
     unchanged: set[ItemHash] = set()
 
     for vm_hash, info in by_hash.items():

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -10,12 +10,7 @@ from datetime import datetime
 from hashlib import sha256
 from typing import Protocol
 
-from aleph_message.models import (
-    ExecutableContent,
-    InstanceContent,
-    ItemHash,
-    VerifiableProgramContent,
-)
+from aleph_message.models import ExecutableContent, ItemHash
 
 from aleph.vm.agent.allocation.plan import AllocationPlan, PlannedVm, PlanVerdict
 from aleph.vm.agent.allocation.teardown import is_removable_by_allocation
@@ -42,7 +37,7 @@ class _Capacity(Protocol):
 
     def simulate(
         self,
-        candidates: list[tuple[ItemHash, ResourceRequirements, bool]],
+        candidates: list[tuple[ItemHash, ResourceRequirements]],
         *,
         releasing: frozenset[ItemHash] = ...,
     ) -> list[AdmissionVerdict]: ...
@@ -172,10 +167,7 @@ def compute_verdict(
                 "message": "this instance is allocated to a different node",
             }
             continue
-        # A v-program belongs in the instance memory bucket but is not an
-        # InstanceContent, the same distinction _admit makes in run.py.
-        is_instance = isinstance(content, (InstanceContent, VerifiableProgramContent))
-        candidates.append((vm_hash, requirements_from_message(content), is_instance))
+        candidates.append((vm_hash, requirements_from_message(content)))
 
     for admission in capacity.simulate(candidates, releasing=frozenset(verdict.removing) | recreating):
         if admission.accepted:

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -55,13 +55,14 @@ def compute_plan_id(planned: list[str], rejected: list[str]) -> str:
 
     The two halves are digested apart and then together: one merged sorted list
     gives the same identity to a push that planned A and refused B as to one
-    that planned B and refused A. Digesting rather than joining with a
-    separator keeps that true for a rejected key, which is whatever junk the
-    push carried in place of a hash and may hold the separator itself.
+    that planned B and refused A. Every key is digested on its own before the
+    join, for the same reason one level down: a rejected key is whatever junk
+    the push carried in place of a hash, so joining the keys directly lets a
+    single key holding the separator pass for the two either side of it.
     """
 
     def digest(hashes: list[str]) -> str:
-        return sha256("\n".join(sorted(hashes)).encode()).hexdigest()
+        return sha256("\n".join(sorted(sha256(key.encode()).hexdigest() for key in hashes)).encode()).hexdigest()
 
     return "sha256:" + sha256(f"{digest(planned)}:{digest(rejected)}".encode()).hexdigest()
 

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -47,13 +47,23 @@ class _Capacity(Protocol):
 LIVE_STATUSES = (VmStatus.RUNNING, VmStatus.BOOTING, VmStatus.DEFINED)
 
 
-def compute_plan_id(hashes: list[str]) -> str:
+def compute_plan_id(planned: list[str], rejected: list[str]) -> str:
     """A stable identity for a plan, for correlation in logs and responses.
 
-    Order-independent, so the scheduler re-pushing the same set in a different
-    order is visibly the same plan.
+    Order-independent within each half, so the scheduler re-pushing the same
+    set in a different order is visibly the same plan.
+
+    The two halves are digested apart and then together: one merged sorted list
+    gives the same identity to a push that planned A and refused B as to one
+    that planned B and refused A. Digesting rather than joining with a
+    separator keeps that true for a rejected key, which is whatever junk the
+    push carried in place of a hash and may hold the separator itself.
     """
-    return "sha256:" + sha256("\n".join(sorted(hashes)).encode()).hexdigest()
+
+    def digest(hashes: list[str]) -> str:
+        return sha256("\n".join(sorted(hashes)).encode()).hexdigest()
+
+    return "sha256:" + sha256(f"{digest(planned)}:{digest(rejected)}".encode()).hexdigest()
 
 
 def build_plan(body: dict, *, now: datetime) -> tuple[AllocationPlan, dict[str, dict]]:
@@ -80,7 +90,7 @@ def build_plan(body: dict, *, now: datetime) -> tuple[AllocationPlan, dict[str, 
             rejected[vm_hash] = {"code": "invalid_message", "message": reason}
             continue
         entries[vm_hash] = PlannedVm(vm_hash=vm_hash, verified=verified)
-    plan_id = compute_plan_id([str(h) for h in entries] + [str(h) for h in rejected])
+    plan_id = compute_plan_id([str(h) for h in entries], [str(h) for h in rejected])
     return AllocationPlan(plan_id=plan_id, received_at=now, entries=entries), rejected
 
 

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -154,7 +154,6 @@ def compute_verdict(
     unchanged: set[ItemHash] = set()
 
     for vm_hash, info in by_hash.items():
-        record = registry.get(vm_hash)
         if vm_hash in plan.entries:
             if info.status in LIVE_STATUSES or info.awaiting_confidential_init:
                 unchanged.add(vm_hash)
@@ -168,6 +167,7 @@ def compute_verdict(
             # or refused for another node it would credit memory nobody is
             # freeing at all.
             continue
+        record = registry.get(vm_hash)
         # A VM the supervisor runs that we hold no record for is left alone
         # and reported as neither dropped nor kept. We know nothing about what
         # it is owed, and an allocation push is not the place to find out.

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -85,9 +85,17 @@ def build_plan(body: dict, *, now: datetime) -> tuple[AllocationPlan, dict[str, 
             logger.warning("Refusing plan entry with an unusable item_hash: %r", raw_hash)
             rejected[str(raw_hash)] = {"code": "invalid_message", "message": "unusable item_hash"}
             continue
+        if vm_hash in rejected:
+            # The same hash pushed twice, refused once. A later entry must not
+            # talk the plan into carrying a hash the answer says was refused.
+            logger.warning("Ignoring a repeat entry for %s: already refused by this push", vm_hash)
+            continue
         outcome, verified, reason = verify_entry(entry)
         if outcome is VerificationOutcome.REJECTED:
             rejected[vm_hash] = {"code": "invalid_message", "message": reason}
+            # The other order of the same duplicate: an earlier entry may
+            # already have put this hash in the plan.
+            entries.pop(vm_hash, None)
             continue
         entries[vm_hash] = PlannedVm(vm_hash=vm_hash, verified=verified)
     plan_id = compute_plan_id([str(h) for h in entries], [str(h) for h in rejected])

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -125,6 +125,9 @@ def _retention_reason(record: AgentVmRecord, info: VmInfo) -> str:
         return "gpu"
     if info.confidential_mode is not ConfidentialMode.NONE:
         return "confidential"
+    # Unreachable while the branches above mirror is_removable_by_allocation,
+    # which is the point: a reason it grows that this does not answers here
+    # rather than passing a VM off as removable.
     return "operator_policy"
 
 

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -148,11 +148,6 @@ def compute_verdict(
     verdict = PlanVerdict()
     by_hash = {ItemHash(info.vm_id): info for info in infos}
     unchanged: set[ItemHash] = set()
-    # Planned VMs the supervisor holds in a dead state are about to be created
-    # again. Their registry records still count as committed, so admission has
-    # to discount them or a recreate is judged against its own resources; the
-    # enforced path does the same thing with check_capacity's exclude_vm_hash.
-    recreating: set[ItemHash] = set()
 
     for vm_hash, info in by_hash.items():
         record = registry.get(vm_hash)
@@ -160,9 +155,18 @@ def compute_verdict(
             if info.status in LIVE_STATUSES or info.awaiting_confidential_init:
                 unchanged.add(vm_hash)
                 verdict.unchanged.append(vm_hash)
-            elif record is not None:
-                recreating.add(vm_hash)
+            # A planned VM the supervisor holds dead is about to be created
+            # again, and its stale record still counts as committed, but that
+            # is simulate's business: it leaves every candidate's own record
+            # out of the sums the way check_capacity's exclude_vm_hash does.
+            # Listing it as released here would credit that memory to the
+            # other candidates too, and for one still waiting on its message
+            # or refused for another node it would credit memory nobody is
+            # freeing at all.
             continue
+        # A VM the supervisor runs that we hold no record for is left alone
+        # and reported as neither dropped nor kept. We know nothing about what
+        # it is owed, and an allocation push is not the place to find out.
         if record is None or info.status is not VmStatus.RUNNING:
             continue
         if is_removable_by_allocation(record, info):
@@ -198,7 +202,7 @@ def compute_verdict(
             continue
         candidates.append((vm_hash, requirements_from_message(content)))
 
-    for admission in capacity.simulate(candidates, releasing=frozenset(verdict.removing) | recreating):
+    for admission in capacity.simulate(candidates, releasing=frozenset(verdict.removing)):
         if admission.accepted:
             verdict.accepted.append(admission.vm_hash)
         else:

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -1,0 +1,179 @@
+"""The immediate answer to a plan push: what we take, drop, refuse or keep."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from aleph_message.models import ItemHash
+from test_supervisor_translate import _make_qemu_instance_message
+
+from aleph.vm.agent.allocation.plan import AllocationPlan, PlannedVm
+from aleph.vm.agent.allocation.verdict import build_plan, compute_verdict
+from aleph.vm.agent.capacity import AdmissionVerdict
+from aleph.vm.supervisor_interface.types import ConfidentialMode, VmStatus
+
+NOW = datetime(2026, 8, 25, tzinfo=timezone.utc)
+HASH_A = ItemHash("a" * 64)
+HASH_B = ItemHash("b" * 64)
+HASH_C = ItemHash("c" * 64)
+
+
+def _info(vm_hash, *, status=VmStatus.RUNNING, gpus=(), confidential=ConfidentialMode.NONE):
+    return SimpleNamespace(
+        vm_id=str(vm_hash),
+        status=status,
+        gpus=list(gpus),
+        confidential_mode=confidential,
+        awaiting_confidential_init=False,
+    )
+
+
+def _record(*, stream=False, credit=False, vprogram=False):
+    return SimpleNamespace(
+        persistent=True,
+        uses_payment_stream=stream,
+        uses_payment_credit=credit,
+        is_vprogram=vprogram,
+        message=_make_qemu_instance_message(),
+    )
+
+
+def _registry(records):
+    return SimpleNamespace(get=lambda vm_hash: records.get(vm_hash))
+
+
+def _capacity(verdicts):
+    return SimpleNamespace(simulate=MagicMock(return_value=verdicts))
+
+
+def _plan(*hashes, verified=True, content=None):
+    message = SimpleNamespace(content=content or _make_qemu_instance_message())
+    entries = {
+        h: PlannedVm(vm_hash=h, verified=SimpleNamespace(message=message, original=message) if verified else None)
+        for h in hashes
+    }
+    return AllocationPlan(plan_id="sha256:test", received_at=NOW, entries=entries)
+
+
+def test_a_running_vm_still_in_the_plan_is_unchanged():
+    verdict = compute_verdict(
+        _plan(HASH_A), infos=[_info(HASH_A)], registry=_registry({HASH_A: _record()}), capacity=_capacity([])
+    )
+
+    assert verdict.unchanged == [HASH_A]
+    assert verdict.accepted == []
+
+
+def test_a_new_vm_that_fits_is_accepted():
+    verdict = compute_verdict(
+        _plan(HASH_C), infos=[], registry=_registry({}), capacity=_capacity([AdmissionVerdict(HASH_C, True)])
+    )
+
+    assert verdict.accepted == [HASH_C]
+
+
+def test_a_new_vm_that_does_not_fit_is_rejected_with_a_code():
+    capacity = _capacity([AdmissionVerdict(HASH_C, False, "insufficient_capacity", "no room")])
+
+    verdict = compute_verdict(_plan(HASH_C), infos=[], registry=_registry({}), capacity=capacity)
+
+    assert verdict.accepted == []
+    assert verdict.rejected[HASH_C]["code"] == "insufficient_capacity"
+
+
+def test_an_entry_without_a_verified_message_is_pending():
+    """No embedded message means no verdict yet: the agent must fetch it."""
+    verdict = compute_verdict(_plan(HASH_C, verified=False), infos=[], registry=_registry({}), capacity=_capacity([]))
+
+    assert verdict.pending == [HASH_C]
+    assert verdict.rejected == {}
+
+
+def test_a_running_vm_absent_from_the_plan_is_removing():
+    verdict = compute_verdict(
+        _plan(), infos=[_info(HASH_B)], registry=_registry({HASH_B: _record()}), capacity=_capacity([])
+    )
+
+    assert verdict.removing == [HASH_B]
+
+
+def test_a_stream_paid_vm_absent_from_the_plan_is_retained_with_its_reason():
+    verdict = compute_verdict(
+        _plan(), infos=[_info(HASH_B)], registry=_registry({HASH_B: _record(stream=True)}), capacity=_capacity([])
+    )
+
+    assert verdict.removing == []
+    assert verdict.retained[HASH_B] == "payment_stream"
+
+
+def test_a_vprogram_absent_from_the_plan_is_removing_despite_being_confidential():
+    """The scheduler is the single source of truth for v-programs."""
+    info = _info(HASH_B, confidential=ConfidentialMode.SEV_SNP)
+
+    verdict = compute_verdict(
+        _plan(),
+        infos=[info],
+        registry=_registry({HASH_B: _record(credit=True, vprogram=True)}),
+        capacity=_capacity([]),
+    )
+
+    assert verdict.removing == [HASH_B]
+    assert verdict.retained == {}
+
+
+def test_admission_counts_the_removals_as_freed():
+    """The plan drops B and adds C, so C is judged against B's release."""
+    capacity = _capacity([AdmissionVerdict(HASH_C, True)])
+
+    compute_verdict(_plan(HASH_C), infos=[_info(HASH_B)], registry=_registry({HASH_B: _record()}), capacity=capacity)
+
+    assert capacity.simulate.call_args.kwargs["releasing"] == frozenset({HASH_B})
+
+
+def test_a_vm_pinned_to_another_node_is_rejected():
+    """The scheduler picks which messages run here; one naming a different CRN
+    is not among them."""
+    content = _make_qemu_instance_message()
+    content.requirements = SimpleNamespace(node=SimpleNamespace(node_hash="other-node"), gpu=None)
+
+    verdict = compute_verdict(
+        _plan(HASH_C, content=content),
+        infos=[],
+        registry=_registry({}),
+        capacity=_capacity([]),
+        node_hash="our-node",
+    )
+
+    assert verdict.rejected[HASH_C]["code"] == "node_mismatch"
+
+
+def test_a_vm_pinned_to_this_node_is_admitted():
+    content = _make_qemu_instance_message()
+    content.requirements = SimpleNamespace(node=SimpleNamespace(node_hash="our-node"), gpu=None)
+
+    verdict = compute_verdict(
+        _plan(HASH_C, content=content),
+        infos=[],
+        registry=_registry({}),
+        capacity=_capacity([AdmissionVerdict(HASH_C, True)]),
+        node_hash="our-node",
+    )
+
+    assert verdict.accepted == [HASH_C]
+
+
+def test_the_same_plan_produces_the_same_plan_id():
+    body = {"vms": [{"item_hash": str(HASH_A)}, {"item_hash": str(HASH_C)}]}
+    reversed_body = {"vms": [{"item_hash": str(HASH_C)}, {"item_hash": str(HASH_A)}]}
+
+    first, _ = build_plan(body, now=NOW)
+    second, _ = build_plan(reversed_body, now=NOW)
+
+    assert first.plan_id == second.plan_id
+
+
+def test_a_different_plan_produces_a_different_plan_id():
+    first, _ = build_plan({"vms": [{"item_hash": str(HASH_A)}]}, now=NOW)
+    second, _ = build_plan({"vms": [{"item_hash": str(HASH_B)}]}, now=NOW)
+
+    assert first.plan_id != second.plan_id

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -177,3 +177,44 @@ def test_a_different_plan_produces_a_different_plan_id():
     second, _ = build_plan({"vms": [{"item_hash": str(HASH_B)}]}, now=NOW)
 
     assert first.plan_id != second.plan_id
+
+
+def test_an_entry_with_an_unusable_item_hash_is_rejected_not_raised():
+    """build_plan is the validation boundary for a body the scheduler controls,
+    so one bad entry must not take the whole push down with it."""
+    body = {"vms": [{"item_hash": "not-a-hash"}, {}, {"item_hash": str(HASH_A)}]}
+
+    plan, rejected = build_plan(body, now=NOW)
+
+    assert list(plan.entries) == [HASH_A]
+    assert rejected["not-a-hash"]["code"] == "invalid_message"
+    assert rejected["None"]["code"] == "invalid_message"
+
+
+def test_a_pinned_vm_is_not_refused_when_we_do_not_know_our_own_hash():
+    """Node identity not yet discovered is a retry, not a verdict: answering
+    node_mismatch would tell the scheduler to place it elsewhere for good."""
+    content = _make_qemu_instance_message()
+    content.requirements = SimpleNamespace(node=SimpleNamespace(node_hash="some-node"), gpu=None)
+
+    verdict = compute_verdict(
+        _plan(HASH_C, content=content), infos=[], registry=_registry({}), capacity=_capacity([]), node_hash=None
+    )
+
+    assert verdict.rejected[HASH_C]["code"] == "node_hash_unknown"
+
+
+def test_a_planned_vm_the_supervisor_holds_dead_is_not_judged_against_itself():
+    """A recreate: the stale registry record still counts as committed, so it
+    has to be discounted or the VM is admitted against its own resources. The
+    enforced path does this with check_capacity's exclude_vm_hash."""
+    capacity = _capacity([AdmissionVerdict(HASH_C, True)])
+
+    compute_verdict(
+        _plan(HASH_C),
+        infos=[_info(HASH_C, status=VmStatus.STOPPED)],
+        registry=_registry({HASH_C: _record()}),
+        capacity=capacity,
+    )
+
+    assert HASH_C in capacity.simulate.call_args.kwargs["releasing"]

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -254,6 +254,16 @@ def test_an_explicitly_empty_plan_is_still_accepted():
     assert plan.entries == {} and rejected == {}
 
 
+def test_a_rejected_key_holding_the_separator_does_not_pass_for_two():
+    """Rejected keys are whatever the push sent in place of a hash, so one
+    refusing a single key with a newline in it must not share an identity with
+    one refusing the two keys either side of that newline."""
+    one, _ = build_plan({"vms": [{"item_hash": "a\nb"}]}, now=NOW)
+    two, _ = build_plan({"vms": [{"item_hash": "a"}, {"item_hash": "b"}]}, now=NOW)
+
+    assert one.plan_id != two.plan_id
+
+
 def test_a_hash_refused_once_does_not_enter_the_plan_on_a_second_entry():
     """A duplicate hash used to land in both halves of the answer, telling the
     scheduler the same VM was refused and pending at once, and the plan then

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -218,3 +218,31 @@ def test_a_planned_vm_the_supervisor_holds_dead_is_not_judged_against_itself():
     )
 
     assert HASH_C in capacity.simulate.call_args.kwargs["releasing"]
+
+
+def test_compute_verdict_drives_the_real_capacity_manager(mocker):
+    """Every other test here hands compute_verdict a double, so the shape of
+    CapacityManager.simulate is never exercised: when the candidate tuple lost
+    its third element, the double kept agreeing with a signature production no
+    longer had and all of these stayed green. Wire the real one in once.
+    """
+    from unittest.mock import AsyncMock
+
+    from aleph.vm.agent.capacity import CapacityManager
+    from aleph.vm.agent.vm_registry import AgentVmRegistry
+    from aleph.vm.supervisor_interface.types import HostInfo
+
+    mocker.patch(
+        "aleph.vm.agent.capacity.psutil.virtual_memory",
+        return_value=mocker.Mock(total=64 * 1024 * 1024 * 1024),
+    )
+    mocker.patch("aleph.vm.agent.capacity.psutil.cpu_count", return_value=16)
+    mocker.patch.object(CapacityManager, "_available_disk_bytes", return_value=100 * 1024**3)
+    # The per-volume check reads the pools directly, not through _available_disk_bytes.
+    mocker.patch("aleph.vm.agent.capacity.storage_pools.roomiest_pool_free_bytes", return_value=100 * 1024**3)
+    supervisor = SimpleNamespace(get_host_info=AsyncMock(return_value=HostInfo(gpu_inventory=[], available_gpus=[])))
+    capacity = CapacityManager(supervisor, AgentVmRegistry())
+
+    verdict = compute_verdict(_plan(HASH_C), infos=[], registry=_registry({}), capacity=capacity)
+
+    assert verdict.accepted == [HASH_C]

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -180,6 +180,20 @@ def test_a_different_plan_produces_a_different_plan_id():
     assert first.plan_id != second.plan_id
 
 
+def test_a_hash_refused_once_does_not_enter_the_plan_on_a_second_entry():
+    """A duplicate hash used to land in both halves of the answer, telling the
+    scheduler the same VM was refused and pending at once, and the plan then
+    carried an entry the answer had refused."""
+    refused_first = {"vms": [{"item_hash": str(HASH_A), "message": "not-an-object"}, {"item_hash": str(HASH_A)}]}
+    refused_second = {"vms": [{"item_hash": str(HASH_A)}, {"item_hash": str(HASH_A), "message": "not-an-object"}]}
+
+    for body in (refused_first, refused_second):
+        plan, rejected = build_plan(body, now=NOW)
+
+        assert HASH_A in rejected
+        assert list(plan.entries) == []
+
+
 def test_swapping_which_half_a_hash_lands_in_changes_the_plan_id():
     """One merged sorted list gave the same identity to a push that planned A
     and refused B as to one that planned B and refused A."""

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -94,6 +94,22 @@ def test_an_entry_without_a_verified_message_is_pending():
     assert verdict.rejected == {}
 
 
+def test_a_vm_id_that_is_not_a_hash_is_dropped_not_raised_on():
+    """The supervisor's list is not ours to vouch for: an operator's own VM, or
+    a second tenant's, carries an id we cannot parse. Converting it unguarded
+    took the whole push down over a VM the push says nothing about, which is
+    the rule build_plan already holds its own entries to."""
+    verdict = compute_verdict(
+        _plan(HASH_C),
+        infos=[_info("operator-scratch-vm"), _info(HASH_B)],
+        registry=_registry({HASH_B: _record()}),
+        capacity=_capacity([AdmissionVerdict(HASH_C, True)]),
+    )
+
+    assert verdict.accepted == [HASH_C]
+    assert verdict.removing == [HASH_B]
+
+
 def test_a_running_vm_absent_from_the_plan_is_removing():
     verdict = compute_verdict(
         _plan(), infos=[_info(HASH_B)], registry=_registry({HASH_B: _record()}), capacity=_capacity([])

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -180,6 +180,20 @@ def test_a_different_plan_produces_a_different_plan_id():
     assert first.plan_id != second.plan_id
 
 
+def test_swapping_which_half_a_hash_lands_in_changes_the_plan_id():
+    """One merged sorted list gave the same identity to a push that planned A
+    and refused B as to one that planned B and refused A."""
+    planned_a = {"vms": [{"item_hash": str(HASH_A)}, {"item_hash": str(HASH_B), "message": "not-an-object"}]}
+    planned_b = {"vms": [{"item_hash": str(HASH_B)}, {"item_hash": str(HASH_A), "message": "not-an-object"}]}
+
+    first, first_rejected = build_plan(planned_a, now=NOW)
+    second, second_rejected = build_plan(planned_b, now=NOW)
+
+    assert list(first.entries) == [HASH_A] and list(first_rejected) == [HASH_B]
+    assert list(second.entries) == [HASH_B] and list(second_rejected) == [HASH_A]
+    assert first.plan_id != second.plan_id
+
+
 def test_an_entry_with_an_unusable_item_hash_is_rejected_not_raised():
     """build_plan is the validation boundary for a body the scheduler controls,
     so one bad entry must not take the whole push down with it."""

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -12,6 +12,8 @@ from test_supervisor_translate import _make_qemu_instance_message
 from aleph.vm.agent.allocation.plan import AllocationPlan, PlannedVm
 from aleph.vm.agent.allocation.verdict import build_plan, compute_verdict
 from aleph.vm.agent.capacity import AdmissionVerdict
+from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.conf import settings
 from aleph.vm.supervisor_interface.types import ConfidentialMode, VmStatus
 
 NOW = datetime(2026, 8, 25, tzinfo=timezone.utc)
@@ -48,12 +50,13 @@ def _capacity(verdicts):
     return SimpleNamespace(simulate=MagicMock(return_value=verdicts))
 
 
-def _plan(*hashes, verified=True, content=None):
+def _verified(content=None):
     message = SimpleNamespace(content=content or _make_qemu_instance_message())
-    entries = {
-        h: PlannedVm(vm_hash=h, verified=SimpleNamespace(message=message, original=message) if verified else None)
-        for h in hashes
-    }
+    return SimpleNamespace(message=message, original=message)
+
+
+def _plan(*hashes, verified=True, content=None):
+    entries = {h: PlannedVm(vm_hash=h, verified=_verified(content) if verified else None) for h in hashes}
     return AllocationPlan(plan_id="sha256:test", received_at=NOW, entries=entries)
 
 
@@ -250,27 +253,11 @@ def test_a_pinned_vm_is_not_refused_when_we_do_not_know_our_own_hash():
     assert verdict.rejected[HASH_C]["code"] == "node_hash_unknown"
 
 
-def test_a_planned_vm_the_supervisor_holds_dead_is_not_judged_against_itself():
-    """A recreate: the stale registry record still counts as committed, so it
-    has to be discounted or the VM is admitted against its own resources. The
-    enforced path does this with check_capacity's exclude_vm_hash."""
-    capacity = _capacity([AdmissionVerdict(HASH_C, True)])
+def _real_capacity(mocker, *, memory_gib=64, registry=None):
+    """A real CapacityManager over a stubbed host.
 
-    compute_verdict(
-        _plan(HASH_C),
-        infos=[_info(HASH_C, status=VmStatus.STOPPED)],
-        registry=_registry({HASH_C: _record()}),
-        capacity=capacity,
-    )
-
-    assert HASH_C in capacity.simulate.call_args.kwargs["releasing"]
-
-
-def test_compute_verdict_drives_the_real_capacity_manager(mocker):
-    """Every other test here hands compute_verdict a double, so the shape of
-    CapacityManager.simulate is never exercised: when the candidate tuple lost
-    its third element, the double kept agreeing with a signature production no
-    longer had and all of these stayed green. Wire the real one in once.
+    The double the other tests use answers whatever it was handed, so nothing
+    it agrees to says anything about what simulate does with a plan.
     """
     from unittest.mock import AsyncMock
 
@@ -280,7 +267,7 @@ def test_compute_verdict_drives_the_real_capacity_manager(mocker):
 
     mocker.patch(
         "aleph.vm.agent.capacity.psutil.virtual_memory",
-        return_value=mocker.Mock(total=64 * 1024 * 1024 * 1024),
+        return_value=mocker.Mock(total=memory_gib * 1024**3),
     )
     mocker.patch("aleph.vm.agent.capacity.psutil.cpu_count", return_value=16)
     mocker.patch.object(CapacityManager, "_available_disk_bytes", return_value=100 * 1024**3)
@@ -292,8 +279,77 @@ def test_compute_verdict_drives_the_real_capacity_manager(mocker):
     )
     mocker.patch("aleph.vm.agent.capacity.reclaimable_bytes", return_value=0)
     supervisor = SimpleNamespace(get_host_info=AsyncMock(return_value=HostInfo(gpu_inventory=[], available_gpus=[])))
-    capacity = CapacityManager(supervisor, AgentVmRegistry())
+    return CapacityManager(supervisor, registry or AgentVmRegistry())
+
+
+def _tight_host(mocker):
+    """40 GiB, less the two reservations, leaves a 30720 MiB instance bucket:
+    room for one 16384 MiB instance and not two."""
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 8192)
+
+
+def _registry_holding(vm_hash, memory_mib):
+    registry = AgentVmRegistry()
+    recorded = _make_qemu_instance_message(memory=memory_mib)
+    registry.record(vm_hash, message=recorded, original=recorded, persistent=True)
+    return registry
+
+
+def test_compute_verdict_drives_the_real_capacity_manager(mocker):
+    """Every other test here hands compute_verdict a double, so the shape of
+    CapacityManager.simulate is never exercised: when the candidate tuple lost
+    its third element, the double kept agreeing with a signature production no
+    longer had and all of these stayed green. Wire the real one in once.
+    """
+    capacity = _real_capacity(mocker)
 
     verdict = compute_verdict(_plan(HASH_C), infos=[], registry=_registry({}), capacity=capacity)
 
     assert verdict.accepted == [HASH_C]
+
+
+def test_a_recreate_is_not_judged_against_its_own_stale_record(mocker):
+    """The supervisor holds C dead and the registry still has its record, so
+    the memory it asks for is counted twice unless the record is discounted.
+    simulate does that for every candidate, which is why compute_verdict no
+    longer lists a recreate as released.
+    """
+    _tight_host(mocker)
+    registry = _registry_holding(HASH_C, 16384)
+    capacity = _real_capacity(mocker, memory_gib=40, registry=registry)
+
+    verdict = compute_verdict(
+        _plan(HASH_C, content=_make_qemu_instance_message(memory=16384)),
+        infos=[_info(HASH_C, status=VmStatus.STOPPED)],
+        registry=registry,
+        capacity=capacity,
+    )
+
+    assert verdict.accepted == [HASH_C]
+
+
+def test_a_recreate_still_waiting_on_its_message_frees_nothing(mocker):
+    """C is planned but carries no message, so it is pending a CCN fetch and
+    nothing is stopping it. Releasing it would hand its 16384 MiB to A and
+    answer yes where the enforced path, which still sees C's record, answers
+    no: an advisory verdict must never be the stronger of the two.
+    """
+    _tight_host(mocker)
+    registry = _registry_holding(HASH_C, 16384)
+    capacity = _real_capacity(mocker, memory_gib=40, registry=registry)
+    plan = AllocationPlan(
+        plan_id="sha256:test",
+        received_at=NOW,
+        entries={
+            HASH_C: PlannedVm(vm_hash=HASH_C, verified=None),
+            HASH_A: PlannedVm(vm_hash=HASH_A, verified=_verified(_make_qemu_instance_message(memory=16384))),
+        },
+    )
+
+    verdict = compute_verdict(
+        plan, infos=[_info(HASH_C, status=VmStatus.STOPPED)], registry=registry, capacity=capacity
+    )
+
+    assert verdict.pending == [HASH_C]
+    assert verdict.rejected[HASH_A]["code"] == "insufficient_capacity"

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -1,6 +1,7 @@
 """The immediate answer to a plan push: what we take, drop, refuse or keep."""
 
 from datetime import datetime, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -238,8 +239,13 @@ def test_compute_verdict_drives_the_real_capacity_manager(mocker):
     )
     mocker.patch("aleph.vm.agent.capacity.psutil.cpu_count", return_value=16)
     mocker.patch.object(CapacityManager, "_available_disk_bytes", return_value=100 * 1024**3)
-    # The per-volume check reads the pools directly, not through _available_disk_bytes.
-    mocker.patch("aleph.vm.agent.capacity.storage_pools.roomiest_pool_free_bytes", return_value=100 * 1024**3)
+    # The per-volume check walks the pools directly, not _available_disk_bytes,
+    # and asks each what it could reclaim. Neither exists on a CI runner.
+    mocker.patch(
+        "aleph.vm.agent.capacity.storage_pools.eligible_pool_free_bytes",
+        return_value=[(SimpleNamespace(path=Path("/pool0"), index=0), 100 * 1024**3)],
+    )
+    mocker.patch("aleph.vm.agent.capacity.reclaimable_bytes", return_value=0)
     supervisor = SimpleNamespace(get_host_info=AsyncMock(return_value=HostInfo(gpu_inventory=[], available_gpus=[])))
     capacity = CapacityManager(supervisor, AgentVmRegistry())
 

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 from aleph_message.models import ItemHash
 from test_supervisor_translate import _make_qemu_instance_message
 
@@ -178,6 +179,22 @@ def test_a_different_plan_produces_a_different_plan_id():
     second, _ = build_plan({"vms": [{"item_hash": str(HASH_B)}]}, now=NOW)
 
     assert first.plan_id != second.plan_id
+
+
+@pytest.mark.parametrize("body", [{"vms": 5}, {"vms": None}, {"vms": "abc"}, {}, []])
+def test_a_body_we_cannot_read_is_refused_not_read_as_an_empty_plan(body):
+    """An empty plan stops everything this node runs, so a malformed body must
+    not resolve to one. The string case is the dangerous one: it was walked
+    character by character and answered as a plan of nothing at all."""
+    with pytest.raises(ValueError, match="vms"):
+        build_plan(body, now=NOW)
+
+
+def test_an_explicitly_empty_plan_is_still_accepted():
+    """The scheduler wanting nothing here is a real push, not a malformed one."""
+    plan, rejected = build_plan({"vms": []}, now=NOW)
+
+    assert plan.entries == {} and rejected == {}
 
 
 def test_a_hash_refused_once_does_not_enter_the_plan_on_a_second_entry():

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -32,9 +32,9 @@ def _info(vm_hash, *, status=VmStatus.RUNNING, gpus=(), confidential=Confidentia
     )
 
 
-def _record(*, stream=False, credit=False, vprogram=False):
+def _record(*, stream=False, credit=False, vprogram=False, persistent=True):
     return SimpleNamespace(
-        persistent=True,
+        persistent=persistent,
         uses_payment_stream=stream,
         uses_payment_credit=credit,
         is_vprogram=vprogram,
@@ -109,6 +109,60 @@ def test_a_stream_paid_vm_absent_from_the_plan_is_retained_with_its_reason():
 
     assert verdict.removing == []
     assert verdict.retained[HASH_B] == "payment_stream"
+
+
+@pytest.mark.parametrize(
+    ("record", "info", "reason"),
+    [
+        (_record(persistent=False), _info(HASH_B), "non_persistent"),
+        (_record(stream=True), _info(HASH_B), "payment_stream"),
+        (_record(credit=True), _info(HASH_B), "payment_credit"),
+        (_record(), _info(HASH_B, gpus=["0000:01:00.0"]), "gpu"),
+        (_record(), _info(HASH_B, confidential=ConfidentialMode.SEV_SNP), "confidential"),
+    ],
+)
+def test_every_reason_an_allocation_may_not_stop_a_vm_is_reported(record, info, reason):
+    """_retention_reason has to stay a mirror of is_removable_by_allocation:
+    a VM the one keeps and the other has no reason for comes back as
+    operator_policy, which says nothing to the scheduler."""
+    verdict = compute_verdict(_plan(), infos=[info], registry=_registry({HASH_B: record}), capacity=_capacity([]))
+
+    assert verdict.removing == []
+    assert verdict.retained[HASH_B] == reason
+
+
+def test_a_vm_waiting_on_its_confidential_session_is_left_alone():
+    """A confidential VM is created but not started: only its owner can boot
+    it, by uploading the session certificates. It is not running, so the
+    status alone reads as a recreate, and re-creating it would throw away the
+    VM the owner is about to send its secret to."""
+    awaiting = _info(HASH_A, status=VmStatus.STOPPED)
+    awaiting.awaiting_confidential_init = True
+
+    verdict = compute_verdict(
+        _plan(HASH_A), infos=[awaiting], registry=_registry({HASH_A: _record()}), capacity=_capacity([])
+    )
+
+    assert verdict.unchanged == [HASH_A]
+    assert verdict.accepted == []
+
+
+@pytest.mark.parametrize(
+    ("record", "info"),
+    [
+        (None, _info(HASH_B)),
+        (_record(), _info(HASH_B, status=VmStatus.STOPPED)),
+    ],
+    ids=["no record of it", "not running"],
+)
+def test_a_vm_outside_the_plan_we_cannot_speak_for_is_not_reported(record, info):
+    """Neither dropped nor kept. One we hold no record for we know nothing
+    about, and one already stopped needs nothing done to it."""
+    verdict = compute_verdict(
+        _plan(), infos=[info], registry=_registry({HASH_B: record} if record else {}), capacity=_capacity([])
+    )
+
+    assert verdict.removing == [] and verdict.retained == {}
 
 
 def test_a_vprogram_absent_from_the_plan_is_removing_despite_being_confidential():

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aleph_message.models import ItemHash
@@ -11,10 +11,10 @@ from test_supervisor_translate import _make_qemu_instance_message
 
 from aleph.vm.agent.allocation.plan import AllocationPlan, PlannedVm
 from aleph.vm.agent.allocation.verdict import build_plan, compute_verdict
-from aleph.vm.agent.capacity import AdmissionVerdict
+from aleph.vm.agent.capacity import AdmissionVerdict, CapacityManager
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
-from aleph.vm.supervisor_interface.types import ConfidentialMode, VmStatus
+from aleph.vm.supervisor_interface.types import ConfidentialMode, HostInfo, VmStatus
 
 NOW = datetime(2026, 8, 25, tzinfo=timezone.utc)
 HASH_A = ItemHash("a" * 64)
@@ -323,12 +323,6 @@ def _real_capacity(mocker, *, memory_gib=64, registry=None):
     The double the other tests use answers whatever it was handed, so nothing
     it agrees to says anything about what simulate does with a plan.
     """
-    from unittest.mock import AsyncMock
-
-    from aleph.vm.agent.capacity import CapacityManager
-    from aleph.vm.agent.vm_registry import AgentVmRegistry
-    from aleph.vm.supervisor_interface.types import HostInfo
-
     mocker.patch(
         "aleph.vm.agent.capacity.psutil.virtual_memory",
         return_value=mocker.Mock(total=memory_gib * 1024**3),


### PR DESCRIPTION
Task 4 of the async scheduler allocations stack (design: `docs/plans/2026-08-20-async-allocations-design.md`). Stacked on #1159.

`build_plan` verifies each entry and keeps the rejected ones out of the plan entirely, so nothing downstream can act on a message that failed verification. `compute_verdict` diffs the plan against what the supervisor reports and runs one cumulative admission over the additions, counting the removals as freed: a plan that drops B and adds C admits C against B's memory.

Both are pure and await-free. The handler must not yield between reading the supervisor's view and swapping the desired state, or the verdict it just returned could already be stale.

A VM pinned to another CRN via `requirements.node.node_hash` is refused with `node_mismatch` rather than admitted: the scheduler chooses which messages run here, and one naming a different node is not among them.

`AllocationState` is defined here but deliberately not mirrored from `VmStatus`. The supervisor owns what a VM is doing; these are the phases that precede it knowing the VM at all, and they stop existing once `create_vm` returns.

No endpoint calls this yet, so nothing changes at runtime.

## Tests

34 new in `tests/supervisor/test_allocation_verdict.py`, written before the code, three of them driving a real `CapacityManager` because a double cannot show what `simulate` does with a plan. Full `tests/supervisor` FAILED set identical to `dev-2.1` (44 environment-only failures, none in a file this PR touches); mypy at the `dev-2.1` error set exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HoNHA7oAuN8FGwYPnZvcwi

