### PR TITLE
feat(agent): background reconciler for scheduler allocations

### DIFF
--- a/src/aleph/vm/agent/allocation/plan.py
+++ b/src/aleph/vm/agent/allocation/plan.py
@@ -7,10 +7,43 @@ down VMs that were migrated elsewhere during the downtime.
 
 from dataclasses import dataclass, field
 from datetime import datetime
+from enum import Enum
 
 from aleph_message.models import ItemHash
 
 from aleph.vm.agent.allocation.verify import VerifiedMessage
+
+
+class AllocationState(str, Enum):
+    """Agent-side phases, which all precede the supervisor knowing the VM.
+
+    Deliberately NOT a mirror of VmStatus: once create_vm returns, VmStatus is
+    the answer and this state stops existing. Two disjoint fields cannot drift,
+    whereas a merged enum would need maintaining in lockstep forever.
+    """
+
+    PLANNED = "planned"
+    RESOLVING = "resolving"
+    DOWNLOADING = "downloading"
+    SUBMITTING = "submitting"
+    FAILED = "failed"
+
+
+@dataclass
+class FailureRecord:
+    """Why a planned VM is not running, and when we will try again.
+
+    Kept in the reconciler and NOT in AgentVmRegistry on purpose: the registry
+    is what CapacityManager sums committed resources over, and a VM that failed
+    to start must not count as committed.
+    """
+
+    code: str
+    message: str
+    attempts: int
+    first_failed_at: datetime
+    last_failed_at: datetime
+    next_retry_at: datetime
 
 
 @dataclass

--- a/src/aleph/vm/agent/allocation/plan.py
+++ b/src/aleph/vm/agent/allocation/plan.py
@@ -5,13 +5,39 @@ reconciler with no plan deletes nothing: acting on a stale plan risks tearing
 down VMs that were migrated elsewhere during the downtime.
 """
 
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 
+from aleph_message.exceptions import UnknownHashError
 from aleph_message.models import ItemHash
 
 from aleph.vm.agent.allocation.verify import VerifiedMessage
+from aleph.vm.supervisor_interface.types import VmInfo, VmStatus
+
+logger = logging.getLogger(__name__)
+
+# A VM in one of these states is the supervisor's business already: creating it
+# again would be a second VM under the same hash.
+LIVE_STATUSES = (VmStatus.RUNNING, VmStatus.BOOTING, VmStatus.DEFINED)
+
+
+def by_hash(infos: list[VmInfo]) -> dict[ItemHash, VmInfo]:
+    """The supervisor's VMs, keyed by item hash.
+
+    An id that is not one is dropped rather than raised on, the way
+    supervisor_hashes and check_payment drop theirs: it names a VM the plan
+    says nothing about, so letting it through would take down a whole push or
+    wedge a whole convergence pass over something neither is about.
+    """
+    known: dict[ItemHash, VmInfo] = {}
+    for info in infos:
+        try:
+            known[ItemHash(str(info.vm_id))] = info
+        except (UnknownHashError, ValueError):
+            logger.warning("The supervisor lists a VM whose id is not an item hash: %r", info.vm_id)
+    return known
 
 
 class AllocationState(str, Enum):

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -31,6 +31,12 @@ logger = logging.getLogger(__name__)
 # again would be a second VM under the same hash.
 LIVE_STATUSES = (VmStatus.RUNNING, VmStatus.BOOTING, VmStatus.DEFINED)
 
+# States a dropped VM can be torn down from. DEFINED and BOOTING are excluded
+# deliberately: those are mid-creation, and deleting one races the creation
+# that is still in flight. A VM stuck there is caught on a later pass once it
+# reaches one of these.
+TEARDOWN_STATUSES = (VmStatus.RUNNING, VmStatus.STOPPED, VmStatus.FAILED)
+
 
 class AllocationReconciler:
     """Holds the desired state and converges to it in the background."""
@@ -102,7 +108,10 @@ class AllocationReconciler:
                 logger.exception("Allocation reconcile pass failed; retrying at the next wake-up")
             try:
                 await asyncio.wait_for(self._wakeup.wait(), timeout=settings.ALLOCATION_RECONCILE_INTERVAL)
-            except TimeoutError:
+            except asyncio.TimeoutError:
+                # Not the builtin: the two are only the same class from 3.11,
+                # and pyproject still supports 3.10, where catching the builtin
+                # would let the first quiet interval kill the reconciler.
                 pass
             self._wakeup.clear()
 
@@ -123,7 +132,7 @@ class AllocationReconciler:
     async def _teardown_dropped(self, plan: AllocationPlan, infos: list[VmInfo]) -> None:
         for info in infos:
             vm_hash = ItemHash(info.vm_id)
-            if vm_hash in plan.entries or info.status is not VmStatus.RUNNING:
+            if vm_hash in plan.entries or info.status not in TEARDOWN_STATUSES:
                 continue
             record = self.registry.get(vm_hash)
             if record is None or not is_removable_by_allocation(record, info):

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -1,0 +1,194 @@
+"""Converging the CRN onto the scheduler's plan, in the background.
+
+Level-triggered, not event-sourced: each pass re-reads the desired state and
+diffs it against what the supervisor reports, so a re-pushed identical plan is
+an empty diff and a plan arriving mid-convergence simply wins at the next step
+boundary. This is the seam pull mode plugs into: replacing "the scheduler
+pushed a plan" with "the agent fetched a plan" is a change to submit()'s
+caller and nothing else.
+"""
+
+import asyncio
+import logging
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
+
+from aleph_message.models import ItemHash
+
+from aleph.vm.agent.allocation.plan import (
+    AllocationPlan,
+    AllocationState,
+    FailureRecord,
+)
+from aleph.vm.agent.allocation.teardown import is_removable_by_allocation, teardown_vm
+from aleph.vm.agent.run import start_persistent_vm
+from aleph.vm.conf import settings
+from aleph.vm.supervisor_interface.types import VmInfo, VmStatus
+
+logger = logging.getLogger(__name__)
+
+# A VM in one of these states is the supervisor's business already: creating it
+# again would be a second VM under the same hash.
+LIVE_STATUSES = (VmStatus.RUNNING, VmStatus.BOOTING, VmStatus.DEFINED)
+
+
+class AllocationReconciler:
+    """Holds the desired state and converges to it in the background."""
+
+    def __init__(
+        self,
+        *,
+        supervisor,
+        registry,
+        capacity,
+        expiry,
+        update_watcher,
+        pubsub_getter: Callable[[], object | None],
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.supervisor = supervisor
+        self.registry = registry
+        self.capacity = capacity
+        self.expiry = expiry
+        self.update_watcher = update_watcher
+        # Resolved per use, never stored: app["pubsub"] is created by a startup
+        # hook registered after setup_webapp, and only when WATCH_FOR_MESSAGES
+        # is on, so it does not exist when this object is built.
+        self._pubsub_getter = pubsub_getter
+        self._now = now or (lambda: datetime.now(tz=timezone.utc))
+        self._desired: AllocationPlan | None = None
+        self._wakeup = asyncio.Event()
+        self._failures: dict[ItemHash, FailureRecord] = {}
+        self._states: dict[ItemHash, AllocationState] = {}
+
+    # ── Public surface ──
+
+    def submit(self, plan: AllocationPlan) -> None:
+        """Record a new desired state and wake the loop.
+
+        Await-free on purpose: the handler calls this in the same event-loop
+        turn as it computed the verdict it is about to return, so nothing can
+        change underneath it in between.
+        """
+        self._desired = plan
+        for vm_hash in list(self._failures):
+            if vm_hash not in plan.entries:
+                self._forget(vm_hash)
+        for vm_hash in list(self._states):
+            if vm_hash not in plan.entries:
+                self._forget(vm_hash)
+        self._wakeup.set()
+
+    def notify_vm_down(self, vm_id: str) -> None:
+        """A VM went STOPPED or FAILED. If the plan still wants it, converge."""
+        if self._desired and ItemHash(vm_id) in self._desired.entries:
+            self._wakeup.set()
+
+    def planned_hashes(self) -> set[ItemHash]:
+        return set(self._desired.entries) if self._desired else set()
+
+    def state_for(self, vm_hash: ItemHash) -> tuple[AllocationState | None, FailureRecord | None]:
+        """What the agent is doing about this VM, for the executions list."""
+        return self._states.get(vm_hash), self._failures.get(vm_hash)
+
+    async def run(self) -> None:
+        """Converge, then wait for a wake-up or the backstop interval."""
+        while True:
+            try:
+                await self._converge_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Allocation reconcile pass failed; retrying at the next wake-up")
+            try:
+                await asyncio.wait_for(self._wakeup.wait(), timeout=settings.ALLOCATION_RECONCILE_INTERVAL)
+            except TimeoutError:
+                pass
+            self._wakeup.clear()
+
+    # ── One pass ──
+
+    async def _converge_once(self) -> None:
+        plan = self._desired
+        if plan is None:
+            # Post-restart: no plan means delete nothing. A stale plan is worse
+            # than none, so the agent waits to be told rather than acting on
+            # what it remembers.
+            return
+
+        infos = await self.supervisor.list_vms()
+        await self._teardown_dropped(plan, infos)
+        await self._start_missing(plan, infos)
+
+    async def _teardown_dropped(self, plan: AllocationPlan, infos: list[VmInfo]) -> None:
+        for info in infos:
+            vm_hash = ItemHash(info.vm_id)
+            if vm_hash in plan.entries or info.status is not VmStatus.RUNNING:
+                continue
+            record = self.registry.get(vm_hash)
+            if record is None or not is_removable_by_allocation(record, info):
+                continue
+            logger.info("Plan %s dropped %s; tearing it down", plan.plan_id, vm_hash)
+            await teardown_vm(vm_hash, supervisor=self.supervisor, registry=self.registry)
+
+    async def _start_missing(self, plan: AllocationPlan, infos: list[VmInfo]) -> None:
+        live = {
+            ItemHash(info.vm_id) for info in infos if info.status in LIVE_STATUSES or info.awaiting_confidential_init
+        }
+        now = self._now()
+        todo = [vm_hash for vm_hash in plan.entries if vm_hash not in live and self._retry_due(vm_hash, now)]
+        if not todo:
+            return
+
+        semaphore = asyncio.Semaphore(settings.ALLOCATION_DOWNLOAD_CONCURRENCY)
+
+        async def start(vm_hash: ItemHash) -> None:
+            async with semaphore:
+                await self._start_one(vm_hash)
+
+        await asyncio.gather(*(start(vm_hash) for vm_hash in todo), return_exceptions=True)
+
+    def _retry_due(self, vm_hash: ItemHash, now: datetime) -> bool:
+        failure = self._failures.get(vm_hash)
+        return failure is None or failure.next_retry_at <= now
+
+    async def _start_one(self, vm_hash: ItemHash) -> None:
+        self._states[vm_hash] = AllocationState.DOWNLOADING
+        try:
+            await start_persistent_vm(
+                vm_hash,
+                self._pubsub_getter(),
+                supervisor=self.supervisor,
+                registry=self.registry,
+                capacity=self.capacity,
+                expiry=self.expiry,
+                update_watcher=self.update_watcher,
+            )
+        except Exception as error:
+            self._record_failure(vm_hash, error)
+            return
+        self._forget(vm_hash)
+
+    def _forget(self, vm_hash: ItemHash) -> None:
+        self._failures.pop(vm_hash, None)
+        self._states.pop(vm_hash, None)
+
+    def _record_failure(self, vm_hash: ItemHash, error: Exception) -> None:
+        now = self._now()
+        previous = self._failures.get(vm_hash)
+        attempts = (previous.attempts if previous else 0) + 1
+        delay = min(
+            settings.ALLOCATION_RETRY_BASE_INTERVAL * (2 ** (attempts - 1)),
+            settings.ALLOCATION_RETRY_MAX_INTERVAL,
+        )
+        code = getattr(getattr(error, "code", None), "value", "") or type(error).__name__
+        logger.warning("Starting %s failed (attempt %d): %s", vm_hash, attempts, error)
+        self._failures[vm_hash] = FailureRecord(
+            code=code,
+            message=str(error)[:200],
+            attempts=attempts,
+            first_failed_at=previous.first_failed_at if previous else now,
+            last_failed_at=now,
+            next_retry_at=now + timedelta(seconds=delay),
+        )
+        self._states[vm_hash] = AllocationState.FAILED

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -40,6 +40,13 @@ logger = logging.getLogger(__name__)
 # deliberately: those are mid-creation, and deleting one races the creation
 # that is still in flight. A VM stuck there is caught on a later pass once it
 # reaches one of these.
+#
+# Wider than the removing list compute_verdict answers with, which is RUNNING
+# only: the answer names what this push stops that was up, while a pass sweeps
+# what the plan dropped whatever state it is in. Capacity stays conservative
+# under the difference, because a commitment is held by the registry record
+# rather than by the status, so a stopped VM left out of releasing has its
+# memory counted against the push that is about to free it.
 TEARDOWN_STATUSES = (VmStatus.RUNNING, VmStatus.STOPPED, VmStatus.FAILED)
 
 

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -136,12 +136,15 @@ class AllocationReconciler:
             # what it remembers.
             return
 
-        infos = await self.supervisor.list_vms()
-        await self._teardown_dropped(plan, infos)
-        await self._start_missing(plan, infos)
+        # Read once and handed to both halves: the two used to key the
+        # supervisor's list by hash apiece, which parsed every id twice and
+        # left them free to disagree about what is running.
+        known = by_hash(await self.supervisor.list_vms())
+        await self._teardown_dropped(plan, known)
+        await self._start_missing(plan, known)
 
-    async def _teardown_dropped(self, plan: AllocationPlan, infos: list[VmInfo]) -> None:
-        for vm_hash, info in by_hash(infos).items():
+    async def _teardown_dropped(self, plan: AllocationPlan, known: dict[ItemHash, VmInfo]) -> None:
+        for vm_hash, info in known.items():
             if vm_hash in plan.entries or info.status not in TEARDOWN_STATUSES:
                 continue
             # The plan is re-read here rather than taken from the pass, which
@@ -166,10 +169,10 @@ class AllocationReconciler:
                 # it did that on every interval for as long as it kept failing.
                 logger.exception("Tearing down %s failed; leaving it for the next pass", vm_hash)
 
-    async def _start_missing(self, plan: AllocationPlan, infos: list[VmInfo]) -> None:
+    async def _start_missing(self, plan: AllocationPlan, known: dict[ItemHash, VmInfo]) -> None:
         live = {
             vm_hash
-            for vm_hash, info in by_hash(infos).items()
+            for vm_hash, info in known.items()
             if info.status in LIVE_STATUSES or info.awaiting_confidential_init
         }
         now = self._now()

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -188,6 +188,14 @@ class AllocationReconciler:
                 update_watcher=self.update_watcher,
             )
         except Exception as error:
+            if self._desired is None or vm_hash not in self._desired.entries:
+                # A newer plan dropped this VM while its create was in flight.
+                # submit() has already pruned its state, and recording the
+                # failure now would put it back for a VM nothing will retry,
+                # leaving state_for reporting on something we have stopped
+                # caring about until the next push clears it again.
+                logger.info("Start of %s failed after the plan dropped it: %s", vm_hash, error)
+                return
             self._record_failure(vm_hash, error)
             return
         self._forget(vm_hash)

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -143,7 +143,14 @@ class AllocationReconciler:
             if record is None or not is_removable_by_allocation(record, info):
                 continue
             logger.info("Plan %s dropped %s; tearing it down", plan.plan_id, vm_hash)
-            await teardown_vm(vm_hash, supervisor=self.supervisor, registry=self.registry)
+            try:
+                await teardown_vm(vm_hash, supervisor=self.supervisor, registry=self.registry)
+            except Exception:
+                # Isolated per VM, the way _start_one isolates a start. One VM
+                # the supervisor will not delete used to abort the pass here,
+                # before a single start ran, and teardowns carry no backoff, so
+                # it did that on every interval for as long as it kept failing.
+                logger.exception("Tearing down %s failed; leaving it for the next pass", vm_hash)
 
     async def _start_missing(self, plan: AllocationPlan, infos: list[VmInfo]) -> None:
         live = {

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -144,10 +144,19 @@ class AllocationReconciler:
         for vm_hash, info in by_hash(infos).items():
             if vm_hash in plan.entries or info.status not in TEARDOWN_STATUSES:
                 continue
+            # The plan is re-read here rather than taken from the pass, which
+            # may have been parked in list_vms or in an earlier teardown while
+            # a push re-added this VM. A start can afford to act on a snapshot
+            # one push out of date, because the next pass undoes it; a teardown
+            # cannot, since GONE reaps the volumes. The read and the await
+            # below are in one turn, so nothing lands in between.
+            current = self._desired
+            if current is None or vm_hash in current.entries:
+                continue
             record = self.registry.get(vm_hash)
             if record is None or not is_removable_by_allocation(record, info):
                 continue
-            logger.info("Plan %s dropped %s; tearing it down", plan.plan_id, vm_hash)
+            logger.info("Plan %s dropped %s; tearing it down", current.plan_id, vm_hash)
             try:
                 await teardown_vm(vm_hash, supervisor=self.supervisor, registry=self.registry)
             except Exception:

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -26,6 +26,7 @@ from aleph.vm.agent.allocation.plan import (
 from aleph.vm.agent.allocation.teardown import is_removable_by_allocation, teardown_vm
 from aleph.vm.agent.capacity import CapacityManager
 from aleph.vm.agent.expiry import ExpiryManager
+from aleph.vm.agent.pubsub import PubSub
 from aleph.vm.agent.run import start_persistent_vm
 from aleph.vm.agent.update_watcher import UpdateWatcher
 from aleph.vm.agent.vm_registry import AgentVmRegistry
@@ -53,7 +54,7 @@ class AllocationReconciler:
         capacity: CapacityManager,
         expiry: ExpiryManager,
         update_watcher: UpdateWatcher,
-        pubsub_getter: Callable[[], object | None],
+        pubsub_getter: Callable[[], PubSub | None],
         now: Callable[[], datetime] | None = None,
     ) -> None:
         self.supervisor = supervisor

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -13,12 +13,15 @@ import logging
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 
+from aleph_message.exceptions import UnknownHashError
 from aleph_message.models import ItemHash
 
 from aleph.vm.agent.allocation.plan import (
+    LIVE_STATUSES,
     AllocationPlan,
     AllocationState,
     FailureRecord,
+    by_hash,
 )
 from aleph.vm.agent.allocation.teardown import is_removable_by_allocation, teardown_vm
 from aleph.vm.agent.run import start_persistent_vm
@@ -26,10 +29,6 @@ from aleph.vm.conf import settings
 from aleph.vm.supervisor_interface.types import VmInfo, VmStatus
 
 logger = logging.getLogger(__name__)
-
-# A VM in one of these states is the supervisor's business already: creating it
-# again would be a second VM under the same hash.
-LIVE_STATUSES = (VmStatus.RUNNING, VmStatus.BOOTING, VmStatus.DEFINED)
 
 # States a dropped VM can be torn down from. DEFINED and BOOTING are excluded
 # deliberately: those are mid-creation, and deleting one races the creation
@@ -87,7 +86,14 @@ class AllocationReconciler:
 
     def notify_vm_down(self, vm_id: str) -> None:
         """A VM went STOPPED or FAILED. If the plan still wants it, converge."""
-        if self._desired and ItemHash(vm_id) in self._desired.entries:
+        if self._desired is None:
+            return
+        try:
+            vm_hash = ItemHash(str(vm_id))
+        except (UnknownHashError, ValueError):
+            # Not ours to converge, and the event stream is no place to raise.
+            return
+        if vm_hash in self._desired.entries:
             self._wakeup.set()
 
     def planned_hashes(self) -> set[ItemHash]:
@@ -130,8 +136,7 @@ class AllocationReconciler:
         await self._start_missing(plan, infos)
 
     async def _teardown_dropped(self, plan: AllocationPlan, infos: list[VmInfo]) -> None:
-        for info in infos:
-            vm_hash = ItemHash(info.vm_id)
+        for vm_hash, info in by_hash(infos).items():
             if vm_hash in plan.entries or info.status not in TEARDOWN_STATUSES:
                 continue
             record = self.registry.get(vm_hash)
@@ -142,7 +147,9 @@ class AllocationReconciler:
 
     async def _start_missing(self, plan: AllocationPlan, infos: list[VmInfo]) -> None:
         live = {
-            ItemHash(info.vm_id) for info in infos if info.status in LIVE_STATUSES or info.awaiting_confidential_init
+            vm_hash
+            for vm_hash, info in by_hash(infos).items()
+            if info.status in LIVE_STATUSES or info.awaiting_confidential_init
         }
         now = self._now()
         todo = [vm_hash for vm_hash in plan.entries if vm_hash not in live and self._retry_due(vm_hash, now)]

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -24,8 +24,13 @@ from aleph.vm.agent.allocation.plan import (
     by_hash,
 )
 from aleph.vm.agent.allocation.teardown import is_removable_by_allocation, teardown_vm
+from aleph.vm.agent.capacity import CapacityManager
+from aleph.vm.agent.expiry import ExpiryManager
 from aleph.vm.agent.run import start_persistent_vm
+from aleph.vm.agent.update_watcher import UpdateWatcher
+from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
+from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.supervisor_interface.types import VmInfo, VmStatus
 
 logger = logging.getLogger(__name__)
@@ -43,11 +48,11 @@ class AllocationReconciler:
     def __init__(
         self,
         *,
-        supervisor,
-        registry,
-        capacity,
-        expiry,
-        update_watcher,
+        supervisor: Supervisor,
+        registry: AgentVmRegistry,
+        capacity: CapacityManager,
+        expiry: ExpiryManager,
+        update_watcher: UpdateWatcher,
         pubsub_getter: Callable[[], object | None],
         now: Callable[[], datetime] | None = None,
     ) -> None:

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -10,10 +10,15 @@ from datetime import datetime
 from hashlib import sha256
 from typing import Protocol
 
-from aleph_message.exceptions import UnknownHashError
 from aleph_message.models import ExecutableContent, ItemHash
 
-from aleph.vm.agent.allocation.plan import AllocationPlan, PlannedVm, PlanVerdict
+from aleph.vm.agent.allocation.plan import (
+    LIVE_STATUSES,
+    AllocationPlan,
+    PlannedVm,
+    PlanVerdict,
+    by_hash,
+)
 from aleph.vm.agent.allocation.teardown import is_removable_by_allocation
 from aleph.vm.agent.allocation.verify import VerificationOutcome, verify_entry
 from aleph.vm.agent.capacity import (
@@ -42,10 +47,6 @@ class _Capacity(Protocol):
         *,
         releasing: frozenset[ItemHash] = ...,
     ) -> list[AdmissionVerdict]: ...
-
-
-# A VM the supervisor is already working on does not need re-creating.
-LIVE_STATUSES = (VmStatus.RUNNING, VmStatus.BOOTING, VmStatus.DEFINED)
 
 
 def compute_plan_id(planned: list[str], rejected: list[str]) -> str:
@@ -141,24 +142,6 @@ def _required_node_hash(content: ExecutableContent) -> str | None:
     return str(required) if required else None
 
 
-def _by_hash(infos: list[VmInfo]) -> dict[ItemHash, VmInfo]:
-    """The supervisor's VMs, keyed by item hash.
-
-    An id that is not one is dropped rather than raised on, the way
-    supervisor_hashes and check_payment drop theirs: it cannot name a VM this
-    plan lists, and letting it through would take down a whole push over a VM
-    the push says nothing about. build_plan holds the entries it reads to the
-    same rule.
-    """
-    by_hash: dict[ItemHash, VmInfo] = {}
-    for info in infos:
-        try:
-            by_hash[ItemHash(str(info.vm_id))] = info
-        except (UnknownHashError, ValueError):
-            logger.warning("The supervisor lists a VM whose id is not an item hash: %r", info.vm_id)
-    return by_hash
-
-
 def compute_verdict(
     plan: AllocationPlan,
     *,
@@ -177,10 +160,10 @@ def compute_verdict(
     it is, no plan can place a GPU VM.
     """
     verdict = PlanVerdict()
