### PR TITLE
fix(packaging): allow dnsmasq to create SNP DHCP lease files

### DIFF
--- a/.github/workflows/build-deb-package-and-integration-tests.yml
+++ b/.github/workflows/build-deb-package-and-integration-tests.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Initialize git submodules
         run: git submodule init
 
+      - name: Test dnsmasq AppArmor package integration
+        run: packaging/tests/test_dnsmasq_apparmor.sh
+
       # Runner image 20260726.254 ships podman 5.8.4 but leaves a stale crun 1.14.1
       # at /usr/bin/crun, breaking every podman run/build with "unknown version
       # specified". Point podman at the current crun in /usr/local/bin.
@@ -69,6 +72,8 @@ jobs:
           dpkg --contents packaging/target/${{ matrix.artifact_name }} | grep /opt/aleph-vm/bin/supervisor-launcher
           dpkg --contents packaging/target/${{ matrix.artifact_name }} | grep /opt/aleph-vm/bin/aleph-vm-controller
           dpkg --contents packaging/target/${{ matrix.artifact_name }} | grep /opt/aleph-vm/bin/controller-launcher
+          dpkg --contents packaging/target/${{ matrix.artifact_name }} | grep /usr/lib/aleph-vm/configure-dnsmasq-apparmor
+          dpkg --contents packaging/target/${{ matrix.artifact_name }} | grep /usr/share/aleph-vm/apparmor/usr.sbin.dnsmasq
 
       - uses: actions/upload-artifact@v4
         with:

--- a/packaging/aleph-vm/DEBIAN/postinst
+++ b/packaging/aleph-vm/DEBIAN/postinst
@@ -5,6 +5,11 @@ if ! id -u jailman > /dev/null 2>&1; then
   useradd jailman
 fi
 
+# The distro dnsmasq profile supports site-local additions. Keep our rule in a
+# package-owned fragment and add only its include to the administrator-owned
+# local file.
+/usr/lib/aleph-vm/configure-dnsmasq-apparmor install
+
 rm -fr /srv/jailer  # Upgrade from < 0.1.11
 rm -fr /tmp/aleph   # Upgrade from < 0.1.11
 mkdir -p /var/lib/aleph/vm/jailer

--- a/packaging/aleph-vm/DEBIAN/prerm
+++ b/packaging/aleph-vm/DEBIAN/prerm
@@ -6,3 +6,10 @@ for unit in aleph-vm-agent.service aleph-vm-supervisor.service; do
   systemctl stop "$unit" || true
   systemctl reset-failed "$unit" 2>/dev/null || true
 done
+
+# On removal, drop only aleph-vm's managed include after stopping its services
+# but while the package-owned policy fragment is still present. Keep it across
+# upgrades; postinst refreshes the include and reloads the new policy.
+if [ "${1:-}" = "remove" ] && [ -x /usr/lib/aleph-vm/configure-dnsmasq-apparmor ]; then
+  /usr/lib/aleph-vm/configure-dnsmasq-apparmor remove || true
+fi

--- a/packaging/aleph-vm/usr/lib/aleph-vm/configure-dnsmasq-apparmor
+++ b/packaging/aleph-vm/usr/lib/aleph-vm/configure-dnsmasq-apparmor
@@ -67,8 +67,8 @@ rewrite_local_file() {
     content_tmp="$(mktemp "$(dirname "$target")/.aleph-vm-dnsmasq-content.XXXXXX")"
     # Remove only lines owned by this helper. Any administrator additions,
     # including additions placed between our markers, remain intact.
-    awk -v begin="$BEGIN_MARKER" -v include="$INCLUDE_LINE" -v end="$END_MARKER" \
-      '$0 != begin && $0 != include && $0 != end { print }' \
+    awk -v begin="$BEGIN_MARKER" -v managed_include="$INCLUDE_LINE" -v end="$END_MARKER" \
+      '$0 != begin && $0 != managed_include && $0 != end { print }' \
       "$target" > "$content_tmp"
     cat "$content_tmp" > "$tmp"
     rm -f "$content_tmp"

--- a/packaging/aleph-vm/usr/lib/aleph-vm/configure-dnsmasq-apparmor
+++ b/packaging/aleph-vm/usr/lib/aleph-vm/configure-dnsmasq-apparmor
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -eu
+umask 022
+
+APPARMOR_DIR="${ALEPH_VM_APPARMOR_DIR:-/etc/apparmor.d}"
+POLICY_FILE="${ALEPH_VM_DNSMASQ_APPARMOR_POLICY:-/usr/share/aleph-vm/apparmor/usr.sbin.dnsmasq}"
+PROFILE="$APPARMOR_DIR/usr.sbin.dnsmasq"
+LOCAL="$APPARMOR_DIR/local/usr.sbin.dnsmasq"
+BEGIN_MARKER="# BEGIN aleph-vm managed dnsmasq AppArmor rules"
+INCLUDE_LINE="include if exists \"$POLICY_FILE\""
+END_MARKER="# END aleph-vm managed dnsmasq AppArmor rules"
+
+warn() {
+  echo "aleph-vm: $*" >&2
+}
+
+reload_profile() {
+  [ -f "$PROFILE" ] || return 0
+  command -v aa-enabled >/dev/null 2>&1 || return 0
+  command -v apparmor_parser >/dev/null 2>&1 || return 0
+  aa-enabled --quiet 2>/dev/null || return 0
+
+  if ! apparmor_parser -r -W -T "$PROFILE"; then
+    # Match dh_apparmor behavior: a transient or pre-existing parser failure
+    # must not leave the application package unconfigured.
+    warn "could not reload the dnsmasq AppArmor profile"
+  fi
+}
+
+profile_includes_local_file() {
+  grep -Eq \
+    '^[[:space:]]*(#include|include)([[:space:]]+if[[:space:]]+exists)?[[:space:]]+<local/usr\.sbin\.dnsmasq>[[:space:]]*$' \
+    "$PROFILE"
+}
+
+resolve_local_file() {
+  if [ -L "$LOCAL" ]; then
+    readlink -f "$LOCAL" 2>/dev/null || true
+  else
+    printf '%s\n' "$LOCAL"
+  fi
+}
+
+rewrite_local_file() {
+  action="$1"
+  target="$(resolve_local_file)"
+
+  if [ -z "$target" ]; then
+    warn "leaving dangling symlink untouched: $LOCAL"
+    return 0
+  fi
+  if [ -e "$target" ] && [ ! -f "$target" ]; then
+    warn "leaving non-regular local profile untouched: $LOCAL"
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$target")"
+  tmp="$(mktemp "$(dirname "$target")/.aleph-vm-dnsmasq.XXXXXX")"
+  content_tmp=""
+  trap 'rm -f "$tmp" ${content_tmp:+"$content_tmp"}' RETURN
+
+  if [ -f "$target" ]; then
+    # Package targets use GNU coreutils, where --preserve=all retains owner,
+    # mode, ACLs and extended attributes. The fallback keeps this fixture
+    # runnable on non-GNU development hosts.
+    cp --preserve=all -- "$target" "$tmp" 2>/dev/null || cp -p "$target" "$tmp"
+    content_tmp="$(mktemp "$(dirname "$target")/.aleph-vm-dnsmasq-content.XXXXXX")"
+    # Remove only lines owned by this helper. Any administrator additions,
+    # including additions placed between our markers, remain intact.
+    awk -v begin="$BEGIN_MARKER" -v include="$INCLUDE_LINE" -v end="$END_MARKER" \
+      '$0 != begin && $0 != include && $0 != end { print }' \
+      "$target" > "$content_tmp"
+    cat "$content_tmp" > "$tmp"
+    rm -f "$content_tmp"
+    content_tmp=""
+  else
+    : > "$tmp"
+    chmod 0644 "$tmp"
+  fi
+
+  if [ "$action" = install ]; then
+    if [ -s "$tmp" ] && [ -n "$(tail -n 1 "$tmp")" ]; then
+      printf '\n' >> "$tmp"
+    fi
+    printf '%s\n%s\n%s\n' \
+      "$BEGIN_MARKER" "$INCLUDE_LINE" "$END_MARKER" >> "$tmp"
+  fi
+
+  mv -f "$tmp" "$target"
+  trap - RETURN
+}
+
+case "${1:-}" in
+  install)
+    if [ ! -f "$POLICY_FILE" ]; then
+      warn "AppArmor policy fragment is missing: $POLICY_FILE"
+      exit 0
+    fi
+    if [ -f "$PROFILE" ] && ! profile_includes_local_file; then
+      warn "dnsmasq AppArmor profile does not include <local/usr.sbin.dnsmasq>; policy fragment was not enabled"
+      exit 0
+    fi
+    rewrite_local_file install
+    reload_profile
+    ;;
+  remove)
+    if [ -e "$LOCAL" ] || [ -L "$LOCAL" ]; then
+      rewrite_local_file remove
+      reload_profile
+    fi
+    ;;
+  *)
+    echo "Usage: $0 {install|remove}" >&2
+    exit 2
+    ;;
+esac

