### PR TITLE
fix(agent): keep the SNP instance attestation port in the desired forward set

### DIFF
--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -34,6 +34,7 @@ from aleph.vm.agent.snp_instance_launch import (
     build_snp_instance_spec,
     is_snp_instance,
     remove_snp_instance_staging,
+    resolve_instance_attestation_port,
 )
 from aleph.vm.agent.translate import build_create_vm_spec, build_program_create_vm_spec
 from aleph.vm.agent.update_watcher import UpdateWatcher
@@ -155,6 +156,38 @@ async def resolve_port_forwards(vm_id: VmId, content, *, strict: bool = False) -
     return forwards
 
 
+async def resolve_instance_desired_forwards(vm_id: VmId, content, *, strict: bool = False) -> list[PortForwardSpec]:
+    """The full desired forward set for an instance: the user's aggregate
+    settings plus always-SSH (``resolve_port_forwards``), and, for a SEV-SNP
+    confidential instance, the runtime manifest's RA-TLS attestation port.
+
+    Every instance forward computation must go through here: a reconciler
+    that diffs against a set missing the attestation port tears its host
+    mapping down (this is how SNP instances lost their 8443 mapping in the
+    field: the aggregate watcher and the re-adoption healing path converged
+    on the aggregate+SSH set). The CLI discovers the guest's attestation
+    endpoint through that mapping.
+
+    A manifest fetch failure raises (VmSetupError) instead of returning the
+    reduced set, for the same reason ``strict=`` exists on the aggregate
+    fetch: a convergence caller must skip healing rather than converge onto
+    a set that strips the attestation mapping.
+    """
+    forwards = await resolve_port_forwards(vm_id, content, strict=strict)
+    if is_snp_instance(content):
+        attest_port = int(await resolve_instance_attestation_port(content))
+        if not any(int(f.vm_port) == attest_port and f.protocol is Protocol.TCP for f in forwards):
+            forwards.append(
+                PortForwardSpec(
+                    vm_id=vm_id,
+                    host_port=HostPort(0),
+                    vm_port=GuestPort(attest_port),
+                    protocol=Protocol.TCP,
+                )
+            )
+    return forwards
+
+
 async def _reconcile_forwards(supervisor: Supervisor, vm_id: VmId, desired_specs: list[PortForwardSpec]) -> None:
     """Diff `desired_specs` against what the hypervisor currently reports for
     `vm_id` and issue add/remove calls so the two converge. The hypervisor
@@ -178,7 +211,7 @@ async def reconcile_port_forwards(supervisor: Supervisor, vm_id: VmId, content) 
     Agent policy half of the old fetch_port_redirect_config_and_setup: compute
     the desired set, then converge through ``_reconcile_forwards``.
     """
-    await _reconcile_forwards(supervisor, vm_id, await resolve_port_forwards(vm_id, content))
+    await _reconcile_forwards(supervisor, vm_id, await resolve_instance_desired_forwards(vm_id, content))
 
 
 def resolve_vprogram_port_forwards(vm_id: VmId, attest_port: int | None) -> list[PortForwardSpec]:
@@ -242,7 +275,11 @@ async def reconcile_adopted_port_forwards(supervisor: Supervisor, registry: Agen
             # strict: a failed aggregate fetch must skip healing, not converge
             # the VM onto the SSH-only fallback set (which would remove the
             # user's aggregate-declared forwards on a transient CCN error).
-            await _reconcile_forwards(supervisor, vm_id, await resolve_port_forwards(vm_id, content, strict=True))
+            # A failed runtime-manifest fetch (SNP instances) skips the same
+            # way, so healing never strips the attestation mapping either.
+            await _reconcile_forwards(
+                supervisor, vm_id, await resolve_instance_desired_forwards(vm_id, content, strict=True)
+            )
         # Programs get no agent-side forwards: nothing to heal.
     except Exception:
         logger.warning("Could not reconcile port forwards for adopted VM %s; left as found", vm_hash, exc_info=True)
@@ -352,7 +389,8 @@ async def finish_instance_create(supervisor: Supervisor, vm_id: VmId, content) -
     """Post-create completion shared by the normal create path and the migration
     import runner: wait until the instance reports RUNNING, then apply the
     agent's resolved port forwards (always-22 plus the user's port-forwarding
-    aggregate) through supervisor.add_port_forward.
+    aggregate, plus the attestation port for SNP instances) through
+    supervisor.add_port_forward.
 
     create_vm_from_spec only reloads *persisted* host port mappings, so a fresh
     destination (migration) would otherwise come up with no port forward at all
@@ -360,7 +398,7 @@ async def finish_instance_create(supervisor: Supervisor, vm_id: VmId, content) -
     instance identical to a freshly created one.
     """
     await _wait_until_running(supervisor, vm_id)
-    for forward in await resolve_port_forwards(vm_id, content):
+    for forward in await resolve_instance_desired_forwards(vm_id, content):
         await supervisor.add_port_forward(forward)
 
 
@@ -543,17 +581,10 @@ async def create_vm_execution(
         try:
             await finish_instance_create(supervisor, info.vm_id, content)
             if attest_port is not None:
-                # The guest attestation service (aleph.ra-tls) the runtime
-                # manifest pinned: forward it alongside SSH and the user's
-                # own aggregate so the owner can attest post-boot.
-                await supervisor.add_port_forward(
-                    PortForwardSpec(
-                        vm_id=info.vm_id,
-                        host_port=HostPort(0),
-                        vm_port=GuestPort(attest_port),
-                        protocol=Protocol.TCP,
-                    )
-                )
+                # finish_instance_create mapped the attestation port already
+                # (it is part of the instance's desired forward set); wait
+                # until the guest service (aleph.ra-tls) behind it listens
+                # before declaring the create done.
                 await _wait_until_attest_endpoint_listens(supervisor, info.vm_id, attest_port)
         except Exception:
             # Readiness or port-forward setup failed: tear the half-started VM

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -175,7 +175,7 @@ async def resolve_instance_desired_forwards(vm_id: VmId, content, *, strict: boo
     """
     forwards = await resolve_port_forwards(vm_id, content, strict=strict)
     if is_snp_instance(content):
-        attest_port = int(await resolve_instance_attestation_port(content))
+        attest_port = await resolve_instance_attestation_port(content)
         if not any(int(f.vm_port) == attest_port and f.protocol is Protocol.TCP for f in forwards):
             forwards.append(
                 PortForwardSpec(

--- a/src/aleph/vm/agent/snp_instance_launch.py
+++ b/src/aleph/vm/agent/snp_instance_launch.py
@@ -107,7 +107,13 @@ def select_attestation_port(manifest: InstanceRuntimeManifest) -> int:
     """The guest attestation port, ordered by preference over
     ``manifest.attestation``: the ``aleph.ra-tls`` descriptor's port, falling
     back to the first descriptor for a runtime that only implements another
-    protocol."""
+    protocol.
+
+    Deliberately NOT the same contract as the V-PROGRAM's
+    ``_select_attestation_port`` (vprogram_launch.py), which returns None
+    when no ``aleph.ra-tls`` tcp descriptor exists: instance manifests pin
+    ``attestation`` to at least one entry with a tcp transport, so this
+    selector always has a port to return. Do not "harmonize" the two."""
     for descriptor in manifest.attestation:
         if descriptor.protocol == "aleph.ra-tls":
             return descriptor.transport.port

--- a/src/aleph/vm/agent/snp_instance_launch.py
+++ b/src/aleph/vm/agent/snp_instance_launch.py
@@ -103,6 +103,33 @@ async def fetch_instance_runtime_manifest(runtime_ref: str) -> InstanceRuntimeMa
         raise VmSetupError(msg) from error
 
 
+def select_attestation_port(manifest: InstanceRuntimeManifest) -> int:
+    """The guest attestation port, ordered by preference over
+    ``manifest.attestation``: the ``aleph.ra-tls`` descriptor's port, falling
+    back to the first descriptor for a runtime that only implements another
+    protocol."""
+    for descriptor in manifest.attestation:
+        if descriptor.protocol == "aleph.ra-tls":
+            return descriptor.transport.port
+    return manifest.attestation[0].transport.port
+
+
+async def resolve_instance_attestation_port(content: InstanceContent) -> int:
+    """Re-derive the RA-TLS attestation port from the runtime manifest alone.
+
+    The port-forward reconcilers (the aggregate watcher and the re-adoption
+    healing path) need the port to keep the host DNAT mapping in their
+    desired set, but must not pay for ``build_snp_instance_spec``: that
+    stages the whole runtime bundle, which the running VM already booted
+    from. The manifest is a small STORE file: one message-metadata lookup,
+    with the file itself coming from the local download cache after the
+    first create. Raises VmSetupError when the manifest cannot be fetched or
+    parsed; the caller decides whether that is fatal.
+    """
+    manifest = await fetch_instance_runtime_manifest(str(content.environment.trusted_execution.runtime))
+    return select_attestation_port(manifest)
+
+
 async def build_snp_instance_spec(vm_hash: ItemHash, content: InstanceContent) -> tuple[CreateVmSpec, int]:
     """Validate, fetch/stage the runtime bundle, and build the SNP CreateVmSpec
     for a confidential instance with its own LUKS-encrypted rootfs. Returns
@@ -155,14 +182,7 @@ async def build_snp_instance_spec(vm_hash: ItemHash, content: InstanceContent) -
     initrd_path = snp_staging.member_path(bundle_dir, members.initrd, "initrd")
     kernel_cmdline = manifest.boot.cmdline_template.format(owner=owner)
 
-    # Ordered by preference (manifest.attestation): prefer the aleph.ra-tls
-    # descriptor's port; fall back to the first descriptor for a runtime that
-    # only implements another protocol.
-    attest_port = manifest.attestation[0].transport.port
-    for descriptor in manifest.attestation:
-        if descriptor.protocol == "aleph.ra-tls":
-            attest_port = descriptor.transport.port
-            break
+    attest_port = select_attestation_port(manifest)
 
     resources = QemuDownloader(content, namespace=str(vm_hash))
     await resources.download_all()

--- a/tests/supervisor/test_snp_instance_port_map.py
+++ b/tests/supervisor/test_snp_instance_port_map.py
@@ -1,0 +1,172 @@
+"""The port-forward reconcilers must treat a SEV-SNP instance's attestation
+port as part of its desired forward set.
+
+Field regression (2026-09-03): the create path mapped the manifest's RA-TLS
+port, but the aggregate watcher (``reconcile_port_forwards``) and the
+re-adoption healing path (``reconcile_adopted_port_forwards``) converged on
+the aggregate+SSH set only, so the first pass after create tore the 8443
+mapping down and the CLI's attestation-endpoint discovery broke. Mirrors
+tests/supervisor/test_vprogram_port_map.py, which covers the same property
+for V-PROGRAMs.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from test_snp_instance_launch import VM_HASH, snp_instance_content
+
+from aleph.vm.agent import run as run_module
+from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor_interface.errors import VmSetupError
+from aleph.vm.supervisor_interface.types import (
+    GuestPort,
+    HostPort,
+    PortForwardInfo,
+    PortForwardSpec,
+    Protocol,
+    VmId,
+)
+
+ATTEST_PORT = 8443
+VM_ID = VmId(str(VM_HASH))
+
+
+class FakeSupervisor:
+    """The forward surface of the Supervisor, with a real in-memory mapping
+    store (like test_vprogram_port_map's fake) so reconcile diffs behave the
+    way the real hypervisor's would."""
+
+    def __init__(self, vm_ports: list[int]):
+        self._next_host_port = 40000
+        self._forwards: dict[tuple[int, Protocol], int] = {}
+        for port in vm_ports:
+            self._forwards[(port, Protocol.TCP)] = self._next_host_port
+            self._next_host_port += 1
+        self.added: list[PortForwardSpec] = []
+        self.removed: list[tuple[int, Protocol]] = []
+
+    async def add_port_forward(self, spec: PortForwardSpec) -> PortForwardInfo:
+        self.added.append(spec)
+        host_port = self._next_host_port
+        self._next_host_port += 1
+        self._forwards[(int(spec.vm_port), spec.protocol)] = host_port
+        return PortForwardInfo(
+            vm_id=spec.vm_id, host_port=HostPort(host_port), vm_port=spec.vm_port, protocol=spec.protocol
+        )
+
+    async def remove_port_forward(self, vm_id, host_port, protocol) -> None:
+        for key, value in list(self._forwards.items()):
+            if value == host_port and key[1] == protocol:
+                self.removed.append(key)
+                del self._forwards[key]
+
+    async def list_port_forwards(self, vm_id=None) -> list[PortForwardInfo]:
+        return [
+            PortForwardInfo(vm_id=VM_ID, host_port=HostPort(host), vm_port=GuestPort(port), protocol=protocol)
+            for (port, protocol), host in self._forwards.items()
+        ]
+
+    def ports(self) -> set[int]:
+        return {port for (port, _protocol) in self._forwards}
+
+
+@pytest.fixture
+def snp_content():
+    return snp_instance_content()
+
+
+@pytest.fixture
+def _no_aggregate(monkeypatch):
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+
+
+@pytest.fixture
+def _attest_port(monkeypatch):
+    monkeypatch.setattr(run_module, "resolve_instance_attestation_port", AsyncMock(return_value=ATTEST_PORT))
+
+
+@pytest.mark.asyncio
+async def test_watcher_reconcile_keeps_the_attest_mapping(snp_content, _no_aggregate, _attest_port):
+    """An aggregate-change reconcile of an SNP instance whose forwards are
+    already correct (SSH + attest) removes nothing and adds nothing."""
+    supervisor = FakeSupervisor([22, ATTEST_PORT])
+
+    await run_module.reconcile_port_forwards(supervisor, VM_ID, snp_content)
+
+    assert supervisor.removed == []
+    assert supervisor.added == []
+    assert supervisor.ports() == {22, ATTEST_PORT}
+
+
+@pytest.mark.asyncio
+async def test_watcher_reconcile_restores_a_missing_attest_mapping(snp_content, _no_aggregate, _attest_port):
+    """A reconcile pass heals a stripped attest mapping instead of accepting
+    the reduced state (the same pass used to be the one stripping it)."""
+    supervisor = FakeSupervisor([22])
+
+    await run_module.reconcile_port_forwards(supervisor, VM_ID, snp_content)
+
+    assert supervisor.ports() == {22, ATTEST_PORT}
+    assert supervisor.removed == []
+
+
+@pytest.mark.asyncio
+async def test_adopted_healing_includes_the_attest_port(snp_content, _no_aggregate, _attest_port):
+    """Re-adoption healing (agent restart) also treats the attest port as
+    desired: an adopted SNP instance found without it gets it back."""
+    supervisor = FakeSupervisor([22])
+    registry = AgentVmRegistry()
+    registry.record(VM_HASH, message=snp_content, original=snp_content, persistent=True)
+
+    await run_module.reconcile_adopted_port_forwards(supervisor, registry, VM_HASH)
+
+    assert supervisor.ports() == {22, ATTEST_PORT}
+    assert supervisor.removed == []
+
+
+@pytest.mark.asyncio
+async def test_manifest_fetch_failure_skips_healing(snp_content, _no_aggregate, monkeypatch):
+    """A failed runtime-manifest fetch must skip healing (leave the forwards
+    exactly as found), never converge onto a set without the attest port."""
+    monkeypatch.setattr(
+        run_module,
+        "resolve_instance_attestation_port",
+        AsyncMock(side_effect=VmSetupError("manifest unavailable")),
+    )
+    supervisor = FakeSupervisor([22, ATTEST_PORT])
+    registry = AgentVmRegistry()
+    registry.record(VM_HASH, message=snp_content, original=snp_content, persistent=True)
+
+    await run_module.reconcile_adopted_port_forwards(supervisor, registry, VM_HASH)
+
+    assert supervisor.ports() == {22, ATTEST_PORT}
+    assert supervisor.removed == []
+    assert supervisor.added == []
+
+
+@pytest.mark.asyncio
+async def test_plain_instance_never_fetches_a_manifest(_no_aggregate, monkeypatch):
+    """A non-SNP instance's desired set is unchanged, and the manifest
+    resolver is never consulted for it."""
+    resolver = AsyncMock(return_value=ATTEST_PORT)
+    monkeypatch.setattr(run_module, "resolve_instance_attestation_port", resolver)
+    content = SimpleNamespace(address="0xabc", environment=SimpleNamespace(trusted_execution=None))
+
+    forwards = await run_module.resolve_instance_desired_forwards(VM_ID, content)
+
+    assert {(int(f.vm_port), f.protocol) for f in forwards} == {(22, Protocol.TCP)}
+    resolver.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_aggregate_declared_attest_port_is_not_duplicated(snp_content, _attest_port, monkeypatch):
+    """A user aggregate that already forwards the attest port yields exactly
+    one spec for it, not two."""
+    payload = {str(VM_HASH): {"ports": {str(ATTEST_PORT): {"tcp": True, "udp": False}}}}
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value=payload))
+
+    forwards = await run_module.resolve_instance_desired_forwards(VM_ID, snp_content)
+
+    attest_specs = [f for f in forwards if int(f.vm_port) == ATTEST_PORT and f.protocol is Protocol.TCP]
+    assert len(attest_specs) == 1

--- a/tests/supervisor/test_snp_instance_port_map.py
+++ b/tests/supervisor/test_snp_instance_port_map.py
@@ -62,6 +62,10 @@ class FakeSupervisor:
                 del self._forwards[key]
 
     async def list_port_forwards(self, vm_id=None) -> list[PortForwardInfo]:
+        # Single-VM fake: honor the filter explicitly so a caller asking for
+        # another VM gets nothing rather than this VM's forwards.
+        if vm_id is not None and VmId(str(vm_id)) != VM_ID:
+            return []
         return [
             PortForwardInfo(vm_id=VM_ID, host_port=HostPort(host), vm_port=GuestPort(port), protocol=protocol)
             for (port, protocol), host in self._forwards.items()
@@ -139,6 +143,26 @@ async def test_manifest_fetch_failure_skips_healing(snp_content, _no_aggregate, 
     registry.record(VM_HASH, message=snp_content, original=snp_content, persistent=True)
 
     await run_module.reconcile_adopted_port_forwards(supervisor, registry, VM_HASH)
+
+    assert supervisor.ports() == {22, ATTEST_PORT}
+    assert supervisor.removed == []
+    assert supervisor.added == []
+
+
+@pytest.mark.asyncio
+async def test_watcher_reconcile_propagates_manifest_failure(snp_content, _no_aggregate, monkeypatch):
+    """The watcher entry point itself must fail closed: a manifest fetch
+    failure propagates (for the caller's per-VM try/except) with no forwards
+    touched, rather than converging onto a set without the attest port."""
+    monkeypatch.setattr(
+        run_module,
+        "resolve_instance_attestation_port",
+        AsyncMock(side_effect=VmSetupError("manifest unavailable")),
+    )
+    supervisor = FakeSupervisor([22, ATTEST_PORT])
+
+    with pytest.raises(VmSetupError):
+        await run_module.reconcile_port_forwards(supervisor, VM_ID, snp_content)
 
     assert supervisor.ports() == {22, ATTEST_PORT}
     assert supervisor.removed == []

--- a/tests/supervisor/test_snp_instance_run.py
+++ b/tests/supervisor/test_snp_instance_run.py
@@ -113,6 +113,7 @@ async def test_snp_instance_create_uses_snp_builder(monkeypatch):
     spec = _snp_spec()
     build_snp = AsyncMock(return_value=(spec, _ATTEST_PORT))
     monkeypatch.setattr(run_module, "build_snp_instance_spec", build_snp)
+    monkeypatch.setattr(run_module, "resolve_instance_attestation_port", AsyncMock(return_value=_ATTEST_PORT))
     build_sev = AsyncMock()
     monkeypatch.setattr(run_module, "build_create_vm_spec", build_sev)
     monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
@@ -158,6 +159,7 @@ async def test_snp_instance_never_awaits_confidential_init(monkeypatch):
     )
     spec = _snp_spec()
     monkeypatch.setattr(run_module, "build_snp_instance_spec", AsyncMock(return_value=(spec, _ATTEST_PORT)))
+    monkeypatch.setattr(run_module, "resolve_instance_attestation_port", AsyncMock(return_value=_ATTEST_PORT))
     monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
     monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
     persist = AsyncMock()
@@ -204,6 +206,7 @@ async def test_snp_instance_with_gpus_rejected(monkeypatch):
     )
     build_snp = AsyncMock()
     monkeypatch.setattr(run_module, "build_snp_instance_spec", build_snp)
+    monkeypatch.setattr(run_module, "resolve_instance_attestation_port", AsyncMock(return_value=_ATTEST_PORT))
 
     supervisor = _fake_supervisor()
     registry = AgentVmRegistry()
@@ -253,6 +256,7 @@ async def test_legacy_sev_instance_path_untouched(monkeypatch):
     monkeypatch.setattr(run_module, "build_create_vm_spec", build_sev)
     build_snp = AsyncMock()
     monkeypatch.setattr(run_module, "build_snp_instance_spec", build_snp)
+    monkeypatch.setattr(run_module, "resolve_instance_attestation_port", AsyncMock(return_value=_ATTEST_PORT))
     monkeypatch.setattr(run_module, "persist_record", AsyncMock())
 
     awaiting = _info(VmStatus.BOOTING, awaiting_confidential_init=True)
@@ -284,6 +288,7 @@ async def test_snp_instance_failure_cleans_staging(monkeypatch):
     )
     spec = _snp_spec()
     monkeypatch.setattr(run_module, "build_snp_instance_spec", AsyncMock(return_value=(spec, _ATTEST_PORT)))