-    by_hash = _by_hash(infos)
+    known = by_hash(infos)
     unchanged: set[ItemHash] = set()
 
-    for vm_hash, info in by_hash.items():
+    for vm_hash, info in known.items():
         if vm_hash in plan.entries:
             if info.status in LIVE_STATUSES or info.awaiting_confidential_init:
                 unchanged.add(vm_hash)

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -204,6 +204,9 @@ async def _reconcile_after_event_gap(app: web.Application) -> None:
         if status is None or status in (VmStatus.STOPPED, VmStatus.FAILED):
             logger.info("Reconcile after event-stream gap: dropping agent state for %s (status: %s)", vm_id, status)
             await _drop_vm_state(app, vm_id)
+            # Same nudge the live stream gives: a VM that died during the gap
+            # is still planned, and should not wait out the backstop interval.
+            app["allocation_reconciler"].notify_vm_down(vm_id)
 
 
 async def watch_supervisor_events(app: web.Application) -> None:

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -324,7 +324,9 @@ def setup_webapp(supervisor: Supervisor):
     )
 
     async def _start_allocation_reconciler(app: web.Application) -> None:
-        app["_allocation_reconciler"] = asyncio.get_running_loop().create_task(app["allocation_reconciler"].run())
+        app["_allocation_reconciler"] = create_task_log_exceptions(
+            app["allocation_reconciler"].run(), name="allocation reconciler"
+        )
 
     async def _stop_allocation_reconciler(app: web.Application) -> None:
         task = app.get("_allocation_reconciler")

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -16,6 +16,7 @@ from aiohttp.web_exceptions import HTTPException
 from aiohttp_cors import ResourceOptions, setup
 
 from aleph.vm import storage, storage_pools
