### PR TITLE
feat(agent): aleph-message 1.4.0, reject TDX instances before any I/O

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -39,7 +39,7 @@ debian-package-code:
 	# Versions below MUST mirror pyproject.toml so the .deb ships what the code is tested against.
 	# protobuf is pinned to 5.29.6: 5.29.0 has a compilation issue; 6.x needs grpcio/tools 1.71+.
 	# legacy-cgi is packaging-only: it backfills the `cgi` module removed from the Python 3.13+ stdlib.
-	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==1.3.1' 'eth-account~=0.10' 'sentry-sdk==2.8' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2' 'aiosqlite==0.19' 'alembic==1.13.1' 'aiohttp-cors~=0.7.0' 'pydantic-settings~=2.6.1' 'solathon==1.0.7' 'protobuf==5.29.6' 'grpcio>=1.70,<1.71' 'redis>=4.2' 'legacy-cgi>=1.0'
+	build_venv/bin/pip install --no-cache-dir  --progress-bar off --target ./aleph-vm/opt/aleph-vm/ 'aleph-message==1.4' 'eth-account~=0.10' 'sentry-sdk==2.8' 'aleph-superfluid~=0.2.1' 'sqlalchemy[asyncio]>=2' 'aiosqlite==0.19' 'alembic==1.13.1' 'aiohttp-cors~=0.7.0' 'pydantic-settings~=2.6.1' 'solathon==1.0.7' 'protobuf==5.29.6' 'grpcio>=1.70,<1.71' 'redis>=4.2' 'legacy-cgi>=1.0'
 	build_venv/bin/python3 -m compileall ./aleph-vm/opt/aleph-vm/
 
 debian-package-resources: firecracker-bins vmlinux target/bin/sevctl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,10 @@ dependencies = [
   "aiohttp-cors~=0.7.0",
   "aiosqlite==0.19",
   "alembic==1.13.1",
-  "aleph-message==1.4.0",
+  "aleph-message==1.4",
   "aleph-superfluid~=0.2.1",
   "eth-account~=0.10",
-  "grpcio>=1.70,<1.71",                                                                                   # generated _pb2_grpc.py embeds GRPC_GENERATED_VERSION=1.70.0; older installs RuntimeError on import
+  "grpcio>=1.70,<1.71",      # generated _pb2_grpc.py embeds GRPC_GENERATED_VERSION=1.70.0; older installs RuntimeError on import
   "jsonschema==4.19.1",
   "jwcrypto==1.5.6",
   "msgpack==1.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "aiohttp-cors~=0.7.0",
   "aiosqlite==0.19",
   "alembic==1.13.1",
-  "aleph-message==1.3.1",
+  "aleph-message==1.4.0",
   "aleph-superfluid~=0.2.1",
   "eth-account~=0.10",
   "grpcio>=1.70,<1.71",                                                                                   # generated _pb2_grpc.py embeds GRPC_GENERATED_VERSION=1.70.0; older installs RuntimeError on import

--- a/src/aleph/vm/agent/translate.py
+++ b/src/aleph/vm/agent/translate.py
@@ -47,6 +47,8 @@ async def build_create_vm_spec(
     Validation is performed before any I/O. Raises InvalidBackendError for:
     - non-instance messages
     - non-QEMU hypervisor (instances are QEMU-only)
+    - measured TEE modes: sev_snp belongs to build_snp_instance_spec, and
+      tdx has no launch path on this CRN yet
 
     Confidential (trusted_execution set) instances ARE supported: the firmware
     ref is resolved to a host path and ``spec.tee`` is populated so the engine
@@ -71,6 +73,22 @@ async def build_create_vm_spec(
     if effective_hypervisor != HypervisorType.qemu:
         raise InvalidBackendError(f"instances are QEMU-only, got hypervisor {effective_hypervisor!r}")
 
+    trusted_execution = getattr(message.environment, "trusted_execution", None)
+    if trusted_execution is not None:
+        if getattr(trusted_execution, "is_snp", False):
+            # SNP instances are built by build_snp_instance_spec
+            # (snp_instance_launch.py), which supplies the measured runtime
+            # bundle (OVMF/kernel/initrd/cmdline). This path has none of
+            # that: a routing mistake that reached here would silently build
+            # a SEV spec with no firmware. Fail loudly instead.
+            raise InvalidBackendError("SNP instances are built by build_snp_instance_spec, not this path")
+        if getattr(trusted_execution, "is_measured", False):
+            # Other measured modes (tdx) have no launch path on this CRN yet.
+            # Their messages carry no firmware ref (measured modes forbid it),
+            # so falling through would crash on the firmware resolve with an
+            # error that hides the real cause. Reject with the real cause.
+            raise InvalidBackendError(f"{trusted_execution.mode} instances are not supported by this CRN")
+
     # --- Materialise resources ---
 
     resources = QemuDownloader(message, namespace=str(vm_hash))
@@ -86,15 +104,7 @@ async def build_create_vm_spec(
     # AMDSEVPolicy.NO_DBG, so it is always present; the supervisor applies it
     # verbatim and holds no opinion of its own.
     tee: TeeConfig | None = None
-    trusted_execution = getattr(message.environment, "trusted_execution", None)
     if trusted_execution is not None:
-        if getattr(trusted_execution, "is_snp", False):
-            # SNP instances are built by build_snp_instance_spec
-            # (snp_instance_launch.py), which supplies the measured runtime
-            # bundle (OVMF/kernel/initrd/cmdline). This path has none of
-            # that: a routing mistake that reached here would silently build
-            # a SEV spec with no firmware. Fail loudly instead.
-            raise InvalidBackendError("SNP instances are built by build_snp_instance_spec, not this path")
         firmware_path = await get_existing_file(trusted_execution.firmware)
         tee = TeeConfig(
             backend=TeeBackend.SEV,

--- a/tests/supervisor/test_supervisor_translate.py
+++ b/tests/supervisor/test_supervisor_translate.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from aleph_message.models import ItemHash
+from aleph_message.models import ItemHash, Payment, PaymentType
 from aleph_message.models.execution.environment import (
     HypervisorType,
     InstanceEnvironment,
@@ -41,12 +41,14 @@ def _make_qemu_instance_message(
     authorized_keys: list[str] | None = None,
     hypervisor: HypervisorType | None = HypervisorType.qemu,
     trusted_execution: TrustedExecutionEnvironment | None = None,
+    payment: Payment | None = None,
 ) -> InstanceContent:
     return InstanceContent(
         address="0x1234567890abcdef1234567890abcdef12345678",
         time=1.0,
         allow_amend=False,
         authorized_keys=authorized_keys,
+        payment=payment,
         environment=InstanceEnvironment(
             internet=internet,
             aleph_api=False,
@@ -272,6 +274,79 @@ async def test_confidential_instance_populates_tee(monkeypatch: pytest.MonkeyPat
     assert requested_policy != int(AMDSEVPolicy.NO_DBG)
     assert spec.tee.session_dir == settings.CONFIDENTIAL_SESSION_DIRECTORY / _VM_HASH
     assert spec.tee.firmware_path == firmware_path
+
+
+@pytest.mark.asyncio
+async def test_snp_instance_rejected_before_any_download(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An SEV-SNP instance reaching this path is a routing mistake (run.py
+    sends it to build_snp_instance_spec): rejected loudly, before any I/O."""
+    from aleph_message.models.execution.environment import (
+        LaunchMeasurement,
+        SevSnpRegisters,
+        TeePlatform,
+    )
+
+    async def fail_download_all(self: Any) -> None:
+        raise AssertionError("download must not run for a rejected message")
+
+    monkeypatch.setattr(QemuDownloader, "download_all", fail_download_all)
+
+    message = _make_qemu_instance_message(
+        trusted_execution=TrustedExecutionEnvironment(
+            mode="sev_snp",
+            runtime=_FAKE_HASH,
+            measurements=[
+                LaunchMeasurement(
+                    platform=TeePlatform.sev_snp,
+                    registers=SevSnpRegisters(launch="aa" * 48),
+                    vcpu_type="EPYC-v4",
+                )
+            ],
+            policy=0x30000,
+        ),
+        payment=Payment(type=PaymentType.credit),
+    )
+
+    with pytest.raises(InvalidBackendError, match="build_snp_instance_spec"):
+        await build_create_vm_spec(_VM_HASH, message)
+
+
+@pytest.mark.asyncio
+async def test_tdx_instance_rejected_before_any_download(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A TDX instance has no launch path on this CRN: rejected with the mode
+    named, before any I/O (its message carries no firmware to resolve)."""
+    from aleph_message.models.execution.environment import (
+        LaunchMeasurement,
+        TdxRegisters,
+        TeePlatform,
+    )
+
+    async def fail_download_all(self: Any) -> None:
+        raise AssertionError("download must not run for a rejected message")
+
+    monkeypatch.setattr(QemuDownloader, "download_all", fail_download_all)
+
+    message = _make_qemu_instance_message(
+        trusted_execution=TrustedExecutionEnvironment(
+            mode="tdx",
+            runtime=_FAKE_HASH,
+            measurements=[
+                LaunchMeasurement(
+                    platform=TeePlatform.tdx,
+                    registers=TdxRegisters(
+                        mrtd="11" * 48,
+                        rtmr1="22" * 48,
+                        rtmr2="33" * 48,
+                        mrconfigid="44" * 48,
+                    ),
+                )
+            ],
+        ),
+        payment=Payment(type=PaymentType.credit),
+    )
+
+    with pytest.raises(InvalidBackendError, match="tdx instances are not supported"):
+        await build_create_vm_spec(_VM_HASH, message)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
aleph-vm side of increment 1 of the Intel TDX design (aleph-message #161 / aleph-rs #391 / pyaleph #1266). Closes the schema increment.

- **`aleph-message==1.4.0`** (was 1.3.1; the delta is exactly the TDX schema PR). The supervisor can now parse a `mode: tdx` instance message instead of failing validation.
- **Clean rejection instead of a crash.** A tdx instance passed `is_snp_instance` as false and fell into `build_create_vm_spec`, which resolved `trusted_execution.firmware`; measured modes forbid a firmware ref, so it crashed on `get_existing_file(None)` with an error hiding the real cause. The plain path now rejects any measured mode it cannot build, naming the mode: `"tdx instances are not supported by this CRN"`.
- **Guards hoisted before the download.** The docstring promised validation before any I/O, but the SNP misrouting guard sat after `download_all()`; a rejected message would first download its rootfs. Both guards (SNP misrouting, unsupported measured mode) now run in the pre-I/O validation block, and both gained tests asserting the downloader never runs.

No launch-path change: SNP instances still route to `build_snp_instance_spec`, SEV instances still build here, V-PROGRAM stays schema-locked to `sev_snp`. The TDX launch path arrives with the verifier increments.

Gates: `tests/supervisor/` translate + SNP + routing + vprogram suites against the 1.4.0 package (106 passed), ruff format, isort, mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUWEzYLgSidwttzQGtzB43
