### PR TITLE
ci: trigger on any dev* branch, not a single hardcoded name

### DIFF
--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -4,10 +4,10 @@ name: "Build Packages and tests on Droplets"
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, 'dev*']
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [main, dev]
+    branches: [main, 'dev*']
 
 # This action build the package for Ubuntu and Debian
 # Then run e2e integration tests on Digital Ocean droplets (on demand VM)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,10 +15,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, 'dev*']
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [main, dev]
+    branches: [main, 'dev*']
   schedule:
     - cron: '15 16 * * 0'
 

--- a/.github/workflows/golden-measurements.yml
+++ b/.github/workflows/golden-measurements.yml
@@ -8,7 +8,7 @@ name: "Golden SEV-SNP measurements"
 # static-musl attest-agent), about 20 minutes on a 4-vCPU runner since the
 # kernel became a whitelist config (nix/kernel-config.fragment); it was
 # 2h20m on nixpkgs' distro config. Trigger surface instead:
-#   - PRs and dev/main pushes touching the measured inputs
+#   - PRs and dev*/main pushes touching the measured inputs
 #   - a weekly cron, which catches reproducibility drift with unchanged
 #     inputs (the flake is fully pinned, so any diff on cron is drift)
 #   - manual dispatch
@@ -19,7 +19,7 @@ on:
     # Mondays, 06:17 UTC.
     - cron: "17 6 * * 1"
   push:
-    branches: [main, dev]
+    branches: [main, 'dev*']
     paths:
       - "nix/**"
       # The initrd bakes the attest-agent binary. Its measured input set is
@@ -34,8 +34,8 @@ on:
       - ".github/workflows/golden-measurements.yml"
   pull_request:
     # od/** covers stacked PRs (increment N+1 based on increment N's
-    # branch), which must carry CI before the stack lands on dev.
-    branches: [main, dev, od/**]
+    # branch), which must carry CI before the stack lands on a dev branch.
+    branches: [main, 'dev*', od/**]
     paths:
       - "nix/**"
       # The initrd bakes the attest-agent binary. Its measured input set is

--- a/.github/workflows/test-build-examples.yml
+++ b/.github/workflows/test-build-examples.yml
@@ -5,10 +5,10 @@ name: "Build Examples"
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, 'dev*']
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [main, dev]
+    branches: [main, 'dev*']
 
 
 jobs:

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -4,7 +4,7 @@ name: "Rust supervisor daemon"
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, 'dev*']
     paths:
       - "rust/**"
       - "proto/**"
@@ -21,8 +21,8 @@ on:
       - ".github/workflows/test-rust.yml"
   pull_request:
     # od/** covers stacked PRs (increment N+1 based on increment N's
-    # branch), which must carry CI before the stack lands on dev.
-    branches: [main, dev, od/**]
+    # branch), which must carry CI before the stack lands on a dev branch.
+    branches: [main, 'dev*', od/**]
     paths:
       - "rust/**"
       - "proto/**"

--- a/.github/workflows/test-using-pytest.yml
+++ b/.github/workflows/test-using-pytest.yml
@@ -4,11 +4,11 @@ name: "py.test and linting"
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, 'dev*']
   pull_request:
     # od/** covers stacked PRs (increment N+1 based on increment N's
-    # branch), which must carry CI before the stack lands on dev.
-    branches: [main, dev, od/**]
+    # branch), which must carry CI before the stack lands on a dev branch.
+    branches: [main, 'dev*', od/**]
 
 
 jobs:


### PR DESCRIPTION
`dev` was merged into `main` and deleted, so every workflow trigger list named a branch that no longer exists. A PR against `dev-2.1` ran **no CI at all**.

Rather than swap in the new name and be back here at 2.2, the six workflows now match the glob `dev*`, which covers `dev`, `dev-2.1` and whatever comes next.

| Workflow | push | pull_request |
|---|---|---|
| `build-deb-package-and-integration-tests` | ✓ | ✓ |
| `codeql-analysis` | ✓ | ✓ |
| `test-build-examples` | ✓ | ✓ |
| `test-rust` | ✓ | ✓ (keeps `od/**`) |
| `test-using-pytest` | ✓ | ✓ (keeps `od/**`) |
| `golden-measurements` | ✓ | ✓ (keeps `od/**`) |

One caveat worth knowing: the glob does not cross a slash, so `dev*` matches `dev-2.1` but **not** `dev/foo` — that would need `dev**`. Every release branch so far uses the dash form.

The `od/**` entries are untouched: they exist so a stacked PR (increment N+1 based on increment N's branch) carries CI before the stack reaches the release branch, which this does not affect. `deploy-main-on-staging` is `main`-only by design and is left alone.

This PR bootstraps itself: for `pull_request`, GitHub evaluates the workflow file from the merge ref, so the change is live for its own checks. Once merged, PRs already targeting `dev-2.1` pick it up the same way without needing a rebase.

`yamlfix --check .` passes, and every trigger list was verified by parsing the YAML rather than by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HoNHA7oAuN8FGwYPnZvcwi