### PR TITLE
feat(agent): the v2 allocation endpoints, answering now and converging later

### DIFF
--- a/src/aleph/vm/agent/allocation/plan.py
+++ b/src/aleph/vm/agent/allocation/plan.py
@@ -46,6 +46,11 @@ class AllocationState(str, Enum):
     Deliberately NOT a mirror of VmStatus: once create_vm returns, VmStatus is
     the answer and this state stops existing. Two disjoint fields cannot drift,
     whereas a merged enum would need maintaining in lockstep forever.
+
+    The reconciler sets DOWNLOADING and FAILED, the only two it can observe.
+    The rest are the executions list's to report from the plan: PLANNED for
+    an entry the loop has not reached, RESOLVING for one still waiting on its
+    message, SUBMITTING for one handed to the supervisor.
     """
 
     PLANNED = "planned"

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -230,6 +230,12 @@ class AllocationReconciler:
         self._states.pop(vm_hash, None)
 
     def _record_failure(self, vm_hash: ItemHash, error: Exception) -> None:
+        # There is no terminal failure, on purpose. The plan is the authority
+        # on what should run here, so a VM it still lists is still owed an
+        # attempt, at the capped interval; giving up would leave a listed VM
+        # not running with nothing outside this node able to tell. The
+        # scheduler dropping the hash is what ends the retries, and submit()
+        # clears the record then.
         now = self._now()
         previous = self._failures.get(vm_hash)
         attempts = (previous.attempts if previous else 0) + 1

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -27,6 +27,7 @@ from aleph.vm.agent.capacity import (
     requirements_from_message,
 )
 from aleph.vm.agent.vm_registry import AgentVmRecord
+from aleph.vm.resources import GpuDevice
 from aleph.vm.supervisor_interface.types import ConfidentialMode, VmInfo, VmStatus
 
 logger = logging.getLogger(__name__)
@@ -46,6 +47,7 @@ class _Capacity(Protocol):
         candidates: list[tuple[ItemHash, ResourceRequirements]],
         *,
         releasing: frozenset[ItemHash] = ...,
+        available_gpus: list[GpuDevice] | None = ...,
     ) -> list[AdmissionVerdict]: ...
 
 
@@ -149,15 +151,15 @@ def compute_verdict(
     registry: _Registry,
     capacity: _Capacity,
     node_hash: str | None = None,
+    available_gpus: list[GpuDevice] | None = None,
 ) -> PlanVerdict:
     """The immediate answer: what we take, what we drop, what we refuse.
 
-    No GPU inventory reaches simulate from here, so a candidate asking for a
-    card is refused rather than admitted on memory alone. Reading the host's
-    cards is an async call on the supervisor and this stays await-free, for
-    the reason at the top of the module, so that read belongs to the handler
-    that will make this answer authoritative and has yet to be written. Until
-    it is, no plan can place a GPU VM.
+    ``available_gpus`` is the host's unattached cards. Reading them is an
+    async call on the supervisor and this stays await-free, for the reason at
+    the top of the module, so the handler reads them first and hands them in.
+    Without them simulate refuses every candidate that asks for a card, which
+    is the right answer to give when the cards were not looked at.
     """
     verdict = PlanVerdict()
     known = by_hash(infos)
@@ -216,10 +218,26 @@ def compute_verdict(
             continue
         candidates.append((vm_hash, requirements_from_message(content)))
 
-    for admission in capacity.simulate(candidates, releasing=frozenset(verdict.removing)):
+    admissions = capacity.simulate(candidates, releasing=frozenset(verdict.removing), available_gpus=available_gpus)
+    for admission in admissions:
         if admission.accepted:
             verdict.accepted.append(admission.vm_hash)
         else:
             verdict.rejected[admission.vm_hash] = {"code": admission.code, "message": admission.detail}
 
     return verdict
+
+
+def narrow_plan(plan: AllocationPlan, verdict: PlanVerdict) -> AllocationPlan:
+    """The plan the reconciler is handed: the push, less what the answer refused.
+
+    A refused entry must never reach the loop. Left in, it would be retried
+    forever at backoff rate, and started the moment room appeared, on a node
+    the scheduler was told had refused it and has since placed it elsewhere
+    from. Pending entries stay: nothing judged them, and the fetch that will
+    is the loop's own. The identity stays too, since it names the push, and a
+    re-push of the same set is the same plan whatever the host had room for
+    the first time.
+    """
+    entries = {vm_hash: planned for vm_hash, planned in plan.entries.items() if vm_hash not in verdict.rejected}
+    return AllocationPlan(plan_id=plan.plan_id, received_at=plan.received_at, entries=entries)

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -539,7 +539,11 @@ class CapacityManager:
 
         ``gpus`` is None rather than empty when no inventory was given:
         unknown is not zero, and the caller that has the inventory is the one
-        that read it from the supervisor.
+        that read it from the supervisor. It lists the cards free of any live
+        hold, the node-wide view: there is no owner to ask for here, so a card
+        one user holds is absent even though simulate would let that user's
+        own candidate take it. The per-candidate answer is the one to trust
+        for a given VM; this figure is what anyone else could count on.
         """
         caps = self._caps()
         committed_instance, committed_program, committed_vcpus = self._committed_resources(())

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -58,6 +58,9 @@ class ResourceRequirements:
     # though it is not an InstanceContent.
     is_instance: bool = False
     gpu_device_ids: list[str] = field(default_factory=list)
+    # Whose VM this is, for the GPU ledger: a hold this address took is
+    # available to it, the way resolve_gpus consumes an owner's own hold.
+    owner: str | None = None
 
 
 # The filename suffixes a volume's file carries in ``{pool}/{vm_hash}/``. A
@@ -198,6 +201,7 @@ def requirements_from_message(
         max_volume_mib=max(volume_sizes_mib, default=0),
         is_instance=is_instance_bucket(content),
         gpu_device_ids=requested_gpu_ids(content),
+        owner=str(address) if (address := getattr(content, "address", None)) else None,
     )
 
 
@@ -275,6 +279,37 @@ def requested_gpu_ids(content: ExecutableContent) -> list[str]:
     """The vendor:device ids of the GPUs a message requests."""
     requested = content.requirements.gpu if content.requirements and content.requirements.gpu else []
     return [gpu.device_id for gpu in requested]
+
+
+@dataclass(frozen=True)
+class HostCaps:
+    """The ceilings admission judges against, read from the host once per call.
+
+    Instances share physical memory less the host and program reservations,
+    programs share the program reservation. vCPU time is safe to oversubscribe
+    because the kernel time-slices it, so that cap is the core count times
+    VCPU_OVERCOMMIT_FACTOR (4 vCPUs per core at 4.0).
+    """
+
+    physical_memory_mib: int
+    physical_cores: int
+    instance_memory_mib: int
+    program_memory_mib: int
+    vcpus: int
+
+    @classmethod
+    def read(cls) -> HostCaps:
+        physical_memory_mib = psutil.virtual_memory().total // (1024 * 1024)
+        physical_cores = psutil.cpu_count() or 1
+        host_reserved_mib = settings.HOST_MEMORY_RESERVED_MIB
+        program_reserved_mib = settings.PROGRAM_MEMORY_RESERVED_MIB
+        return cls(
+            physical_memory_mib=physical_memory_mib,
+            physical_cores=physical_cores,
+            instance_memory_mib=max(physical_memory_mib - host_reserved_mib - program_reserved_mib, 0),
+            program_memory_mib=program_reserved_mib,
+            vcpus=int(physical_cores * settings.VCPU_OVERCOMMIT_FACTOR),
+        )
 
 
 @dataclass
@@ -421,19 +456,14 @@ class CapacityManager:
         required_vcpus = vcpus
         required_disk_mib = disk_mib
 
-        physical_memory_mib = psutil.virtual_memory().total // (1024 * 1024)
-        physical_cores = psutil.cpu_count() or 1
+        caps = self._caps()
+        physical_memory_mib = caps.physical_memory_mib
+        physical_cores = caps.physical_cores
         host_reserved_mib = settings.HOST_MEMORY_RESERVED_MIB
         program_reserved_mib = settings.PROGRAM_MEMORY_RESERVED_MIB
-
-        instance_memory_cap_mib = max(physical_memory_mib - host_reserved_mib - program_reserved_mib, 0)
-        program_memory_cap_mib = program_reserved_mib
-
-        # vCPU overcommit: CPU time is safe to oversubscribe because the
-        # kernel scheduler time-slices it, so the cap is the physical core
-        # count multiplied by the configured factor (e.g. 4 vCPUs per core
-        # with VCPU_OVERCOMMIT_FACTOR=4.0).
-        vcpu_cap = int(physical_cores * settings.VCPU_OVERCOMMIT_FACTOR)
+        instance_memory_cap_mib = caps.instance_memory_mib
+        program_memory_cap_mib = caps.program_memory_mib
+        vcpu_cap = caps.vcpus
 
         if is_instance:
             bucket_name = "instance"
@@ -494,6 +524,33 @@ class CapacityManager:
                 },
             )
 
