### PR TITLE
feat(packaging): build a deb for Ubuntu 26.04 (resolute)

### DIFF
--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["debian-12", "debian-13", "ubuntu-22.04", "ubuntu-24.04"]
+        os: ["debian-12", "debian-13", "ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04"]
         include:
           - os: "debian-12"
             make_target: "all-podman-debian-12"
@@ -33,6 +33,9 @@ jobs:
           - os: "ubuntu-24.04"
             make_target: "all-podman-ubuntu-2404"
             artifact_name: "aleph-vm.ubuntu-24.04.deb"
+          - os: "ubuntu-26.04"
+            make_target: "all-podman-ubuntu-2604"
+            artifact_name: "aleph-vm.ubuntu-26.04.deb"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -162,6 +162,13 @@ jobs:
             package_name: "aleph-vm.ubuntu-24.04.deb"
             concurrency_group: "droplet-aleph-vm-ubuntu-24-04"
 
+          - os_name: "Ubuntu 26.04"
+            os_image: "ubuntu-26-04-x64"
+            alias: "ubuntu-26-04"
+            package_build_command: "all-podman-ubuntu-2604"
+            package_name: "aleph-vm.ubuntu-26.04.deb"
+            concurrency_group: "droplet-aleph-vm-ubuntu-26-04"
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["debian-12", "debian-13", "ubuntu-22.04", "ubuntu-24.04"]
+        os: ["debian-12", "debian-13", "ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04"]
         include:
           - os: "debian-12"
             make_target: "all-podman-debian-12"
@@ -29,6 +29,9 @@ jobs:
           - os: "ubuntu-24.04"
             make_target: "all-podman-ubuntu-2404"
             artifact_name: "aleph-vm.ubuntu-24.04.deb"
+          - os: "ubuntu-26.04"
+            make_target: "all-podman-ubuntu-2604"
+            artifact_name: "aleph-vm.ubuntu-26.04.deb"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ Unless your focus is developing the VM-Connector, using the Docker image is easi
    sudo apt install /opt/aleph-vm.ubuntu-24.04.deb
    ```
 
+   **On Ubuntu 26.04 (Resolute Raccoon)**, recommended for SEV-SNP hosts
+   (ships QEMU 10.2, which can launch SEV-SNP guests):
+   ```shell
+   sudo wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/2.0.1/aleph-vm.ubuntu-26.04.deb
+   sudo apt install /opt/aleph-vm.ubuntu-26.04.deb
+   ```
+
 3. **Disable Systemd Service**  
    To prevent conflicts, deactivate the system version of aleph-vm by disabling its `systemd` service.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Unless your focus is developing the VM-Connector, using the Docker image is easi
    **On Ubuntu 26.04 (Resolute Raccoon)**, recommended for SEV-SNP hosts
    (ships QEMU 10.2, which can launch SEV-SNP guests):
    ```shell
-   sudo wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/2.0.1/aleph-vm.ubuntu-26.04.deb
+   sudo wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/1.2.0/aleph-vm.ubuntu-26.04.deb
    sudo apt install /opt/aleph-vm.ubuntu-26.04.deb
    ```
 

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -137,6 +137,17 @@ all-podman-ubuntu-2404: version
 	file target/aleph-vm.deb
 	mv target/aleph-vm.deb target/aleph-vm.ubuntu-24.04.deb
 
+all-podman-ubuntu-2604: version
+	cd .. && podman build -t localhost/aleph-vm-packaging-ubuntu-2604:latest -f ./packaging/ubuntu-26.04.dockerfile .
+	mkdir -p ./target
+	podman run --rm -ti \
+		-w /opt/packaging \
+		-v ./target:/opt/packaging/target \
+		localhost/aleph-vm-packaging-ubuntu-2604:latest \
+		make
+	file target/aleph-vm.deb
+	mv target/aleph-vm.deb target/aleph-vm.ubuntu-26.04.deb
+
 # extract Python requirements from Debian 12 container
 requirements-debian-12: all-podman-debian-12
 	podman run --rm -ti \
@@ -173,6 +184,15 @@ requirements-ubuntu-24.04: all-podman-ubuntu-2404
 		ubuntu:noble \
 		bash -c "/opt/extract_requirements.sh /mnt/requirements-ubuntu-24.04.txt"
 
+# extract Python requirements from Ubuntu 26.04 container
+requirements-ubuntu-26.04: all-podman-ubuntu-2604
+	podman run --rm -ti \
+		-v ./target/aleph-vm.ubuntu-26.04.deb:/opt/packaging/target/aleph-vm.deb:ro \
+		-v ./extract_requirements.sh:/opt/extract_requirements.sh:ro \
+		-v ./requirements-ubuntu-26.04.txt:/mnt/requirements-ubuntu-26.04.txt \
+		ubuntu:resolute \
+		bash -c "/opt/extract_requirements.sh /mnt/requirements-ubuntu-26.04.txt"
+
 # run on host in order to sign with GPG
 repository-bookworm:
 	cd ./repositories/bookworm && reprepro -Vb . includedeb bookworm ../../target/aleph-vm.debian-12.deb && cd ..
@@ -189,7 +209,11 @@ repository-trixie:
 repository-noble:
 	cd ./repositories/noble && reprepro -Vb . includedeb noble ../../target/aleph-vm.ubuntu-24.04.deb && cd ..
 
-repositories: repository-bookworm repository-trixie repository-jammy repository-noble
+# run on host in order to sign with GPG
+repository-resolute:
+	cd ./repositories/resolute && reprepro -Vb . includedeb resolute ../../target/aleph-vm.ubuntu-26.04.deb && cd ..
 
-all-podman: all-podman-debian-12 all-podman-debian-13 all-podman-ubuntu-2204 all-podman-ubuntu-2404 repositories
+repositories: repository-bookworm repository-trixie repository-jammy repository-noble repository-resolute
+
+all-podman: all-podman-debian-12 all-podman-debian-13 all-podman-ubuntu-2204 all-podman-ubuntu-2404 all-podman-ubuntu-2604 repositories
 

--- a/packaging/repositories/noble/conf/distributions
+++ b/packaging/repositories/noble/conf/distributions
@@ -1,0 +1,9 @@
+Origin: Aleph-IM
+Label: aleph-im
+Suite: stable
+Codename: noble
+Version: 3.0
+Architectures: amd64 source
+Components: contrib
+Description: Aleph-im packages
+SignWith: yes

--- a/packaging/repositories/resolute/conf/distributions
+++ b/packaging/repositories/resolute/conf/distributions
@@ -1,0 +1,9 @@
+Origin: Aleph-IM
+Label: aleph-im
+Suite: stable
+Codename: resolute
+Version: 3.0
+Architectures: amd64 source
+Components: contrib
+Description: Aleph-im packages
+SignWith: yes

--- a/packaging/ubuntu-26.04.dockerfile
+++ b/packaging/ubuntu-26.04.dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:26.04
+
+# protobuf-compiler: protoc for tonic-build (rust/crates/supervisor-proto).
+RUN apt-get update && apt-get -y upgrade && apt-get install -y \
+    make \
+    git \
+    curl \
+    sudo \
+    python3-pip \
+    python3-venv \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+# rustup instead of the distro cargo: plain cargo ignores
+# rust-toolchain.toml, rustup enforces the pin. The default toolchain
+# mirrors rust/rust-toolchain.toml (if they drift, rustup auto-installs the
+# toml channel below); sevctl builds with the same toolchain.
+RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
+    | sh -s -- -y --profile minimal --default-toolchain 1.90
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /opt
+
+# Preinstall the toolchain pinned in rust/rust-toolchain.toml (design doc
+# 2026-07-04-rust-supervisor-daemon-design.md, section 9) in its own layer,
+# before the sources, so local image rebuilds do not re-download it on every
+# source change. rustup reads the file when invoked from inside rust/.
+COPY ../rust/rust-toolchain.toml ./rust/rust-toolchain.toml
+RUN cd ./rust && rustup show
+
+COPY ../src/aleph ./src/aleph
+COPY ../proto ./proto
+COPY ../rust ./rust
+COPY ../packaging ./packaging
+COPY ../kernels ./kernels
+
+COPY ../examples/ ./examples


### PR DESCRIPTION
Ubuntu 26.04 LTS ships QEMU 10.2.1, making it the second packaged target (after Debian 13) whose stock QEMU can launch SEV-SNP guests: the sev-snp-guest QOM object gate added in #1179 passes on it out of the box. This gives SNP-capable community CRNs an Ubuntu option instead of requiring Debian 13.

- packaging/ubuntu-26.04.dockerfile: identical to the other targets except the base image
- Makefile: all-podman-ubuntu-2604, requirements-ubuntu-26.04, repository-resolute, wired into the repositories and all-podman aggregates
- Both CI matrices (PR builds and release-on-tag) build and attach aleph-vm.ubuntu-26.04.deb
- README install snippet, flagged as the recommended Ubuntu for SEV-SNP hosts
- Drive-by fix: repositories/noble/conf/distributions was never committed although the repository-noble target references it, so the aggregate repositories target could not run; added it

Note for the repo settings: if the new build should gate merges like the others, add "Build ubuntu-26.04 Package" to the required status checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019H6oFfJpeqtZ34gWQqxuqY