### PR TITLE
build: pin released aleph-message 1.3.1 instead of the git ref

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -42,10 +42,9 @@ debian-package-code:
 	python3 -m venv build_venv
 	build_venv/bin/pip install   --progress-bar off --upgrade pip setuptools wheel
 	# Versions below MUST mirror pyproject.toml so the .deb ships what the code is tested against.
-	# MERGE GATE: aleph-message is git-pinned to the V-PROGRAM schema ref, swap for a release with pyproject.toml.
 	# protobuf is pinned to 5.29.6: 5.29.0 has a compilation issue; 6.x needs grpcio/tools 1.71+.
 	# legacy-cgi is packaging-only: it backfills the `cgi` module removed from the Python 3.13+ stdlib.
-	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message @ git+https://github.com/aleph-im/aleph-message@4ad261ff25f595a64589d49bf36f514c402e7c5e' 'eth-account~=0.10' 'sentry-sdk==2.8' 'qmp==1.1' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2' 'aiosqlite==0.19' 'alembic==1.13.1' 'aiohttp-cors~=0.7.0' 'pydantic-settings~=2.6.1' 'pyroute2==0.7.12' 'python-cpuid==0.1.1' 'solathon==1.0.7' 'protobuf==5.29.6' 'grpcio>=1.70,<1.71' 'redis>=4.2' 'legacy-cgi>=1.0'
+	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==1.3.1' 'eth-account~=0.10' 'sentry-sdk==2.8' 'qmp==1.1' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2' 'aiosqlite==0.19' 'alembic==1.13.1' 'aiohttp-cors~=0.7.0' 'pydantic-settings~=2.6.1' 'pyroute2==0.7.12' 'python-cpuid==0.1.1' 'solathon==1.0.7' 'protobuf==5.29.6' 'grpcio>=1.70,<1.71' 'redis>=4.2' 'legacy-cgi>=1.0'
 	build_venv/bin/python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux target/bin/sevctl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,11 @@ dependencies = [
   "aiohttp-cors~=0.7.0",
   "aiosqlite==0.19",
   "alembic==1.13.1",
-  # MERGE GATE: replace the git pin with a released aleph-message version (V-PROGRAM schema, PR #158)
-  "aleph-message @ git+https://github.com/aleph-im/aleph-message@4ad261ff25f595a64589d49bf36f514c402e7c5e",
+  "aleph-message==1.3.1",
   "aleph-superfluid~=0.2.1",
   "dbus-python==1.3.2",
   "eth-account~=0.10",
-  "grpcio>=1.70,<1.71",                                                                                     # generated _pb2_grpc.py embeds GRPC_GENERATED_VERSION=1.70.0; older installs RuntimeError on import
+  "grpcio>=1.70,<1.71",                                                                                   # generated _pb2_grpc.py embeds GRPC_GENERATED_VERSION=1.70.0; older installs RuntimeError on import
   "jsonschema==4.19.1",
   "jwcrypto==1.5.6",
   "msgpack==1.1.2",


### PR DESCRIPTION
The `MERGE GATE` git pin (`4ad261ff`, the pre-squash V-PROGRAM schema branch) is now covered by the [1.3.1 release](https://pypi.org/project/aleph-message/1.3.1/) on PyPI, so aleph-vm can use the same released version as pyaleph (aleph-im/pyaleph#1261).

The only delta between the pinned tree and 1.3.1 is aleph-im/aleph-message#160 (serde-strict V-PROGRAM scalars), which tightens CCN-side validation and does not affect the messages aleph-vm itself produces or parses.

Verified locally with `aleph-message==1.3.1` installed: all 152 tests in `tests/supervisor/test_snp_*`, `tests/supervisor/test_vprogram*` and `tests/vprogram/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkaSkidXtLL63prnqo7NS5