### PR TITLE
fix(examples): keep the confidential image's encrypted root readable by the OVMF's GRUB

### DIFF
--- a/examples/example_confidential_image/build_debian_image.sh
+++ b/examples/example_confidential_image/build_debian_image.sh
@@ -140,7 +140,14 @@ echo -n "${DISK_PASSWORD}" >"${KEY_FILE}"
 
 sudo cryptsetup --batch-mode --type luks1 --key-file "${KEY_FILE}" luksFormat "${OS_PARTITION_DEVICE_ID}"
 sudo cryptsetup open --key-file "${KEY_FILE}" "${OS_PARTITION_DEVICE_ID}" "${MAPPER_NAME}"
-sudo mkfs.ext4 "${MAPPED_DEVICE_ID}"
+# The GRUB embedded in the confidential OVMF is what opens this volume and
+# loads its grub.cfg, and its ext2 driver cannot read a filesystem created
+# with the orphan_file and metadata_csum_seed features: the guest unlocks
+# the volume, prints "Failed to find any grub configuration on the encrypted
+# volume" and halts. e2fsprogs 1.47.2 (Ubuntu 26.04) enables both by
+# default, so turn them off explicitly instead of depending on the build
+# host's mke2fs.conf.
+sudo mkfs.ext4 -O ^orphan_file,^metadata_csum_seed "${MAPPED_DEVICE_ID}"
 
 echo "Copying root file system to the new OS partition..."
 sudo mkdir -p "${MOUNT_POINT}"


### PR DESCRIPTION
`examples/example_confidential_image/build_debian_image.sh` formats the LUKS root with a bare `mkfs.ext4`, so the filesystem features come from the build host's `mke2fs.conf`. On Ubuntu 26.04 (e2fsprogs 1.47.2) that now includes `orphan_file` and `metadata_csum_seed`, and the GRUB embedded in the confidential OVMF cannot read the result. The guest unlocks the volume and stops right after:

```
Entering grub config
Attempting to decrypt master key...
Slot 0 opened
Failed to find any grub configuration on the encrypted volume
```

`/boot/grub/grub.cfg` is present on the volume; GRUB just cannot read the filesystem. Ubuntu 24.04 (e2fsprogs 1.47.0) did not enable either feature, which is why images built there boot.

Pin the feature set with `mkfs.ext4 -O ^orphan_file,^metadata_csum_seed`. Found on the new aleph-testnets TEE server (aleph-testnets #39/#40 carry the same change for the vendored copy). Users building encrypted images on a recent Ubuntu hit the same thing, so this is user-facing, not just CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnureenxugkU48aFn5HL6h