### PR TITLE
feat(agent): truthful SNP capability advertisement (sev-snp-guest gate, operator surfacing)

### DIFF
--- a/docs/architecture/confidential.md
+++ b/docs/architecture/confidential.md
@@ -105,6 +105,20 @@ in `MachineProperties` (`src/aleph/vm/agent/resources.py`,
 facts are different axes, and keeping them siblings leaves room for a future
 `tdx` or GPU-CC platform key without a schema break.
 
+### Host requirements for SEV-SNP
+
+SEV-SNP guest launches need QEMU >= 9.1, the first release with the
+`sev-snp-guest` QOM object the probe checks for. Of the packaged targets,
+only Debian 13 ships one; Ubuntu 24.04 (QEMU 8.2) and Debian 12 (QEMU 7.2)
+can serve plain SEV/SEV-ES but not SNP, whatever `query-cpu-definitions`
+reports. `kvm_amd nested=0` is fine, a legitimate hardening posture: the
+filter ignores nested-virt-only unavailable features since 2.0.1, so it no
+longer empties the advertisement. The probe retries every 60s after an empty
+result, so a live QEMU upgrade heals the advertisement without an agent
+restart. Check either end: `/about/capability`'s `tee_unavailable_reason`,
+or the agent's startup log line (`log_snp_launch_capability`,
+`src/aleph/vm/agent/supervisor.py`).
+
 ### The attestation stack
 
 Three crates, cleanly separated by role.

--- a/docs/architecture/confidential.md
+++ b/docs/architecture/confidential.md
@@ -109,9 +109,9 @@ facts are different axes, and keeping them siblings leaves room for a future
 
 SEV-SNP guest launches need QEMU >= 9.1, the first release with the
 `sev-snp-guest` QOM object the probe checks for. Of the packaged targets,
-only Debian 13 ships one; Ubuntu 24.04 (QEMU 8.2) and Debian 12 (QEMU 7.2)
-can serve plain SEV/SEV-ES but not SNP, whatever `query-cpu-definitions`
-reports. `kvm_amd nested=0` is fine, a legitimate hardening posture: the
+Debian 13 (QEMU 9.x) and Ubuntu 26.04 (QEMU 10.2) ship one; Ubuntu 24.04
+(QEMU 8.2) and Debian 12 (QEMU 7.2) can serve plain SEV/SEV-ES but not SNP,
+whatever `query-cpu-definitions` reports. `kvm_amd nested=0` is fine, a legitimate hardening posture: the
 filter ignores nested-virt-only unavailable features since 2.0.1, so it no
 longer empties the advertisement. The probe retries every 60s after an empty
 result, so a live QEMU upgrade heals the advertisement without an agent

--- a/src/aleph/vm/agent/resources.py
+++ b/src/aleph/vm/agent/resources.py
@@ -9,7 +9,10 @@ from pydantic import BaseModel, Field
 
 from aleph.vm.agent.aggregate import get_compatible_gpus, update_aggregate_settings
 from aleph.vm.agent.machine import get_cpu_info, get_hardware_info, get_memory_info
-from aleph.vm.agent.vcpu_probe import get_supported_snp_vcpu_types
+from aleph.vm.agent.vcpu_probe import (
+    get_snp_launch_capability,
+    get_supported_snp_vcpu_types,
+)
 from aleph.vm.conf import settings
 from aleph.vm.resources import GpuDevice
 from aleph.vm.sevclient import SevClient
@@ -139,6 +142,12 @@ class MachineCapability(BaseModel):
     cpu: ExtendedCpuProperties
     memory: MemoryProperties
     tee: TeeProperties | None = None
+    tee_unavailable_reason: str | None = Field(
+        default=None,
+        description="Why SEV-SNP is not advertised, for a node whose silicon supports it but "
+        "cannot currently launch (e.g. QEMU too old). Human-facing only: the scheduler reads "
+        "/about/usage/system, which does not carry this field.",
+    )
 
 
 async def _gpus_from_host_info(host_info) -> GpuProperties:
