### PR TITLE
fix(agent): SNP vCPU probe no longer requires nested virtualization

### DIFF
--- a/src/aleph/vm/agent/vcpu_probe.py
+++ b/src/aleph/vm/agent/vcpu_probe.py
@@ -84,8 +84,10 @@ async def query_cpu_definitions() -> list[dict]:
 # guest never uses them, and the launch path passes -cpu without enforce, so
 # QEMU merely masks them with a warning. Disabling nested virt is a
 # legitimate host hardening posture and must not empty the advertisement.
-# The set is the SVM feature word (CPUID 0x8000_000A EDX) plus the svm bit
-# itself (0x8000_0001 ECX).
+# The set is every name QEMU gives to the SVM feature word (FEAT_SVM over
+# CPUID 0x8000_000A EDX in target/i386/cpu.c; gmet is on QEMU master and not
+# yet in a release) plus the svm bit itself (0x8000_0001 ECX): exactly the
+# features Linux KVM exposes only when kvm_amd runs with nested=1.
 NESTED_VIRT_FEATURES = frozenset(
     {
         "svm",
@@ -102,7 +104,7 @@ NESTED_VIRT_FEATURES = frozenset(
         "avic",
         "v-vmsave-vmload",
         "vgif",
-        "x2avic",
+        "gmet",
         "svme-addr-chk",
         "vnmi",
     }

--- a/src/aleph/vm/agent/vcpu_probe.py
+++ b/src/aleph/vm/agent/vcpu_probe.py
@@ -79,13 +79,46 @@ async def query_cpu_definitions() -> list[dict]:
             process.kill()
 
 
+# Features QEMU reports as unavailable when the host runs kvm_amd nested=0.
+# They exist only to run nested hypervisors inside the guest: an SEV-SNP
+# guest never uses them, and the launch path passes -cpu without enforce, so
+# QEMU merely masks them with a warning. Disabling nested virt is a
+# legitimate host hardening posture and must not empty the advertisement.
+# The set is the SVM feature word (CPUID 0x8000_000A EDX) plus the svm bit
+# itself (0x8000_0001 ECX).
+NESTED_VIRT_FEATURES = frozenset(
+    {
+        "svm",
+        "npt",
+        "lbrv",
+        "svm-lock",
+        "nrip-save",
+        "tsc-scale",
+        "vmcb-clean",
+        "flushbyasid",
+        "decodeassists",
+        "pause-filter",
+        "pfthreshold",
+        "avic",
+        "v-vmsave-vmload",
+        "vgif",
+        "x2avic",
+        "svme-addr-chk",
+        "vnmi",
+    }
+)
+
+
 def filter_snp_vcpu_types(definitions: list[dict]) -> list[str]:
-    """Keep the EPYC-family models QEMU reports as runnable on this host
-    (empty unavailable-features means every feature the model needs exists)."""
+    """Keep the EPYC-family models QEMU reports as runnable on this host.
+
+    Unavailable features that only matter for nested virtualization are
+    ignored: see NESTED_VIRT_FEATURES."""
     return sorted(
         definition["name"]
         for definition in definitions
-        if definition["name"].startswith("EPYC") and not definition.get("unavailable-features")
+        if definition["name"].startswith("EPYC")
+        and not (set(definition.get("unavailable-features") or ()) - NESTED_VIRT_FEATURES)
     )
 
 

--- a/tests/supervisor/test_vprogram_probe.py
+++ b/tests/supervisor/test_vprogram_probe.py
@@ -39,6 +39,25 @@ def test_filter_snp_vcpu_types():
     assert filter_snp_vcpu_types(definitions) == ["EPYC", "EPYC-v4"]
 
 
+def test_filter_ignores_nested_virt_features():
+    # kvm_amd nested=0 is a legitimate hardening posture: QEMU then reports
+    # svm/npt/nrip-save unavailable on every EPYC model, but SNP guests never
+    # use nested virt and the launch path passes -cpu without enforce.
+    definitions = [
+        {"name": "EPYC-v4", "unavailable-features": ["svm", "npt", "nrip-save"]},
+        {"name": "EPYC-Genoa", "unavailable-features": ["svm", "npt", "nrip-save"]},
+    ]
+    assert filter_snp_vcpu_types(definitions) == ["EPYC-Genoa", "EPYC-v4"]
+
+
+def test_filter_still_rejects_genuinely_missing_features():
+    definitions = [
+        {"name": "EPYC-Milan", "unavailable-features": ["svm", "perfctr-core"]},
+        {"name": "EPYC", "unavailable-features": []},
+    ]
+    assert filter_snp_vcpu_types(definitions) == ["EPYC"]
+
+
 @pytest.mark.asyncio
 async def test_get_supported_snp_vcpu_types_no_snp(mocker):
     mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=False)

--- a/tests/supervisor/test_vprogram_probe.py
+++ b/tests/supervisor/test_vprogram_probe.py
@@ -13,6 +13,7 @@ import pytest
 from aleph.vm.agent import resources
 from aleph.vm.agent.resources import get_machine_capability, get_machine_properties
 from aleph.vm.agent.vcpu_probe import (
+    NESTED_VIRT_FEATURES,
     PROBE_RETRY_SECONDS,
     filter_snp_vcpu_types,
     get_supported_snp_vcpu_types,
@@ -56,6 +57,18 @@ def test_filter_still_rejects_genuinely_missing_features():
         {"name": "EPYC", "unavailable-features": []},
     ]
     assert filter_snp_vcpu_types(definitions) == ["EPYC"]
+
+
+def test_filter_ignores_every_nested_virt_feature():
+    # Guards the ignore list as a whole: every name in NESTED_VIRT_FEATURES
+    # must be tolerated, so a filter refactor cannot quietly start rejecting
+    # models over one of them. (Drift the other way, a nested-virt name QEMU
+    # adds that this list lacks, can only be caught against a live QEMU.)
+    definitions = [
+        {"name": "EPYC-Milan", "unavailable-features": sorted(NESTED_VIRT_FEATURES)},
+        {"name": "EPYC-Milan-v2", "unavailable-features": ["monitor"]},
+    ]
+    assert filter_snp_vcpu_types(definitions) == ["EPYC-Milan"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Field report F1 (2026-08-31, community SNP CRN rollout): hosts running kvm_amd nested=0 (a legitimate hardening posture) advertise no SNP guest CPU models at all, because every QEMU EPYC model reports svm/npt/nrip-save unavailable and the probe filter required zero unavailable features. The operator had to re-enable nested virt to get a tee block, undoing his mitigation.

SNP guests never use nested virtualization, and the launch path passes -cpu without enforce (QEMU masks missing features with a warning), so the filter was strictly stricter than the launch. The filter now ignores the SVM feature family (CPUID 0x8000000A EDX plus the svm bit) when judging models; a genuinely missing feature still disqualifies.

Part of the 2.0.1 field-report fix series (see docs/plans/2026-08-31-snp-field-report-fixes-implementation.md on the follow-up branch). Stacked PR: od/snp-qemu-capability-gate builds on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FD3aTuxD4L5BSfN9GMNHt