### PR TITLE
feat(agent): bind SNP instance unlock authority to the message sender

### DIFF
--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -532,7 +532,7 @@ async def create_vm_execution(
                 if requested_gpu_ids(content):
                     msg = "GPU passthrough is not supported on SEV-SNP instances yet"
                     raise VmSetupError(msg)
-                spec, attest_port = await build_snp_instance_spec(vm_hash, content)
+                spec, attest_port = await build_snp_instance_spec(vm_hash, content, str(message.sender))
             else:
                 spec = await build_create_vm_spec(vm_hash, content)
             # Agent-side admission, after the download so a failed download

--- a/src/aleph/vm/agent/snp_instance_launch.py
+++ b/src/aleph/vm/agent/snp_instance_launch.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # A lowercased 0x-prefixed 20-byte hex address: v1 confidential instances are
-# EVM-keyed only (owner-auth is EIP-191; see build_snp_instance_spec).
+# EVM-keyed only (the unlock authority signs EIP-191; see build_snp_instance_spec).
 _EVM_ADDRESS_PATTERN = re.compile(r"0x[0-9a-f]{40}")
 
 
@@ -148,7 +148,8 @@ async def build_snp_instance_spec(vm_hash: ItemHash, content: InstanceContent, s
     an on-behalf-of deployment the delegate (whose authorization from the
     owner the CCN already enforced) is the one that holds the passphrase and
     unlocks. content.address stays the billing/ownership identity and may be
-    non-EVM; the sender must be EVM-keyed (owner-auth is EIP-191).
+    non-EVM; the sender must be EVM-keyed (the unlock authority signs
+    EIP-191).
 
     Rejections fire in this order, all before any staging I/O: an
     attestation_port override, a host without SNP support, a policy above 32
@@ -171,7 +172,10 @@ async def build_snp_instance_spec(vm_hash: ItemHash, content: InstanceContent, s
         raise VmSetupError(msg)
     unlock_address = str(sender).lower()
     if not _EVM_ADDRESS_PATTERN.fullmatch(unlock_address):
-        msg = "SNP confidential instances require an EVM-keyed sender in v1 (owner-auth is EIP-191)"
+        msg = (
+            "SNP confidential instances require an EVM-keyed sender in v1 "
+            "(the EIP-191 unlock authority must be an EVM key)"
+        )
         raise VmSetupError(msg)
 
     if content.authorized_keys or content.variables:

--- a/src/aleph/vm/agent/snp_instance_launch.py
+++ b/src/aleph/vm/agent/snp_instance_launch.py
@@ -136,10 +136,19 @@ async def resolve_instance_attestation_port(content: InstanceContent) -> int:
     return select_attestation_port(manifest)
 
 
-async def build_snp_instance_spec(vm_hash: ItemHash, content: InstanceContent) -> tuple[CreateVmSpec, int]:
+async def build_snp_instance_spec(vm_hash: ItemHash, content: InstanceContent, sender: str) -> tuple[CreateVmSpec, int]:
     """Validate, fetch/stage the runtime bundle, and build the SNP CreateVmSpec
     for a confidential instance with its own LUKS-encrypted rootfs. Returns
     the spec and the guest attestation port.
+
+    ``sender`` is the address that signed the INSTANCE message, and it is what
+    fills the measured cmdline's unlock-authority slot: the guest accepts a
+    secret injection only from the key that signed the deployment. For a
+    directly-signed message sender == content.address, so nothing changes; for
+    an on-behalf-of deployment the delegate (whose authorization from the
+    owner the CCN already enforced) is the one that holds the passphrase and
+    unlocks. content.address stays the billing/ownership identity and may be
+    non-EVM; the sender must be EVM-keyed (owner-auth is EIP-191).
 
     Rejections fire in this order, all before any staging I/O: an
     attestation_port override, a host without SNP support, a policy above 32
@@ -160,8 +169,8 @@ async def build_snp_instance_spec(vm_hash: ItemHash, content: InstanceContent) -
     if int(trusted_execution.policy) >= 2**32:
         msg = "SNP guest policy above 32 bits is not supported yet"
         raise VmSetupError(msg)
-    owner = str(content.address).lower()
-    if not _EVM_ADDRESS_PATTERN.fullmatch(owner):
+    unlock_address = str(sender).lower()
+    if not _EVM_ADDRESS_PATTERN.fullmatch(unlock_address):
         msg = "SNP confidential instances require an EVM-keyed sender in v1 (owner-auth is EIP-191)"
         raise VmSetupError(msg)
 
@@ -186,7 +195,9 @@ async def build_snp_instance_spec(vm_hash: ItemHash, content: InstanceContent) -
     ovmf_path = snp_staging.member_path(bundle_dir, members.ovmf, "ovmf")
     kernel_path = snp_staging.member_path(bundle_dir, members.kernel, "kernel")
     initrd_path = snp_staging.member_path(bundle_dir, members.initrd, "initrd")
-    kernel_cmdline = manifest.boot.cmdline_template.format(owner=owner)
+    # The template's slot is named {owner} (a frozen runtime-manifest
+    # contract); the value it binds is the unlock authority above.
+    kernel_cmdline = manifest.boot.cmdline_template.format(owner=unlock_address)
 
     attest_port = select_attestation_port(manifest)
 

--- a/tests/supervisor/test_snp_instance_launch.py
+++ b/tests/supervisor/test_snp_instance_launch.py
@@ -356,11 +356,13 @@ async def test_rejects_attestation_port_set(staged_instance_bundle):
 
 
 @pytest.mark.asyncio
-async def test_rejects_non_evm_sender(snp_supported):
+@pytest.mark.parametrize("address", [OWNER_LOWER, NON_EVM_ADDRESS])
+async def test_rejects_non_evm_sender(snp_supported, address):
     """The unlock authority is the message sender; a non-EVM sender cannot
-    sign EIP-191 injections and is rejected regardless of content.address."""
+    sign EIP-191 injections and is rejected regardless of content.address
+    (exercised with both an EVM and a non-EVM owner)."""
     with pytest.raises(VmSetupError, match="EVM"):
-        await build_snp_instance_spec(VM_HASH, snp_instance_content(), NON_EVM_ADDRESS)
+        await build_snp_instance_spec(VM_HASH, snp_instance_content(address=address), NON_EVM_ADDRESS)
 
 
 @pytest.mark.asyncio
@@ -386,6 +388,7 @@ async def test_delegated_create_binds_the_sender_not_the_owner(staged_instance_b
 async def test_sender_is_lowercased_into_the_cmdline(staged_instance_bundle):
     """EIP-55 checksum case must not leak into the measured slot: the guest
     compares lowercase-to-lowercase."""
+    # Lowercases exactly to DELEGATE_LOWER, hence the assertion below.
     checksummed = "0xFeedFaceFeedFaceFeedFaceFeedFaceFeedFace"
     spec, _ = await build_snp_instance_spec(VM_HASH, snp_instance_content(), checksummed)
     assert spec.tee is not None

--- a/tests/supervisor/test_snp_instance_launch.py
+++ b/tests/supervisor/test_snp_instance_launch.py
@@ -55,6 +55,7 @@ BUNDLE_REF = "b1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1eeb1ee"
 
 OWNER_LOWER = "0x1234567890abcdef1234567890abcdef12345678"
 NON_EVM_ADDRESS = "5FHwkrdxDCvSXWvBaHf3Aq6X8AfUY5vLwLLpAt7dQxCg"
+DELEGATE_LOWER = "0xfeedfacefeedfacefeedfacefeedfacefeedface"
 
 # The reference instance manifest shape (tests/vprogram/test_manifest.py), with
 # the bundle digest/size patched per-test to match the locally built tarball.
@@ -264,7 +265,7 @@ def staged_instance_bundle(tmp_path, storage_files, snp_supported, snp_vcpu_type
 
 @pytest.mark.asyncio
 async def test_build_snp_instance_spec_happy_path(staged_instance_bundle):
-    spec, attest_port = await build_snp_instance_spec(VM_HASH, snp_instance_content())
+    spec, attest_port = await build_snp_instance_spec(VM_HASH, snp_instance_content(), OWNER_LOWER)
 
     assert spec.tee is not None
     assert spec.tee.backend is TeeBackend.SEV_SNP
@@ -301,7 +302,7 @@ async def test_prefers_the_ra_tls_attestation_port(tmp_path, staged_instance_bun
         ],
     )
 
-    _, attest_port = await build_snp_instance_spec(VM_HASH, snp_instance_content())
+    _, attest_port = await build_snp_instance_spec(VM_HASH, snp_instance_content(), OWNER_LOWER)
 
     assert attest_port == 8443
 
@@ -318,7 +319,7 @@ async def test_falls_back_to_the_first_attestation_port_without_ra_tls(tmp_path,
         ],
     )
 
-    _, attest_port = await build_snp_instance_spec(VM_HASH, snp_instance_content())
+    _, attest_port = await build_snp_instance_spec(VM_HASH, snp_instance_content(), OWNER_LOWER)
 
     assert attest_port == 7000
 
@@ -335,7 +336,7 @@ async def test_snp_instance_spec_selects_the_measured_cpu_model(staged_instance_
         )
     ]
     content = snp_instance_content(trusted_execution_overrides={"measurements": measurements})
-    spec, _attest_port = await build_snp_instance_spec(VM_HASH, content)
+    spec, _attest_port = await build_snp_instance_spec(VM_HASH, content, OWNER_LOWER)
     assert spec.tee is not None
     assert spec.tee.cpu_model == "EPYC-Genoa-v2"
 
@@ -344,21 +345,51 @@ async def test_snp_instance_spec_selects_the_measured_cpu_model(staged_instance_
 async def test_snp_instance_spec_refuses_a_model_the_host_cannot_launch(staged_instance_bundle, snp_vcpu_types):
     snp_vcpu_types(["EPYC"])
     with pytest.raises(VmSetupError, match="launch measurements"):
-        await build_snp_instance_spec(VM_HASH, snp_instance_content())
+        await build_snp_instance_spec(VM_HASH, snp_instance_content(), OWNER_LOWER)
 
 
 @pytest.mark.asyncio
 async def test_rejects_attestation_port_set(staged_instance_bundle):
     content = snp_instance_content(trusted_execution_overrides={"attestation_port": 9000})
     with pytest.raises(VmSetupError, match="attestation_port"):
-        await build_snp_instance_spec(VM_HASH, content)
+        await build_snp_instance_spec(VM_HASH, content, OWNER_LOWER)
 
 
 @pytest.mark.asyncio
 async def test_rejects_non_evm_sender(snp_supported):
-    content = snp_instance_content(address=NON_EVM_ADDRESS)
+    """The unlock authority is the message sender; a non-EVM sender cannot
+    sign EIP-191 injections and is rejected regardless of content.address."""
     with pytest.raises(VmSetupError, match="EVM"):
-        await build_snp_instance_spec(VM_HASH, content)
+        await build_snp_instance_spec(VM_HASH, snp_instance_content(), NON_EVM_ADDRESS)
+
+
+@pytest.mark.asyncio
+async def test_non_evm_owner_with_evm_sender_is_accepted(staged_instance_bundle):
+    """content.address is billing/ownership only: a non-EVM owner deploys
+    fine as long as the signing sender is EVM-keyed."""
+    content = snp_instance_content(address=NON_EVM_ADDRESS)
+    spec, _ = await build_snp_instance_spec(VM_HASH, content, OWNER_LOWER)
+    assert spec.tee is not None
+    assert spec.tee.kernel_cmdline == f"console=ttyS0 luks=1 owner={OWNER_LOWER}"
+
+
+@pytest.mark.asyncio
+async def test_delegated_create_binds_the_sender_not_the_owner(staged_instance_bundle):
+    """An on-behalf-of deployment: the measured cmdline binds the delegate
+    that signed the message (and holds the passphrase), not content.address."""
+    spec, _ = await build_snp_instance_spec(VM_HASH, snp_instance_content(), DELEGATE_LOWER)
+    assert spec.tee is not None
+    assert spec.tee.kernel_cmdline == f"console=ttyS0 luks=1 owner={DELEGATE_LOWER}"
+
+
+@pytest.mark.asyncio
+async def test_sender_is_lowercased_into_the_cmdline(staged_instance_bundle):
+    """EIP-55 checksum case must not leak into the measured slot: the guest
+    compares lowercase-to-lowercase."""
+    checksummed = "0xFeedFaceFeedFaceFeedFaceFeedFaceFeedFace"
+    spec, _ = await build_snp_instance_spec(VM_HASH, snp_instance_content(), checksummed)
+    assert spec.tee is not None
+    assert spec.tee.kernel_cmdline == f"console=ttyS0 luks=1 owner={DELEGATE_LOWER}"
 
 
 @pytest.mark.asyncio
@@ -373,7 +404,7 @@ async def test_rejects_vprogram_manifest(tmp_path, storage_files, snp_supported)
 
     content = snp_instance_content()
     with pytest.raises(VmSetupError, match="aleph-instance-runtime"):
-        await build_snp_instance_spec(VM_HASH, content)
+        await build_snp_instance_spec(VM_HASH, content, OWNER_LOWER)
 
 
 @pytest.mark.asyncio
@@ -383,7 +414,7 @@ async def test_rejects_policy_above_u32(snp_supported):
     over_u32_policy = (1 << 32) | (1 << 17)
     content = snp_instance_content(trusted_execution_overrides={"policy": over_u32_policy})
     with pytest.raises(VmSetupError, match="policy"):
-        await build_snp_instance_spec(VM_HASH, content)
+        await build_snp_instance_spec(VM_HASH, content, OWNER_LOWER)
 
 
 @pytest.mark.asyncio
@@ -391,14 +422,14 @@ async def test_rejects_host_without_snp(monkeypatch):
     monkeypatch.setattr("aleph.vm.agent.snp_instance_launch.check_amd_sev_snp_supported", lambda: False)
     content = snp_instance_content()
     with pytest.raises(VmSetupError, match="SEV-SNP"):
-        await build_snp_instance_spec(VM_HASH, content)
+        await build_snp_instance_spec(VM_HASH, content, OWNER_LOWER)
 
 
 @pytest.mark.asyncio
 async def test_warns_and_ignores_authorized_keys(caplog, staged_instance_bundle):
     content = snp_instance_content(authorized_keys=["ssh-ed25519 AAAAB3NzaC1lZDI1NTE5AAAAIAbc owner@example.com"])
     with caplog.at_level("WARNING"):
-        spec, _ = await build_snp_instance_spec(VM_HASH, content)
+        spec, _ = await build_snp_instance_spec(VM_HASH, content, OWNER_LOWER)
 
     assert spec.ssh_authorized_keys == []
     assert any("authorized_keys" in record.message for record in caplog.records)
@@ -410,7 +441,7 @@ async def test_warns_and_ignores_variables(caplog, staged_instance_bundle):
     are unmeasured host inputs too, so they are ignored with a warning."""
     content = snp_instance_content(variables={"SECRET": "value"})
     with caplog.at_level("WARNING"):
-        await build_snp_instance_spec(VM_HASH, content)
+        await build_snp_instance_spec(VM_HASH, content, OWNER_LOWER)
 
     assert any("variables" in record.message for record in caplog.records)
 

--- a/tests/supervisor/test_snp_instance_run.py
+++ b/tests/supervisor/test_snp_instance_run.py
@@ -41,6 +41,7 @@ from aleph.vm.supervisor_interface.types import (
 )
 
 _ATTEST_PORT = 8443
+_SENDER = "0x1234567890abcdef1234567890abcdef12345678"
 
 
 def _snp_spec() -> CreateVmSpec:
@@ -106,7 +107,7 @@ async def test_snp_instance_create_uses_snp_builder(monkeypatch):
     the recorded port forwards include SSH (22) and the attestation port
     (8443, from build_snp_instance_spec's returned attest_port)."""
     content = snp_instance_content()
-    message = MagicMock(content=content)
+    message = MagicMock(content=content, sender=_SENDER)
     monkeypatch.setattr(
         run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
     )
@@ -134,7 +135,7 @@ async def test_snp_instance_create_uses_snp_builder(monkeypatch):
         VM_HASH, supervisor=supervisor, registry=registry, capacity=_fake_capacity(), persistent=True
     )
 
-    build_snp.assert_awaited_once_with(VM_HASH, content)
+    build_snp.assert_awaited_once_with(VM_HASH, content, _SENDER)
     build_sev.assert_not_awaited()
     sent_spec = supervisor.create_vm.await_args.args[0]
     assert sent_spec.tee is not None
@@ -153,7 +154,7 @@ async def test_snp_instance_never_awaits_confidential_init(monkeypatch):
     so the path must fall straight through to finish_instance_create / the
     port-forward stage rather than the SEV await branch."""
     content = snp_instance_content()
-    message = MagicMock(content=content)
+    message = MagicMock(content=content, sender=_SENDER)
     monkeypatch.setattr(
         run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
     )
@@ -200,7 +201,7 @@ async def test_snp_instance_with_gpus_rejected(monkeypatch):
             )
         }
     )
-    message = MagicMock(content=content)
+    message = MagicMock(content=content, sender=_SENDER)
     monkeypatch.setattr(
         run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
     )
@@ -227,7 +228,7 @@ async def test_legacy_sev_instance_path_untouched(monkeypatch):
     build_create_vm_spec, never build_snp_instance_spec; its spec carries no
     kernel_cmdline (build_create_vm_spec never sets one)."""
     content = _make_qemu_instance_message(trusted_execution=TrustedExecutionEnvironment())
-    message = MagicMock(content=content)
+    message = MagicMock(content=content, sender=_SENDER)
     monkeypatch.setattr(
         run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
     )
@@ -282,7 +283,7 @@ async def test_snp_instance_failure_cleans_staging(monkeypatch):
     remove_snp_instance_staging and forget the registry record, mirroring the
     V-PROGRAM build/create failure branch."""
     content = snp_instance_content()
-    message = MagicMock(content=content)
+    message = MagicMock(content=content, sender=_SENDER)
     monkeypatch.setattr(
         run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
     )
@@ -312,7 +313,7 @@ async def test_snp_instance_port_forward_failure_cleans_staging(monkeypatch):
     be deleted and its staging removed, mirroring the create-failure branch
     (run.py's finish_instance_create/attest-gate except block)."""
     content = snp_instance_content()
-    message = MagicMock(content=content)
+    message = MagicMock(content=content, sender=_SENDER)
     monkeypatch.setattr(
         run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
     )


### PR DESCRIPTION
## Problem

An SNP confidential instance created with `--on-behalf-of` measures `content.address` (the owner) into the cmdline's unlock slot, so only the owner key can inject the LUKS passphrase. For a browser-wallet owner (the whole point of on-behalf-of), that key is not available to the CLI: delegated deployments could be created but never unlocked. Found running the first live E2E.

## Change

Fill the measured `{owner}` slot with the address that **signed the INSTANCE message** instead: the key that deployed the instance (and encrypted/holds the passphrase) is the key that unlocks it.

- Directly-signed messages: sender == content.address, nothing changes.
- Delegated messages: the CCN already enforced the owner's security-aggregate authorization of the sender, so unlock authority still chains from the owner. A delegate that can deploy arbitrary instances on the owner's account gains nothing new by also being able to unlock its own deployments.
- The guest is untouched (it compares the EIP-191 signer against whatever the measured slot holds), so no runtime bundle republish and no measurement-computation change: the client simply computes the expected measurement with the signer's address, which is what the aleph-rs client ships.
- `content.address` remains the billing/ownership identity and may now be non-EVM as long as the sender is EVM-keyed. The rejection message always said "EVM-keyed sender"; the code now checks the sender it named.

Known trade-offs, accepted for v1 (an in-guest delegation-certificate scheme can layer on later without conflicting): the owner cannot unlock a delegated instance themself, and revoking a delegation does not affect already-running VMs (the address is baked into the launch measurement).

## Tests

`test_snp_instance_launch.py`: delegated create binds the sender (not content.address), non-EVM sender rejected regardless of address, non-EVM owner with EVM sender accepted, checksum-cased sender lowercased into the slot. `test_snp_instance_run.py` updated for the new signature (sender plumbed from the loaded message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcVreAzpudAwcpP6fX7XGy