@@ -263,9 +272,23 @@ async def _get_static_machine_capability() -> MachineCapability:
 
 async def get_machine_capability() -> MachineCapability:
     """What ``/about/capability`` reports. Static part cached, TEE block
-    re-evaluated per call so a recovered probe is advertised again."""
+    re-evaluated per call so a recovered probe is advertised again.
+
+    Unlike ``get_machine_properties``, this also names *why* SNP is not
+    advertised when the silicon supports it but the current QEMU cannot
+    launch it (e.g. too old): human-facing only, so it is populated solely
+    when ``check_amd_sev_snp_supported()`` is true, to keep the non-TEE
+    fleet's response free of noise.
+    """
     static = await _get_static_machine_capability()
-    return static.model_copy(update={"tee": await _get_tee_properties()})
+    capability = await get_snp_launch_capability()
+    tee = (
+        TeeProperties(sev_snp=SevSnpProperties(supported_vcpu_types=capability.supported_vcpu_types))
+        if capability.supported_vcpu_types
+        else None
+    )
+    reason = capability.unavailable_reason if check_amd_sev_snp_supported() else None
+    return static.model_copy(update={"tee": tee, "tee_unavailable_reason": reason})
 
 
 def _disk_usage_from_pools(host_info) -> DiskUsage:

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -19,6 +19,7 @@ from aleph.vm.agent.capacity import CapacityManager
 from aleph.vm.agent.expiry import ExpiryManager
 from aleph.vm.agent.migration.reaper import reap_orphan_migration_files
 from aleph.vm.agent.update_watcher import UpdateWatcher
+from aleph.vm.agent.vcpu_probe import get_snp_launch_capability
 from aleph.vm.agent.vm.backup import BackupManager
 from aleph.vm.agent.vm.program_client import ProgramGuestClient
 from aleph.vm.agent.vm_registry import AgentVmRegistry, rehydrate_registry
@@ -26,7 +27,7 @@ from aleph.vm.conf import settings
 from aleph.vm.sevclient import SevClient
 from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.supervisor_interface.client import GrpcSupervisor
-from aleph.vm.utils import create_task_log_exceptions
+from aleph.vm.utils import check_amd_sev_snp_supported, create_task_log_exceptions
 from aleph.vm.version import __version__
 
 from .node_identity import (
@@ -437,6 +438,30 @@ async def _rehydrate_vm_registry(app: web.Application) -> None:
     logger.info("Rehydrated %d VM record(s) into the agent registry", count)
 
 
+async def log_snp_launch_capability(_app) -> None:
+    """on_startup hook: tell the operator, once and loudly, when SNP silicon
+    is enabled but this host still cannot launch confidential guests (field
+    report F2: a capable EPYC host silently advertised nothing, and later a
+    QEMU too old to launch). Never fails startup."""
+    try:
+        if not check_amd_sev_snp_supported():
+            return
+        capability = await get_snp_launch_capability()
+        if capability.supported_vcpu_types:
+            logger.info(
+                "SEV-SNP confidential launches available; advertising guest CPU models: %s",
+                ", ".join(capability.supported_vcpu_types),
+            )
+        else:
+            logger.warning(
+                "SEV-SNP silicon is enabled on this host but confidential launches are "
+                "DISABLED, so the node will not advertise SNP capability: %s",
+                capability.unavailable_reason,
+            )
+    except Exception:
+        logger.exception("Could not determine SNP launch capability at startup")
+
+
 def run():
     """Run the agent web server."""
     settings.check()
@@ -465,6 +490,7 @@ def run():
     )
     app.on_startup.append(_run_migration_reaper)
     app.on_startup.append(_rehydrate_vm_registry)
+    app.on_startup.append(log_snp_launch_capability)
     app.on_startup.append(start_node_hash_discovery)
     app.on_cleanup.append(stop_node_hash_discovery)
 

--- a/src/aleph/vm/agent/vcpu_probe.py
+++ b/src/aleph/vm/agent/vcpu_probe.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import time
+from dataclasses import dataclass
 
 from aleph.vm.utils import check_amd_sev_snp_supported
 
@@ -21,6 +22,24 @@ PROBE_TIMEOUT_SECONDS = 15.0
 # PROBE_TIMEOUT_SECONDS) on every usage poll and every launch, short enough
 # that a transient failure at boot heals without anyone restarting the agent.
 PROBE_RETRY_SECONDS = 60.0
+
+# The QOM type QEMU registers only when it can actually launch SEV-SNP
+# guests. Older QEMU (e.g. the 8.2.2 Ubuntu 24.04 ships) reports EPYC CPU
+# models fine but has no such object, so every SNP launch would fail.
+SNP_GUEST_QOM_TYPE = "sev-snp-guest"
+
+
+@dataclass(frozen=True)
+class QemuSnpFacts:
+    cpu_definitions: list[dict]
+    qom_type_names: frozenset[str]
+    qemu_version: str  # "9.1.2", or "" when the greeting lacks one
+
+
+@dataclass(frozen=True)
+class SnpLaunchCapability:
+    supported_vcpu_types: list[str]
+    unavailable_reason: str | None  # None iff supported_vcpu_types is non-empty
 
 
 async def _read_qmp_response(stdout: asyncio.StreamReader) -> dict:
@@ -36,8 +55,9 @@ async def _read_qmp_response(stdout: asyncio.StreamReader) -> dict:
         return message
 
 
-async def query_cpu_definitions() -> list[dict]:
-    """Ask a KVM-accelerated QEMU which CPU models it can launch on this host."""
+async def query_qemu_snp_facts() -> QemuSnpFacts:
+    """Ask a KVM-accelerated QEMU which CPU models it can launch on this host,
+    and whether it has the object needed to launch SEV-SNP guests at all."""
     process = await asyncio.create_subprocess_exec(
         "qemu-system-x86_64",
         "-machine",
@@ -55,22 +75,34 @@ async def query_cpu_definitions() -> list[dict]:
     )
     assert process.stdin is not None and process.stdout is not None
 
-    async def _converse() -> list[dict]:
+    async def _converse() -> QemuSnpFacts:
         assert process.stdin is not None and process.stdout is not None
         greeting = await _read_qmp_response(process.stdout)
         if "QMP" not in greeting:
             msg = f"Unexpected QMP greeting: {greeting}"
             raise RuntimeError(msg)
+        version_info = greeting.get("QMP", {}).get("version", {}).get("qemu", {})
+        qemu_version = ""
+        if version_info:
+            qemu_version = f"{version_info.get('major')}.{version_info.get('minor')}.{version_info.get('micro')}"
         definitions: list[dict] | None = None
-        for command in ("qmp_capabilities", "query-cpu-definitions", "quit"):
+        qom_types: list[dict] | None = None
+        for command in ("qmp_capabilities", "query-cpu-definitions", "qom-list-types", "quit"):
             process.stdin.write(json.dumps({"execute": command}).encode() + b"\n")
             await process.stdin.drain()
             response = await _read_qmp_response(process.stdout)
             if command == "query-cpu-definitions":
                 definitions = response["return"]
+            elif command == "qom-list-types":
+                qom_types = response["return"]
         await process.wait()
         assert definitions is not None
-        return definitions
+        assert qom_types is not None
+        return QemuSnpFacts(
+            cpu_definitions=definitions,
+            qom_type_names=frozenset(entry["name"] for entry in qom_types),
+            qemu_version=qemu_version,
+        )
 
     try:
         return await asyncio.wait_for(_converse(), timeout=PROBE_TIMEOUT_SECONDS)
@@ -124,30 +156,61 @@ def filter_snp_vcpu_types(definitions: list[dict]) -> list[str]:
     )
 
 
+def _capability_from_facts(facts: QemuSnpFacts) -> SnpLaunchCapability:
+    if SNP_GUEST_QOM_TYPE not in facts.qom_type_names:
+        version = facts.qemu_version or "unknown version"
+        return SnpLaunchCapability(
+            [],
+            f"QEMU ({version}) has no '{SNP_GUEST_QOM_TYPE}' object and cannot launch "
+            f"SEV-SNP guests. QEMU >= 9.1 is required (of the packaged targets, only "
+            f"Debian 13 ships one).",
+        )
+    supported = filter_snp_vcpu_types(facts.cpu_definitions)
+    if not supported:
+        return SnpLaunchCapability(
+            [],
+            "QEMU reports no launchable EPYC guest CPU model on this host "
+            "(every EPYC model has genuinely unavailable features).",
+        )
+    return SnpLaunchCapability(supported, None)
+
+
+_NO_SILICON = SnpLaunchCapability(
+    [],
+    "host kernel does not expose SEV-SNP: kvm_amd sev_snp parameter is not 'Y' "
+    "or /dev/sev is missing (BIOS SNP setting, kernel version, or firmware).",
+)
+_PROBE_FAILED = SnpLaunchCapability([], "QEMU vCPU probe failed; see agent logs.")
+
+
 class _ProbeCache:
     """Process-wide memory of the QEMU probe.
 