+from aleph.vm.agent.allocation.reconciler import AllocationReconciler
 from aleph.vm.agent.capacity import CapacityManager
 from aleph.vm.agent.expiry import ExpiryManager
 from aleph.vm.agent.migration.reaper import reap_orphan_migration_files
@@ -231,6 +232,9 @@ async def watch_supervisor_events(app: web.Application) -> None:
             async for event in supervisor.watch_events():
                 if event.new_status in (VmStatus.STOPPED, VmStatus.FAILED):
                     await _drop_vm_state(app, event.vm_id)
+                    # If the plan still wants this VM, converge now rather than
+                    # waiting out the reconciler's backstop interval.
+                    app["allocation_reconciler"].notify_vm_down(event.vm_id)
         except NotImplementedSupervisorError:
             logger.info("Supervisor does not implement WatchEvents; agent state relies on its own reaps only")
             return
@@ -300,6 +304,33 @@ def setup_webapp(supervisor: Supervisor):
 
     app["expiry"].on_reaped = _on_expiry_reaped
     app["update_watcher"].on_reaped = _on_update_reaped
+
+    app["allocation_reconciler"] = AllocationReconciler(
+        supervisor=app["supervisor"],
+        registry=app["vm_registry"],
+        capacity=app["capacity"],
+        expiry=app["expiry"],
+        update_watcher=app["update_watcher"],
+        # Lazy on purpose: app["pubsub"] is created by start_watch_for_messages_task,
+        # an on_startup hook registered in run_server (so after every hook appended
+        # here) and only when settings.WATCH_FOR_MESSAGES is on. Reading it now
+        # would KeyError, and caching it when the task starts would silently drop
+        # update-watching for reconciler-started VMs. start_persistent_vm accepts
+        # None and skips watching.
+        pubsub_getter=lambda: app.get("pubsub"),
+    )
+
+    async def _start_allocation_reconciler(app: web.Application) -> None:
+        app["_allocation_reconciler"] = asyncio.get_running_loop().create_task(app["allocation_reconciler"].run())
+
+    async def _stop_allocation_reconciler(app: web.Application) -> None:
+        task = app.get("_allocation_reconciler")
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    app.on_startup.append(_start_allocation_reconciler)  # type: ignore[arg-type]
+    app.on_cleanup.append(_stop_allocation_reconciler)  # type: ignore[arg-type]
 
     # The supervisor daemon owns the VMs, so its event stream is the only way
     # for the agent to learn that a VM went down without polling; feed the

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -433,6 +433,23 @@ class Settings(BaseSettings):
     """Absolute time window (seconds) for the signed payload's `iat` relative
     to the supervisor's wall clock. Used by the Aleph-EIP191-V1 verifier."""
 