--- a/packaging/aleph-vm/usr/share/aleph-vm/apparmor/usr.sbin.dnsmasq
+++ b/packaging/aleph-vm/usr/share/aleph-vm/apparmor/usr.sbin.dnsmasq
@@ -1,0 +1,3 @@
+# The SNP supervisor starts one dnsmasq process per VM and keeps its DHCP
+# leases here. This file is included from dnsmasq's site-local profile.
+/var/lib/aleph/vm/dhcp/*.leases rw,

--- a/packaging/tests/test_dnsmasq_apparmor.sh
+++ b/packaging/tests/test_dnsmasq_apparmor.sh
@@ -12,6 +12,7 @@ POLICY="$TMP_ROOT/usr/share/aleph-vm/apparmor/usr.sbin.dnsmasq"
 LOCAL="$APPARMOR_DIR/local/usr.sbin.dnsmasq"
 PARSER_LOG="$TMP_ROOT/apparmor-parser.log"
 FAKE_BIN="$TMP_ROOT/bin"
+HOST_AWK="$(command -v awk)"
 
 mkdir -p "$(dirname "$POLICY")" "$APPARMOR_DIR/local" "$FAKE_BIN"
 cp "$POLICY_SOURCE" "$POLICY"
@@ -25,14 +26,43 @@ cat > "$FAKE_BIN/apparmor_parser" <<'EOF'
 printf '%s\n' "$*" >> "$PARSER_LOG"
 exit "${APPARMOR_PARSER_EXIT:-0}"
 EOF
-chmod +x "$FAKE_BIN/aa-enabled" "$FAKE_BIN/apparmor_parser"
+cat > "$FAKE_BIN/awk" <<'EOF'
+#!/bin/sh
+# Match gawk's rejection of `include` as a -v variable name so this fixture
+# also catches the packaging failure on hosts where gawk provides /usr/bin/awk.
+for argument do
+  case "$argument" in
+    include=*) exit 2 ;;
+  esac
+done
+exec "$HOST_AWK" "$@"
+EOF
+chmod +x "$FAKE_BIN/aa-enabled" "$FAKE_BIN/apparmor_parser" "$FAKE_BIN/awk"
 
 run_helper() {
-  PATH="$FAKE_BIN:$PATH" \
-  ALEPH_VM_APPARMOR_DIR="$APPARMOR_DIR" \
-  ALEPH_VM_DNSMASQ_APPARMOR_POLICY="$POLICY" \
-  PARSER_LOG="$PARSER_LOG" \
+  local aa_enabled_exit="$1"
+  local apparmor_parser_exit="$2"
+  shift 2
+
+  env \
+    PATH="$FAKE_BIN:$PATH" \
+    ALEPH_VM_APPARMOR_DIR="$APPARMOR_DIR" \
+    ALEPH_VM_DNSMASQ_APPARMOR_POLICY="$POLICY" \
+    PARSER_LOG="$PARSER_LOG" \
+    HOST_AWK="$HOST_AWK" \
+    AA_ENABLED_EXIT="$aa_enabled_exit" \
+    APPARMOR_PARSER_EXIT="$apparmor_parser_exit" \
     "$HELPER" "$@"
+}
+
+file_mode() {
+  local mode
+
+  if mode="$(stat -c '%a' "$1" 2>/dev/null)"; then
+    printf '%s\n' "$mode"
+  else
+    stat -f '%Lp' "$1"
+  fi
 }
 
 assert_count() {
@@ -57,20 +87,20 @@ cat > "$APPARMOR_DIR/usr.sbin.dnsmasq" <<'EOF'
 }
 EOF
 
-run_helper install
+run_helper 0 0 install
 cp "$LOCAL" "$TMP_ROOT/local-after-first-install"
-run_helper install
+run_helper 0 0 install
 cmp "$LOCAL" "$TMP_ROOT/local-after-first-install"
 
 grep -Fqx '/srv/operator/dnsmasq/** r,' "$LOCAL"
-[ "$(stat -f '%Lp' "$LOCAL" 2>/dev/null || stat -c '%a' "$LOCAL")" = 640 ]
+[ "$(file_mode "$LOCAL")" = 640 ]
 assert_count 1 '# BEGIN aleph-vm managed dnsmasq AppArmor rules' "$LOCAL"
 assert_count 1 "include if exists \"$POLICY\"" "$LOCAL"
 assert_count 1 '# END aleph-vm managed dnsmasq AppArmor rules' "$LOCAL"
 [ "$(wc -l < "$PARSER_LOG" | tr -d ' ')" = 2 ]
 grep -Fqx -- "-r -W -T $APPARMOR_DIR/usr.sbin.dnsmasq" "$PARSER_LOG"
 
-run_helper remove
+run_helper 0 0 remove
 grep -Fqx '/srv/operator/dnsmasq/** r,' "$LOCAL"
 if grep -Fq 'aleph-vm managed' "$LOCAL" || grep -Fq "$POLICY" "$LOCAL"; then
   echo "managed AppArmor lines remain after removal" >&2
@@ -87,7 +117,7 @@ cat > "$APPARMOR_DIR/usr.sbin.dnsmasq" <<'EOF'
 EOF
 rm -f "$PARSER_LOG"
 missing_hook_stderr="$TMP_ROOT/missing-hook.stderr"
-run_helper install 2> "$missing_hook_stderr"
+run_helper 0 0 install 2> "$missing_hook_stderr"
 cmp "$LOCAL" "$TMP_ROOT/local-before-missing-hook"
 [ ! -e "$PARSER_LOG" ]
 grep -Fq 'does not include <local/usr.sbin.dnsmasq>' "$missing_hook_stderr"
@@ -95,7 +125,7 @@ grep -Fq 'does not include <local/usr.sbin.dnsmasq>' "$missing_hook_stderr"
 # Installing without a distro profile prepares the local include for a future
 # AppArmor installation but does not attempt a reload.
 rm -f "$APPARMOR_DIR/usr.sbin.dnsmasq" "$PARSER_LOG"
-run_helper install
+run_helper 0 0 install
 assert_count 1 "include if exists \"$POLICY\"" "$LOCAL"
 [ ! -e "$PARSER_LOG" ]
 
@@ -105,11 +135,11 @@ cat > "$APPARMOR_DIR/usr.sbin.dnsmasq" <<'EOF'
   #include if exists <local/usr.sbin.dnsmasq>
 }
 EOF
-AA_ENABLED_EXIT=1 run_helper install
+run_helper 1 0 install
 [ ! -e "$PARSER_LOG" ]
 
 # A parser failure is reported but follows dh_apparmor's nonfatal behavior.
-APPARMOR_PARSER_EXIT=1 run_helper install 2> "$TMP_ROOT/parser-warning"
+run_helper 0 1 install 2> "$TMP_ROOT/parser-warning"
 grep -Fq 'could not reload the dnsmasq AppArmor profile' "$TMP_ROOT/parser-warning"
 
 grep -Fqx '/var/lib/aleph/vm/dhcp/*.leases rw,' "$POLICY_SOURCE"

--- a/packaging/tests/test_dnsmasq_apparmor.sh
+++ b/packaging/tests/test_dnsmasq_apparmor.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HELPER="$REPO_ROOT/packaging/aleph-vm/usr/lib/aleph-vm/configure-dnsmasq-apparmor"
+POLICY_SOURCE="$REPO_ROOT/packaging/aleph-vm/usr/share/aleph-vm/apparmor/usr.sbin.dnsmasq"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+APPARMOR_DIR="$TMP_ROOT/etc/apparmor.d"
+POLICY="$TMP_ROOT/usr/share/aleph-vm/apparmor/usr.sbin.dnsmasq"
+LOCAL="$APPARMOR_DIR/local/usr.sbin.dnsmasq"
+PARSER_LOG="$TMP_ROOT/apparmor-parser.log"
+FAKE_BIN="$TMP_ROOT/bin"
+
+mkdir -p "$(dirname "$POLICY")" "$APPARMOR_DIR/local" "$FAKE_BIN"
+cp "$POLICY_SOURCE" "$POLICY"
+
+cat > "$FAKE_BIN/aa-enabled" <<'EOF'
+#!/bin/sh
+exit "${AA_ENABLED_EXIT:-0}"
+EOF
+cat > "$FAKE_BIN/apparmor_parser" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$PARSER_LOG"
+exit "${APPARMOR_PARSER_EXIT:-0}"
+EOF
+chmod +x "$FAKE_BIN/aa-enabled" "$FAKE_BIN/apparmor_parser"
+
+run_helper() {
+  PATH="$FAKE_BIN:$PATH" \
+  ALEPH_VM_APPARMOR_DIR="$APPARMOR_DIR" \
+  ALEPH_VM_DNSMASQ_APPARMOR_POLICY="$POLICY" \
+  PARSER_LOG="$PARSER_LOG" \
+    "$HELPER" "$@"
+}
+
+assert_count() {
+  expected="$1"
+  pattern="$2"
+  file="$3"
+  actual="$(grep -Fxc "$pattern" "$file" || true)"
+  [ "$actual" = "$expected" ] || {
+    echo "expected $expected copies of '$pattern' in $file, got $actual" >&2
+    exit 1
+  }
+}
+
+cat > "$LOCAL" <<'EOF'
+# Administrator-owned dnsmasq additions
+/srv/operator/dnsmasq/** r,
+EOF
+chmod 0640 "$LOCAL"
+cat > "$APPARMOR_DIR/usr.sbin.dnsmasq" <<'EOF'
+/usr/sbin/dnsmasq {
+  include if exists <local/usr.sbin.dnsmasq>
+}
+EOF
+
+run_helper install
+cp "$LOCAL" "$TMP_ROOT/local-after-first-install"
+run_helper install
+cmp "$LOCAL" "$TMP_ROOT/local-after-first-install"
+
+grep -Fqx '/srv/operator/dnsmasq/** r,' "$LOCAL"
+[ "$(stat -f '%Lp' "$LOCAL" 2>/dev/null || stat -c '%a' "$LOCAL")" = 640 ]
+assert_count 1 '# BEGIN aleph-vm managed dnsmasq AppArmor rules' "$LOCAL"
+assert_count 1 "include if exists \"$POLICY\"" "$LOCAL"
+assert_count 1 '# END aleph-vm managed dnsmasq AppArmor rules' "$LOCAL"
+[ "$(wc -l < "$PARSER_LOG" | tr -d ' ')" = 2 ]
+grep -Fqx -- "-r -W -T $APPARMOR_DIR/usr.sbin.dnsmasq" "$PARSER_LOG"
+
+run_helper remove
+grep -Fqx '/srv/operator/dnsmasq/** r,' "$LOCAL"
+if grep -Fq 'aleph-vm managed' "$LOCAL" || grep -Fq "$POLICY" "$LOCAL"; then
+  echo "managed AppArmor lines remain after removal" >&2
+  exit 1
+fi
+[ "$(wc -l < "$PARSER_LOG" | tr -d ' ')" = 3 ]
+
+# A custom distro profile without the local hook cannot activate our fragment.
+# Leave the administrator file untouched, skip reload and emit a clear warning.
+cp "$LOCAL" "$TMP_ROOT/local-before-missing-hook"
+cat > "$APPARMOR_DIR/usr.sbin.dnsmasq" <<'EOF'
+/usr/sbin/dnsmasq {
+}
+EOF
+rm -f "$PARSER_LOG"
+missing_hook_stderr="$TMP_ROOT/missing-hook.stderr"
+run_helper install 2> "$missing_hook_stderr"
+cmp "$LOCAL" "$TMP_ROOT/local-before-missing-hook"
+[ ! -e "$PARSER_LOG" ]
+grep -Fq 'does not include <local/usr.sbin.dnsmasq>' "$missing_hook_stderr"
+
+# Installing without a distro profile prepares the local include for a future
+# AppArmor installation but does not attempt a reload.
+rm -f "$APPARMOR_DIR/usr.sbin.dnsmasq" "$PARSER_LOG"
+run_helper install
+assert_count 1 "include if exists \"$POLICY\"" "$LOCAL"
+[ ! -e "$PARSER_LOG" ]
+
+# Disabled AppArmor also leaves the package install successful and skips reload.
+cat > "$APPARMOR_DIR/usr.sbin.dnsmasq" <<'EOF'
+/usr/sbin/dnsmasq {
+  #include if exists <local/usr.sbin.dnsmasq>
+}
+EOF
+AA_ENABLED_EXIT=1 run_helper install
+[ ! -e "$PARSER_LOG" ]
+
+# A parser failure is reported but follows dh_apparmor's nonfatal behavior.
+APPARMOR_PARSER_EXIT=1 run_helper install 2> "$TMP_ROOT/parser-warning"
+grep -Fq 'could not reload the dnsmasq AppArmor profile' "$TMP_ROOT/parser-warning"
+
+grep -Fqx '/var/lib/aleph/vm/dhcp/*.leases rw,' "$POLICY_SOURCE"
+
+echo "dnsmasq AppArmor packaging tests passed"


### PR DESCRIPTION
The SNP supervisor starts one dnsmasq process per tap and stores its lease database at `/var/lib/aleph/vm/dhcp/<vm-id>.leases`. On Ubuntu with the distro dnsmasq AppArmor profile enforced, creation of that file is denied, dnsmasq exits, and the SNP execution is restarted.

Related GitHub issue: https://github.com/aleph-im/aleph-vm/issues/1187

## Self proofreading checklist

- [x] The new code is clear, easy to read and well commented.
- [x] New code uses standard shell and AppArmor mechanisms.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New helper functions have focused names and comments where behavior is non-obvious.
- [x] Package lifecycle behavior is covered by a fixture test.
- [x] The package-owned policy fragment documents the permission and its purpose.
- [x] No dependency changed, so no Debian build-script update is required.

## Changes

The Debian package now ships a narrow AppArmor fragment containing:

```text
/var/lib/aleph/vm/dhcp/*.leases rw,
```

`postinst` adds one marked absolute include for that package-owned fragment to the distro-supported `local/usr.sbin.dnsmasq` file and conditionally reloads the dnsmasq profile. The helper preserves administrator content and file metadata, is idempotent across upgrades, accepts both modern `include` and legacy `#include` local hooks, and warns without modifying the local file if a custom base profile does not provide the hook.

On package removal, `prerm` removes only aleph-vm's managed lines after its services stop and reloads the profile while the package fragment still exists. Upgrades retain the include for `postinst` to refresh.

The package CI now runs a shell fixture covering install, repeat install, removal, a missing base-profile hook, absent or disabled AppArmor, parser failure, operator-rule preservation, and file-mode preservation. It also asserts that both new files are present in every supported `.deb` variant.

## How to test

Run the focused package test on any development host:

```shell
packaging/tests/test_dnsmasq_apparmor.sh
```

On an Ubuntu package test host, build and install the `.deb`, then verify the real profile and an SNP launch:

```shell
sudo apparmor_parser -r -W -T /etc/apparmor.d/usr.sbin.dnsmasq
sudo journalctl -k --since '10 minutes ago' | grep -iE 'apparmor.*dnsmasq.*DENIED' || true
```

The focused Bash syntax, fixture, staged-diff, and file-mode checks pass locally. A full `.deb` build was not run on the preparation Mac because Podman and `dpkg-deb` are unavailable there; the existing package matrix will build and inspect Debian 12/13 and Ubuntu 22.04/24.04/26.04 packages.

## Print screen / video

Not applicable.

## Notes

The change does not replace the distro dnsmasq profile and does not claim ownership of the administrator's local profile. If package removal scripts are forcibly skipped, the remaining include is harmless after the package-owned fragment disappears because it uses `include if exists`.