-    A successful probe is a fact about this QEMU build, kernel and silicon, so it
-    is kept for the life of the process. A failed one is not a fact about the
-    host, only about that attempt (a spawn that timed out during boot, say), so
-    it is kept only for PROBE_RETRY_SECONDS and then tried again. The generic
-    ``async_cache`` cannot tell the two apart: it would pin the empty list from
-    a failed attempt forever, and this list feeds both what the node advertises
-    and which models it will launch, so one bad probe at startup would take the
-    node out of the confidential pool until someone restarted the agent.
+    A successful, non-empty probe is a fact about this QEMU build, kernel and
+    silicon, so it is kept for the life of the process. An exception, or a
+    successful probe that comes back empty (no launchable model, or no
+    sev-snp-guest object), is not a durable fact: a live QEMU upgrade can fix
+    it, so it is kept only for PROBE_RETRY_SECONDS and then tried again. The
+    generic ``async_cache`` cannot tell the two apart: it would pin the empty
+    result forever, and this feeds both what the node advertises and which
+    models it will launch, so one bad probe at startup (or a QEMU that has
+    since been upgraded) would take the node out of the confidential pool
+    until someone restarted the agent.
 
     The lock keeps concurrent first callers (the usage endpoint and a launch
     racing at startup) from each spawning a qemu.
     """
 
     def __init__(self) -> None:
-        self.supported: list[str] | None = None
+        self.kept: SnpLaunchCapability | None = None
         self.failed_at: float | None = None
+        self.last_empty: SnpLaunchCapability | None = None
         self.lock = asyncio.Lock()
 
     def reset(self) -> None:
-        self.supported = None
+        self.kept = None
         self.failed_at = None
+        self.last_empty = None
 
 
 _probe_cache = _ProbeCache()
@@ -158,26 +221,42 @@ def reset_snp_vcpu_probe_cache() -> None:
     _probe_cache.reset()
 
 
-async def get_supported_snp_vcpu_types() -> list[str]:
-    """SNP guest CPU models this node can launch; [] when SNP is unsupported
-    or the probe fails. We never advertise what we cannot prove."""
+async def get_snp_launch_capability() -> SnpLaunchCapability:
+    """The SNP guest CPU models this node can actually launch, and why not
+    when it can't. We never advertise what we cannot prove."""
     if not check_amd_sev_snp_supported():
