### PR TITLE
feat(agent): report allocation state in the v2 executions list

### DIFF
--- a/src/aleph/vm/agent/allocation/plan.py
+++ b/src/aleph/vm/agent/allocation/plan.py
@@ -48,15 +48,14 @@ class AllocationState(str, Enum):
     whereas a merged enum would need maintaining in lockstep forever.
 
     The reconciler sets DOWNLOADING and FAILED, the only two it can observe.
-    The rest are the executions list's to report from the plan: PLANNED for
-    an entry the loop has not reached, RESOLVING for one still waiting on its
-    message, SUBMITTING for one handed to the supervisor.
+    The executions list derives the other two from the plan, for an entry the
+    loop has not reached: PLANNED when the push carried its message, RESOLVING
+    when the create will have to fetch it first.
     """
 
     PLANNED = "planned"
     RESOLVING = "resolving"
     DOWNLOADING = "downloading"
-    SUBMITTING = "submitting"
     FAILED = "failed"
 
 

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -112,6 +112,17 @@ class AllocationReconciler:
     def planned_hashes(self) -> set[ItemHash]:
         return set(self._desired.entries) if self._desired else set()
 
+    def pending_hashes(self) -> set[ItemHash]:
+        """The planned VMs whose message the push did not carry.
+
+        They are started like any other; the fetch happens inside the create.
+        Exposed so the executions list can say "waiting on its message" for
+        one the loop has not reached yet, where a verified entry is "planned".
+        """
+        if self._desired is None:
+            return set()
+        return {vm_hash for vm_hash, planned in self._desired.entries.items() if planned.verified is None}
+
     def state_for(self, vm_hash: ItemHash) -> tuple[AllocationState | None, FailureRecord | None]:
         """What the agent is doing about this VM, for the executions list."""
         return self._states.get(vm_hash), self._failures.get(vm_hash)

--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -290,7 +290,6 @@ async def list_executions(request: web.Request) -> web.Response:
     )
 
 
-@cors_allow_all
 def _allocation_block(state: AllocationState | None, failure: FailureRecord | None) -> dict | None:
     """What the agent is doing about a VM, for the executions list; None once
     the agent has nothing to add to the supervisor's word."""
@@ -304,6 +303,7 @@ def _allocation_block(state: AllocationState | None, failure: FailureRecord | No
     }
 
 
+@cors_allow_all
 async def list_executions_v2(request: web.Request) -> web.Response:
     """List all executions. Returning their status and ip.
 

--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -22,6 +22,8 @@ from pydantic import ValidationError
 from aleph.vm import haproxy
 from aleph.vm.agent import payment, status
 from aleph.vm.agent.aggregate import update_aggregate_settings
+from aleph.vm.agent.allocation.plan import AllocationState, FailureRecord
+from aleph.vm.agent.allocation.reconciler import AllocationReconciler
 from aleph.vm.agent.allocation.teardown import is_removable_by_allocation, teardown_vm
 from aleph.vm.agent.capacity import CapacityManager, requested_gpu_ids
 from aleph.vm.agent.custom_logs import set_vm_for_logging
@@ -206,6 +208,9 @@ def _datetime_from_ns(ns: int) -> datetime | None:
     )
 
 
+_TIMES_KEYS = ("defined_at", "preparing_at", "prepared_at", "starting_at", "started_at", "stopping_at", "stopped_at")
+
+
 def _times_dict(info: VmInfo) -> dict[str, datetime | None]:
     """The VmExecutionTimes-shaped dict the v2 endpoint has always served."""
     return {
@@ -286,45 +291,89 @@ async def list_executions(request: web.Request) -> web.Response:
 
 
 @cors_allow_all
+def _allocation_block(state: AllocationState | None, failure: FailureRecord | None) -> dict | None:
+    """What the agent is doing about a VM, for the executions list; None once
+    the agent has nothing to add to the supervisor's word."""
+    if state is None:
+        return None
+    return {
+        "state": state.value,
+        "attempts": failure.attempts if failure else 0,
+        "error": {"code": failure.code, "message": failure.message} if failure else None,
+        "next_retry_at": failure.next_retry_at if failure else None,
+    }
+
+
 async def list_executions_v2(request: web.Request) -> web.Response:
-    """List all executions. Returning their status and ip"""
+    """List all executions. Returning their status and ip.
+
+    Two disjoint fields per entry: ``state`` is the supervisor's status,
+    verbatim, and ``allocation`` is what the agent is doing about the VM in
+    the phases the supervisor cannot see. A VM the plan lists that the
+    supervisor does not yet know is listed here with ``state`` None, so the
+    scheduler can tell "working on it" from "never heard of it", which it
+    used to have to guess. A VM the supervisor knows can still carry an
+    allocation block: a create in flight for one it holds dead, or the
+    failure that keeps it dead.
+    """
     # Same single-tenant assumption as list_executions: list_vms() is
     # hypervisor-global, so under a multi-tenant supervisor this would report
     # VMs the agent does not own. See the note there.
     supervisor: Supervisor = request.app["supervisor"]
     registry: AgentVmRegistry = request.app["vm_registry"]
+    reconciler: AllocationReconciler = request.app["allocation_reconciler"]
     infos = await supervisor.list_vms()
     host_info = await supervisor.get_host_info()
     mapped_ports = _group_port_forwards(await supervisor.list_port_forwards())
-    return web.json_response(
-        {
-            info.vm_id: {
-                "networking": (
-                    {
-                        "ipv4_network": info.ipv4.network_cidr,
-                        "host_ipv4": host_info.host_ipv4,
-                        "ipv6_network": info.ipv6.network_cidr,
-                        "ipv6_ip": info.ipv6.address,
-                        "ipv4_ip": info.ipv4.address,
-                        "mapped_ports": mapped_ports.get(info.vm_id, {}),
-                    }
-                    if info.ipv4.network_cidr
-                    else {}
-                ),
-                "status": _times_dict(info),
-                "running": info.status is VmStatus.RUNNING,
-                # Confidential VMs are only started once their owner uploads the
-                # session certificates: not running, but not dead either.
-                "awaiting_confidential_init": info.awaiting_confidential_init,
-                # cast: info.vm_id is a VmId (opaque str at the boundary); the
-                # agent knows its own VMs are keyed by item hash. See the
-                # ownership note at the top of list_executions.
-                "vm_type": _vm_type_name(registry.get(cast(ItemHash, info.vm_id)), info),
-            }
-            for info in infos
-        },
-        dumps=dumps_for_json,
-    )
+    entries = {
+        info.vm_id: {
+            "networking": (
+                {
+                    "ipv4_network": info.ipv4.network_cidr,
+                    "host_ipv4": host_info.host_ipv4,
+                    "ipv6_network": info.ipv6.network_cidr,
+                    "ipv6_ip": info.ipv6.address,
+                    "ipv4_ip": info.ipv4.address,
+                    "mapped_ports": mapped_ports.get(info.vm_id, {}),
+                }
+                if info.ipv4.network_cidr
+                else {}
+            ),
+            "status": _times_dict(info),
+            "state": info.status.value,
+            # Kept for existing consumers, now an alias of state.
+            "running": info.status is VmStatus.RUNNING,
+            # Confidential VMs are only started once their owner uploads the
+            # session certificates: not running, but not dead either.
+            "awaiting_confidential_init": info.awaiting_confidential_init,
+            # cast: info.vm_id is a VmId (opaque str at the boundary); the
+            # agent knows its own VMs are keyed by item hash. See the
+            # ownership note at the top of list_executions.
+            "vm_type": _vm_type_name(registry.get(cast(ItemHash, info.vm_id)), info),
+            "allocation": _allocation_block(*reconciler.state_for(cast(ItemHash, info.vm_id))),
+        }
+        for info in infos
+    }
+    pending = reconciler.pending_hashes()
+    for vm_hash in reconciler.planned_hashes():
+        if str(vm_hash) in entries:
+            continue
+        state, failure = reconciler.state_for(vm_hash)
+        if state is None:
+            # The loop has not reached it: what it will do first is fetch the
+            # message, or not.
+            state = AllocationState.RESOLVING if vm_hash in pending else AllocationState.PLANNED
+        record = registry.get(vm_hash)
+        entries[str(vm_hash)] = {
+            "networking": {},
+            "status": dict.fromkeys(_TIMES_KEYS),
+            "state": None,
+            "running": False,
+            "awaiting_confidential_init": False,
+            "vm_type": VmType.from_message_content(record.message).name if record is not None else None,
+            "allocation": _allocation_block(state, failure),
+        }
+    return web.json_response(entries, dumps=dumps_for_json)
 
 
 @cors_allow_all

--- a/tests/supervisor/test_allocation_reconciler.py
+++ b/tests/supervisor/test_allocation_reconciler.py
@@ -322,6 +322,22 @@ async def test_a_successful_start_clears_a_previous_failure(reconciler, monkeypa
     assert reconciler.state_for(HASH_C) == (None, None)
 
 
+def test_pending_hashes_are_the_entries_the_push_carried_no_message_for(reconciler):
+    reconciler.submit(
+        AllocationPlan(
+            plan_id="sha256:test",
+            received_at=NOW,
+            entries={
+                HASH_B: PlannedVm(vm_hash=HASH_B, verified=SimpleNamespace(message=MagicMock())),
+                HASH_C: PlannedVm(vm_hash=HASH_C),
+            },
+        )
+    )
+
+    assert reconciler.pending_hashes() == {HASH_C}
+    assert reconciler.planned_hashes() == {HASH_B, HASH_C}
+
+
 @pytest.mark.asyncio
 async def test_a_newer_plan_supersedes_the_previous_one(reconciler, monkeypatch):
     """Level-triggered: the desired state is re-read every pass."""

--- a/tests/supervisor/test_executions_list_allocation.py
+++ b/tests/supervisor/test_executions_list_allocation.py
@@ -175,3 +175,20 @@ async def test_an_absent_vm_keeps_the_shape_consumers_read(aiohttp_client):
     assert set(body[str(HASH_C)]) == set(live)
     assert set(body[str(HASH_C)]["status"]) == set(live["status"])
     assert body[str(HASH_C)]["vm_type"] == "instance"
+
+
+@pytest.mark.asyncio
+async def test_the_listing_answers_cross_origin_readers(aiohttp_client):
+    """The console reads this from a browser, like the legacy list. CORS
+    comes from the route's registration in setup_webapp, not from the
+    decorator on the view, which only sets an attribute nothing reads."""
+    client = await aiohttp_client(_app())
+    origin = {"Origin": "https://console.example"}
+
+    preflight = await client.options(LIST, headers={**origin, "Access-Control-Request-Method": "GET"})
+    response = await client.get(LIST, headers=origin)
+
+    assert preflight.status == 200
+    assert preflight.headers["Access-Control-Allow-Origin"] == "https://console.example"
+    assert response.status == 200
+    assert response.headers["Access-Control-Allow-Origin"] == "https://console.example"

--- a/tests/supervisor/test_executions_list_allocation.py
+++ b/tests/supervisor/test_executions_list_allocation.py
@@ -1,0 +1,177 @@
+"""What the CRN advertises per VM once allocation is asynchronous.
+
+Two disjoint fields: `state` is the supervisor's VmStatus, verbatim, and
+`allocation` covers the phases that precede the supervisor knowing the VM at
+all. They are never merged into one enum, which would have to be maintained in
+lockstep with VmStatus forever.
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aleph_message.models import ItemHash
+from test_supervisor_translate import _make_qemu_instance_message
+
+from aleph.vm.agent.allocation.plan import AllocationState, FailureRecord
+from aleph.vm.agent.supervisor import setup_webapp
+from aleph.vm.supervisor_interface.types import (
+    Backend,
+    HostInfo,
+    IpAssignment,
+    VmId,
+    VmInfo,
+    VmStatus,
+)
+
+NOW = datetime(2026, 8, 25, tzinfo=timezone.utc)
+HASH_A = ItemHash("a" * 64)
+HASH_C = ItemHash("c" * 64)
+LIST = "/v2/about/executions/list"
+
+
+def _info(vm_hash, status=VmStatus.RUNNING) -> VmInfo:
+    return VmInfo(
+        vm_id=VmId(str(vm_hash)),
+        status=status,
+        ipv4=IpAssignment(),
+        ipv6=IpAssignment(),
+        uptime_secs=0,
+        backend=Backend.QEMU,
+        numa_node=None,
+        status_message="",
+    )
+
+
+def _reconciler(*, planned=(), pending=(), states=None):
+    """A double over the three reads the list makes: the plan, the entries
+    still waiting on their message, and the loop's own state per VM."""
+    states = states or {}
+    return SimpleNamespace(
+        planned_hashes=lambda: set(planned),
+        pending_hashes=lambda: set(pending),
+        state_for=lambda vm_hash: states.get(vm_hash, (None, None)),
+        # The app starts the loop and wires the event watcher to it.
+        run=AsyncMock(),
+        notify_vm_down=MagicMock(),
+    )
+
+
+def _app(*, infos=(), reconciler=None):
+    supervisor = MagicMock(
+        list_vms=AsyncMock(return_value=list(infos)),
+        get_host_info=AsyncMock(return_value=HostInfo(host_ipv4="10.0.0.1")),
+        list_port_forwards=AsyncMock(return_value=[]),
+    )
+    app = setup_webapp(supervisor=supervisor)
+    app["allocation_reconciler"] = reconciler or _reconciler()
+    return app
+
+
+async def _listing(aiohttp_client, app):
+    client = await aiohttp_client(app)
+    response = await client.get(LIST)
+    assert response.status == 200
+    return await response.json()
+
+
+@pytest.mark.asyncio
+async def test_a_planned_vm_the_loop_has_not_reached_is_visible(aiohttp_client):
+    """Otherwise the scheduler cannot tell 'working on it' from 'never heard
+    of it', which is exactly what it used to have to guess."""
+    body = await _listing(aiohttp_client, _app(reconciler=_reconciler(planned=[HASH_C])))
+
+    assert body[str(HASH_C)]["state"] is None
+    assert body[str(HASH_C)]["allocation"]["state"] == "planned"
+    assert body[str(HASH_C)]["running"] is False
+
+
+@pytest.mark.asyncio
+async def test_a_planned_vm_still_waiting_on_its_message_says_so(aiohttp_client):
+    reconciler = _reconciler(planned=[HASH_C], pending=[HASH_C])
+
+    body = await _listing(aiohttp_client, _app(reconciler=reconciler))
+
+    assert body[str(HASH_C)]["allocation"]["state"] == "resolving"
+
+
+@pytest.mark.asyncio
+async def test_the_loops_own_state_wins_over_the_derived_one(aiohttp_client):
+    reconciler = _reconciler(planned=[HASH_C], pending=[HASH_C], states={HASH_C: (AllocationState.DOWNLOADING, None)})
+
+    body = await _listing(aiohttp_client, _app(reconciler=reconciler))
+
+    assert body[str(HASH_C)]["allocation"]["state"] == "downloading"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_allocation_reports_its_reason_and_retry_time(aiohttp_client):
+    failure = FailureRecord(
+        code="resource_download_error",
+        message="rootfs 404",
+        attempts=2,
+        first_failed_at=NOW,
+        last_failed_at=NOW,
+        next_retry_at=NOW + timedelta(seconds=60),
+    )
+    reconciler = _reconciler(planned=[HASH_C], states={HASH_C: (AllocationState.FAILED, failure)})
+
+    body = await _listing(aiohttp_client, _app(reconciler=reconciler))
+
+    allocation = body[str(HASH_C)]["allocation"]
+    assert allocation["state"] == "failed"
+    assert allocation["error"] == {"code": "resource_download_error", "message": "rootfs 404"}
+    assert allocation["attempts"] == 2
+    # Rendered the way the status times are, by the same serializer.
+    assert allocation["next_retry_at"] == "2026-08-25 00:01:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_a_running_vm_reports_the_supervisors_status_and_no_allocation_block(aiohttp_client):
+    body = await _listing(aiohttp_client, _app(infos=[_info(HASH_A)]))
+
+    assert body[str(HASH_A)]["state"] == "running"
+    assert body[str(HASH_A)]["allocation"] is None
+    # Existing consumers keep working: an alias of state, not a second truth.
+    assert body[str(HASH_A)]["running"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_planned_vm_the_supervisor_runs_is_listed_once_with_no_allocation_block(aiohttp_client):
+    """The plan's entry and the supervisor's are the same VM."""
+    body = await _listing(aiohttp_client, _app(infos=[_info(HASH_A)], reconciler=_reconciler(planned=[HASH_A])))
+
+    assert list(body) == [str(HASH_A)]
+    assert body[str(HASH_A)]["allocation"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_vm_the_supervisor_holds_dead_still_carries_the_agents_failure(aiohttp_client):
+    """Disjoint fields, both present: the supervisor's word on the VM it has,
+    and the agent's on why the recreate is not happening."""
+    failure = FailureRecord(
+        code="x", message="y", attempts=1, first_failed_at=NOW, last_failed_at=NOW, next_retry_at=NOW
+    )
+    reconciler = _reconciler(planned=[HASH_A], states={HASH_A: (AllocationState.FAILED, failure)})
+
+    body = await _listing(aiohttp_client, _app(infos=[_info(HASH_A, VmStatus.FAILED)], reconciler=reconciler))
+
+    assert body[str(HASH_A)]["state"] == "failed"
+    assert body[str(HASH_A)]["allocation"]["state"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_an_absent_vm_keeps_the_shape_consumers_read(aiohttp_client):
+    """Same keys as a live entry, so a reader iterating the list does not
+    special-case the ones that are not up yet. The type comes from the
+    record when there is one, a recreate for instance."""
+    app = _app(reconciler=_reconciler(planned=[HASH_C]))
+    content = _make_qemu_instance_message()
+    app["vm_registry"].record(HASH_C, message=content, original=content, persistent=True)
+    body = await _listing(aiohttp_client, app)
+    live = (await _listing(aiohttp_client, _app(infos=[_info(HASH_A)])))[str(HASH_A)]
+
+    assert set(body[str(HASH_C)]) == set(live)
+    assert set(body[str(HASH_C)]["status"]) == set(live["status"])
+    assert body[str(HASH_C)]["vm_type"] == "instance"

--- a/tests/supervisor/test_executions_list_allocation.py
+++ b/tests/supervisor/test_executions_list_allocation.py
@@ -162,6 +162,23 @@ async def test_a_vm_the_supervisor_holds_dead_still_carries_the_agents_failure(a
 
 
 @pytest.mark.asyncio
+async def test_a_vm_the_supervisor_holds_dead_shows_the_recreate_in_flight(aiohttp_client):
+    """The other half of the same claim: the loop is downloading for a VM
+    the supervisor still lists as dead, so both words are out at once."""
+    reconciler = _reconciler(planned=[HASH_A], states={HASH_A: (AllocationState.DOWNLOADING, None)})
+
+    body = await _listing(aiohttp_client, _app(infos=[_info(HASH_A, VmStatus.FAILED)], reconciler=reconciler))
+
+    assert body[str(HASH_A)]["state"] == "failed"
+    assert body[str(HASH_A)]["allocation"] == {
+        "state": "downloading",
+        "attempts": 0,
+        "error": None,
+        "next_retry_at": None,
+    }
+
+
+@pytest.mark.asyncio
 async def test_an_absent_vm_keeps_the_shape_consumers_read(aiohttp_client):
     """Same keys as a live entry, so a reader iterating the list does not
     special-case the ones that are not up yet. The type comes from the


### PR DESCRIPTION
Task 7 of the async allocations plan, the last one: `/v2/about/executions/list` reports what the agent is doing about a VM before, and beside, what the supervisor says.

## Two disjoint fields per entry

- **`state`**: the supervisor's `VmStatus`, verbatim. `running` stays, now an alias of it for existing consumers.
- **`allocation`**: the agent's phases the supervisor cannot see, or `null` when it has nothing to add. The loop's own `downloading` and `failed` (with the failure's `code`/`message`, `attempts` and `next_retry_at`), or `planned` / `resolving` derived from the plan for an entry the loop has not reached, the difference being whether the create will have to fetch the message first.

A VM the plan lists that the supervisor does not yet know is listed with `state: null` and the same keys as a live entry (`networking: {}`, all-null `status` times, `vm_type` from the registry record if a recreate left one), so the scheduler can tell "working on it" from "never heard of it", which it used to have to guess, and a reader iterating the list does not special-case the ones not up yet. A VM the supervisor knows can still carry an allocation block: the failure that keeps a dead one dead, or a recreate in flight.

## Two small things on the reconciler

- `pending_hashes()`: the planned entries the push carried no message for. It is the one fact the list needs from the plan that `planned_hashes()` did not give.
- `AllocationState.SUBMITTING` is removed. Nothing could set it without a hook in the create path, and an enum member nothing sets is a state a reader will wait for in vain. `PLANNED` and `RESOLVING`, flagged as unused on #1173 and #1202, now have their consumer.

## Verification

8 endpoint tests through the real app over a fake supervisor, plus one unit test for `pending_hashes`. Six mutations (derived states swapped, derivation overriding the loop's own state, dedupe removed, allocation dropped for known VMs, `state` nulled, `pending_hashes` emptied), each caught by its intended test. Suite 45 failed / 1126 passed against a freshly measured `dev-2.1` baseline of 45 / 1117, same three unrelated files. mypy at the 47-error baseline, ruff and isort clean.

That closes the plan. Left from its "after" list: the design doc's sections 6 and 11 are stale (they predate `check_message` and the merged prerequisites) and live on the unmerged `od/async-allocations-design` branch.