+    monkeypatch.setattr(run_module, "resolve_instance_attestation_port", AsyncMock(return_value=_ATTEST_PORT))
     remove_staging = MagicMock()
     monkeypatch.setattr(run_module, "remove_snp_instance_staging", remove_staging)
 
@@ -302,10 +307,10 @@ async def test_snp_instance_failure_cleans_staging(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_snp_instance_port_forward_failure_cleans_staging(monkeypatch):
-    """The second teardown path: create_vm succeeds but a later port-forward
-    fails. The half-started VM must be deleted and its staging removed, mirroring
-    the create-failure branch (run.py's finish_instance_create/port-forward
-    except block)."""
+    """The second teardown path: create_vm succeeds but the port-forward
+    application inside finish_instance_create fails. The half-started VM must
+    be deleted and its staging removed, mirroring the create-failure branch
+    (run.py's finish_instance_create/attest-gate except block)."""
     content = snp_instance_content()
     message = MagicMock(content=content)
     monkeypatch.setattr(
@@ -313,9 +318,10 @@ async def test_snp_instance_port_forward_failure_cleans_staging(monkeypatch):
     )
     spec = _snp_spec()
     monkeypatch.setattr(run_module, "build_snp_instance_spec", AsyncMock(return_value=(spec, _ATTEST_PORT)))
-    # finish_instance_create succeeds; the attestation-port forward that follows
-    # raises, so the failure lands in the second except block.
-    monkeypatch.setattr(run_module, "finish_instance_create", AsyncMock())
+    monkeypatch.setattr(run_module, "resolve_instance_attestation_port", AsyncMock(return_value=_ATTEST_PORT))
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value={}))
+    monkeypatch.setattr(run_module.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(run_module, "_wait_until_attest_endpoint_listens", AsyncMock())
     remove_staging = MagicMock()
     monkeypatch.setattr(run_module, "remove_snp_instance_staging", remove_staging)
 


### PR DESCRIPTION
## Problem

Found while running the first end-to-end SNP confidential instance against a live 2.0.1 CRN: after a successful create, `/v2/about/executions/list` showed only port 22 in `mapped_ports` while the guest's RA-TLS endpoint (8443) kept serving over direct IPv6. The CLI discovers the attestation endpoint through that mapping, so `aleph instance attest` failed with "attestation port not yet mapped" (workaround: `--url`).

Root cause: the create path maps the runtime manifest's attestation port, but both port-forward reconcilers compute an instance's desired set as aggregate + always-SSH only:

- `reconcile_port_forwards` (port-forwarding aggregate watcher), and
- `reconcile_adopted_port_forwards` (re-adoption healing after an agent restart) — its instance branch, while V-PROGRAMs already have an attest-aware branch.

The first pass after create diffs the live forwards against that reduced set and removes the attestation mapping.

## Fix

Route every instance forward computation through one desired-set helper, `resolve_instance_desired_forwards`, which appends the manifest's RA-TLS port for `mode=sev_snp` instances (deduped against an aggregate-declared forward for the same port). Mirrors the V-PROGRAM pattern:

- `resolve_instance_attestation_port` re-derives the port from the runtime manifest alone (one cached STORE lookup, no bundle staging), like `resolve_vprogram_attestation_port`; the selection loop is factored into `select_attestation_port` and shared with `build_snp_instance_spec`.
- A manifest fetch failure raises instead of returning the reduced set, for the same reason `strict=` exists on the aggregate fetch: reconcilers skip healing rather than converge onto a set that strips the mapping.
- `finish_instance_create` now applies the attestation forward with the rest of the desired set; the create path's separate `add_port_forward` is gone and only the listen gate (`_wait_until_attest_endpoint_listens`) remains. This also means a migrated SNP instance comes up with its attestation mapping, like a fresh one.

## Tests

New `tests/supervisor/test_snp_instance_port_map.py` (mirroring `test_vprogram_port_map.py`): watcher reconcile keeps and restores the mapping, adoption healing includes it, a manifest fetch failure leaves forwards as found, a plain instance never consults the manifest, and an aggregate-declared 8443 is not duplicated. The existing create-path teardown test now exercises the real `finish_instance_create` instead of mocking around the removed manual add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcVreAzpudAwcpP6fX7XGy