-        return []
+        return _NO_SILICON
     async with _probe_cache.lock:
-        if _probe_cache.supported is not None:
-            return _probe_cache.supported
+        if _probe_cache.kept is not None:
+            return _probe_cache.kept
         now = time.monotonic()
         if _probe_cache.failed_at is not None and now - _probe_cache.failed_at < PROBE_RETRY_SECONDS:
-            return []
+            return _probe_cache.last_empty or _PROBE_FAILED
         try:
-            definitions = await query_cpu_definitions()
+            facts = await query_qemu_snp_facts()
         except Exception:
             _probe_cache.failed_at = now
+            _probe_cache.last_empty = None
             logger.warning(
                 "QEMU vCPU probe failed, not advertising SNP guest models; retrying in %ss",
                 PROBE_RETRY_SECONDS,
                 exc_info=True,
             )
-            return []
-        _probe_cache.supported = filter_snp_vcpu_types(definitions)
-        return _probe_cache.supported
+            return _PROBE_FAILED
+        capability = _capability_from_facts(facts)
+        if capability.supported_vcpu_types:
+            _probe_cache.kept = capability
+        else:
+            # An empty result is a fact about the current QEMU binary, which
+            # an operator can upgrade live: retry so the fix is picked up
+            # without an agent restart.
+            _probe_cache.failed_at = now
+            _probe_cache.last_empty = capability
+            logger.warning("Not advertising SNP guest models: %s", capability.unavailable_reason)
+        return capability
+
+
+async def get_supported_snp_vcpu_types() -> list[str]:
+    """SNP guest CPU models this node can launch; [] when SNP is unsupported
+    or the probe fails. We never advertise what we cannot prove."""
+    return (await get_snp_launch_capability()).supported_vcpu_types

--- a/src/aleph/vm/agent/vcpu_probe.py
+++ b/src/aleph/vm/agent/vcpu_probe.py
@@ -167,8 +167,8 @@ def _capability_from_facts(facts: QemuSnpFacts) -> SnpLaunchCapability:
         return SnpLaunchCapability(
             [],
             f"QEMU ({version}) has no '{SNP_GUEST_QOM_TYPE}' object and cannot launch "
-            f"SEV-SNP guests. QEMU >= 9.1 is required (of the packaged targets, only "
-            f"Debian 13 ships one).",
+            f"SEV-SNP guests. QEMU >= 9.1 is required (of the packaged targets, "
+            f"Debian 13 and Ubuntu 26.04 ship one).",
         )
     supported = filter_snp_vcpu_types(facts.cpu_definitions)
     if not supported:

--- a/src/aleph/vm/agent/vcpu_probe.py
+++ b/src/aleph/vm/agent/vcpu_probe.py
@@ -72,6 +72,11 @@ async def query_qemu_snp_facts() -> QemuSnpFacts:
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.DEVNULL,
+        # QMP replies are single JSON lines that keep growing with QEMU
+        # releases (qom-list-types measured 43 KB on QEMU 10.2.1, already 66%
+        # of asyncio's default 64 KiB readline limit); raise it well above
+        # that so a future QEMU does not make every probe fail forever.
+        limit=2**20,
     )
     assert process.stdin is not None and process.stdout is not None
 

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -348,6 +348,7 @@ async def test_system_capability_mock(aiohttp_client, mocker):
         },
         "memory": {"size": 17179869184, "units": "bytes", "type": "", "clock": None, "clock_units": None},
         "tee": None,
+        "tee_unavailable_reason": None,
     }
 
 

