### PR TITLE
fix(agent): count free hugepages as available memory in /about/usage/system

### DIFF
--- a/src/aleph/vm/agent/resources.py
+++ b/src/aleph/vm/agent/resources.py
@@ -1,5 +1,6 @@
 import math
 from datetime import datetime, timezone
+from pathlib import Path
 
 import psutil
 from aiohttp import web
@@ -268,6 +269,30 @@ async def get_machine_capability() -> MachineCapability:
     return static.model_copy(update={"tee": await _get_tee_properties()})
 
 
+HUGEPAGES_SYSFS_PATH = Path("/sys/kernel/mm/hugepages")
+
+
+def hugepages_free_bytes(sysfs_path: Path = HUGEPAGES_SYSFS_PATH) -> int:
+    """Bytes held in free hugepages, summed across every pool size.
+
+    The kernel excludes the whole hugepage pool from MemAvailable, but on a
+    host with hugepage-backed VMs (ALEPH_VM_NUMA_HUGEPAGES) the free pages are
+    exactly the memory future VMs will draw from, so they must count as
+    available or an idle node reports itself full. Pool directories that are
+    missing or unreadable contribute 0 (a host without hugepages reports the
+    plain psutil figure).
+    """
+    free_bytes = 0
+    for pool in sysfs_path.glob("hugepages-*kB"):
+        try:
+            page_size_kib = int(pool.name.removeprefix("hugepages-").removesuffix("kB"))
+            free_pages = int((pool / "free_hugepages").read_text())
+        except (OSError, ValueError):
+            continue
+        free_bytes += free_pages * page_size_kib * 1024
+    return free_bytes
+
+
 def _disk_usage_from_pools(host_info) -> DiskUsage:
     """Aggregate capacity across every volume pool (same-filesystem pools
     counted once). Usage-aware available disk comes from the supervisor's
@@ -294,7 +319,9 @@ async def about_system_usage(request: web.Request):
         ),
         mem=MemoryUsage(
             total_kB=math.ceil(psutil.virtual_memory().total / 1000),
-            available_kB=math.floor(psutil.virtual_memory().available / 1000),
+            # Free hugepages are invisible to MemAvailable but are the very
+            # memory hugepage-backed VMs consume, so they count as available.
+            available_kB=math.floor((psutil.virtual_memory().available + hugepages_free_bytes()) / 1000),
         ),
         disk=_disk_usage_from_pools(host_info),
         period=UsagePeriod(

--- a/tests/supervisor/test_resources.py
+++ b/tests/supervisor/test_resources.py
@@ -1,6 +1,33 @@
+from pathlib import Path
 from unittest import mock
 
+from aleph.vm.agent.resources import hugepages_free_bytes
 from aleph.vm.resources import get_gpu_devices
+
+
+def _make_hugepage_pool(root: Path, name: str, free: str) -> None:
+    pool = root / name
+    pool.mkdir(parents=True)
+    (pool / "free_hugepages").write_text(free)
+
+
+def test_hugepages_free_bytes_sums_all_pool_sizes(tmp_path):
+    _make_hugepage_pool(tmp_path, "hugepages-2048kB", "1024\n")
+    _make_hugepage_pool(tmp_path, "hugepages-1048576kB", "2\n")
+    assert hugepages_free_bytes(tmp_path) == 1024 * 2048 * 1024 + 2 * 1048576 * 1024
+
+
+def test_hugepages_free_bytes_without_hugepage_sysfs_is_zero(tmp_path):
+    assert hugepages_free_bytes(tmp_path / "missing") == 0
+
+
+def test_hugepages_free_bytes_skips_unreadable_pools(tmp_path):
+    # A pool directory without the counter file, and one with garbage in it:
+    # both are skipped, the readable pool is still counted.
+    (tmp_path / "hugepages-2048kB").mkdir()
+    _make_hugepage_pool(tmp_path, "hugepages-1048576kB", "garbage\n")
+    _make_hugepage_pool(tmp_path, "hugepages-4096kB", "3\n")
+    assert hugepages_free_bytes(tmp_path) == 3 * 4096 * 1024
 
 
 def mock_is_kernel_enabled_gpu(pci_host: str) -> bool:

--- a/tests/supervisor/test_views.py
+++ b/tests/supervisor/test_views.py
@@ -316,6 +316,24 @@ async def test_system_usage_mock(aiohttp_client, mocker, mock_app_with_pool):
 
 
 @pytest.mark.asyncio
+async def test_system_usage_counts_free_hugepages_as_available(aiohttp_client, mocker, mock_app_with_pool):
+    """A hugepage host must report the free pool as available memory: the
+    kernel's MemAvailable excludes the whole hugepage pool, but hugepage-backed
+    VMs draw their RAM from it, so psutil alone shows an empty node as full."""
+    mocker.patch("aleph.vm.agent.resources.get_hardware_info", return_value=MOCK_SYSTEM_INFO)
+    fake_mem = mock.Mock(total=64_000_000_000, available=6_000_000_000)
+    mocker.patch("psutil.virtual_memory", return_value=fake_mem)
+    mocker.patch("aleph.vm.agent.resources.hugepages_free_bytes", return_value=50_000_000_000)
+
+    client = await aiohttp_client(await mock_app_with_pool)
+    response: web.Response = await client.get("/about/usage/system")
+    assert response.status == 200
+    resp = await response.json()
+    assert resp["mem"]["total_kB"] == 64_000_000
+    assert resp["mem"]["available_kB"] == 56_000_000
+
+
+@pytest.mark.asyncio
 async def test_system_capability_mock(aiohttp_client, mocker):
     """Test that the capability system endpoints response value. No auth needed"""
     mocker.patch("aleph.vm.agent.resources.get_hardware_info", return_value=MOCK_SYSTEM_INFO)


### PR DESCRIPTION
A node operator running 2.0.0 with `ALEPH_VM_NUMA_HUGEPAGES` enabled reported the node memory as ~83% full with zero VMs. The boot-time hugepage reservation keeps only the headroom out of the pool, and the kernel excludes the entire hugepage pool from `MemAvailable`, which is what `/about/usage/system` reported verbatim via psutil.

This is worse than cosmetic: the scheduler consumes `available_kB` for both `can_fit` and node priority scoring, so a hugepage node is starved of placements. And since launching VMs consumes `HugePages_Free` without moving `MemAvailable`, the reported figure stays pinned regardless of actual load, in both directions.

## Changes

- `hugepages_free_bytes()` in `aleph/vm/agent/resources.py` sums `free_hugepages × page size` across every `/sys/kernel/mm/hugepages/hugepages-*kB` pool (covers both 2M and 1G pools). Missing or unreadable pool entries contribute 0.
- `about_system_usage` adds that figure to `available_kB`. Free hugepages are exactly the memory future hugepage-backed VMs will draw from, so they count as available; as VMs consume the pool the figure now drops accordingly. Hosts without hugepages report the unchanged psutil value (the sum is 0), so no config gate is needed.

No double counting: `MemTotal` includes the hugepage pool while `MemAvailable` excludes it entirely, so the sum never exceeds `total_kB`.

## How to test

Unit tests cover the sysfs parsing against a fake tree, and an endpoint test asserts `available_kB` = MemAvailable + free hugepages. On a real hugepage CRN: reserve pages (`ALEPH_VM_NUMA_HUGEPAGES=1`), hit `/about/usage/system` with no VMs, and check `available_kB` reflects the free pool instead of ~17% of RAM.

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.
- [ ] Documentation has been updated regarding these changes.
- [ ] Dependencies update in the project.toml have been mirrored in the Debian package build script `packaging/Makefile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pyKMDw5vQffSSftuoecv7