+    ALLOCATION_RECONCILE_INTERVAL: int = 60
+    """Backstop pass of the allocation reconciler, in seconds. The loop is
+    normally woken by a plan push or a supervisor event; this only bounds how
+    long a missed wake-up can delay a retry."""
+
+    ALLOCATION_RETRY_BASE_INTERVAL: int = 30
+    """First retry delay after a failed create, in seconds. Doubles per attempt."""
+
+    ALLOCATION_RETRY_MAX_INTERVAL: int = 900
+    """Cap on the allocation retry backoff, in seconds."""
+
+    ALLOCATION_DOWNLOAD_CONCURRENCY: int = 3
+    """How many VMs the reconciler may create at once. The expensive phase
+    (resource download) runs agent-side and outside the supervisor's creation
+    lock, so overlapping it is what makes a large plan converge in reasonable
+    time; create_vm itself is still serialized by that lock."""
+
     ENABLE_QEMU_SUPPORT: bool = Field(default=True)
     INSTANCE_DEFAULT_HYPERVISOR: HypervisorType | None = Field(
         default=HypervisorType.qemu,

--- a/tests/supervisor/test_allocation_reconciler.py
+++ b/tests/supervisor/test_allocation_reconciler.py
@@ -1,0 +1,286 @@
+"""Convergence: what one reconciler pass does with a plan.
+
+Each test drives _converge_once() rather than the infinite run() loop, and
+injects the clock so backoff assertions never sleep.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aleph_message.models import ItemHash
+
+from aleph.vm.agent.allocation import reconciler as reconciler_module
+from aleph.vm.agent.allocation.plan import AllocationPlan, AllocationState, PlannedVm
+from aleph.vm.agent.allocation.reconciler import AllocationReconciler
+from aleph.vm.conf import settings
+from aleph.vm.supervisor_interface.types import ConfidentialMode, VmStatus
+
+NOW = datetime(2026, 8, 25, 12, 0, tzinfo=timezone.utc)
+HASH_B = ItemHash("b" * 64)
+HASH_C = ItemHash("c" * 64)
+
+
+def _hash(index: int) -> ItemHash:
+    return ItemHash(f"{index:064x}")
+
+
+def _info(vm_hash, status=VmStatus.RUNNING):
+    return SimpleNamespace(
+        vm_id=str(vm_hash),
+        status=status,
+        gpus=[],
+        confidential_mode=ConfidentialMode.NONE,
+        awaiting_confidential_init=False,
+    )
+
+
+def _record(*, stream=False, vprogram=False):
+    return SimpleNamespace(
+        persistent=True,
+        uses_payment_stream=stream,
+        uses_payment_credit=False,
+        is_vprogram=vprogram,
+        message=MagicMock(),
+    )
+
+
+def _plan(*hashes):
+    return AllocationPlan(plan_id="sha256:test", received_at=NOW, entries={h: PlannedVm(vm_hash=h) for h in hashes})
+
+
+@pytest.fixture
+def clock():
+    return SimpleNamespace(now=NOW)
+
+
+@pytest.fixture
+def reconciler(clock, monkeypatch):
+    """A reconciler over a fake supervisor and registry, with teardown and the
+    create call replaced so tests can observe them."""
+    supervisor = SimpleNamespace(list_vms=AsyncMock(return_value=[]), delete_vm=AsyncMock())
+    registry = SimpleNamespace(get=lambda h: _record(), forget=MagicMock())
+    monkeypatch.setattr(reconciler_module, "teardown_vm", AsyncMock())
+    instance = AllocationReconciler(
+        supervisor=supervisor,
+        registry=registry,
+        capacity=MagicMock(),
+        expiry=MagicMock(),
+        update_watcher=MagicMock(),
+        pubsub_getter=lambda: None,
+        now=lambda: clock.now,
+    )
+    instance.started = []
+    return instance
+
+
+def _record_starts(reconciler, monkeypatch, *, fail=False):
+    """Replace start_persistent_vm, tracking attempts and peak concurrency."""
+    state = SimpleNamespace(attempts=0, live=0, peak=0)
+
+    async def fake_start(vm_hash, _pubsub, **_kwargs):
+        state.attempts += 1
+        state.live += 1
+        state.peak = max(state.peak, state.live)
+        try:
+            await asyncio.sleep(0)
+            if fail:
+                msg = "download failed"
+                raise RuntimeError(msg)
+            reconciler.started.append(vm_hash)
+        finally:
+            state.live -= 1
+
+    monkeypatch.setattr(reconciler_module, "start_persistent_vm", fake_start)
+    return state
+
+
+@pytest.mark.asyncio
+async def test_with_no_plan_nothing_is_torn_down(reconciler):
+    """The post-restart state. Acting on a remembered plan risks tearing down
+    VMs that were migrated elsewhere during the downtime."""
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_B)]
+
+    await reconciler._converge_once()
+
+    reconciler_module.teardown_vm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_vm_dropped_from_the_plan_is_torn_down(reconciler, monkeypatch):
+    _record_starts(reconciler, monkeypatch)
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_B)]
+    reconciler.submit(_plan())
+
+    await reconciler._converge_once()
+
+    assert reconciler_module.teardown_vm.await_args.args[0] == HASH_B
+
+
+@pytest.mark.asyncio
+async def test_a_stream_paid_vm_is_never_torn_down(reconciler, monkeypatch):
+    _record_starts(reconciler, monkeypatch)
+    reconciler.registry = SimpleNamespace(get=lambda h: _record(stream=True), forget=MagicMock())
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_B)]
+    reconciler.submit(_plan())
+
+    await reconciler._converge_once()
+
+    reconciler_module.teardown_vm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_planned_vm_the_supervisor_does_not_have_is_started(reconciler, monkeypatch):
+    _record_starts(reconciler, monkeypatch)
+    reconciler.submit(_plan(HASH_C))
+
+    await reconciler._converge_once()
+
+    assert reconciler.started == [HASH_C]
+
+
+@pytest.mark.asyncio
+async def test_a_planned_vm_already_running_is_left_alone(reconciler, monkeypatch):
+    starts = _record_starts(reconciler, monkeypatch)
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_C)]
+    reconciler.submit(_plan(HASH_C))
+
+    await reconciler._converge_once()
+
+    assert starts.attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_creates_respect_the_concurrency_bound(reconciler, monkeypatch):
+    """Downloads overlap, but not without bound: one host, one disk."""
+    monkeypatch.setattr(settings, "ALLOCATION_DOWNLOAD_CONCURRENCY", 2)
+    starts = _record_starts(reconciler, monkeypatch)
+    reconciler.submit(_plan(*[_hash(i) for i in range(6)]))
+
+    await reconciler._converge_once()
+
+    assert starts.attempts == 6
+    assert starts.peak == 2
+
+
+@pytest.mark.asyncio
+async def test_a_failed_start_is_remembered_with_a_retry_time(reconciler, monkeypatch):
+    _record_starts(reconciler, monkeypatch, fail=True)
+    reconciler.submit(_plan(HASH_C))
+
+    await reconciler._converge_once()
+
+    state, failure = reconciler.state_for(HASH_C)
+    assert state is AllocationState.FAILED
+    assert failure.attempts == 1
+    assert failure.next_retry_at == NOW + timedelta(seconds=settings.ALLOCATION_RETRY_BASE_INTERVAL)
+
+
+@pytest.mark.asyncio
+async def test_a_failure_is_not_retried_before_its_backoff_expires(reconciler, monkeypatch):
+    starts = _record_starts(reconciler, monkeypatch, fail=True)
+    reconciler.submit(_plan(HASH_C))
+
+    await reconciler._converge_once()
+    await reconciler._converge_once()
+
+    assert starts.attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_backoff_doubles_and_is_capped(reconciler, monkeypatch, clock):
+    _record_starts(reconciler, monkeypatch, fail=True)
+    reconciler.submit(_plan(HASH_C))
+    delays = []
+
+    for _ in range(8):
+        await reconciler._converge_once()
+        _, failure = reconciler.state_for(HASH_C)
+        delays.append((failure.next_retry_at - clock.now).total_seconds())
+        clock.now = failure.next_retry_at
+
+    assert delays[0] == settings.ALLOCATION_RETRY_BASE_INTERVAL
+    assert delays[1] == settings.ALLOCATION_RETRY_BASE_INTERVAL * 2
+    assert max(delays) == settings.ALLOCATION_RETRY_MAX_INTERVAL
+
+
+@pytest.mark.asyncio
+async def test_a_vm_that_leaves_the_plan_loses_its_failure_record(reconciler, monkeypatch):
+    """Otherwise a hash the scheduler gave up on is retried forever."""
+    _record_starts(reconciler, monkeypatch, fail=True)
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+
+    reconciler.submit(_plan())
+
+    assert reconciler.state_for(HASH_C) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_a_successful_start_clears_a_previous_failure(reconciler, monkeypatch, clock):
+    _record_starts(reconciler, monkeypatch, fail=True)
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+    _, failure = reconciler.state_for(HASH_C)
+    clock.now = failure.next_retry_at
+    _record_starts(reconciler, monkeypatch, fail=False)
+
+    await reconciler._converge_once()
+
+    assert reconciler.state_for(HASH_C) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_a_newer_plan_supersedes_the_previous_one(reconciler, monkeypatch):
+    """Level-triggered: the desired state is re-read every pass."""
+    _record_starts(reconciler, monkeypatch)
+    reconciler.submit(_plan(HASH_C))
+    reconciler.submit(_plan(HASH_B))
+
+    await reconciler._converge_once()
+
+    assert reconciler.started == [HASH_B]
+
+
+@pytest.mark.asyncio
+async def test_the_event_watcher_nudges_the_reconciler_when_a_vm_goes_down():
+    """A VM that dies while still planned must be retried at once, not at the
+    backstop interval. The watcher is the agent's only push channel for it.
+
+    Covered here rather than in the watcher's own suite, which no longer
+    exists: removing the Python supervisor daemon deleted that file wholesale
+    because its fixtures were built on LocalSupervisor, even though
+    watch_supervisor_events is agent-side and survived.
+    """
+    from aleph.vm.agent.supervisor import watch_supervisor_events
+    from aleph.vm.supervisor_interface.types import VmEvent, VmId
+
+    vm_id = VmId(str(HASH_C))
+    boot = VmEvent(vm_id=vm_id, old_status=VmStatus.DEFINED, new_status=VmStatus.RUNNING, timestamp_ns=1)
+    stop = VmEvent(vm_id=vm_id, old_status=VmStatus.RUNNING, new_status=VmStatus.STOPPED, timestamp_ns=2)
+    consumed = asyncio.Event()
+
+    class FakeSupervisor:
+        async def watch_events(self):
+            yield boot  # coming up is not going down: must not nudge
+            yield stop
+            consumed.set()
+            await asyncio.Event().wait()  # block like a live stream
+
+    app: dict[str, Any] = {
+        "supervisor": FakeSupervisor(),
+        "expiry": MagicMock(),
+        "update_watcher": MagicMock(),
+        "program_client": MagicMock(forget=AsyncMock()),
+        "allocation_reconciler": MagicMock(),
+    }
+
+    task = asyncio.ensure_future(watch_supervisor_events(app))
+    await asyncio.wait_for(consumed.wait(), timeout=2)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    app["allocation_reconciler"].notify_vm_down.assert_called_once_with(vm_id)

--- a/tests/supervisor/test_allocation_reconciler.py
+++ b/tests/supervisor/test_allocation_reconciler.py
@@ -284,3 +284,42 @@ async def test_the_event_watcher_nudges_the_reconciler_when_a_vm_goes_down():
     await asyncio.gather(task, return_exceptions=True)
 
     app["allocation_reconciler"].notify_vm_down.assert_called_once_with(vm_id)
+
+
+@pytest.mark.asyncio
+async def test_notify_vm_down_wakes_the_loop_only_for_a_planned_vm(reconciler):
+    """The watcher calls this for every VM that goes down, most of which this
+    reconciler has no opinion about. Waking on those is pure churn."""
+    reconciler.submit(_plan(HASH_C))
+    reconciler._wakeup.clear()
+
+    reconciler.notify_vm_down(str(HASH_B))
+    assert reconciler._wakeup.is_set() is False
+
+    reconciler.notify_vm_down(str(HASH_C))
+    assert reconciler._wakeup.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_a_dropped_vm_is_torn_down_even_if_it_already_died(reconciler, monkeypatch):
+    """A FAILED VM dropped from the plan still owns disks and a registry record
+    that keeps counting against capacity, so leaving it is a slow leak."""
+    _record_starts(reconciler, monkeypatch)
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_B, status=VmStatus.FAILED)]
+    reconciler.submit(_plan())
+
+    await reconciler._converge_once()
+
+    assert reconciler_module.teardown_vm.await_args.args[0] == HASH_B
+
+
+@pytest.mark.asyncio
+async def test_a_vm_still_being_created_is_not_torn_down(reconciler, monkeypatch):
+    """DEFINED is mid-creation: deleting it races the create still in flight."""
+    _record_starts(reconciler, monkeypatch)
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_B, status=VmStatus.DEFINED)]
+    reconciler.submit(_plan())
+
+    await reconciler._converge_once()
+
+    reconciler_module.teardown_vm.assert_not_awaited()

--- a/tests/supervisor/test_allocation_reconciler.py
+++ b/tests/supervisor/test_allocation_reconciler.py
@@ -121,6 +121,27 @@ async def test_a_vm_dropped_from_the_plan_is_torn_down(reconciler, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_a_vm_a_newer_plan_re_added_is_not_torn_down(reconciler, monkeypatch):
+    """A push landing while the pass was parked in list_vms, or in an earlier
+    teardown, went unread: the pass held its own snapshot, so a VM the newer
+    plan wants was retired as GONE and its volumes reaped. Every other step is
+    safe to take one push out of date, because the next pass undoes it. This
+    one is not."""
+    _record_starts(reconciler, monkeypatch)
+    reconciler.submit(_plan())
+
+    async def list_vms():
+        reconciler.submit(_plan(HASH_B))
+        return [_info(HASH_B)]
+
+    reconciler.supervisor.list_vms = list_vms
+
+    await reconciler._converge_once()
+
+    reconciler_module.teardown_vm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_a_stream_paid_vm_is_never_torn_down(reconciler, monkeypatch):
     _record_starts(reconciler, monkeypatch)
     reconciler.registry = SimpleNamespace(get=lambda h: _record(stream=True), forget=MagicMock())

--- a/tests/supervisor/test_allocation_reconciler.py
+++ b/tests/supervisor/test_allocation_reconciler.py
@@ -133,6 +133,21 @@ async def test_a_stream_paid_vm_is_never_torn_down(reconciler, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_a_teardown_that_keeps_failing_does_not_block_the_starts(reconciler, monkeypatch):
+    """Starts are isolated per VM; teardowns were not, so one VM the supervisor
+    refused to delete aborted the pass before _start_missing ran, on every
+    interval, and teardowns have no backoff to slow that down."""
+    starts = _record_starts(reconciler, monkeypatch)
+    monkeypatch.setattr(reconciler_module, "teardown_vm", AsyncMock(side_effect=RuntimeError("delete failed")))
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_B)]
+    reconciler.submit(_plan(HASH_C))
+
+    await reconciler._converge_once()
+
+    assert starts.attempts == 1
+
+
+@pytest.mark.asyncio
 async def test_a_vm_id_that_is_not_a_hash_does_not_wedge_the_pass(reconciler, monkeypatch):
     """The supervisor's list is not ours to vouch for: an operator's own VM, or
     a second tenant's, carries an id we cannot parse. Converting it unguarded

--- a/tests/supervisor/test_allocation_reconciler.py
+++ b/tests/supervisor/test_allocation_reconciler.py
@@ -291,6 +291,24 @@ async def test_a_vm_that_leaves_the_plan_loses_its_failure_record(reconciler, mo
 
 
 @pytest.mark.asyncio
+async def test_a_vm_the_plan_still_lists_keeps_its_backoff(reconciler, monkeypatch):
+    """The complement of the test above: submit() prunes the state of the VMs
+    it drops and only those. Pruning every VM would hand a scheduler polling
+    with the same plan a fresh attempt on each push, which is exactly the
+    hammering the backoff exists to stop."""
+    starts = _record_starts(reconciler, monkeypatch, fail=True)
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+
+    assert starts.attempts == 1
+    _, failure = reconciler.state_for(HASH_C)
+    assert failure.attempts == 1
+
+
+@pytest.mark.asyncio
 async def test_a_successful_start_clears_a_previous_failure(reconciler, monkeypatch, clock):
     _record_starts(reconciler, monkeypatch, fail=True)
     reconciler.submit(_plan(HASH_C))

--- a/tests/supervisor/test_allocation_reconciler.py
+++ b/tests/supervisor/test_allocation_reconciler.py
@@ -239,6 +239,25 @@ async def test_backoff_doubles_and_is_capped(reconciler, monkeypatch, clock):
 
 
 @pytest.mark.asyncio
+async def test_a_start_that_fails_after_the_plan_drops_it_is_not_remembered(reconciler, monkeypatch):
+    """submit() prunes the state of a VM it drops, but a create already in
+    flight recorded its failure afterwards and put the record back, so
+    state_for went on reporting a VM nothing would ever retry."""
+
+    async def fake_start(vm_hash, _pubsub, **_kwargs):
+        reconciler.submit(_plan())
+        msg = "download failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(reconciler_module, "start_persistent_vm", fake_start)
+    reconciler.submit(_plan(HASH_C))
+
+    await reconciler._converge_once()
+
+    assert reconciler.state_for(HASH_C) == (None, None)
+
+
+@pytest.mark.asyncio
 async def test_a_vm_that_leaves_the_plan_loses_its_failure_record(reconciler, monkeypatch):
     """Otherwise a hash the scheduler gave up on is retried forever."""
     _record_starts(reconciler, monkeypatch, fail=True)

--- a/tests/supervisor/test_allocation_reconciler.py
+++ b/tests/supervisor/test_allocation_reconciler.py
@@ -133,6 +133,22 @@ async def test_a_stream_paid_vm_is_never_torn_down(reconciler, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_a_vm_id_that_is_not_a_hash_does_not_wedge_the_pass(reconciler, monkeypatch):
+    """The supervisor's list is not ours to vouch for: an operator's own VM, or
+    a second tenant's, carries an id we cannot parse. Converting it unguarded
+    raised out of the pass before any teardown or start ran, and since run()
+    logs and retries, the reconciler went on looking alive while converging
+    nothing for as long as that VM existed."""
+    starts = _record_starts(reconciler, monkeypatch)
+    reconciler.supervisor.list_vms.return_value = [_info("operator-scratch-vm")]
+    reconciler.submit(_plan(HASH_C))
+
+    await reconciler._converge_once()
+
+    assert starts.attempts == 1
+
+
+@pytest.mark.asyncio
 async def test_a_planned_vm_the_supervisor_does_not_have_is_started(reconciler, monkeypatch):
     _record_starts(reconciler, monkeypatch)
     reconciler.submit(_plan(HASH_C))

--- a/tests/supervisor/test_allocation_reconciler.py
+++ b/tests/supervisor/test_allocation_reconciler.py
@@ -364,12 +364,90 @@ async def test_a_dropped_vm_is_torn_down_even_if_it_already_died(reconciler, mon
 
 
 @pytest.mark.asyncio
-async def test_a_vm_still_being_created_is_not_torn_down(reconciler, monkeypatch):
-    """DEFINED is mid-creation: deleting it races the create still in flight."""
+@pytest.mark.parametrize("status", [VmStatus.DEFINED, VmStatus.BOOTING])
+async def test_a_vm_still_being_created_is_not_torn_down(reconciler, monkeypatch, status):
+    """Both are mid-creation: deleting one races the create still in flight."""
     _record_starts(reconciler, monkeypatch)
-    reconciler.supervisor.list_vms.return_value = [_info(HASH_B, status=VmStatus.DEFINED)]
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_B, status=status)]
     reconciler.submit(_plan())
 
     await reconciler._converge_once()
 
     reconciler_module.teardown_vm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_vm_waiting_on_its_confidential_session_is_not_started_again(reconciler, monkeypatch):
+    """A confidential VM sits in a non-live status until its owner uploads the
+    session certificates, so status alone reads as one that needs creating.
+    Creating it again would throw away the VM the owner is about to boot."""
+    starts = _record_starts(reconciler, monkeypatch)
+    awaiting = _info(HASH_C, status=VmStatus.STOPPED)
+    awaiting.awaiting_confidential_init = True
+    reconciler.supervisor.list_vms.return_value = [awaiting]
+    reconciler.submit(_plan(HASH_C))
+
+    await reconciler._converge_once()
+
+    assert starts.attempts == 0
+
+
+# ── The loop around a pass ─────────────────────────────────────────────────
+
+
+def _stop_after(reconciler, monkeypatch, passes: int, *, failing: int | None = None):
+    """Drive run() for a fixed number of passes, then cancel out of it."""
+    seen: list[int] = []
+
+    async def fake_converge():
+        seen.append(len(seen) + 1)
+        if failing is not None and len(seen) == failing:
+            msg = "pass blew up"
+            raise RuntimeError(msg)
+        if len(seen) == passes:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(reconciler, "_converge_once", fake_converge)
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_the_loop_converges_again_when_it_is_woken(reconciler, monkeypatch):
+    """A wake-up already set must be seen rather than waited out: the interval
+    is the backstop, not the pace."""
+    monkeypatch.setattr(settings, "ALLOCATION_RECONCILE_INTERVAL", 3600)
+    seen = _stop_after(reconciler, monkeypatch, passes=2)
+    reconciler._wakeup.set()
+
+    # Bounded, so a wake-up cleared before the wait fails here in a second
+    # rather than sitting out the backstop it was supposed to pre-empt.
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(reconciler.run(), timeout=1)
+
+    assert len(seen) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_quiet_interval_does_not_end_the_loop(reconciler, monkeypatch):
+    """Nothing wakes it, so the backstop expires and wait_for raises. Letting
+    that escape would end convergence for the life of the process."""
+    monkeypatch.setattr(settings, "ALLOCATION_RECONCILE_INTERVAL", 0.01)
+    seen = _stop_after(reconciler, monkeypatch, passes=2)
+
+    with pytest.raises(asyncio.CancelledError):
+        await reconciler.run()
+
+    assert len(seen) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_pass_that_raises_does_not_end_the_loop(reconciler, monkeypatch):
+    """One bad pass is not a reason to stop converging: the next one may find
+    the supervisor answering again."""
+    monkeypatch.setattr(settings, "ALLOCATION_RECONCILE_INTERVAL", 0.01)
+    seen = _stop_after(reconciler, monkeypatch, passes=2, failing=1)
+
+    with pytest.raises(asyncio.CancelledError):
+        await reconciler.run()
+
+    assert len(seen) == 2


### PR DESCRIPTION
Task 5 of the async scheduler allocations stack (design: `docs/plans/2026-08-20-async-allocations-design.md`). Stacked on #1172.

Level-triggered: each pass re-reads the desired state and diffs it against what the supervisor reports, so an identical re-push is an empty diff and a plan arriving mid-convergence wins at the next step boundary. This is the seam pull mode plugs into: swapping "the scheduler pushed a plan" for "the agent fetched a plan" changes `submit()`'s caller and nothing else.

Creates run with bounded concurrency (`ALLOCATION_DOWNLOAD_CONCURRENCY`, default 3), because the download phase is agent-side and outside the supervisor's creation lock; `create_vm` itself stays serialized by that lock. Failures are remembered with an exponential backoff instead of vanishing, and are cleared when the VM starts or leaves the plan, so a hash the scheduler gave up on is not retried forever.

With no plan the reconciler deletes nothing. That is the post-restart state: acting on a remembered plan risks tearing down VMs migrated elsewhere during the downtime.

`pubsub` is resolved per use rather than held: `app["pubsub"]` is created by a startup hook registered after `setup_webapp`, and only when `WATCH_FOR_MESSAGES` is on, so reading it at construction would `KeyError` and caching it at task start would silently drop update-watching for reconciler-started VMs.

The supervisor event watcher now nudges the reconciler when a VM goes down, so one that dies while still planned is retried immediately rather than at the backstop interval.

The reconciler is constructed and its task started, but nothing submits a plan yet: the v2 endpoints land in the next PR. Until then it converges against `None` and does nothing.

## Tests

12 new in `tests/supervisor/test_allocation_reconciler.py`, written before the code; each drives `_converge_once()` with an injected clock, so no backoff assertion sleeps. Full `tests/supervisor` FAILED set identical to `main` (10 environment-only failures); mypy at the `main` error set exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HoNHA7oAuN8FGwYPnZvcwi