--- a/tests/supervisor/test_vprogram_probe.py
+++ b/tests/supervisor/test_vprogram_probe.py
@@ -6,6 +6,7 @@ list must reflect what this exact QEMU + kernel + silicon can launch.
 """
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
@@ -406,3 +407,34 @@ async def test_silicon_off_reason_names_the_kernel(mocker):
     capability = await get_snp_launch_capability()
     assert capability.supported_vcpu_types == []
     assert "kvm_amd" in capability.unavailable_reason
+
+
+# ---------------------------------------------------------------------------
+# The agent startup notice (report F2): a capable EPYC host that silently
+# advertised nothing must instead tell the operator why, once and loudly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_startup_notice_warns_when_silicon_ok_but_qemu_cannot_launch(mocker, caplog):
+    from aleph.vm.agent.supervisor import log_snp_launch_capability
+
+    mocker.patch("aleph.vm.agent.supervisor.check_amd_sev_snp_supported", return_value=True)
+    mocker.patch(
+        "aleph.vm.agent.supervisor.get_snp_launch_capability",
+        new_callable=AsyncMock,
+        return_value=SnpLaunchCapability([], "QEMU (8.2.2) has no 'sev-snp-guest' object..."),
+    )
+    with caplog.at_level(logging.WARNING):
+        await log_snp_launch_capability(None)
+    assert any("DISABLED" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_startup_notice_silent_without_snp_silicon(mocker, caplog):
+    from aleph.vm.agent.supervisor import log_snp_launch_capability
+
+    mocker.patch("aleph.vm.agent.supervisor.check_amd_sev_snp_supported", return_value=False)
+    with caplog.at_level(logging.INFO):
+        await log_snp_launch_capability(None)
+    assert not caplog.records

--- a/tests/supervisor/test_vprogram_probe.py
+++ b/tests/supervisor/test_vprogram_probe.py
@@ -16,6 +16,7 @@ from aleph.vm.agent.vcpu_probe import (
     NESTED_VIRT_FEATURES,
     PROBE_RETRY_SECONDS,
     QemuSnpFacts,
+    SnpLaunchCapability,
     filter_snp_vcpu_types,
     get_snp_launch_capability,
     get_supported_snp_vcpu_types,
@@ -324,6 +325,26 @@ async def test_capability_advertisement_recovers_after_a_failed_first_probe(mock
     assert capability.tee is not None
     assert capability.tee.sev_snp is not None
     assert capability.tee.sev_snp.supported_vcpu_types == ["EPYC-v4"]
+    assert capability.tee_unavailable_reason is None
+
+
+@pytest.mark.asyncio
+async def test_capability_carries_unavailability_reason(mocker):
+    # A node with SNP silicon but a QEMU that cannot launch it tells the
+    # operator why in /about/capability instead of a silent missing tee block.
+    _static_host(mocker)
+    mocker.patch(
+        "aleph.vm.agent.resources.get_memory_info",
+        return_value={"size": 64, "units": "GiB", "type": "DDR5", "clock": 4800},
+    )
+    mocker.patch(
+        "aleph.vm.agent.resources.get_snp_launch_capability",
+        new_callable=AsyncMock,
+        return_value=SnpLaunchCapability([], "QEMU (8.2.2) has no 'sev-snp-guest' object..."),
+    )
+    capability = await get_machine_capability()
+    assert capability.tee is None
+    assert "sev-snp-guest" in capability.tee_unavailable_reason
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_vprogram_probe.py
+++ b/tests/supervisor/test_vprogram_probe.py
@@ -15,11 +15,21 @@ from aleph.vm.agent.resources import get_machine_capability, get_machine_propert
 from aleph.vm.agent.vcpu_probe import (
     NESTED_VIRT_FEATURES,
     PROBE_RETRY_SECONDS,
+    QemuSnpFacts,
     filter_snp_vcpu_types,
+    get_snp_launch_capability,
     get_supported_snp_vcpu_types,
     reset_snp_vcpu_probe_cache,
 )
 from aleph.vm.utils import async_cache
+
+
+def _facts(definitions, qom=("sev-snp-guest",), version="9.1.2"):
+    return QemuSnpFacts(
+        cpu_definitions=definitions,
+        qom_type_names=frozenset(qom),
+        qemu_version=version,
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -74,7 +84,7 @@ def test_filter_ignores_every_nested_virt_feature():
 @pytest.mark.asyncio
 async def test_get_supported_snp_vcpu_types_no_snp(mocker):
     mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=False)
-    probe = mocker.patch("aleph.vm.agent.vcpu_probe.query_cpu_definitions", new_callable=AsyncMock)
+    probe = mocker.patch("aleph.vm.agent.vcpu_probe.query_qemu_snp_facts", new_callable=AsyncMock)
     assert await get_supported_snp_vcpu_types() == []
     probe.assert_not_awaited()
 
@@ -84,7 +94,7 @@ async def test_get_supported_snp_vcpu_types_probe_failure(mocker):
     # We never advertise what we cannot prove: a failed probe advertises nothing
     mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=True)
     mocker.patch(
-        "aleph.vm.agent.vcpu_probe.query_cpu_definitions",
+        "aleph.vm.agent.vcpu_probe.query_qemu_snp_facts",
         new_callable=AsyncMock,
         side_effect=OSError("qemu-system-x86_64 not found"),
     )
@@ -95,12 +105,14 @@ async def test_get_supported_snp_vcpu_types_probe_failure(mocker):
 async def test_get_supported_snp_vcpu_types_success(mocker):
     mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=True)
     mocker.patch(
-        "aleph.vm.agent.vcpu_probe.query_cpu_definitions",
+        "aleph.vm.agent.vcpu_probe.query_qemu_snp_facts",
         new_callable=AsyncMock,
-        return_value=[
-            {"name": "EPYC-Milan", "unavailable-features": []},
-            {"name": "EPYC-Genoa", "unavailable-features": ["flag"]},
-        ],
+        return_value=_facts(
+            [
+                {"name": "EPYC-Milan", "unavailable-features": []},
+                {"name": "EPYC-Genoa", "unavailable-features": ["flag"]},
+            ]
+        ),
     )
     assert await get_supported_snp_vcpu_types() == ["EPYC-Milan"]
 
@@ -189,7 +201,9 @@ def test_check_amd_sev_snp_requires_dev_sev(mocker):
 
 def _snp_host(mocker, probe):
     mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=True)
-    return mocker.patch("aleph.vm.agent.vcpu_probe.query_cpu_definitions", new_callable=AsyncMock, **probe)
+    if "return_value" in probe:
+        probe = {**probe, "return_value": _facts(probe["return_value"])}
+    return mocker.patch("aleph.vm.agent.vcpu_probe.query_qemu_snp_facts", new_callable=AsyncMock, **probe)
 
 
 def _clock(mocker, start: float = 1000.0):
@@ -227,7 +241,7 @@ async def test_a_failed_probe_is_retried_after_the_window_and_recovers(mocker):
     assert await get_supported_snp_vcpu_types() == []
 
     probe.side_effect = None
-    probe.return_value = [{"name": "EPYC-v4", "unavailable-features": []}]
+    probe.return_value = _facts([{"name": "EPYC-v4", "unavailable-features": []}])
     clock["t"] += PROBE_RETRY_SECONDS
     assert await get_supported_snp_vcpu_types() == ["EPYC-v4"]
     assert probe.await_count == 2
@@ -246,10 +260,10 @@ async def test_concurrent_first_callers_probe_once(mocker):
     async def slow_probe():
         started.set()
         await release.wait()
-        return [{"name": "EPYC-v4", "unavailable-features": []}]
+        return _facts([{"name": "EPYC-v4", "unavailable-features": []}])
 
     mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=True)
-    probe = mocker.patch("aleph.vm.agent.vcpu_probe.query_cpu_definitions", side_effect=slow_probe)
+    probe = mocker.patch("aleph.vm.agent.vcpu_probe.query_qemu_snp_facts", side_effect=slow_probe)
 
     first = asyncio.create_task(get_supported_snp_vcpu_types())
     await started.wait()
@@ -281,7 +295,7 @@ async def test_advertisement_recovers_after_a_failed_first_probe(mocker):
     assert (await get_machine_properties()).tee is None
 
     probe.side_effect = None
-    probe.return_value = [{"name": "EPYC-v4", "unavailable-features": []}]
+    probe.return_value = _facts([{"name": "EPYC-v4", "unavailable-features": []}])
     clock["t"] += PROBE_RETRY_SECONDS
     properties = await get_machine_properties()
     assert properties.tee is not None
@@ -304,7 +318,7 @@ async def test_capability_advertisement_recovers_after_a_failed_first_probe(mock
     assert (await get_machine_capability()).tee is None
 
     probe.side_effect = None
-    probe.return_value = [{"name": "EPYC-v4", "unavailable-features": []}]
+    probe.return_value = _facts([{"name": "EPYC-v4", "unavailable-features": []}])
     clock["t"] += PROBE_RETRY_SECONDS
     capability = await get_machine_capability()
     assert capability.tee is not None
@@ -320,3 +334,54 @@ async def test_static_properties_stay_cached_across_calls(mocker):
     await get_machine_properties()
     await get_machine_properties()
     assert hardware.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Gating on QEMU actually having the sev-snp-guest QOM type (report F2): a
+# QEMU build that probes EPYC models fine but cannot launch SNP guests must
+# not be advertised, and the gap must heal live when QEMU is upgraded.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_sev_snp_guest_object_advertises_nothing_with_reason(mocker):
+    # Ubuntu 24.04 ships QEMU 8.2.2: EPYC models probe fine but the binary
+    # has no sev-snp-guest object, so every launch would fail (report F2).
+    mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=True)
+    mocker.patch(
+        "aleph.vm.agent.vcpu_probe.query_qemu_snp_facts",
+        new_callable=AsyncMock,
+        return_value=_facts([{"name": "EPYC-v4", "unavailable-features": []}], qom=("sev-guest",), version="8.2.2"),
+    )
+    capability = await get_snp_launch_capability()
+    assert capability.supported_vcpu_types == []
+    assert "sev-snp-guest" in capability.unavailable_reason
+    assert "8.2.2" in capability.unavailable_reason
+
+
+@pytest.mark.asyncio
+async def test_empty_result_is_retried_and_heals_after_qemu_upgrade(mocker):
+    # The crabbz timeline: QEMU upgraded live from 8.2.2 to 9.1; the node
+    # must start advertising without an agent restart.
+    clock = _clock(mocker)
+    mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=True)
+    probe = mocker.patch(
+        "aleph.vm.agent.vcpu_probe.query_qemu_snp_facts",
+        new_callable=AsyncMock,
+        return_value=_facts([{"name": "EPYC-v4", "unavailable-features": []}], qom=("sev-guest",)),
+    )
+    assert (await get_snp_launch_capability()).supported_vcpu_types == []
+    probe.return_value = _facts([{"name": "EPYC-v4", "unavailable-features": []}])
+    # inside the retry window the empty result is served from cache
+    clock["t"] += PROBE_RETRY_SECONDS / 2
+    assert (await get_snp_launch_capability()).supported_vcpu_types == []
+    clock["t"] += PROBE_RETRY_SECONDS
+    assert (await get_snp_launch_capability()).supported_vcpu_types == ["EPYC-v4"]
+
+
+@pytest.mark.asyncio
+async def test_silicon_off_reason_names_the_kernel(mocker):
+    mocker.patch("aleph.vm.agent.vcpu_probe.check_amd_sev_snp_supported", return_value=False)
+    capability = await get_snp_launch_capability()
+    assert capability.supported_vcpu_types == []
+    assert "kvm_amd" in capability.unavailable_reason


### PR DESCRIPTION
Field report F2: a host can pass every capability signal aleph-vm checks and still be unable to launch an SNP guest. Of the packaged targets only Debian 13 ships a QEMU with the sev-snp-guest object (>= 9.1); Ubuntu 24.04 has 8.2.2 and Debian 12 has 7.2, and nothing verified the object existed. Diagnosing this took the reporter and two node operators a day of custom host scripts.

Stacked on #1178. Four commits:

- The QMP probe now also runs qom-list-types and refuses to advertise SNP when the sev-snp-guest object is absent, carrying a human-readable reason (QEMU version included). An empty probe result is retried every 60s instead of being pinned for the process lifetime, so a live QEMU upgrade heals the advertisement without an agent restart (exactly the mid-test upgrade sequence from the report).
- /about/capability gains tee_unavailable_reason (only when SNP silicon is present), so the next person asks the node itself instead of writing host diagnostics. The scheduler-read /about/usage/system payload is unchanged.
- The agent logs a startup notice: INFO with the advertised models, or a WARNING naming exactly why confidential launches are disabled.
- docs/architecture/confidential.md documents the QEMU >= 9.1 host requirement.
- The QMP subprocess stream limit is raised to 1 MiB: qom-list-types replies already measure 43 KB against asyncio's 64 KiB default readline limit and grow with every QEMU release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FD3aTuxD4L5BSfN9GMNHt