### PR TITLE
fix: SNP launches fail loudly instead of wedging invisibly

### DIFF
--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -294,6 +294,54 @@ async def _wait_until_running(
         await asyncio.sleep(interval)
 
 
+_ATTEST_READY_TIMEOUT_SECONDS = 90.0
+_ATTEST_READY_POLL_INTERVAL_SECONDS = 2.0
+
+
+async def _wait_until_attest_endpoint_listens(
+    supervisor: Supervisor,
+    vm_id: VmId,
+    attest_port: int,
+    *,
+    timeout: float | None = None,
+    interval: float | None = None,
+) -> None:
+    """Gate a confidential create on the guest's RA-TLS attestation service
+    accepting a TCP connection.
+
+    RUNNING only proves the controller unit is active: an SNP launch can wedge
+    inside firmware while QEMU lives on, and the attestation endpoint is the
+    guest's sole consumer-facing contract. A guest that never listens is a
+    failed launch and must fail the create loudly (the caller tears down and
+    the scheduler retries), not survive as a zombie the owner can only watch.
+    """
+    if timeout is None:
+        timeout = _ATTEST_READY_TIMEOUT_SECONDS
+    if interval is None:
+        interval = _ATTEST_READY_POLL_INTERVAL_SECONDS
+    info = await supervisor.get_vm(vm_id)
+    address = info.ipv4.address
+    if not address:
+        msg = f"VM {vm_id} has no IPv4 assignment to reach its attestation endpoint"
+        raise VmStartupError(msg)
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        try:
+            _reader, writer = await asyncio.wait_for(asyncio.open_connection(address, attest_port), timeout=5.0)
+        except (OSError, asyncio.TimeoutError):
+            if asyncio.get_running_loop().time() >= deadline:
+                msg = (
+                    f"VM {vm_id} guest attestation endpoint {address}:{attest_port} did not "
+                    f"accept a TCP connection within {timeout}s: the guest likely failed to boot"
+                )
+                raise VmStartupError(msg) from None
+            await asyncio.sleep(interval)
+        else:
+            writer.close()
+            await writer.wait_closed()
+            return
+
+
 async def finish_instance_create(supervisor: Supervisor, vm_id: VmId, content) -> None:
     """Post-create completion shared by the normal create path and the migration
     import runner: wait until the instance reports RUNNING, then apply the
@@ -500,6 +548,7 @@ async def create_vm_execution(
                         protocol=Protocol.TCP,
                     )
                 )
+                await _wait_until_attest_endpoint_listens(supervisor, info.vm_id, attest_port)
         except Exception:
             # Readiness or port-forward setup failed: tear the half-started VM
             # down, but never let a teardown error mask the original failure.
@@ -559,6 +608,8 @@ async def create_vm_execution(
             # sole consumer, so failing the create loudly (and letting the
             # scheduler retry) beats keeping an unusable VM alive.
             await reconcile_vprogram_port_forwards(supervisor, info.vm_id, attest_port)
+            if attest_port is not None:
+                await _wait_until_attest_endpoint_listens(supervisor, info.vm_id, attest_port)
         except Exception:
             registry.forget(vm_hash)
             try:

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -337,8 +337,14 @@ async def _wait_until_attest_endpoint_listens(
                 raise VmStartupError(msg) from None
             await asyncio.sleep(interval)
         else:
-            writer.close()
-            await writer.wait_closed()
+            # The gate's success condition (TCP accept) is already met here:
+            # if the RA-TLS server RSTs this probe connection right after
+            # accept, that is a close-time detail, not a launch failure.
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except OSError:
+                pass
             return
 
 

--- a/src/aleph/vm/supervisor/local.py
+++ b/src/aleph/vm/supervisor/local.py
@@ -36,6 +36,7 @@ from aleph.vm.supervisor_interface.errors import (
     InvalidBackendError,
     NotImplementedSupervisorError,
     VmNotFoundError,
+    VmSetupError,
 )
 from aleph.vm.supervisor_interface.types import (
     Backend,
@@ -378,6 +379,15 @@ class LocalSupervisor(Supervisor):
     # Lifecycle
     async def create_vm(self, spec: CreateVmSpec) -> VmInfo:
         with translating_errors():
+            if spec.tee is not None and spec.tee.backend is TeeBackend.SEV_SNP:
+                msg = (
+                    "SEV-SNP launches require the Rust supervisor daemon "
+                    "(ALEPH_VM_SUPERVISOR_IMPL=rust in /etc/aleph-vm/supervisor.env): "
+                    "the Python supervisor only implements the SEV session flow and "
+                    "would leave an SNP guest waiting forever for an owner "
+                    "initialization that never comes"
+                )
+                raise VmSetupError(msg)
             execution = await self.pool.create_vm_from_spec(spec)
             info = _to_vm_info(execution, _controller_state(execution, self.pool))
             self._emit_event(spec.vm_id, VmStatus.DEFINED, info.status)

--- a/tests/supervisor/test_snp_instance_run.py
+++ b/tests/supervisor/test_snp_instance_run.py
@@ -118,6 +118,9 @@ async def test_snp_instance_create_uses_snp_builder(monkeypatch):
     monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
     monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
     monkeypatch.setattr(run_module, "persist_record", AsyncMock())
+    # The attest-gate itself is unit-tested in test_vprogram_launch.py; here
+    # only the spec-build/create/port-forward wiring is under test.
+    monkeypatch.setattr(run_module, "_wait_until_attest_endpoint_listens", AsyncMock())
 
     supervisor = _fake_supervisor()
     registry = AgentVmRegistry()
@@ -154,6 +157,9 @@ async def test_snp_instance_never_awaits_confidential_init(monkeypatch):
     monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
     persist = AsyncMock()
     monkeypatch.setattr(run_module, "persist_record", persist)
+    # The attest-gate itself is unit-tested in test_vprogram_launch.py; here
+    # only the fall-through past the SEV await branch is under test.
+    monkeypatch.setattr(run_module, "_wait_until_attest_endpoint_listens", AsyncMock())
 
     info = _info(VmStatus.RUNNING, awaiting_confidential_init=False)
     supervisor = _fake_supervisor()

--- a/tests/supervisor/test_snp_instance_run.py
+++ b/tests/supervisor/test_snp_instance_run.py
@@ -119,8 +119,12 @@ async def test_snp_instance_create_uses_snp_builder(monkeypatch):
     monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
     monkeypatch.setattr(run_module, "persist_record", AsyncMock())
     # The attest-gate itself is unit-tested in test_vprogram_launch.py; here
-    # only the spec-build/create/port-forward wiring is under test.
-    monkeypatch.setattr(run_module, "_wait_until_attest_endpoint_listens", AsyncMock())
+    # only the spec-build/create/port-forward wiring is under test. Keep a
+    # reference so we can still assert the create path actually wires the
+    # gate in: a refactor that drops the call site must not leave this suite
+    # green.
+    mock_gate = AsyncMock()
+    monkeypatch.setattr(run_module, "_wait_until_attest_endpoint_listens", mock_gate)
 
     supervisor = _fake_supervisor()
     registry = AgentVmRegistry()
@@ -139,6 +143,7 @@ async def test_snp_instance_create_uses_snp_builder(monkeypatch):
     assert 22 in forwarded_ports
     assert _ATTEST_PORT in forwarded_ports
     assert execution is None
+    mock_gate.assert_awaited_once_with(supervisor, VmId(str(VM_HASH)), _ATTEST_PORT)
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_supervisor_inprocess_error_translation.py
+++ b/tests/supervisor/test_supervisor_inprocess_error_translation.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -10,7 +11,16 @@ from aleph.vm.supervisor.local import LocalSupervisor
 from aleph.vm.supervisor_interface.errors import (
     InsufficientResourcesError as SupInsufficientResources,
 )
-from aleph.vm.supervisor_interface.types import ErrorCode, VmId
+from aleph.vm.supervisor_interface.errors import VmSetupError
+from aleph.vm.supervisor_interface.types import (
+    Backend,
+    CreateVmSpec,
+    ErrorCode,
+    NetworkConfig,
+    TeeBackend,
+    TeeConfig,
+    VmId,
+)
 
 
 @pytest.mark.asyncio
@@ -25,3 +35,40 @@ async def test_internal_exception_in_delete_is_translated():
         await sup.delete_vm(VmId("itemhash123"))
 
     assert excinfo.value.code is ErrorCode.INSUFFICIENT_RESOURCES
+
+
+def _snp_spec(tmp_path: Path) -> CreateVmSpec:
+    return CreateVmSpec(
+        vm_id=VmId("deadbeef" * 8),
+        backend=Backend.QEMU,
+        kernel_path=Path(""),
+        initrd_path=Path(""),
+        disks=[],
+        vcpus=1,
+        memory_mib=512,
+        tee=TeeConfig(
+            backend=TeeBackend.SEV_SNP,
+            policy="0x30000",
+            session_dir=tmp_path,
+            kernel_cmdline="console=ttyS0",
+            cpu_model="EPYC-v4",
+        ),
+        network=NetworkConfig(internet_access=True, requested_ipv6="", ipv6_prefix_len=0),
+        gpus=[],
+        numa_node=None,
+        persistent=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_python_supervisor_rejects_snp_specs(tmp_path):
+    # The Python supervisor's confidential path is SEV-session-only: it would
+    # create the VM and never start it (awaiting_confidential_init forever,
+    # field report F3). Fail the create loudly instead.
+    pool = MagicMock()
+    sup = LocalSupervisor(pool=pool)
+
+    with pytest.raises(VmSetupError, match="Rust supervisor"):
+        await sup.create_vm(_snp_spec(tmp_path))
+
+    pool.create_vm_from_spec.assert_not_called()

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -219,6 +219,9 @@ async def test_create_vm_execution_vprogram_launches_snp(mocker):
         "aleph.vm.agent.run.build_vprogram_spec", new_callable=AsyncMock, return_value=(fake_spec, 8443)
     )
     mock_persist = mocker.patch("aleph.vm.agent.run.persist_record", new_callable=AsyncMock)
+    # The attest-gate itself is unit-tested in test_vprogram_launch.py; here
+    # only the spec-build/create/port-forward wiring is under test.
+    mocker.patch("aleph.vm.agent.run._wait_until_attest_endpoint_listens", new_callable=AsyncMock)
 
     info = _running_vm_info(str(vm_hash))
     assert not info.awaiting_confidential_init

--- a/tests/supervisor/test_vprogram_launch.py
+++ b/tests/supervisor/test_vprogram_launch.py
@@ -524,6 +524,26 @@ async def test_attest_gate_returns_when_guest_listens(mocker):
 
 
 @pytest.mark.asyncio
+async def test_attest_gate_returns_after_retry(mocker):
+    """A guest that refuses the first probe but accepts the next one must
+    still be treated as a success: the poll loop retries within the timeout
+    rather than failing on the first refused connection."""
+    from aleph.vm.agent import run as run_module
+
+    supervisor = AsyncMock()
+    supervisor.get_vm.return_value = SimpleNamespace(vm_id="vm-1", ipv4=SimpleNamespace(address="172.16.3.2"))
+    writer = MagicMock()
+    writer.wait_closed = AsyncMock()
+    mocker.patch(
+        "asyncio.open_connection",
+        new_callable=AsyncMock,
+        side_effect=[ConnectionRefusedError, (MagicMock(), writer)],
+    )
+    await run_module._wait_until_attest_endpoint_listens(supervisor, "vm-1", 8443, timeout=5, interval=0.01)
+    writer.close.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_attest_gate_raises_when_guest_never_listens(mocker):
     from aleph.vm.agent import run as run_module
     from aleph.vm.agent.run import VmStartupError

--- a/tests/supervisor/test_vprogram_launch.py
+++ b/tests/supervisor/test_vprogram_launch.py
@@ -14,7 +14,9 @@ import json
 import shutil
 import tarfile
 from pathlib import Path
+from types import SimpleNamespace
 from typing import IO, Any, cast
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aleph_message.models import VerifiableProgramMessage, parse_message
@@ -506,3 +508,39 @@ def test_remove_vprogram_staging_is_idempotent(tmp_path, monkeypatch):
     # Already gone (second teardown, or a non-V-PROGRAM VM with no staging dir).
     remove_vprogram_staging(vm_hash)
     assert not staging.exists()
+
+
+@pytest.mark.asyncio
+async def test_attest_gate_returns_when_guest_listens(mocker):
+    from aleph.vm.agent import run as run_module
+
+    supervisor = AsyncMock()
+    supervisor.get_vm.return_value = SimpleNamespace(vm_id="vm-1", ipv4=SimpleNamespace(address="172.16.3.2"))
+    writer = MagicMock()
+    writer.wait_closed = AsyncMock()
+    mocker.patch("asyncio.open_connection", new_callable=AsyncMock, return_value=(MagicMock(), writer))
+    await run_module._wait_until_attest_endpoint_listens(supervisor, "vm-1", 8443, timeout=5, interval=0.01)
+    writer.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_attest_gate_raises_when_guest_never_listens(mocker):
+    from aleph.vm.agent import run as run_module
+    from aleph.vm.agent.run import VmStartupError
+
+    supervisor = AsyncMock()
+    supervisor.get_vm.return_value = SimpleNamespace(vm_id="vm-1", ipv4=SimpleNamespace(address="172.16.3.2"))
+    mocker.patch("asyncio.open_connection", new_callable=AsyncMock, side_effect=ConnectionRefusedError)
+    with pytest.raises(VmStartupError, match="attestation endpoint"):
+        await run_module._wait_until_attest_endpoint_listens(supervisor, "vm-1", 8443, timeout=0.05, interval=0.01)
+
+
+@pytest.mark.asyncio
+async def test_attest_gate_raises_without_ipv4(mocker):
+    from aleph.vm.agent import run as run_module
+    from aleph.vm.agent.run import VmStartupError
+
+    supervisor = AsyncMock()
+    supervisor.get_vm.return_value = SimpleNamespace(vm_id="vm-1", ipv4=SimpleNamespace(address=""))
+    with pytest.raises(VmStartupError, match="IPv4"):
+        await run_module._wait_until_attest_endpoint_listens(supervisor, "vm-1", 8443, timeout=0.05, interval=0.01)

--- a/tests/supervisor/test_vprogram_port_map.py
+++ b/tests/supervisor/test_vprogram_port_map.py
@@ -121,6 +121,9 @@ async def test_vprogram_create_maps_attestation_port(mocker):
         return_value=(fake_spec, ATTEST_PORT),
     )
     mocker.patch("aleph.vm.agent.run.persist_record", new_callable=AsyncMock)
+    # The attest-gate itself is unit-tested in test_vprogram_launch.py; here
+    # only the port-forward reconciliation is under test.
+    mocker.patch("aleph.vm.agent.run._wait_until_attest_endpoint_listens", new_callable=AsyncMock)
 
     info = _running_vm_info(str(vm_hash))
     supervisor = FakeSupervisor(info)

--- a/tests/supervisor/test_vprogram_port_map.py
+++ b/tests/supervisor/test_vprogram_port_map.py
@@ -122,8 +122,10 @@ async def test_vprogram_create_maps_attestation_port(mocker):
     )
     mocker.patch("aleph.vm.agent.run.persist_record", new_callable=AsyncMock)
     # The attest-gate itself is unit-tested in test_vprogram_launch.py; here
-    # only the port-forward reconciliation is under test.
-    mocker.patch("aleph.vm.agent.run._wait_until_attest_endpoint_listens", new_callable=AsyncMock)
+    # only the port-forward reconciliation is under test. Keep a reference so
+    # we can still assert the create path actually wires the gate in: a
+    # refactor that drops the call site must not leave this suite green.
+    mock_gate = mocker.patch("aleph.vm.agent.run._wait_until_attest_endpoint_listens", new_callable=AsyncMock)
 
     info = _running_vm_info(str(vm_hash))
     supervisor = FakeSupervisor(info)
@@ -141,6 +143,7 @@ async def test_vprogram_create_maps_attestation_port(mocker):
     pf = supervisor.add_port_forward_calls[0]
     assert pf.vm_port == ATTEST_PORT
     assert pf.protocol is Protocol.TCP
+    mock_gate.assert_awaited_once_with(supervisor, VmId(str(vm_hash)), ATTEST_PORT)
 
     # Idempotency: re-running the reconcile (e.g. daemon re-adopts the VM on
     # restart) must not create a duplicate mapping.


### PR DESCRIPTION
Field report F3: a V-PROGRAM on a community CRN sat in awaiting_confidential_init forever, with the owner seeing only "VM is starting" and no error surfaced to anyone. Root cause analysis showed two layers, both fixed here:

- The Python supervisor only implements the SEV session flow: for any spec with tee set it creates the VM but never starts the controller, waiting for an owner initialization that never comes for SNP. It now rejects SEV-SNP specs up front with a VmSetupError naming the remedy (ALEPH_VM_SUPERVISOR_IMPL=rust), before touching the pool. The released 2.0.0 debs default to the Python supervisor (the rust flip in #1171 merged 4.5 hours after the tag was cut), so every stock 2.0.0 community node hits exactly this; 2.0.1 ships the rust default, and this guard keeps an operator-pinned python impl honest.

- RUNNING only proves the controller unit is active: an SNP guest can wedge inside firmware while QEMU lives on. Confidential creates (V-PROGRAM and SNP instance) now gate on the guest's RA-TLS attestation endpoint accepting a TCP connection within a bounded window (90s, module constants), failing the create loudly (teardown + scheduler retry) instead of leaving a zombie only the owner can watch. A healthy guest pays one get_vm plus a millisecond TCP connect.

Ops notes from review, for the release checklist: the scheduler's allocation-client HTTP timeout should exceed create + 120s (RUNNING wait) + 95s (gate worst case); watch the demo CRN's first V-PROGRAM launches for RA-TLS bind times approaching the 90s window.

Part of the 2.0.1 field-report fix series (with #1178 and #1179).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FD3aTuxD4L5BSfN9GMNHt