### PR TITLE
fix(agent): convergence reconciles must not converge on the SSH-only fallback

### DIFF
--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -205,13 +205,23 @@ async def _reconcile_forwards(supervisor: Supervisor, vm_id: VmId, desired_specs
             await supervisor.add_port_forward(spec)
 
 
-async def reconcile_port_forwards(supervisor: Supervisor, vm_id: VmId, content) -> None:
+async def reconcile_port_forwards(supervisor: Supervisor, vm_id: VmId, content, *, strict: bool = False) -> None:
     """Drive the hypervisor's forwards to match the aggregate settings.
 
     Agent policy half of the old fetch_port_redirect_config_and_setup: compute
     the desired set, then converge through ``_reconcile_forwards``.
+
+    ``strict=`` follows ``resolve_port_forwards``' contract and the caller's
+    situation: a caller reconciling a VM that already has forwards (the
+    aggregate watcher, the user-triggered refresh endpoint) must pass
+    ``strict=True``, because converging onto the SSH-only fallback after a
+    transient aggregate-fetch failure would tear the user's own forwards
+    down. A caller establishing a VM's FIRST forwards (the legacy-SEV
+    post-init setup in the operator API) keeps the lenient default: there is
+    nothing to tear down yet, and the SSH-only fallback at least makes the
+    VM reachable, mirroring the create path.
     """
-    await _reconcile_forwards(supervisor, vm_id, await resolve_instance_desired_forwards(vm_id, content))
+    await _reconcile_forwards(supervisor, vm_id, await resolve_instance_desired_forwards(vm_id, content, strict=strict))
 
 
 def resolve_vprogram_port_forwards(vm_id: VmId, attest_port: int | None) -> list[PortForwardSpec]:

--- a/src/aleph/vm/agent/tasks.py
+++ b/src/aleph/vm/agent/tasks.py
@@ -233,7 +233,10 @@ async def _handle_port_forwarding_aggregate(
         if info.status is not VmStatus.RUNNING:
             continue
         try:
-            await reconcile_port_forwards(supervisor, vm_id, record.message)
+            # strict: this VM's forwards already exist; a transient aggregate
+            # failure must skip this pass (logged below), not converge the VM
+            # onto the SSH-only fallback and delete the user's forwards.
+            await reconcile_port_forwards(supervisor, vm_id, record.message, strict=True)
         except Exception:
             logger.exception("Failed to update port redirects for %s", vm_hash)
 

--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -1085,6 +1085,15 @@ async def operate_update(request: web.Request) -> web.Response:
         # Configuration will be fetched when the VM starts; not an error.
         return web.json_response({"status": "ok", "msg": "VM not starting yet"}, dumps=dumps_for_json, status=200)
 
-    await reconcile_port_forwards(supervisor, vm_id, record.message)
+    try:
+        # strict: the caller asked for a refresh of forwards that already
+        # exist; failing the request beats silently converging the VM onto
+        # the SSH-only fallback and deleting the user's forwards.
+        await reconcile_port_forwards(supervisor, vm_id, record.message, strict=True)
+    except Exception:
+        logger.warning("Port-forward refresh for %s could not fetch its inputs", vm_hash, exc_info=True)
+        raise web.HTTPServiceUnavailable(
+            reason="Could not fetch the port-forwarding settings; forwards left unchanged, retry shortly"
+        ) from None
     await sync_domain_mappings(request.app["supervisor"])
     return web.json_response({}, dumps=dumps_for_json, status=200)

--- a/src/aleph/vm/agent/views/operator.py
+++ b/src/aleph/vm/agent/views/operator.py
@@ -629,6 +629,10 @@ async def operate_confidential_inject_secret(request: web.Request, authenticated
         # port 22 and is unreachable.
         from aleph.vm.agent.run import reconcile_port_forwards
 
+        # Deliberately NOT strict: this is the VM's first forward setup (it
+        # was awaiting init until now), so there is nothing to tear down and
+        # the SSH-only fallback at least makes the VM reachable, mirroring
+        # the create path's rationale.
         await reconcile_port_forwards(supervisor, vm_id, record.message)
 
         # inject_secret only returns on the success path (a QMP failure raises),

--- a/tests/supervisor/test_port_forward_reconcile_strict.py
+++ b/tests/supervisor/test_port_forward_reconcile_strict.py
@@ -1,0 +1,65 @@
+"""``reconcile_port_forwards``'s strict mode: convergence callers whose VM
+already has forwards must not treat a transient aggregate-fetch failure as
+"the user removed every port" and converge onto the SSH-only fallback,
+tearing the user's own forwards down. The aggregate watcher and the
+user-triggered refresh endpoint pass ``strict=True``; the legacy-SEV
+post-init first setup keeps the lenient default (nothing to tear down yet).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from test_snp_instance_port_map import VM_ID, FakeSupervisor
+
+from aleph.vm.agent import run as run_module
+from aleph.vm.supervisor_interface.types import Protocol
+
+USER_PORT = 8080
+
+
+def _plain_instance_content():
+    return SimpleNamespace(address="0xabc", environment=SimpleNamespace(trusted_execution=None))
+
+
+@pytest.mark.asyncio
+async def test_strict_reconcile_propagates_aggregate_failure(monkeypatch):
+    """strict=True: an aggregate-fetch failure raises with no forwards
+    touched, so the caller skips the pass instead of converging."""
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(side_effect=RuntimeError("CCN down")))
+    supervisor = FakeSupervisor([22, USER_PORT])
+
+    with pytest.raises(RuntimeError, match="CCN down"):
+        await run_module.reconcile_port_forwards(supervisor, VM_ID, _plain_instance_content(), strict=True)
+
+    assert supervisor.ports() == {22, USER_PORT}
+    assert supervisor.removed == []
+    assert supervisor.added == []
+
+
+@pytest.mark.asyncio
+async def test_lenient_default_converges_on_the_ssh_fallback(monkeypatch):
+    """The lenient default keeps the pre-existing first-setup behavior: an
+    aggregate failure falls back to SSH-only and converges onto it. This is
+    exactly why convergence callers must not use the default."""
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(side_effect=RuntimeError("CCN down")))
+    supervisor = FakeSupervisor([22, USER_PORT])
+
+    await run_module.reconcile_port_forwards(supervisor, VM_ID, _plain_instance_content())
+
+    assert supervisor.ports() == {22}
+    assert supervisor.removed == [(USER_PORT, Protocol.TCP)]
+
+
+@pytest.mark.asyncio
+async def test_strict_reconcile_still_converges_when_the_fetch_works(monkeypatch):
+    """strict only changes failure handling: with the aggregate reachable,
+    a strict pass applies the user's declared set normally."""
+    payload = {str(VM_ID): {"ports": {str(USER_PORT): {"tcp": True, "udp": False}}}}
+    monkeypatch.setattr(run_module, "get_user_settings", AsyncMock(return_value=payload))
+    supervisor = FakeSupervisor([22])
+
+    await run_module.reconcile_port_forwards(supervisor, VM_ID, _plain_instance_content(), strict=True)
+
+    assert supervisor.ports() == {22, USER_PORT}
+    assert supervisor.removed == []


### PR DESCRIPTION
Follow-up to #1189, from its review's non-blocking observation. Stacked on `od/snp-attest-port-reconcile`; retarget to `main` after #1189 merges.

## Problem

`resolve_port_forwards` falls back to SSH-only when the port-forwarding aggregate cannot be fetched. That fallback is right when establishing a VM's *first* forwards (worst case it starts with SSH only), but every *convergence* caller that diffs against it deletes the user's own forwards on a transient CCN error:

- the port-forwarding aggregate watcher (`_handle_port_forwarding_aggregate`), and
- the user-triggered refresh endpoint (`operate_update`).

The re-adoption healing path already guarded against exactly this with `strict=True`; these two did not.

## Change

`reconcile_port_forwards` gains a `strict=` parameter (default lenient, threaded through `resolve_instance_desired_forwards`, so an SNP instance's manifest-fetch failure is treated the same way), chosen per caller:

- **watcher**: `strict=True` — a failure skips the pass, caught and logged per-VM as before.
- **refresh endpoint**: `strict=True` — a failure now returns 503 with the forwards left unchanged, instead of 200 after silently tearing them down.
- **legacy-SEV post-init first setup** (`operator.py`): keeps the lenient default, with a comment: it establishes the first forwards, nothing exists to tear down, and SSH-only at least makes the VM reachable (the create path's rationale).

## Tests

`test_port_forward_reconcile_strict.py`: strict propagates the failure with no forwards touched; the lenient default still converges onto the SSH fallback (pinning why convergence callers must not use it); strict changes nothing when the fetch succeeds. Full sweep of every suite touching the changed call sites passes (146 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUTt5c9gxStxywZVtbVnRG