### PR TITLE
fix(dhcp): keep IPv6 resolvers out of DHCPv4 option 6

### DIFF
--- a/docs/architecture/networking.md
+++ b/docs/architecture/networking.md
@@ -238,7 +238,7 @@ only ever lease precisely that address (there is no MAC to key a
 `--dhcp-hostsdir` reservation on, since the SNP NIC has no fixed MAC).
 `DhcpConfig::for_snp` derives the config from the VM's `TapAssignment`
 (guest IP, gateway as DHCP option 3, tap-prefix netmask, the daemon's
-resolved nameservers as option 6 when any were found); `--port=0` disables
+resolved IPv4 nameservers as option 6 when any were found); `--port=0` disables
 dnsmasq's own DNS server so per-tap instances never collide on port 53.
 Each server runs as a transient systemd unit named
 `aleph-vm-dhcp-{vm_hash}.service`, launched via `systemd-run --collect -p

--- a/rust/crates/supervisor-daemon/src/dhcp.rs
+++ b/rust/crates/supervisor-daemon/src/dhcp.rs
@@ -72,8 +72,8 @@ pub struct DhcpConfig {
     /// The tap IPv6 prefix length (from the /124-per-VM scheme), the
     /// DHCPv6 `--dhcp-range` prefix and the RA on-link prefix.
     pub ipv6_prefix_len: u8,
-    /// The daemon's resolved nameservers, DHCP option 6. Empty omits the
-    /// option (the guest gets no DNS, the same as a nameserver-less host).
+    /// The daemon's resolved IPv4 nameservers, emitted in DHCPv4 option 6.
+    /// An empty list omits the option.
     pub nameservers: Vec<String>,
     /// The `--dhcp-range` lease-time literal (e.g. "1h").
     pub lease: String,
@@ -93,9 +93,10 @@ impl DhcpConfig {
     /// the VM hash.
     ///
     /// Fails (fail-closed) if the tap's IPv4 network CIDR carries no parseable
-    /// prefix length: silently falling back to `/32` would hand the guest an
-    /// unroutable single-host netmask, so the caller must surface the error
-    /// rather than boot an unreachable VM.
+    /// prefix length or if a nameserver is not a valid IP address: silently
+    /// falling back to `/32` would hand the guest an unroutable single-host
+    /// netmask, while silently dropping malformed DNS configuration would boot
+    /// a guest with no working resolver.
     pub fn for_snp(
         vm_hash: &str,
         tap: &TapAssignment,
@@ -104,6 +105,19 @@ impl DhcpConfig {
     ) -> Result<Self, DhcpError> {
         let prefix = cidr_prefix_len(&tap.ipv4.network_cidr, "IPv4")?;
         let ipv6_prefix_len = cidr_prefix_len(&tap.ipv6.network_cidr, "IPv6")?;
+        let mut ipv4_nameservers = Vec::new();
+        for server in nameservers {
+            match server.parse::<std::net::IpAddr>() {
+                Ok(std::net::IpAddr::V4(_)) => ipv4_nameservers.push(server.clone()),
+                Ok(std::net::IpAddr::V6(_)) => {}
+                Err(source) => {
+                    return Err(DhcpError::InvalidNameserver {
+                        nameserver: server.clone(),
+                        source,
+                    });
+                }
+            }
+        }
         Ok(Self {
             vm_hash: vm_hash.to_string(),
             device_name: tap.device_name.clone(),
@@ -112,7 +126,7 @@ impl DhcpConfig {
             netmask: netmask_for_prefix(prefix),
             guest_ipv6: tap.ipv6.address.clone(),
             ipv6_prefix_len,
-            nameservers: nameservers.to_vec(),
+            nameservers: ipv4_nameservers,
             lease: DEFAULT_LEASE.to_string(),
             lease_file: lease_file_path(lease_dir, vm_hash)
                 .to_string_lossy()
@@ -169,7 +183,8 @@ impl DhcpConfig {
             ),
             "--enable-ra".to_string(),
         ];
-        // Option 6: DNS servers, only when the daemon resolved some.
+        // `for_snp` mirrors conf.py's DNS_NAMESERVERS_IPV4 split so DHCPv4
+        // option 6 never receives an IPv6 address.
         if !self.nameservers.is_empty() {
             args.push(format!("--dhcp-option=6,{}", self.nameservers.join(",")));
         }
@@ -260,6 +275,12 @@ pub enum DhcpError {
         family: &'static str,
         cidr: String,
         source: ParseIntError,
+    },
+
+    #[error("DNS nameserver {nameserver:?} is not a valid IP address: {source}")]
+    InvalidNameserver {
+        nameserver: String,
+        source: std::net::AddrParseError,
     },
 
     #[error("cannot run {program}: {source}")]
@@ -571,6 +592,59 @@ mod tests {
         );
         // The gateway option is still handed out.
         assert!(args.contains(&"--dhcp-option=3,172.16.4.1".to_string()));
+    }
+
+    #[test]
+    fn dnsmasq_args_filter_ipv6_nameservers_from_option_6() {
+        let config = DhcpConfig::for_snp(
+            &"e".repeat(64),
+            &snp_tap(),
+            &[
+                "192.0.2.53".to_string(),
+                "2001:db8::53".to_string(),
+                "192.0.2.54".to_string(),
+                "2001:db8::54".to_string(),
+            ],
+            std::path::Path::new("/run/aleph/dhcp"),
+        )
+        .unwrap();
+        let args = config.dnsmasq_args();
+        let option_6 = args
+            .iter()
+            .filter(|arg| arg.starts_with("--dhcp-option=6"))
+            .collect::<Vec<_>>();
+        assert_eq!(option_6.len(), 1);
+        assert_eq!(option_6[0], "--dhcp-option=6,192.0.2.53,192.0.2.54");
+    }
+
+    #[test]
+    fn dnsmasq_args_omit_option_6_with_only_ipv6_nameservers() {
+        let config = DhcpConfig::for_snp(
+            &"e".repeat(64),
+            &snp_tap(),
+            &["2001:db8::53".to_string(), "2001:db8::54".to_string()],
+            std::path::Path::new("/run/aleph/dhcp"),
+        )
+        .unwrap();
+        let args = config.dnsmasq_args();
+        assert!(
+            !args.iter().any(|arg| arg.starts_with("--dhcp-option=6")),
+            "DHCPv4 option 6 must not contain IPv6 nameservers, got {args:?}"
+        );
+    }
+
+    #[test]
+    fn for_snp_rejects_a_malformed_nameserver() {
+        let result = DhcpConfig::for_snp(
+            &"e".repeat(64),
+            &snp_tap(),
+            &["192.0.2.53".to_string(), "1.1.1".to_string()],
+            std::path::Path::new("/run/aleph/dhcp"),
+        );
+        assert!(matches!(
+            result,
+            Err(DhcpError::InvalidNameserver { nameserver, .. }) if nameserver == "1.1.1"
+        ));
     }
 
     #[test]

--- a/rust/crates/supervisor-daemon/src/dhcp.rs
+++ b/rust/crates/supervisor-daemon/src/dhcp.rs
@@ -92,6 +92,9 @@ impl DhcpConfig {
     /// lease file lives under `lease_dir` (created by the backend), named by
     /// the VM hash.
     ///
+    /// Only IPv4 nameservers are forwarded in DHCPv4 option 6. Valid IPv6
+    /// nameservers are omitted; an IPv6-only list therefore emits no option 6.
+    ///
     /// Fails (fail-closed) if the tap's IPv4 network CIDR carries no parseable
     /// prefix length or if a nameserver is not a valid IP address: silently
     /// falling back to `/32` would hand the guest an unroutable single-host


### PR DESCRIPTION
An SNP launch currently passes every detected resolver to numeric DHCP option 6. A dual-stack list therefore produces an argument such as `--dhcp-option=6,192.0.2.53,2001:db8::53`, which dnsmasq rejects as a bad IP address and the scheduler subsequently restarts the VM.

Related GitHub issue: https://github.com/aleph-im/aleph-vm/issues/1187

## Self proofreading checklist

- [x] The new code is clear, easy to read and well commented.
- [x] New code uses the standard library's IP address parser.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] Changed behavior is documented at the `DhcpConfig` construction and argument-building seams.
- [x] All new behavior is covered by relevant unit tests.
- [x] Existing operator documentation remains accurate; no configuration key changed.
- [x] No dependency changed, so no Debian build-script update is required.

## Changes

`DhcpConfig::for_snp` now parses each configured resolver as an `IpAddr`, retains IPv4 resolvers for DHCPv4 option 6, and ignores valid IPv6 resolvers for that option. Malformed resolver values still fail configuration instead of being silently dropped, matching the Python setup behavior.

For example:

```text
before: --dhcp-option=6,192.0.2.53,2001:db8::53,192.0.2.54
after:  --dhcp-option=6,192.0.2.53,192.0.2.54
```

If the resolver list contains only IPv6 addresses, option 6 is omitted. The existing DHCPv6 single-address range and router advertisement configuration are unchanged, so IPv6 remains active for the guest.

## How to test

From the Rust workspace:

```shell
cargo test --locked -p supervisor-daemon dhcp
cargo fmt --check
```

The added tests cover a mixed IPv4/IPv6 list, an IPv6-only list, and a malformed resolver. Existing tests cover IPv4-only and empty lists.

Local `cargo fmt --check` and diff checks pass. The focused Cargo test could not run on the preparation Mac because its installed compiler is Rust 1.86 while the repository pins Rust 1.90; the dependency check stopped before compilation. The repository's Rust CI uses the pinned toolchain and will run the full locked test suite.

## Print screen / video

Not applicable.

## Notes

This PR intentionally does not add DHCPv6 DNS option 23. IPv6 address allocation and RA behavior remain unchanged, while the guest continues to receive reachable IPv4 DNS servers through DHCPv4 when they are available.