+    def _caps(self) -> HostCaps:
+        return HostCaps.read()
+
+    def headroom(self, available_gpus: list[GpuDevice] | None = None) -> dict:
+        """What a plan could still be admitted against, for the scheduler.
+
+        The caps less what the registry commits, the live free disk, and the
+        cards not under a live hold: the same figures ``check_capacity``
+        judges a request by, so advertising them cannot promise what a
+        create would then refuse. Floored at zero, since a registry holding
+        more than the caps (a phantom record, a shrunk host) means nothing is
+        left, not that the node owes memory.
+
+        ``gpus`` is None rather than empty when no inventory was given:
+        unknown is not zero, and the caller that has the inventory is the one
+        that read it from the supervisor.
+        """
+        caps = self._caps()
+        committed_instance, committed_program, committed_vcpus = self._committed_resources(())
+        return {
+            "instance_memory_mib": max(caps.instance_memory_mib - committed_instance, 0),
+            "program_memory_mib": max(caps.program_memory_mib - committed_program, 0),
+            "vcpus": max(caps.vcpus - committed_vcpus, 0),
+            "disk_mib": self._available_disk_bytes() // (1024 * 1024),
+            "gpus": None if available_gpus is None else [gpu.device_id for gpu in self._unheld_gpus(available_gpus)],
+        }
+
     def simulate(
         self,
         candidates: list[tuple[ItemHash, ResourceRequirements]],
@@ -531,7 +588,9 @@ class CapacityManager:
         and this call is not. Matching is cumulative like the rest: two
         candidates wanting the only card of a kind get one yes. A card under a
         live hold counts as taken, since the hold is some user's pending
-        create.
+        create, unless the hold is the candidate's own user's: that is the
+        reserve-then-allocate flow, and the create will consume the hold the
+        way resolve_gpus does.
 
         Without ``available_gpus`` there is no inventory to judge against, so a
         candidate that asks for a card is refused rather than admitted on
@@ -564,7 +623,7 @@ class CapacityManager:
         committed_program = max(committed_program, 0)
         committed_vcpus = max(committed_vcpus, 0)
 
-        gpu_pool = None if available_gpus is None else self._unheld_gpus(available_gpus)
+        gpu_pool = None if available_gpus is None else list(available_gpus)
 
         verdicts: list[AdmissionVerdict] = []
         committed_disk = 0
@@ -589,7 +648,7 @@ class CapacityManager:
                 # Last, and only once the candidate has cleared everything
                 # else: taking cards is what makes the pool cumulative, so a
                 # candidate refused on memory must not walk off with them.
-                gpu_refusal = self._take_gpus(requirements.gpu_device_ids, gpu_pool)
+                gpu_refusal = self._take_gpus(requirements.gpu_device_ids, gpu_pool, owner=requirements.owner)
                 if gpu_refusal is not None:
                     logger.info("Plan candidate %s refused: %s", vm_hash, gpu_refusal)
                     refusal = ("gpu_unavailable", "no available GPU matches this request")
@@ -637,13 +696,17 @@ class CapacityManager:
         """
         return [gpu for gpu in available_gpus if (hold := self.holds.get(gpu.pci_host)) is None or hold.is_expired()]
 
-    @staticmethod
-    def _take_gpus(device_ids: list[str], pool: list[GpuDevice] | None) -> str | None:
+    def _take_gpus(self, device_ids: list[str], pool: list[GpuDevice] | None, *, owner: str | None) -> str | None:
         """Consume one card per requested id from ``pool``. None if it fits.
 
         All or nothing, like reserve_gpus: a candidate that cannot get every
         card it asked for takes none, so it does not strand cards a later
         candidate could have used.
+
+        A card under another user's live hold is skipped, one under
+        ``owner``'s own hold is not, mirroring ``_match_requests``. Read-only
+        on the ledger: expired holds are read as free and left in place,
+        because simulate mutates nothing.
         """
         if not device_ids:
             return None
@@ -652,9 +715,13 @@ class CapacityManager:
         taken: list[GpuDevice] = []
         for device_id in device_ids:
             for gpu in pool:
-                if gpu.device_id == device_id and gpu not in taken:
-                    taken.append(gpu)
-                    break
+                if gpu.device_id != device_id or gpu in taken:
+                    continue
+                hold = self.holds.get(gpu.pci_host)
+                if hold is not None and not hold.is_expired() and hold.user != owner:
+                    continue
+                taken.append(gpu)
+                break
             else:
                 return f"No available GPU matching device_id {device_id!r}"
         for gpu in taken:
@@ -742,8 +809,13 @@ class CapacityManager:
         """
         return max(storage_pools.pools_disk_usage()[1], 0) + reclaimable_bytes()
 
-    async def _available_gpus(self) -> list[GpuDevice]:
-        """Host cards not attached to any VM, per the supervisor's HostInfo."""
+    async def available_gpus(self) -> list[GpuDevice]:
+        """Host cards not attached to any VM, per the supervisor's HostInfo.
+
+        Public because simulate and headroom take the inventory as an
+        argument: both are synchronous, and this read is not, so the handler
+        that calls them reads it first.
+        """
         host_info = await self.supervisor.get_host_info()
         return [GpuDevice.model_validate(gpu) for gpu in host_info.available_gpus]
 
@@ -766,7 +838,7 @@ class CapacityManager:
         if not requested_device_ids:
             return expiration_date
         async with self._lock:
-            available_gpus = await self._available_gpus()
+            available_gpus = await self.available_gpus()
             resolved = self._match_requests(available_gpus, requested_device_ids, user, consume_own_hold=False)
             for gpu in resolved:
                 self.holds[gpu.pci_host] = GpuHold(user=user, expiration=expiration_date)
@@ -787,7 +859,7 @@ class CapacityManager:
         if not requested_device_ids:
             return []
         async with self._lock:
-            available_gpus = await self._available_gpus()
+            available_gpus = await self.available_gpus()
             resolved = self._match_requests(available_gpus, requested_device_ids, owner, consume_own_hold=True)
         return [
             GpuSpec(

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -293,6 +293,8 @@ class HostCaps:
 
     physical_memory_mib: int
     physical_cores: int
+    host_reserved_mib: int
+    program_reserved_mib: int
     instance_memory_mib: int
     program_memory_mib: int
     vcpus: int
@@ -306,6 +308,8 @@ class HostCaps:
         return cls(
             physical_memory_mib=physical_memory_mib,
             physical_cores=physical_cores,
+            host_reserved_mib=host_reserved_mib,
+            program_reserved_mib=program_reserved_mib,
             instance_memory_mib=max(physical_memory_mib - host_reserved_mib - program_reserved_mib, 0),
             program_memory_mib=program_reserved_mib,
             vcpus=int(physical_cores * settings.VCPU_OVERCOMMIT_FACTOR),
@@ -459,8 +463,8 @@ class CapacityManager:
         caps = self._caps()
         physical_memory_mib = caps.physical_memory_mib
         physical_cores = caps.physical_cores
-        host_reserved_mib = settings.HOST_MEMORY_RESERVED_MIB
-        program_reserved_mib = settings.PROGRAM_MEMORY_RESERVED_MIB
+        host_reserved_mib = caps.host_reserved_mib
+        program_reserved_mib = caps.program_reserved_mib
         instance_memory_cap_mib = caps.instance_memory_mib
         program_memory_cap_mib = caps.program_memory_mib
         vcpu_cap = caps.vcpus

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -498,21 +498,27 @@ async def create_vm_execution(
         # create guard: it adopts any retained volumes for this hash and keeps
         # the storage reconciler off a VM that is still being built.
         with creating(str(vm_hash)):
-            capacity.check_message(content, exclude_vm_hash=vm_hash)
             # Snapshot before any allocation: a persistent program's volumes may
             # already exist (host persistence), and a failed create must not
             # wipe them (see _retire_after_create_failure).
             had_volumes = await asyncio.to_thread(vm_has_volumes, vm_hash)
-            spec, _resources = await build_program_create_vm_spec(vm_hash, content)
-            info = await supervisor.create_vm(spec)
+            # Recorded before admission, like the instance path. The record is
+            # what a concurrent create's admission counts, so recording after
+            # create_vm returned let two programs that only fit once both pass
+            # against a sum that saw neither; the record's own hash is left
+            # out of its own check.
             record = registry.record(
                 vm_hash, message=content, original=original_message.content, persistent=bool(content.on.persistent)
             )
             try:
+                capacity.check_message(content, exclude_vm_hash=vm_hash)
+                spec, _resources = await build_program_create_vm_spec(vm_hash, content)
+                info = await supervisor.create_vm(spec)
                 await _wait_until_running(supervisor, info.vm_id)
             except Exception:
-                # Readiness failed: retire the half-started VM, but never let a
-                # teardown error mask the original failure.
+                # Admission, build, create or readiness failed: retire the
+                # record and whatever was started, but never let a teardown
+                # error mask the original failure.
                 await _retire_after_create_failure(
                     vm_hash, supervisor=supervisor, registry=registry, had_volumes=had_volumes, what="program VM"
                 )

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -78,6 +78,8 @@ from .views import (
     status_public_config,
     update_allocations,
 )
+from .views.allocation_auth import MAX_SIGNED_PLAN_BODY_BYTES
+from .views.allocations_v2 import capacity_check, update_allocations_v2
 from .views.migration import (
     migration_cleanup,
     migration_disk_download,
@@ -272,7 +274,11 @@ def setup_webapp(supervisor: Supervisor):
     recreation, GPU reservation, persistent programs) goes through the
     `Supervisor` interface.
     """
-    app = web.Application(middlewares=[drain_middleware, error_middleware])
+    # The ceiling on a buffered body. Each signed route enforces its own cap
+    # below it (allocation_auth), and the largest of those is a plan body,
+    # so this has to admit one: aiohttp's 1 MiB default cut a plan off inside
+    # the verifier, which reported it as a bad signature.
+    app = web.Application(middlewares=[drain_middleware, error_middleware], client_max_size=MAX_SIGNED_PLAN_BODY_BYTES)
     app.on_response_prepare.append(on_prepare_server_version)
     # Agent-owned drain flag: drain_middleware rejects new VM requests when set;
     # flipped by drain_in_flight_requests.
@@ -412,6 +418,8 @@ def setup_webapp(supervisor: Supervisor):
     other_routes = [
         # /control APIs are used to control the VMs and access their logs
         web.post("/control/allocations", update_allocations),
+        web.post("/v2/control/allocations", update_allocations_v2),
+        web.post("/v2/control/capacity/check", capacity_check),
         web.post("/control/network/recreate", recreate_network),
         web.post("/control/proxy/regenerate", regenerate_proxy),
         # Migration endpoints (scheduler-only, uses Aleph-EIP191-V1 auth)

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -78,7 +78,6 @@ from .views import (
     status_public_config,
     update_allocations,
 )
-from .views.allocation_auth import MAX_SIGNED_PLAN_BODY_BYTES
 from .views.allocations_v2 import capacity_check, update_allocations_v2
 from .views.migration import (
     migration_cleanup,
@@ -274,13 +273,7 @@ def setup_webapp(supervisor: Supervisor):
     recreation, GPU reservation, persistent programs) goes through the
     `Supervisor` interface.
     """
-    # The ceiling on any buffered body, signed or not. It has to admit a plan
-    # body, the largest thing a signed route takes: aiohttp's 1 MiB default
-    # cut a plan off inside the verifier, which reported it as a bad
-    # signature. The signed routes each enforce their own, smaller cap below
-    # it (allocation_auth); the operator routes, which authenticate by JWK,
-    # go from a 1 MiB ceiling to this one, which the control plane can bear.
-    app = web.Application(middlewares=[drain_middleware, error_middleware], client_max_size=MAX_SIGNED_PLAN_BODY_BYTES)
+    app = web.Application(middlewares=[drain_middleware, error_middleware])
     app.on_response_prepare.append(on_prepare_server_version)
     # Agent-owned drain flag: drain_middleware rejects new VM requests when set;
     # flipped by drain_in_flight_requests.

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -274,10 +274,12 @@ def setup_webapp(supervisor: Supervisor):
     recreation, GPU reservation, persistent programs) goes through the
     `Supervisor` interface.
     """
-    # The ceiling on a buffered body. Each signed route enforces its own cap
-    # below it (allocation_auth), and the largest of those is a plan body,
-    # so this has to admit one: aiohttp's 1 MiB default cut a plan off inside
-    # the verifier, which reported it as a bad signature.
+    # The ceiling on any buffered body, signed or not. It has to admit a plan
+    # body, the largest thing a signed route takes: aiohttp's 1 MiB default
+    # cut a plan off inside the verifier, which reported it as a bad
+    # signature. The signed routes each enforce their own, smaller cap below
+    # it (allocation_auth); the operator routes, which authenticate by JWK,
+    # go from a 1 MiB ceiling to this one, which the control plane can bear.
     app = web.Application(middlewares=[drain_middleware, error_middleware], client_max_size=MAX_SIGNED_PLAN_BODY_BYTES)
     app.on_response_prepare.append(on_prepare_server_version)
     # Agent-owned drain flag: drain_middleware rejects new VM requests when set;

--- a/src/aleph/vm/agent/views/allocation_auth.py
+++ b/src/aleph/vm/agent/views/allocation_auth.py
@@ -33,6 +33,21 @@ ALEPH_EIP191_V1_SCHEME = "Aleph-EIP191-V1"
 # requests are short JSON; 1 MiB is plenty.
 MAX_SIGNED_REQUEST_BODY_BYTES = 1 * 1024 * 1024
 
+# A plan body carries one signed message per VM, so it is far larger than any
+# other signed request. Still bounded, since the body is buffered to hash it.
+MAX_SIGNED_PLAN_BODY_BYTES = 8 * 1024 * 1024
+
+
+class RequestTooLarge(Exception):
+    """The body exceeds the cap for this route.
+
+    Its own exception rather than a False: a False means the request could
+    not be authenticated and answers 401, which sends a scheduler whose plan
+    outgrew the cap looking at its key. Too large answers 413, and only for
+    a signer the verifier has already accepted, so an anonymous client still
+    learns nothing about the cap.
+    """
+
 
 ALLOWED_AUTH_PARAMS = frozenset({"sig", "payload"})
 
@@ -128,13 +143,16 @@ async def _accept_payload_if_new(signer_key: str, payload_hash: str, iat: int) -
         return True
 
 
-async def _verify_aleph_signature(request: web.Request, auth_header: str) -> bool:
+async def _verify_aleph_signature(
+    request: web.Request, auth_header: str, *, max_body_bytes: int = MAX_SIGNED_REQUEST_BODY_BYTES
+) -> bool:
     """Verify a request bearing an `Authorization: Aleph-EIP191-V1 ...` header.
 
     Returns True iff the signature is valid, recovers an authorized signer,
     binds the request, and is not a duplicate of an already-accepted payload.
-    All failure modes return False (the dispatcher decides the response
-    shape).
+    Every failure mode returns False (the dispatcher decides the response
+    shape) except a body over ``max_body_bytes``, which raises
+    RequestTooLarge once the signer is known to be authorized.
 
     Side effect: calls `await request.read()`, which buffers the body into
     aiohttp's request cache. Downstream handlers using `request.json()` or
@@ -186,8 +204,10 @@ async def _verify_aleph_signature(request: web.Request, auth_header: str) -> boo
         # (chunked encoding) is rejected: scheduler clients always send
         # length-delimited JSON.
         content_length = request.content_length
-        if content_length is None or content_length > MAX_SIGNED_REQUEST_BODY_BYTES:
+        if content_length is None:
             return False
+        if content_length > max_body_bytes:
+            raise RequestTooLarge
 
         # Body hash binding.
         body = await request.read()
@@ -200,6 +220,8 @@ async def _verify_aleph_signature(request: web.Request, auth_header: str) -> boo
         # that would otherwise fail downstream.
         payload_hash = sha256(payload_bytes).hexdigest()
         return await _accept_payload_if_new(recovered.lower(), payload_hash, iat)
+    except RequestTooLarge:
+        raise
     except Exception as exc:  # broad catch intentional — auth verifier MUST NOT raise
         # Signature recovery, hex decoding, JSON parsing, and field type
         # coercion all raise different exception types. For an auth verifier,
@@ -211,12 +233,17 @@ async def _verify_aleph_signature(request: web.Request, auth_header: str) -> boo
         return False
 
 
-async def authenticate_api_request(request: web.Request) -> bool:
+async def authenticate_api_request(
+    request: web.Request, *, max_body_bytes: int = MAX_SIGNED_REQUEST_BODY_BYTES
+) -> bool:
     """Authenticate a scheduler-only request via Aleph-EIP191-V1.
 
     An `Authorization` header carrying any other scheme, or no `Authorization`
     header at all, is rejected: Aleph-EIP191-V1 is the only accepted scheme.
     The scheme name is matched case-insensitively (RFC 7235 §2.1).
+
+    ``max_body_bytes`` is the route's cap on the signed body; see
+    RequestTooLarge for what exceeding it answers.
     """
     auth = request.headers.get("Authorization", "")
     if not auth:
@@ -224,7 +251,7 @@ async def authenticate_api_request(request: web.Request) -> bool:
     scheme, sep, _ = auth.partition(" ")
     if not sep or scheme.casefold() != ALEPH_EIP191_V1_SCHEME.casefold():
         return False
-    return await _verify_aleph_signature(request, auth)
+    return await _verify_aleph_signature(request, auth, max_body_bytes=max_body_bytes)
 
 
 def log_allocation_auth_config() -> None:
@@ -249,17 +276,28 @@ def log_allocation_auth_config() -> None:
         )
 
 
-def requires_allocation_auth(handler):
+def requires_allocation_auth(handler=None, *, max_body_bytes: int = MAX_SIGNED_REQUEST_BODY_BYTES):
     """Decorator: reject the request with 401 unless the auth check passes.
 
     Requires `Authorization: Aleph-EIP191-V1 sig=...,payload=...`. Apply BELOW
     any CORS decorator so OPTIONS preflights pass through unauthenticated.
+
+    Usable bare (``@requires_allocation_auth``) or with a body cap for the
+    route (``@requires_allocation_auth(max_body_bytes=...)``); a body over
+    the cap answers 413.
     """
 
-    @functools.wraps(handler)
-    async def wrapper(request: web.Request) -> web.StreamResponse:
-        if not await authenticate_api_request(request):
-            return web.HTTPUnauthorized(text="Authentication token received is invalid")
-        return await handler(request)
+    def decorate(handler):
+        @functools.wraps(handler)
+        async def wrapper(request: web.Request) -> web.StreamResponse:
+            try:
+                authorized = await authenticate_api_request(request, max_body_bytes=max_body_bytes)
+            except RequestTooLarge:
+                return web.HTTPRequestEntityTooLarge(max_size=max_body_bytes, actual_size=request.content_length or 0)
+            if not authorized:
+                return web.HTTPUnauthorized(text="Authentication token received is invalid")
+            return await handler(request)
 
-    return wrapper
+        return wrapper
+
+    return decorate(handler) if handler is not None else decorate

--- a/src/aleph/vm/agent/views/allocation_auth.py
+++ b/src/aleph/vm/agent/views/allocation_auth.py
@@ -38,7 +38,7 @@ MAX_SIGNED_REQUEST_BODY_BYTES = 1 * 1024 * 1024
 MAX_SIGNED_PLAN_BODY_BYTES = 8 * 1024 * 1024
 
 
-class RequestTooLarge(Exception):
+class RequestTooLarge(web.HTTPRequestEntityTooLarge):
     """The body exceeds the cap for this route.
 
     Its own exception rather than a False: a False means the request could
@@ -46,6 +46,11 @@ class RequestTooLarge(Exception):
     outgrew the cap looking at its key. Too large answers 413, and only for
     a signer the verifier has already accepted, so an anonymous client still
     learns nothing about the cap.
+
+    An aiohttp 413 rather than a plain exception so that a handler calling
+    the verifier directly, without the decorator, still answers 413: the
+    error middleware renders any HTTPException, and a plain exception
+    escaping such a handler was a 500.
     """
 
 
@@ -207,7 +212,7 @@ async def _verify_aleph_signature(
         if content_length is None:
             return False
         if content_length > max_body_bytes:
-            raise RequestTooLarge
+            raise RequestTooLarge(max_size=max_body_bytes, actual_size=content_length)
 
         # Body hash binding.
         body = await request.read()
@@ -292,8 +297,8 @@ def requires_allocation_auth(handler=None, *, max_body_bytes: int = MAX_SIGNED_R
         async def wrapper(request: web.Request) -> web.StreamResponse:
             try:
                 authorized = await authenticate_api_request(request, max_body_bytes=max_body_bytes)
-            except RequestTooLarge:
-                return web.HTTPRequestEntityTooLarge(max_size=max_body_bytes, actual_size=request.content_length or 0)
+            except RequestTooLarge as too_large:
+                return too_large
             if not authorized:
                 return web.HTTPUnauthorized(text="Authentication token received is invalid")
             return await handler(request)

--- a/src/aleph/vm/agent/views/allocation_auth.py
+++ b/src/aleph/vm/agent/views/allocation_auth.py
@@ -225,7 +225,9 @@ async def _verify_aleph_signature(
         # that would otherwise fail downstream.
         payload_hash = sha256(payload_bytes).hexdigest()
         return await _accept_payload_if_new(recovered.lower(), payload_hash, iat)
-    except RequestTooLarge:
+    except web.HTTPRequestEntityTooLarge:
+        # Ours, or aiohttp's own from request.read(): over the cap is over
+        # the cap, and both come after the signer check.
         raise
     except Exception as exc:  # broad catch intentional — auth verifier MUST NOT raise
         # Signature recovery, hex decoding, JSON parsing, and field type
@@ -301,8 +303,11 @@ def requires_allocation_auth(handler=None, *, max_body_bytes: int = MAX_SIGNED_R
     def decorate(handler):
         @functools.wraps(handler)
         async def wrapper(request: web.Request) -> web.StreamResponse:
-            if request.client_max_size != max_body_bytes:
-                request = request.clone(client_max_size=max_body_bytes)
+            # One over the cap, because aiohttp refuses at its limit rather
+            # than over it. The verifier's own check on Content-Length is the
+            # authority, and a body of exactly the cap must pass both.
+            if request.client_max_size != max_body_bytes + 1:
+                request = request.clone(client_max_size=max_body_bytes + 1)
             try:
                 authorized = await authenticate_api_request(request, max_body_bytes=max_body_bytes)
             except RequestTooLarge as too_large:

--- a/src/aleph/vm/agent/views/allocation_auth.py
+++ b/src/aleph/vm/agent/views/allocation_auth.py
@@ -290,11 +290,19 @@ def requires_allocation_auth(handler=None, *, max_body_bytes: int = MAX_SIGNED_R
     Usable bare (``@requires_allocation_auth``) or with a body cap for the
     route (``@requires_allocation_auth(max_body_bytes=...)``); a body over
     the cap answers 413.
+
+    The cap is the route's alone. aiohttp bounds a buffered body at the
+    application's client_max_size, 1 MiB by default, and that stays: the
+    request is re-bounded to the route's cap before anything reads it (a
+    clone shares the payload and applies its own limit on read), so a plan
+    body gets through here and nowhere else.
     """
 
     def decorate(handler):
         @functools.wraps(handler)
         async def wrapper(request: web.Request) -> web.StreamResponse:
+            if request.client_max_size != max_body_bytes:
+                request = request.clone(client_max_size=max_body_bytes)
             try:
                 authorized = await authenticate_api_request(request, max_body_bytes=max_body_bytes)
             except RequestTooLarge as too_large:

--- a/src/aleph/vm/agent/views/allocations_v2.py
+++ b/src/aleph/vm/agent/views/allocations_v2.py
@@ -12,7 +12,6 @@ message per VM.
 import logging
 from datetime import datetime, timezone
 from http import HTTPStatus
-from json import JSONDecodeError
 
 from aiohttp import web
 
@@ -38,12 +37,14 @@ async def _read_plan(request: web.Request) -> tuple[AllocationPlan, dict[str, di
     """
     try:
         body = await request.json()
-    except JSONDecodeError as error:
+    except ValueError as error:
+        # JSONDecodeError and the UnicodeDecodeError of a body that is not
+        # text: request.json() decodes before it parses.
         raise web.HTTPBadRequest(text="Body is not valid JSON") from error
     try:
         return build_plan(body, now=datetime.now(tz=timezone.utc))
     except ValueError as error:
-        raise web.HTTPBadRequest(text=str(error)) from error
+        raise web.HTTPBadRequest(text="Body is not a plan: 'vms' must be a list") from error
 
 
 @requires_allocation_auth(max_body_bytes=MAX_SIGNED_PLAN_BODY_BYTES)

--- a/src/aleph/vm/agent/views/allocations_v2.py
+++ b/src/aleph/vm/agent/views/allocations_v2.py
@@ -1,0 +1,132 @@
+"""The v2 allocation endpoints: answer now, converge later.
+
+POST /v2/control/allocations records the plan and returns a per-VM verdict at
+once; the reconciler converges on it in the background. POST
+/v2/control/capacity/check answers the same admission question with no side
+effects, so a scheduler can ask several CRNs before committing to one.
+
+Both take a body the legacy cap would refuse: a plan carries one signed
+message per VM.
+"""
+
+import logging
+from datetime import datetime, timezone
+from http import HTTPStatus
+from json import JSONDecodeError
+
+from aiohttp import web
+
+from aleph.vm.agent.allocation.plan import AllocationPlan
+from aleph.vm.agent.allocation.verdict import build_plan, compute_verdict, narrow_plan
+from aleph.vm.agent.capacity import requirements_from_message
+from aleph.vm.agent.node_identity import NodeIdentity
+from aleph.vm.agent.views.allocation_auth import (
+    MAX_SIGNED_PLAN_BODY_BYTES,
+    requires_allocation_auth,
+)
+from aleph.vm.utils import dumps_for_json
+
+logger = logging.getLogger(__name__)
+
+
+async def _read_plan(request: web.Request) -> tuple[AllocationPlan, dict[str, dict]]:
+    """The body as a plan, or the 400 that says why it is not one.
+
+    One validation boundary for both routes: build_plan owns what an entry
+    must look like and what a body must not be read as, so the check and the
+    push cannot disagree about a request.
+    """
+    try:
+        body = await request.json()
+    except JSONDecodeError as error:
+        raise web.HTTPBadRequest(text="Body is not valid JSON") from error
+    try:
+        return build_plan(body, now=datetime.now(tz=timezone.utc))
+    except ValueError as error:
+        raise web.HTTPBadRequest(text=str(error)) from error
+
+
+@requires_allocation_auth(max_body_bytes=MAX_SIGNED_PLAN_BODY_BYTES)
+async def update_allocations_v2(request: web.Request) -> web.Response:
+    """Record the scheduler's plan and answer for each VM right away."""
+    plan, rejected = await _read_plan(request)
+    app = request.app
+    node_identity: NodeIdentity | None = app.get("node_identity")
+    # Both reads are async and come first. From the supervisor's list down
+    # to submit() nothing may yield, or a push landing in between could
+    # invalidate the answer about to be returned; see allocation.verdict.
+    infos = await app["supervisor"].list_vms()
+    available_gpus = await app["capacity"].available_gpus()
+    verdict = compute_verdict(
+        plan,
+        infos=infos,
+        registry=app["vm_registry"],
+        capacity=app["capacity"],
+        node_hash=node_identity.get_node_hash() if node_identity else None,
+        available_gpus=available_gpus,
+    )
+    verdict.rejected.update(rejected)
+    app["allocation_reconciler"].submit(narrow_plan(plan, verdict))
+
+    logger.info(
+        "Plan %s: %d accepted, %d pending, %d unchanged, %d rejected, %d removing, %d retained",
+        plan.plan_id,
+        len(verdict.accepted),
+        len(verdict.pending),
+        len(verdict.unchanged),
+        len(verdict.rejected),
+        len(verdict.removing),
+        len(verdict.retained),
+    )
+    return web.json_response(
+        {
+            "plan_id": plan.plan_id,
+            "accepted": [str(vm_hash) for vm_hash in verdict.accepted],
+            "pending": [str(vm_hash) for vm_hash in verdict.pending],
+            "unchanged": [str(vm_hash) for vm_hash in verdict.unchanged],
+            "removing": [str(vm_hash) for vm_hash in verdict.removing],
+            "rejected": {str(vm_hash): refusal for vm_hash, refusal in verdict.rejected.items()},
+            "retained": {str(vm_hash): reason for vm_hash, reason in verdict.retained.items()},
+            "status_url": "/v2/about/executions/list",
+        },
+        status=HTTPStatus.ACCEPTED,
+        dumps=dumps_for_json,
+    )
+
+
+@requires_allocation_auth(max_body_bytes=MAX_SIGNED_PLAN_BODY_BYTES)
+async def capacity_check(request: web.Request) -> web.Response:
+    """Advisory: would these be admitted here, as things stand?
+
+    Side-effect free by design: no plan is recorded and nothing is held, so
+    a scheduler can ask several CRNs and place on one. Every entry is a
+    candidate and nothing running here is read as dropped, since this is not
+    a plan. A race with a real allocation is settled by the allocation, which
+    judges again and can still refuse.
+    """
+    plan, rejected = await _read_plan(request)
+    capacity = request.app["capacity"]
+    results: dict[str, dict] = {key: {"accepted": False, **refusal} for key, refusal in rejected.items()}
+    candidates = []
+    for vm_hash, planned in plan.entries.items():
+        if planned.verified is None:
+            # Without the message there is nothing to size, and a check must
+            # not go and fetch one: say so rather than guess.
+            results[str(vm_hash)] = {
+                "accepted": False,
+                "code": "message_required",
+                "message": "embed the signed message for this VM to be sized",
+            }
+            continue
+        candidates.append((vm_hash, requirements_from_message(planned.verified.message.content)))
+    available_gpus = await capacity.available_gpus()
+    for admission in capacity.simulate(candidates, available_gpus=available_gpus):
+        results[str(admission.vm_hash)] = (
+            {"accepted": True}
+            if admission.accepted
+            else {"accepted": False, "code": admission.code, "message": admission.detail}
+        )
+    return web.json_response(
+        {"results": results, "capacity": capacity.headroom(available_gpus)},
+        dumps=dumps_for_json,
+    )

--- a/tests/supervisor/conftest.py
+++ b/tests/supervisor/conftest.py
@@ -142,8 +142,10 @@ def scheduler_auth(monkeypatch):
     account = Account.create()
     monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [account.address])
 
-    def sign(body_dict: dict, *, path: str = "/control/allocations", method: str = "POST"):
-        body = json.dumps(body_dict).encode()
+    def sign(body_dict: dict | bytes, *, path: str = "/control/allocations", method: str = "POST"):
+        # Bytes are signed as given, for a test that sends something that is
+        # not JSON at all.
+        body = body_dict if isinstance(body_dict, bytes) else json.dumps(body_dict).encode()
         payload = {
             "method": method,
             "path": path,

--- a/tests/supervisor/conftest.py
+++ b/tests/supervisor/conftest.py
@@ -8,10 +8,16 @@ so migrated tests share one construction path.
 
 from __future__ import annotations
 
+import json
+import time
+from hashlib import sha256
 from pathlib import Path
 
 import pytest
+from eth_account import Account
+from eth_account.messages import encode_defunct
 
+from aleph.vm.conf import settings
 from aleph.vm.supervisor_interface.types import (
     Backend,
     CreateVmSpec,
@@ -72,3 +78,81 @@ def make_spec(
 def spec_factory():
     """Fixture handle for make_spec, for tests that prefer dependency injection."""
     return make_spec
+
+
+def sign_message(content_dict: dict, account, *, chain: str = "ETH", message_type: str = "INSTANCE") -> dict:
+    """A full message envelope signed the way the network does: item_hash is
+    sha256(item_content), and the signature covers chain/sender/type/hash."""
+    item_content = json.dumps(content_dict)
+    item_hash = sha256(item_content.encode()).hexdigest()
+    buffer = f"{chain}\n{account.address}\n{message_type}\n{item_hash}".encode()
+    signature = account.sign_message(encode_defunct(buffer)).signature.hex()
+    return {
+        "chain": chain,
+        "sender": account.address,
+        "type": message_type,
+        "item_hash": item_hash,
+        "item_type": "inline",
+        "item_content": item_content,
+        "content": content_dict,
+        "signature": signature if signature.startswith("0x") else "0x" + signature,
+        "time": 1.0,
+        "channel": "TEST",
+    }
+
+
+def instance_content_dict(address: str) -> dict:
+    """A minimal QEMU instance content, owned by ``address``."""
+    return {
+        "address": address,
+        "time": 1.0,
+        "allow_amend": False,
+        "environment": {"internet": True, "aleph_api": False, "hypervisor": "qemu"},
+        "resources": {"vcpus": 2, "memory": 2048, "seconds": 300},
+        "volumes": [],
+        "rootfs": {
+            "parent": {"ref": "d" * 64, "use_latest": False},
+            "persistence": "host",
+            "size_mib": 10000,
+        },
+    }
+
+
+@pytest.fixture
+def signed_message():
+    """Build a correctly signed instance message under a fresh key.
+
+    Returns a callable so a test can sign its own content, or sign the
+    default one and then break it."""
+
+    def make(content: dict | None = None, *, account=None) -> dict:
+        account = account or Account.create()
+        return sign_message(content or instance_content_dict(account.address), account)
+
+    return make
+
+
+@pytest.fixture
+def scheduler_auth(monkeypatch):
+    """Authorize a throwaway scheduler key and sign requests as it.
+
+    The signed payload binds the method, the path and the body hash, so the
+    caller must pass the exact path it will POST to.
+    """
+    account = Account.create()
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [account.address])
+
+    def sign(body_dict: dict, *, path: str = "/control/allocations", method: str = "POST"):
+        body = json.dumps(body_dict).encode()
+        payload = {
+            "method": method,
+            "path": path,
+            "body_sha256": sha256(body).hexdigest(),
+            "iat": int(time.time()),
+        }
+        payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        signed = account.sign_message(encode_defunct(payload_bytes))
+        header = f"Aleph-EIP191-V1 sig={signed.signature.hex()},payload={payload_bytes.hex()}"
+        return body, {"Authorization": header, "Content-Type": "application/json"}
+
+    return sign

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -248,6 +248,7 @@ def test_requirements_from_message_extracts_resources():
 
     assert (req.vcpus, req.memory_mib, req.is_instance) == (2, 2048, True)
     assert req.gpu_device_ids == [_DEVICE_ID]
+    assert req.owner == message.address
     # rootfs size is summed into disk_mib (the message fixture sets size_mib=10000)
     assert req.disk_mib == 10000
 
@@ -636,9 +637,17 @@ def test_simulate_releases_vcpus_not_only_memory(mocker):
 # ── simulate: GPU admission ────────────────────────────────────────────────
 
 
-def _gpu_requirements(*, device_ids: list[str], memory_mib: int = 1024) -> ResourceRequirements:
+def _gpu_requirements(
+    *, device_ids: list[str], memory_mib: int = 1024, owner: str | None = None
+) -> ResourceRequirements:
     return ResourceRequirements(
-        vcpus=1, memory_mib=memory_mib, disk_mib=0, max_volume_mib=0, is_instance=True, gpu_device_ids=device_ids
+        vcpus=1,
+        memory_mib=memory_mib,
+        disk_mib=0,
+        max_volume_mib=0,
+        is_instance=True,
+        gpu_device_ids=device_ids,
+        owner=owner,
     )
 
 
@@ -702,6 +711,23 @@ def test_simulate_treats_a_held_card_as_taken(mocker):
     verdicts = manager.simulate([(_HASH_A, _gpu_requirements(device_ids=[_DEVICE_ID]))], available_gpus=[gpu])
 
     assert verdicts[0].accepted is False
+
+
+def test_simulate_lets_a_candidate_use_the_hold_its_own_user_took(mocker):
+    """The reserve endpoint exists so a user can hold a card before asking
+    the scheduler for the VM. resolve_gpus consumes that user's own hold at
+    create; an advisory answer that counted it as taken would refuse exactly
+    the allocation the hold was placed for."""
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
+    gpu = _gpu_device()
+    manager = _manager()
+    manager.holds[gpu.pci_host] = GpuHold(user="0xUSER", expiration=datetime.now(tz=timezone.utc) + timedelta(hours=1))
+    mine = _gpu_requirements(device_ids=[_DEVICE_ID], owner="0xUSER")
+    theirs = _gpu_requirements(device_ids=[_DEVICE_ID], owner="0xOTHER")
+
+    assert manager.simulate([(_HASH_A, mine)], available_gpus=[gpu])[0].accepted is True
+    assert manager.simulate([(_HASH_A, theirs)], available_gpus=[gpu])[0].accepted is False
+    assert manager.holds[gpu.pci_host].user == "0xUSER"
 
 
 def test_simulate_does_not_evict_expired_holds(mocker):
@@ -1306,3 +1332,70 @@ def test_existing_volume_files_spans_pools_and_skips_what_is_not_a_volume(mocker
     assert set(found) == {"rootfs.qcow2", "data.ext4"}
     assert found["rootfs.qcow2"] == first / "rootfs.qcow2"
     assert found["data.ext4"] == second / "data.ext4"
+
+
+# ── headroom: what the capacity-check endpoint advertises ──────────────────
+
+
+def test_headroom_is_the_caps_less_what_is_recorded(mocker):
+    """64 GiB, 16 cores, reservations of 2048 and 8192: a 55296 MiB instance
+    bucket, 8192 MiB of program bucket, 64 vCPUs at the default factor.
+    Recording an instance takes its memory and vCPUs out of the figures."""
+    mocker.patch.object(settings, "HOST_MEMORY_RESERVED_MIB", 2048)
+    mocker.patch.object(settings, "PROGRAM_MEMORY_RESERVED_MIB", 8192)
+    mocker.patch.object(settings, "VCPU_OVERCOMMIT_FACTOR", 4.0)
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16, disk_bytes=100 * 1024 * 1024 * 1024)
+    manager = _manager()
+
+    before = manager.headroom()
+    content = _make_qemu_instance_message(memory=16384, vcpus=4)
+    manager.registry.record(_HASH_A, message=content, original=content, persistent=True)
+    after = manager.headroom()
+
+    assert before == {
+        "instance_memory_mib": 55296,
+        "program_memory_mib": 8192,
+        "vcpus": 64,
+        "disk_mib": 100 * 1024,
+        "gpus": None,
+    }
+    assert after["instance_memory_mib"] == 55296 - 16384
+    assert after["vcpus"] == 64 - 4
+    assert after["program_memory_mib"] == 8192
+
+
+def test_headroom_lists_the_cards_a_plan_may_count_on(mocker):
+    """Given the inventory, the cards not under a live hold, by device id.
+    Without it, None rather than an empty list: unknown is not zero."""
+    _patch_host(mocker, memory_bytes=64 * 1024 * 1024 * 1024, cores=16)
+    free = _gpu_device("0000:01:00.0")
+    held = _gpu_device("0000:02:00.0")
+    manager = _manager()
+    live = datetime.now(tz=timezone.utc) + timedelta(hours=1)
+    manager.holds[held.pci_host] = GpuHold(user="someone", expiration=live)
+
+    assert manager.headroom(available_gpus=[free, held])["gpus"] == [free.device_id]
+    assert manager.headroom()["gpus"] is None
+
+
+def test_headroom_never_advertises_below_zero(mocker):
+    """A registry holding more than the caps (a phantom record, a shrunk
+    host) reads as nothing left, not as a negative figure."""
+    _patch_host(mocker, memory_bytes=8 * 1024 * 1024 * 1024, cores=1)
+    registry = AgentVmRegistry()
+    content = _make_qemu_instance_message(memory=65536, vcpus=64)
+    registry.record(_HASH_A, message=content, original=content, persistent=True)
+
+    headroom = _manager(registry=registry).headroom()
+
+    assert headroom["instance_memory_mib"] == 0
+    assert headroom["vcpus"] == 0
+
+
+@pytest.mark.asyncio
+async def test_available_gpus_reads_the_supervisors_unattached_cards():
+    """The inventory simulate and headroom are handed comes from here: the
+    handler reads it, since the read is async and those two are not."""
+    gpu = _gpu_device()
+
+    assert await _manager([gpu]).available_gpus() == [gpu]

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -9,11 +9,12 @@ import pytest
 from aleph_message.models import ItemHash
 from test_supervisor_translate import _make_qemu_instance_message
 
-from aleph.vm.agent.allocation.plan import AllocationPlan, PlannedVm
-from aleph.vm.agent.allocation.verdict import build_plan, compute_verdict
+from aleph.vm.agent.allocation.plan import AllocationPlan, PlannedVm, PlanVerdict
+from aleph.vm.agent.allocation.verdict import build_plan, compute_verdict, narrow_plan
 from aleph.vm.agent.capacity import AdmissionVerdict, CapacityManager
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
+from aleph.vm.resources import GpuDevice, GpuDeviceClass
 from aleph.vm.supervisor_interface.types import ConfidentialMode, HostInfo, VmStatus
 
 NOW = datetime(2026, 8, 25, tzinfo=timezone.utc)
@@ -427,3 +428,75 @@ def test_a_recreate_still_waiting_on_its_message_frees_nothing(mocker):
 
     assert verdict.pending == [HASH_C]
     assert verdict.rejected[HASH_A]["code"] == "insufficient_capacity"
+
+
+DEVICE_ID = "10de:2504"
+
+
+def _gpu_message(device_id=DEVICE_ID):
+    from aleph_message.models.execution.environment import (
+        GpuProperties,
+        HostRequirements,
+    )
+
+    card = GpuProperties(vendor="NVIDIA", device_name="GH100", device_class="0300", device_id=device_id)
+    return _make_qemu_instance_message().model_copy(update={"requirements": HostRequirements(gpu=[card])})
+
+
+def _card(device_id=DEVICE_ID):
+    return GpuDevice(
+        vendor="NVIDIA",
+        device_name="GH100",
+        device_class=GpuDeviceClass.VGA_COMPATIBLE_CONTROLLER,
+        pci_host="0000:01:00.0",
+        device_id=device_id,
+    )
+
+
+def test_a_gpu_candidate_is_refused_when_no_inventory_reached_the_verdict(mocker):
+    """simulate's rule, seen from here: with nothing to judge a card against,
+    a candidate asking for one is refused rather than admitted on memory."""
+    verdict = compute_verdict(
+        _plan(HASH_C, content=_gpu_message()), infos=[], registry=_registry({}), capacity=_real_capacity(mocker)
+    )
+
+    assert verdict.rejected[HASH_C]["code"] == "gpu_unavailable"
+
+
+def test_a_gpu_candidate_is_judged_against_the_inventory_the_caller_read(mocker):
+    """Reading the host's cards is async and this is not, so the handler reads
+    them and hands them in; from here on a GPU VM can be placed."""
+    verdict = compute_verdict(
+        _plan(HASH_C, content=_gpu_message()),
+        infos=[],
+        registry=_registry({}),
+        capacity=_real_capacity(mocker),
+        available_gpus=[_card()],
+    )
+
+    assert verdict.accepted == [HASH_C]
+    assert verdict.rejected == {}
+
+
+def test_narrowing_drops_what_the_answer_refused_and_nothing_else():
+    """What reaches the reconciler is the push less its refusals. A refused
+    entry left in would be retried forever at backoff rate, and started the
+    moment room appeared, after the scheduler was told no and placed it
+    elsewhere. Pending entries were not judged and stay; so does the identity,
+    which is the push's, not the host's room at the time."""
+    plan = AllocationPlan(
+        plan_id="sha256:push",
+        received_at=NOW,
+        entries={
+            HASH_A: PlannedVm(vm_hash=HASH_A, verified=_verified()),
+            HASH_B: PlannedVm(vm_hash=HASH_B, verified=_verified()),
+            HASH_C: PlannedVm(vm_hash=HASH_C, verified=None),
+        },
+    )
+    verdict = PlanVerdict(accepted=[HASH_A], pending=[HASH_C], rejected={HASH_B: {"code": "insufficient_capacity"}})
+
+    narrowed = narrow_plan(plan, verdict)
+
+    assert set(narrowed.entries) == {HASH_A, HASH_C}
+    assert narrowed.entries[HASH_A] is plan.entries[HASH_A]
+    assert (narrowed.plan_id, narrowed.received_at) == (plan.plan_id, plan.received_at)

--- a/tests/supervisor/test_allocation_verify.py
+++ b/tests/supervisor/test_allocation_verify.py
@@ -6,37 +6,15 @@ that includes item_hash. Neither alone is enough.
 """
 
 import json
-from hashlib import sha256
 from pathlib import Path
 
 import pytest
+from conftest import instance_content_dict, sign_message
 from eth_account import Account
-from eth_account.messages import encode_defunct
 
 from aleph.vm.agent.allocation.verify import VerificationOutcome, verify_entry
 
 SIGNED_VPROGRAM = Path(__file__).parent / "fixtures" / "signed_vprogram_message.json"
-
-
-def sign_message(content_dict: dict, account, *, chain="ETH", message_type="INSTANCE") -> dict:
-    """A full message envelope signed the way the network does: item_hash is
-    sha256(item_content), and the signature covers chain/sender/type/hash."""
-    item_content = json.dumps(content_dict)
-    item_hash = sha256(item_content.encode()).hexdigest()
-    buffer = f"{chain}\n{account.address}\n{message_type}\n{item_hash}".encode()
-    signature = account.sign_message(encode_defunct(buffer)).signature.hex()
-    return {
-        "chain": chain,
-        "sender": account.address,
-        "type": message_type,
-        "item_hash": item_hash,
-        "item_type": "inline",
-        "item_content": item_content,
-        "content": content_dict,
-        "signature": signature if signature.startswith("0x") else "0x" + signature,
-        "time": 1.0,
-        "channel": "TEST",
-    }
 
 
 @pytest.fixture
@@ -52,19 +30,7 @@ def signed_vprogram_message():
 
 @pytest.fixture
 def instance_content(account):
-    return {
-        "address": account.address,
-        "time": 1.0,
-        "allow_amend": False,
-        "environment": {"internet": True, "aleph_api": False, "hypervisor": "qemu"},
-        "resources": {"vcpus": 2, "memory": 2048, "seconds": 300},
-        "volumes": [],
-        "rootfs": {
-            "parent": {"ref": "d" * 64, "use_latest": False},
-            "persistence": "host",
-            "size_mib": 10000,
-        },
-    }
+    return instance_content_dict(account.address)
 
 
 def test_a_correctly_signed_message_is_verified(account, instance_content):

--- a/tests/supervisor/test_allocations_v2.py
+++ b/tests/supervisor/test_allocations_v2.py
@@ -199,9 +199,11 @@ async def test_the_hosts_cards_reach_the_verdict(aiohttp_client, scheduler_auth,
 
 @pytest.mark.asyncio
 async def test_a_plan_body_over_the_legacy_cap_reaches_the_handler(aiohttp_client, scheduler_auth):
-    """A plan carries a signed message per VM, so it outgrows the 1 MiB the
-    other signed routes are bounded to. The app's own ceiling used to cut it
-    off inside the verifier, which reported it as a bad signature."""
+    """A plan carries a signed message per VM, so it outgrows the 1 MiB
+    aiohttp bounds a body to by default. That default stays for every other
+    route; this one re-bounds the request to its own cap before reading,
+    where the app-wide limit used to cut the plan off inside the verifier
+    and report it as a bad signature."""
     client = await aiohttp_client(_app())
     body, headers = scheduler_auth({"vms": [], "padding": "x" * (MAX_SIGNED_REQUEST_BODY_BYTES + 1)}, path=PLAN)
 

--- a/tests/supervisor/test_allocations_v2.py
+++ b/tests/supervisor/test_allocations_v2.py
@@ -85,13 +85,15 @@ async def test_the_answer_comes_before_the_vm_is_created(aiohttp_client, schedul
     client = await aiohttp_client(_app(real_reconciler=True))
     body, headers = scheduler_auth({"vms": [{"item_hash": str(HASH_C)}]}, path=PLAN)
 
-    response = await client.post(PLAN, data=body, headers=headers, timeout=aiohttp.ClientTimeout(total=2))
+    response = await client.post(PLAN, data=body, headers=headers, timeout=aiohttp.ClientTimeout(total=10))
 
     assert response.status == 202
     payload = await response.json()
     assert payload["pending"] == [str(HASH_C)]  # no embedded message: judged after the fetch
     assert payload["plan_id"].startswith("sha256:")
-    await asyncio.wait_for(started.wait(), timeout=1)
+    # Bounds on failure, not waits: the loop reaches the create within
+    # milliseconds, and a loaded runner gets the margin.
+    await asyncio.wait_for(started.wait(), timeout=10)
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_allocations_v2.py
+++ b/tests/supervisor/test_allocations_v2.py
@@ -216,6 +216,21 @@ async def test_a_plan_body_over_the_legacy_cap_reaches_the_handler(aiohttp_clien
 
 
 @pytest.mark.asyncio
+async def test_a_plan_body_of_exactly_the_cap_is_taken(aiohttp_client, scheduler_auth):
+    """The cap is inclusive, and it is the verifier's. aiohttp refuses a body
+    at its own limit rather than over it, so a request bounded to exactly the
+    cap failed on the last byte, inside the verifier, as a 401."""
+    client = await aiohttp_client(_app())
+    frame = len(json.dumps({"vms": [], "padding": ""}))
+    body, headers = scheduler_auth({"vms": [], "padding": "x" * (MAX_SIGNED_PLAN_BODY_BYTES - frame)}, path=PLAN)
+    assert len(body) == MAX_SIGNED_PLAN_BODY_BYTES
+
+    response = await client.post(PLAN, data=body, headers=headers)
+
+    assert response.status == 202
+
+
+@pytest.mark.asyncio
 async def test_a_plan_body_over_its_own_cap_is_too_large(aiohttp_client, scheduler_auth):
     """The route's cap is still a cap: over it, 413 and not 202, before a
     byte of the body is read."""

--- a/tests/supervisor/test_allocations_v2.py
+++ b/tests/supervisor/test_allocations_v2.py
@@ -211,6 +211,19 @@ async def test_a_plan_body_over_the_legacy_cap_reaches_the_handler(aiohttp_clien
 
 
 @pytest.mark.asyncio
+async def test_a_legacy_route_answers_too_large_to_a_plan_sized_body(aiohttp_client, scheduler_auth):
+    """The mirror of the test above. The legacy allocation route calls the
+    verifier directly, without the decorator, so once the app ceiling let a
+    plan-sized body through, the verifier's refusal escaped it as a 500."""
+    client = await aiohttp_client(_app())
+    body, headers = scheduler_auth({"persistent_vms": [], "padding": "x" * (MAX_SIGNED_REQUEST_BODY_BYTES + 1)})
+
+    response = await client.post("/control/allocations", data=body, headers=headers)
+
+    assert response.status == 413
+
+
+@pytest.mark.asyncio
 async def test_the_capacity_check_judges_without_touching_anything(
     aiohttp_client, scheduler_auth, signed_message, mocker
 ):

--- a/tests/supervisor/test_allocations_v2.py
+++ b/tests/supervisor/test_allocations_v2.py
@@ -224,6 +224,21 @@ async def test_a_legacy_route_answers_too_large_to_a_plan_sized_body(aiohttp_cli
 
 
 @pytest.mark.asyncio
+async def test_a_body_that_is_not_text_is_a_bad_request(aiohttp_client, scheduler_auth):
+    """request.json() decodes before it parses, and a body that is not UTF-8
+    raises a ValueError that is not a JSONDecodeError. It was a 500, with the
+    decoder's message in the response."""
+    app = _app()
+    client = await aiohttp_client(app)
+    body, headers = scheduler_auth(b'{"vms": "\xff\xfe"}', path=PLAN)
+
+    response = await client.post(PLAN, data=body, headers=headers)
+
+    assert response.status == 400
+    app["allocation_reconciler"].submit.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_the_capacity_check_judges_without_touching_anything(
     aiohttp_client, scheduler_auth, signed_message, mocker
 ):

--- a/tests/supervisor/test_allocations_v2.py
+++ b/tests/supervisor/test_allocations_v2.py
@@ -17,7 +17,10 @@ from aleph_message.models import ItemHash
 from aleph.vm.agent.allocation import reconciler as reconciler_module
 from aleph.vm.agent.capacity import AdmissionVerdict, CapacityManager
 from aleph.vm.agent.supervisor import setup_webapp
-from aleph.vm.agent.views.allocation_auth import MAX_SIGNED_REQUEST_BODY_BYTES
+from aleph.vm.agent.views.allocation_auth import (
+    MAX_SIGNED_PLAN_BODY_BYTES,
+    MAX_SIGNED_REQUEST_BODY_BYTES,
+)
 from aleph.vm.resources import GpuDevice, GpuDeviceClass
 from aleph.vm.supervisor_interface.types import HostInfo
 
@@ -210,6 +213,20 @@ async def test_a_plan_body_over_the_legacy_cap_reaches_the_handler(aiohttp_clien
     response = await client.post(PLAN, data=body, headers=headers)
 
     assert response.status == 202
+
+
+@pytest.mark.asyncio
+async def test_a_plan_body_over_its_own_cap_is_too_large(aiohttp_client, scheduler_auth):
+    """The route's cap is still a cap: over it, 413 and not 202, before a
+    byte of the body is read."""
+    app = _app()
+    client = await aiohttp_client(app)
+    body, headers = scheduler_auth({"vms": [], "padding": "x" * MAX_SIGNED_PLAN_BODY_BYTES}, path=PLAN)
+
+    response = await client.post(PLAN, data=body, headers=headers)
+
+    assert response.status == 413
+    app["allocation_reconciler"].submit.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_allocations_v2.py
+++ b/tests/supervisor/test_allocations_v2.py
@@ -1,0 +1,265 @@
+"""The v2 endpoints answer now and converge later.
+
+Each test drives the real app around a fake supervisor, so what is asserted
+is the wiring: the answer, what reaches the reconciler, what the check
+touches, and that the legacy route is what it was.
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+from aleph_message.models import ItemHash
+
+from aleph.vm.agent.allocation import reconciler as reconciler_module
+from aleph.vm.agent.capacity import AdmissionVerdict, CapacityManager
+from aleph.vm.agent.supervisor import setup_webapp
+from aleph.vm.agent.views.allocation_auth import MAX_SIGNED_REQUEST_BODY_BYTES
+from aleph.vm.resources import GpuDevice, GpuDeviceClass
+from aleph.vm.supervisor_interface.types import HostInfo
+
+HASH_C = ItemHash("c" * 64)
+PLAN = "/v2/control/allocations"
+CHECK = "/v2/control/capacity/check"
+DEVICE_ID = "10de:2504"
+
+
+def _app(*, host_info=None, real_reconciler=False):
+    """The agent app over a fake supervisor. The reconciler is a double
+    unless a test needs the real loop to pick the plan up."""
+    supervisor = MagicMock(
+        list_vms=AsyncMock(return_value=[]),
+        get_host_info=AsyncMock(return_value=host_info or HostInfo()),
+        delete_vm=AsyncMock(),
+    )
+    app = setup_webapp(supervisor=supervisor)
+    app["pubsub"] = None
+    if not real_reconciler:
+        app["allocation_reconciler"] = MagicMock(submit=MagicMock(), run=AsyncMock(), notify_vm_down=MagicMock())
+    return app
+
+
+def _stub_host(mocker, *, memory_gib=64):
+    """A 64 GiB, 16 core host with 100 GiB of disk, for the real CapacityManager."""
+    mocker.patch("aleph.vm.agent.capacity.psutil.virtual_memory", return_value=mocker.Mock(total=memory_gib * 1024**3))
+    mocker.patch("aleph.vm.agent.capacity.psutil.cpu_count", return_value=16)
+    mocker.patch.object(CapacityManager, "_available_disk_bytes", return_value=100 * 1024**3)
+    mocker.patch(
+        "aleph.vm.agent.capacity.storage_pools.eligible_pool_free_bytes",
+        return_value=[(SimpleNamespace(path="/pool0", index=0), 100 * 1024**3)],
+    )
+    mocker.patch("aleph.vm.agent.capacity.reclaimable_bytes", return_value=0)
+
+
+def _card():
+    return GpuDevice(
+        vendor="NVIDIA",
+        device_name="GH100",
+        device_class=GpuDeviceClass.VGA_COMPATIBLE_CONTROLLER,
+        pci_host="0000:01:00.0",
+        device_id=DEVICE_ID,
+    )
+
+
+def _entry(message):
+    return {"item_hash": message["item_hash"], "message": message}
+
+
+@pytest.mark.asyncio
+async def test_the_answer_comes_before_the_vm_is_created(aiohttp_client, scheduler_auth, monkeypatch):
+    """The whole feature in one request: the create it authorizes never
+    finishes, and the answer arrives anyway. Then the loop does pick it up."""
+    started = asyncio.Event()
+
+    async def never_finishes(*_args, **_kwargs):
+        started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(reconciler_module, "start_persistent_vm", never_finishes)
+    client = await aiohttp_client(_app(real_reconciler=True))
+    body, headers = scheduler_auth({"vms": [{"item_hash": str(HASH_C)}]}, path=PLAN)
+
+    response = await client.post(PLAN, data=body, headers=headers, timeout=aiohttp.ClientTimeout(total=2))
+
+    assert response.status == 202
+    payload = await response.json()
+    assert payload["pending"] == [str(HASH_C)]  # no embedded message: judged after the fetch
+    assert payload["plan_id"].startswith("sha256:")
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_an_unsigned_request_is_refused(aiohttp_client):
+    client = await aiohttp_client(_app())
+
+    response = await client.post(PLAN, json={"vms": []})
+
+    assert response.status == 401
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [{"vms": "not-a-list"}, {"vms": 5}, {}, []])
+async def test_a_body_that_is_not_a_plan_is_a_bad_request(aiohttp_client, scheduler_auth, body):
+    """Never read as the empty plan, which is the instruction to stop
+    everything this node runs."""
+    app = _app()
+    client = await aiohttp_client(app)
+    signed, headers = scheduler_auth(body, path=PLAN)
+
+    response = await client.post(PLAN, data=signed, headers=headers)
+
+    assert response.status == 400
+    app["allocation_reconciler"].submit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_tampered_message_is_refused_and_never_reaches_the_reconciler(
+    aiohttp_client, scheduler_auth, signed_message
+):
+    """A body the scheduler could not have obtained from the network must not
+    reach the reconciler, whatever it claims."""
+    message = signed_message()
+    content = json.loads(message["item_content"])
+    content["resources"]["vcpus"] = 64
+    message["item_content"] = json.dumps(content)
+    message["content"] = content
+    app = _app()
+    client = await aiohttp_client(app)
+    body, headers = scheduler_auth({"vms": [_entry(message)]}, path=PLAN)
+
+    response = await client.post(PLAN, data=body, headers=headers)
+
+    assert response.status == 202
+    assert (await response.json())["rejected"][message["item_hash"]]["code"] == "invalid_message"
+    submitted = app["allocation_reconciler"].submit.call_args.args[0]
+    assert submitted.entries == {}
+
+
+@pytest.mark.asyncio
+async def test_an_entry_the_host_refuses_is_answered_and_not_submitted(
+    aiohttp_client, scheduler_auth, signed_message, monkeypatch
+):
+    """Capacity gating: what the answer refused never reaches the loop, which
+    would otherwise retry it forever and start it the moment room appeared."""
+    message = signed_message()
+    app = _app()
+    monkeypatch.setattr(
+        app["capacity"],
+        "simulate",
+        lambda candidates, **_: [AdmissionVerdict(h, False, "insufficient_capacity", "no room") for h, _ in candidates],
+    )
+    client = await aiohttp_client(app)
+    body, headers = scheduler_auth({"vms": [_entry(message)]}, path=PLAN)
+
+    response = await client.post(PLAN, data=body, headers=headers)
+
+    payload = await response.json()
+    assert payload["rejected"][message["item_hash"]]["code"] == "insufficient_capacity"
+    assert payload["accepted"] == []
+    submitted = app["allocation_reconciler"].submit.call_args.args[0]
+    assert ItemHash(message["item_hash"]) not in submitted.entries
+
+
+@pytest.mark.asyncio
+async def test_a_message_the_host_can_take_is_accepted_and_submitted(
+    aiohttp_client, scheduler_auth, signed_message, mocker
+):
+    _stub_host(mocker)
+    message = signed_message()
+    app = _app()
+    client = await aiohttp_client(app)
+    body, headers = scheduler_auth({"vms": [_entry(message)]}, path=PLAN)
+
+    response = await client.post(PLAN, data=body, headers=headers)
+
+    assert (await response.json())["accepted"] == [message["item_hash"]]
+    submitted = app["allocation_reconciler"].submit.call_args.args[0]
+    assert set(submitted.entries) == {ItemHash(message["item_hash"])}
+
+
+@pytest.mark.asyncio
+async def test_the_hosts_cards_reach_the_verdict(aiohttp_client, scheduler_auth, signed_message, mocker):
+    """The one read the pure verdict cannot do for itself: the handler reads
+    the inventory from the supervisor and hands it in, so a GPU VM can be
+    placed at all."""
+    _stub_host(mocker)
+    card = _card()
+    app = _app(host_info=HostInfo(available_gpus=[card.model_dump()]))
+    simulate = mocker.spy(app["capacity"], "simulate")
+    client = await aiohttp_client(app)
+    body, headers = scheduler_auth({"vms": [_entry(signed_message())]}, path=PLAN)
+
+    await client.post(PLAN, data=body, headers=headers)
+
+    assert simulate.call_args.kwargs["available_gpus"] == [card]
+
+
+@pytest.mark.asyncio
+async def test_a_plan_body_over_the_legacy_cap_reaches_the_handler(aiohttp_client, scheduler_auth):
+    """A plan carries a signed message per VM, so it outgrows the 1 MiB the
+    other signed routes are bounded to. The app's own ceiling used to cut it
+    off inside the verifier, which reported it as a bad signature."""
+    client = await aiohttp_client(_app())
+    body, headers = scheduler_auth({"vms": [], "padding": "x" * (MAX_SIGNED_REQUEST_BODY_BYTES + 1)}, path=PLAN)
+
+    response = await client.post(PLAN, data=body, headers=headers)
+
+    assert response.status == 202
+
+
+@pytest.mark.asyncio
+async def test_the_capacity_check_judges_without_touching_anything(
+    aiohttp_client, scheduler_auth, signed_message, mocker
+):
+    """A scheduler asks several CRNs before committing to one, so a check
+    must record no plan and hold nothing. An entry without its message cannot
+    be sized and says so; one with it is judged as a create would judge it."""
+    _stub_host(mocker)
+    message = signed_message()
+    app = _app()
+    client = await aiohttp_client(app)
+    body, headers = scheduler_auth({"vms": [_entry(message), {"item_hash": str(HASH_C)}]}, path=CHECK)
+
+    response = await client.post(CHECK, data=body, headers=headers)
+
+    assert response.status == 200
+    payload = await response.json()
+    assert payload["results"][message["item_hash"]] == {"accepted": True}
+    assert payload["results"][str(HASH_C)]["code"] == "message_required"
+    assert payload["capacity"]["instance_memory_mib"] > 0
+    assert payload["capacity"]["gpus"] == []
+    app["allocation_reconciler"].submit.assert_not_called()
+    assert app["capacity"].holds == {}
+
+
+@pytest.mark.asyncio
+async def test_the_capacity_check_refuses_what_a_create_would_refuse(
+    aiohttp_client, scheduler_auth, signed_message, mocker
+):
+    """Advisory and enforced answer alike: a message asking for more than
+    the host has is refused here with the same code the plan route gives."""
+    _stub_host(mocker, memory_gib=1)
+    message = signed_message()
+    client = await aiohttp_client(_app())
+    body, headers = scheduler_auth({"vms": [_entry(message)]}, path=CHECK)
+
+    response = await client.post(CHECK, data=body, headers=headers)
+
+    result = (await response.json())["results"][message["item_hash"]]
+    assert result["accepted"] is False
+    assert result["code"] == "insufficient_capacity"
+
+
+@pytest.mark.asyncio
+async def test_the_legacy_endpoint_is_untouched(aiohttp_client, scheduler_auth):
+    """The compatibility guarantee: an old scheduler keeps working."""
+    client = await aiohttp_client(_app())
+    body, headers = scheduler_auth({"persistent_vms": []}, path="/control/allocations")
+
+    response = await client.post("/control/allocations", data=body, headers=headers)
+
+    assert response.status == 200
+    assert (await response.json())["success"] is True

--- a/tests/supervisor/test_create_path_disk_admission.py
+++ b/tests/supervisor/test_create_path_disk_admission.py
@@ -85,11 +85,11 @@ def _patch_message(monkeypatch, content):
     return content
 
 
-async def _create(capacity, supervisor=None):
+async def _create(capacity, supervisor=None, registry=None):
     await run_module.create_vm_execution(
         _HASH,
         supervisor=supervisor or _supervisor(),
-        registry=AgentVmRegistry(),
+        registry=registry if registry is not None else AgentVmRegistry(),
         capacity=capacity,
         persistent=True,
     )
@@ -301,3 +301,52 @@ class TestCreateGuard:
 
         assert held == [True]
         assert not is_creating(str(_HASH))
+
+
+class TestTheRecordIsTheCommitment:
+    """Admission sums the registry, so a create in flight is only visible to a
+    concurrent create's admission through its record. The record has to be in
+    place before this create's own admission runs (its own hash is excluded
+    from its own check), or two creates that only fit once both pass against
+    a sum that ignores them both. The instance and V-PROGRAM paths recorded
+    early already; the program path recorded after create_vm returned, which
+    is exactly the window the reconciler's concurrent starts open."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("content", "build"),
+        [
+            pytest.param(_program_content, "build_program_create_vm_spec", id="program"),
+            pytest.param(
+                lambda: _make_qemu_instance_message(hypervisor=HypervisorType.qemu),
+                "build_create_vm_spec",
+                id="instance",
+            ),
+            pytest.param(lambda: _vprogram_content(), "build_vprogram_spec", id="vprogram"),
+        ],
+    )
+    async def test_every_path_records_before_it_admits(self, monkeypatch, content, build):
+        _patch_message(monkeypatch, content())
+        monkeypatch.setattr(run_module, build, AsyncMock())
+        registry = AgentVmRegistry()
+        recorded_at_admission: list[bool] = []
+
+        def refuse(*_args, **_kwargs):
+            recorded_at_admission.append(registry.get(_HASH) is not None)
+            raise InsufficientResourcesError("no room", required={}, available={})
+
+        capacity = _capacity()
+        capacity.check_message.side_effect = refuse
+
+        with pytest.raises(InsufficientResourcesError):
+            await _create(capacity, registry=registry)
+
+        assert recorded_at_admission == [True]
+        # And a refused create leaves no record behind to hold capacity.
+        assert registry.get(_HASH) is None
+
+
+def _vprogram_content():
+    from test_vprogram import load_vprogram_message
+
+    return load_vprogram_message().content

--- a/tests/supervisor/test_vprogram.py
+++ b/tests/supervisor/test_vprogram.py
@@ -5,8 +5,6 @@ docs/plans/2026-07-11-vprogram-scheduler-support-design.md.
 """
 
 import json
-import time
-from hashlib import sha256
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -20,8 +18,6 @@ from aleph_message.models import (
     VerifiableProgramMessage,
     parse_message,
 )
-from eth_account import Account
-from eth_account.messages import encode_defunct
 
 from aleph.vm.agent.messages import update_message
 from aleph.vm.agent.resources import Allocation
@@ -29,7 +25,6 @@ from aleph.vm.agent.run import VmStartupError, create_vm_execution, run_code_on_
 from aleph.vm.agent.supervisor import setup_webapp
 from aleph.vm.agent.tasks import _group_executions_by_payment
 from aleph.vm.agent.vm_registry import AgentVmRecord, AgentVmRegistry
-from aleph.vm.conf import settings
 from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.supervisor_interface.errors import VmSetupError
 from aleph.vm.supervisor_interface.types import (
@@ -43,29 +38,6 @@ from aleph.vm.supervisor_interface.types import (
 from aleph.vm.vm_type import VmType
 
 FIXTURE = Path(__file__).parent / "fixtures" / "vprogram_message.json"
-
-
-def _signed_allocation(account, body_dict):
-    """Body bytes plus the Aleph-EIP191-V1 headers binding them, for /control/allocations."""
-    body = json.dumps(body_dict).encode()
-    payload = {
-        "method": "POST",
-        "path": "/control/allocations",
-        "body_sha256": sha256(body).hexdigest(),
-        "iat": int(time.time()),
-    }
-    payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
-    signed = account.sign_message(encode_defunct(payload_bytes))
-    header = f"Aleph-EIP191-V1 sig={signed.signature.hex()},payload={payload_bytes.hex()}"
-    return body, {"Authorization": header, "Content-Type": "application/json"}
-
-
-@pytest.fixture()
-def scheduler_auth(monkeypatch):
-    """Authorize a throwaway scheduler key and sign requests as it."""
-    account = Account.create()
-    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [account.address])
-    return lambda body_dict: _signed_allocation(account, body_dict)
 
 
 def load_vprogram_message() -> VerifiableProgramMessage:

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -148,6 +148,10 @@ def mock_request(mocker):
         # No query string by default; tests covering H2 override this.
         request.query_string = ""
         request.remote = "127.0.0.1"
+        # The decorator re-bounds a request to its route's cap by cloning it;
+        # this double is its own clone.
+        request.client_max_size = MAX_SIGNED_REQUEST_BODY_BYTES
+        request.clone = lambda **_kwargs: request
         return request
 
     return factory

--- a/tests/supervisor/views/test_allocation_auth.py
+++ b/tests/supervisor/views/test_allocation_auth.py
@@ -7,6 +7,7 @@ import types
 from hashlib import sha256
 
 import pytest
+from aiohttp import web
 from eth_account import Account
 from eth_account.messages import encode_defunct
 from pydantic import ValidationError
@@ -15,11 +16,14 @@ from aleph.vm.agent import utils as orchestrator_utils
 from aleph.vm.agent.utils import get_authorized_allocation_signers
 from aleph.vm.agent.views import allocation_auth
 from aleph.vm.agent.views.allocation_auth import (
+    MAX_SIGNED_PLAN_BODY_BYTES,
     MAX_SIGNED_REQUEST_BODY_BYTES,
+    RequestTooLarge,
     _accepted_payloads,
     _parse_auth_params,
     _verify_aleph_signature,
     log_allocation_auth_config,
+    requires_allocation_auth,
 )
 from aleph.vm.conf import Settings, settings
 
@@ -457,8 +461,10 @@ async def test_verify_concurrent_same_iat_rejects_one(authorize_signer, mocker):
 
 
 @pytest.mark.asyncio
-async def test_verify_rejects_oversized_body(mock_request, authorize_signer):
-    """Content-Length over the cap → reject without reading the body."""
+async def test_verify_reports_an_oversized_body_as_too_large(mock_request, authorize_signer):
+    """Content-Length over the cap is refused without reading the body, and
+    refused as too large rather than as a bad signature: a scheduler whose
+    plan outgrew the cap needs to split it, not rotate its key."""
     payload_bytes = make_signed_payload(body=b"{}")
     auth = make_auth_header(authorize_signer, payload_bytes)
     request = mock_request(
@@ -467,9 +473,74 @@ async def test_verify_rejects_oversized_body(mock_request, authorize_signer):
         content_length=MAX_SIGNED_REQUEST_BODY_BYTES + 1,
     )
 
-    assert await _verify_aleph_signature(request, auth) is False
+    with pytest.raises(RequestTooLarge):
+        await _verify_aleph_signature(request, auth)
     # Body must not be read once the cap rejects.
     request.read.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_an_oversized_body_is_still_refused_for_an_unauthorized_signer(mock_request, monkeypatch):
+    """The size answer comes after the signer check, so an anonymous client
+    gets the same 401 for any body and learns nothing about the cap."""
+    monkeypatch.setattr(settings, "AUTHORIZED_ALLOCATION_SIGNERS", [Account.create().address])
+    payload_bytes = make_signed_payload(body=b"{}")
+    auth = make_auth_header(Account.create(), payload_bytes)
+    request = mock_request(
+        headers={"Authorization": auth},
+        body=b"{}",
+        content_length=MAX_SIGNED_REQUEST_BODY_BYTES + 1,
+    )
+
+    assert await _verify_aleph_signature(request, auth) is False
+
+
+@pytest.mark.asyncio
+async def test_a_route_may_raise_the_cap_for_its_own_bodies(mock_request, authorize_signer):
+    """A plan body carries one signed message per VM, so the v2 routes take
+    bodies the legacy cap refuses. The cap belongs to the route, not to the
+    verifier; the default keeps every existing route where it was."""
+    body = b"x" * (MAX_SIGNED_REQUEST_BODY_BYTES + 1)
+    payload_bytes = make_signed_payload(body=body)
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(headers={"Authorization": auth}, body=body)
+
+    with pytest.raises(RequestTooLarge):
+        await _verify_aleph_signature(request, auth)
+    assert await _verify_aleph_signature(request, auth, max_body_bytes=MAX_SIGNED_PLAN_BODY_BYTES) is True
+
+
+@pytest.mark.asyncio
+async def test_the_decorator_answers_too_large_rather_than_unauthorized(mock_request, authorize_signer):
+    @requires_allocation_auth(max_body_bytes=MAX_SIGNED_PLAN_BODY_BYTES)
+    async def handler(_request):
+        return web.Response(text="ok")
+
+    payload_bytes = make_signed_payload(body=b"{}")
+    auth = make_auth_header(authorize_signer, payload_bytes)
+    request = mock_request(
+        headers={"Authorization": auth},
+        body=b"{}",
+        content_length=MAX_SIGNED_PLAN_BODY_BYTES + 1,
+    )
+
+    response = await handler(request)
+
+    assert response.status == 413
+
+
+@pytest.mark.asyncio
+async def test_the_bare_decorator_still_wraps(mock_request):
+    """The migration routes use it without parentheses; that form must keep
+    working now that the decorator takes a cap."""
+
+    @requires_allocation_auth
+    async def handler(_request):
+        return web.Response(text="ok")
+
+    response = await handler(mock_request())
+
+    assert response.status == 401
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Task 6 of the async allocations plan, and the first PR of the stack with a production caller: until now nothing reached `agent/allocation/`.

## The endpoints

**`POST /v2/control/allocations`** builds the plan from the push, answers for each VM at once (202 with `accepted` / `pending` / `unchanged` / `removing` / `rejected` / `retained` and the `plan_id`), and hands the reconciler the plan less what the answer refused. The handler reads the supervisor's list and the GPU inventory first, both async; from there to `submit()` nothing yields, so the answer returned is the one the plan was recorded against.

**`POST /v2/control/capacity/check`** judges the same entries the way a create would, with no side effects: no plan recorded, nothing held, nothing running read as dropped. An entry without its message answers `message_required` rather than being fetched. The headroom rides along, computed from the same figures admission uses.

Both share `build_plan` as their one validation boundary (a body that is not a plan is 400 on either, never read as the empty plan), and both take a plan-sized body. The legacy route is untouched.

## The three things carried here from the #1172 and #1173 reviews

**GPU inventory.** `compute_verdict` takes `available_gpus` and passes it to `simulate`; the handler reads it through a now-public `CapacityManager.available_gpus()`. A GPU VM can be placed. Along the way, a real wrinkle: `simulate` treated every live hold as taken, but the reserve endpoint exists precisely so a user can hold a card *before* asking the scheduler, so the verdict would have refused the user's own VM. `simulate` now lets a candidate use a hold its own user placed, mirroring `resolve_gpus(consume_own_hold=True)`; `ResourceRequirements` carries the owner for it.

**Capacity gating.** `narrow_plan` drops the refused entries before `submit()`. Left in, they'd be retried forever at backoff rate and started the moment room appeared, on a node the scheduler was told had refused them. Pending entries stay (nothing judged them), and so does the plan id (it names the push, not the host's room at the time).

**Provisional commitments.** This turned out to be half done already. The instance and V-PROGRAM paths in `create_vm_execution` record *before* `check_message(exclude_vm_hash=...)`, so a concurrent create's admission already sees the record: the early record is the provisional commitment. Only the program path recorded after `create_vm` returned, which is exactly the window the reconciler's concurrent starts open. Programs now take the same shape (record, admit, build, create, wait, one failure path that retires), and a parametrized test pins all three paths to record-before-admit. No new ledger.

## Two findings the plan did not have

- **The app's body ceiling.** `web.Application()` was built with aiohttp's default 1 MiB `client_max_size`, so a 2 MiB plan body would be cut off inside `request.read()`, inside the verifier's broad `except`, and reported as a 401. The route-level 8 MiB cap alone fixes nothing. The app ceiling rises to the plan cap; every other signed route keeps 1 MiB through the verifier's own cap, which is now a per-route parameter that answers 413 (only once the signer is checked, so an anonymous client still learns nothing).
- **The plan's handler code was stale in three places** (`compute_verdict` takes `node_hash`; `simulate` takes 2-tuples; `capacity_check`'s `body.get("vms", [])` was the fail-dangerous shape refused in #1172). All adapted.

## Residuals, stated rather than hidden

- One `await` (the `had_volumes` snapshot) sits between record and admission, so two peers on a tight host can refuse *each other* for a pass. Conservative, self-heals through backoff, and cannot normally arise since gating only submits entries `simulate` admitted together.
- Disk is still judged live at admission, as before: two concurrent creates can both pass the disk check before either writes. The second fails at the write, loudly, not silently.
- The capacity check judges capacity only; node pinning is the plan route's business.

## Verification

Every new test was mutation-checked against the specific defect it exists to catch (23 mutations, each failing exactly its own test). Suite: 45 failed / 1107 passed against a freshly measured `dev-2.1` baseline of 45 / 1077, same three unrelated files (root-owned `/var/cache/aleph`, `/var/lib/aleph/vm`). mypy at the 47-error baseline, ruff and isort clean.

Task 7 (`allocation` + `state` in `/v2/about/executions/list`) follows.
