### PR TITLE
fix(agent): keep a refused VM out of the reconciler's teardown set

### DIFF
--- a/src/aleph/vm/agent/allocation/plan.py
+++ b/src/aleph/vm/agent/allocation/plan.py
@@ -88,13 +88,18 @@ class PlannedVm:
 class AllocationPlan:
     """What the push asked for, once the answer has had its say.
 
-    ``refused`` are the hashes the push listed and the answer turned down.
-    They are out of ``entries`` because nothing is to start them, and they are
-    named here because the convergence loop reads a hash the plan does not
-    hold as one the scheduler took away, and deleting a VM means reaping its
-    disks. "Rejected" is not "deleted": the scheduler still believes the VM
-    exists, and every refusal the answer gives is temporary anyway (no room
-    right now, a node that has not read its own hash back yet).
+    ``refused`` are the hashes the push listed and this node turned down,
+    over a message it would not verify or for want of room. They are out of
+    ``entries`` because nothing is to start them, and they are named here
+    because the convergence loop reads a hash the plan does not hold as one
+    the scheduler took away, and deleting a VM means reaping its disks.
+    "Rejected" is not "deleted": the scheduler still believes the VM exists,
+    and the shapes that produce a refusal (a full host, a node that has not
+    read its own hash back since it restarted, a corrupt message from a buggy
+    scheduler or a bad CCN read) are all things that pass.
+
+    A hash the push sent in a form we could not parse is absent from both:
+    it names no VM on this node, so there is nothing for it to protect.
     """
 
     plan_id: str

--- a/src/aleph/vm/agent/allocation/plan.py
+++ b/src/aleph/vm/agent/allocation/plan.py
@@ -86,9 +86,25 @@ class PlannedVm:
 
 @dataclass(frozen=True)
 class AllocationPlan:
+    """What the push asked for, once the answer has had its say.
+
+    ``refused`` are the hashes the push listed and the answer turned down.
+    They are out of ``entries`` because nothing is to start them, and they are
+    named here because the convergence loop reads a hash the plan does not
+    hold as one the scheduler took away, and deleting a VM means reaping its
+    disks. "Rejected" is not "deleted": the scheduler still believes the VM
+    exists, and every refusal the answer gives is temporary anyway (no room
+    right now, a node that has not read its own hash back yet).
+    """
+
     plan_id: str
     received_at: datetime
     entries: dict[ItemHash, PlannedVm]
+    refused: frozenset[ItemHash] = frozenset()
+
+    def lists(self, vm_hash: ItemHash) -> bool:
+        """Whether the push this plan came from named this VM at all."""
+        return vm_hash in self.entries or vm_hash in self.refused
 
 
 @dataclass

--- a/src/aleph/vm/agent/allocation/plan.py
+++ b/src/aleph/vm/agent/allocation/plan.py
@@ -93,10 +93,13 @@ class AllocationPlan:
     ``entries`` because nothing is to start them, and they are named here
     because the convergence loop reads a hash the plan does not hold as one
     the scheduler took away, and deleting a VM means reaping its disks.
-    "Rejected" is not "deleted": the scheduler still believes the VM exists,
-    and the shapes that produce a refusal (a full host, a node that has not
-    read its own hash back since it restarted, a corrupt message from a buggy
-    scheduler or a bad CCN read) are all things that pass.
+    "Rejected" is not "deleted": the scheduler still believes the VM exists.
+    Most of the shapes that produce a refusal pass on their own (a full host,
+    a node that has not read its own hash back since it restarted, a corrupt
+    message from a buggy scheduler or a bad CCN read), and one does not: a VM
+    allocated to another node stays allocated to it. The set holds every
+    refusal all the same, transient or permanent, because waiting for the push
+    to stop naming the VM is the safe reading of both.
 
     A hash the push sent in a form we could not parse is absent from both:
     it names no VM on this node, so there is nothing for it to protect.

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -168,9 +168,12 @@ class AllocationReconciler:
             # answer refused is named: the scheduler was told the VM was
             # rejected, not that it was deleted, so it still believes the VM
             # is here, while a teardown retires it GONE and reaps its disks.
-            # Every refusal is temporary too, so the loop would be destroying
-            # a VM over a full disk or over a node hash it has not read back
-            # since its last restart.
+            # The set holds every refusal, transient or not. Most of them pass
+            # on their own (a full disk, a node hash not read back since the
+            # last restart), and one does not: a VM allocated to another node
+            # stays allocated to it. Waiting for a push to stop naming the VM
+            # is the safe reading either way, since the scheduler that placed
+            # it elsewhere is the one that will stop naming it here.
             if plan.lists(vm_hash) or info.status not in TEARDOWN_STATUSES:
                 continue
             # The plan is re-read here rather than taken from the pass, which

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -164,7 +164,14 @@ class AllocationReconciler:
 
     async def _teardown_dropped(self, plan: AllocationPlan, known: dict[ItemHash, VmInfo]) -> None:
         for vm_hash, info in known.items():
-            if vm_hash in plan.entries or info.status not in TEARDOWN_STATUSES:
+            # Torn down only if the push never named this VM. A hash the
+            # answer refused is named: the scheduler was told the VM was
+            # rejected, not that it was deleted, so it still believes the VM
+            # is here, while a teardown retires it GONE and reaps its disks.
+            # Every refusal is temporary too, so the loop would be destroying
+            # a VM over a full disk or over a node hash it has not read back
+            # since its last restart.
+            if plan.lists(vm_hash) or info.status not in TEARDOWN_STATUSES:
                 continue
             # The plan is re-read here rather than taken from the pass, which
             # may have been parked in list_vms or in an earlier teardown while
@@ -173,7 +180,7 @@ class AllocationReconciler:
             # cannot, since GONE reaps the volumes. The read and the await
             # below are in one turn, so nothing lands in between.
             current = self._desired
-            if current is None or vm_hash in current.entries:
+            if current is None or current.lists(vm_hash):
                 continue
             record = self.registry.get(vm_hash)
             if record is None or not is_removable_by_allocation(record, info):

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -238,6 +238,15 @@ def narrow_plan(plan: AllocationPlan, verdict: PlanVerdict) -> AllocationPlan:
     is the loop's own. The identity stays too, since it names the push, and a
     re-push of the same set is the same plan whatever the host had room for
     the first time.
+
+    Dropped is not forgotten: the refused hashes are carried alongside, so
+    the loop can tell a VM this push refused from one it never mentioned. It
+    tears down the second kind, and a refusal is no reason to destroy a VM.
     """
     entries = {vm_hash: planned for vm_hash, planned in plan.entries.items() if vm_hash not in verdict.rejected}
-    return AllocationPlan(plan_id=plan.plan_id, received_at=plan.received_at, entries=entries)
+    return AllocationPlan(
+        plan_id=plan.plan_id,
+        received_at=plan.received_at,
+        entries=entries,
+        refused=frozenset(plan.entries) - frozenset(entries),
+    )

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -194,6 +194,17 @@ def compute_verdict(
         # it is owed, and an allocation push is not the place to find out.
         if record is None or info.status is not VmStatus.RUNNING:
             continue
+        # A hash the push named and this node refused is out of the entries but
+        # is not a hash the push took away, and the loop keeps its VM for
+        # exactly that reason. The answer has to say the same thing, or the two
+        # halves of this change contradict each other: a scheduler told the VM
+        # is going away stops naming it, and the next push, naming it nowhere,
+        # is the deletion that carrying the refusals forward exists to prevent.
+        # Nothing is freeing that memory either, so it must not go on to
+        # simulate as capacity the other candidates can be admitted against.
+        if plan.lists(vm_hash):
+            verdict.retained[vm_hash] = "refused"
+            continue
         if is_removable_by_allocation(record, info):
             verdict.removing.append(vm_hash)
         else:

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -77,6 +77,12 @@ def build_plan(body: dict, *, now: datetime) -> tuple[AllocationPlan, dict[str, 
     Rejected entries are returned separately: they are answered in the response
     and never enter the plan, so nothing downstream can act on them.
 
+    Separately is not silently: an entry whose hash we could read is named in
+    the plan's ``refused`` set, because the convergence loop tears down every
+    VM the push did not name and a message we would not verify is no reason
+    to delete the VM it names. An entry whose hash we could not read is left
+    out of that set, since it names no VM here and so has nothing to protect.
+
     A bad entry is data to reject, but a body we cannot read raises. An empty
     plan is a real instruction, the one that stops everything this node runs,
     so a shape we cannot make sense of must never be read as one: ``vms: 5``
@@ -90,6 +96,7 @@ def build_plan(body: dict, *, now: datetime) -> tuple[AllocationPlan, dict[str, 
         raise ValueError(msg)
     entries: dict[ItemHash, PlannedVm] = {}
     rejected: dict[str, dict] = {}
+    refused: set[ItemHash] = set()
     for entry in vms:
         # This is the validation boundary for a body the scheduler controls, so
         # a bad entry is data to reject, never an exception: one unusable hash
@@ -109,13 +116,15 @@ def build_plan(body: dict, *, now: datetime) -> tuple[AllocationPlan, dict[str, 
         outcome, verified, reason = verify_entry(entry)
         if outcome is VerificationOutcome.REJECTED:
             rejected[vm_hash] = {"code": "invalid_message", "message": reason}
+            refused.add(vm_hash)
             # The other order of the same duplicate: an earlier entry may
             # already have put this hash in the plan.
             entries.pop(vm_hash, None)
             continue
         entries[vm_hash] = PlannedVm(vm_hash=vm_hash, verified=verified)
     plan_id = compute_plan_id([str(h) for h in entries], [str(h) for h in rejected])
-    return AllocationPlan(plan_id=plan_id, received_at=now, entries=entries), rejected
+    plan = AllocationPlan(plan_id=plan_id, received_at=now, entries=entries, refused=frozenset(refused))
+    return plan, rejected
 
 
 def _retention_reason(record: AgentVmRecord, info: VmInfo) -> str:
@@ -242,11 +251,13 @@ def narrow_plan(plan: AllocationPlan, verdict: PlanVerdict) -> AllocationPlan:
     Dropped is not forgotten: the refused hashes are carried alongside, so
     the loop can tell a VM this push refused from one it never mentioned. It
     tears down the second kind, and a refusal is no reason to destroy a VM.
+    The ones build_plan already refused, over a message it would not verify,
+    are carried through for the same reason.
     """
     entries = {vm_hash: planned for vm_hash, planned in plan.entries.items() if vm_hash not in verdict.rejected}
     return AllocationPlan(
         plan_id=plan.plan_id,
         received_at=plan.received_at,
         entries=entries,
-        refused=frozenset(plan.entries) - frozenset(entries),
+        refused=plan.refused | (frozenset(plan.entries) - frozenset(entries)),
     )

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -61,6 +61,12 @@ class ResourceRequirements:
     # Whose VM this is, for the GPU ledger: a hold this address took is
     # available to it, the way resolve_gpus consumes an owner's own hold.
     owner: str | None = None
+    # The volumes the two disk figures above were summed from, when they came
+    # from a message. Kept so a caller that knows which VM this is can look up
+    # what it already holds and charge it only the difference; the figures
+    # themselves stay the declared ones, since a caller with no VM to name
+    # (the reserve endpoint) has nothing to discount against.
+    volumes: tuple[DeclaredVolume, ...] = ()
 
 
 # The filename suffixes a volume's file carries in ``{pool}/{vm_hash}/``. A
@@ -193,7 +199,8 @@ def requirements_from_message(
     ``volumes`` is ``declared_volumes(content)``, which a caller that already
     has that list (``check_message``) passes in rather than deriving it twice.
     """
-    volume_sizes_mib = [volume.size_mib for volume in (declared_volumes(content) if volumes is None else volumes)]
+    declared = declared_volumes(content) if volumes is None else volumes
+    volume_sizes_mib = [volume.size_mib for volume in declared]
     return ResourceRequirements(
         vcpus=content.resources.vcpus,
         memory_mib=content.resources.memory,
@@ -202,6 +209,7 @@ def requirements_from_message(
         is_instance=is_instance_bucket(content),
         gpu_device_ids=requested_gpu_ids(content),
         owner=str(address) if (address := getattr(content, "address", None)) else None,
+        volumes=tuple(declared),
     )
 
 
@@ -273,6 +281,41 @@ def held_volumes(vm_hash: ItemHash | str, volumes: list[DeclaredVolume]) -> list
         size_bytes = min(file_size_bytes(path), volume.size_mib * 1024 * 1024)
         held.append(HeldVolume(path=path, size_bytes=size_bytes))
     return held
+
+
+@dataclass(frozen=True)
+class DiskRequest:
+    """The disk figures admission judges, once the discount is applied."""
+
+    disk_mib: int
+    max_volume_mib: int
+    max_volume_credit: HeldVolume | None
+
+
+def discounted_disk(vm_hash: ItemHash | str | None, volumes: list[DeclaredVolume]) -> DiskRequest:
+    """What these volumes still need, less what that VM already holds.
+
+    One implementation for every path that judges disk, so an advisory answer
+    can never be stricter than the enforced one. ``vm_hash`` is None for a
+    caller with no VM to look up (the reserve endpoint admits a message no VM
+    owns yet), and then nothing is discounted and nothing is looked for.
+
+    The largest declared volume decides the per-pool check, and it is judged
+    at its declared size: shrinking that figure by what is held elsewhere
+    would let a discount from one volume excuse the placement of another.
+    What the VM already holds *for that volume* is instead credited to the
+    pool its file sits on, which is the only pool that would have to find
+    room for it again.
+    """
+    held = held_volumes(vm_hash, volumes) if vm_hash is not None else [None] * len(volumes)
+    declared_mib = sum(volume.size_mib for volume in volumes)
+    held_mib = sum(hit.size_bytes for hit in held if hit is not None) // (1024 * 1024)
+    largest = max(range(len(volumes)), key=lambda index: volumes[index].size_mib, default=None)
+    return DiskRequest(
+        disk_mib=max(declared_mib - held_mib, 0),
+        max_volume_mib=volumes[largest].size_mib if largest is not None else 0,
+        max_volume_credit=held[largest] if largest is not None else None,
+    )
 
 
 def requested_gpu_ids(content: ExecutableContent) -> list[str]:
@@ -366,23 +409,14 @@ class CapacityManager:
         one declared volume must not pay for a second one too.
         """
         volumes = declared_volumes(content)
-        held = held_volumes(exclude_vm_hash, volumes) if exclude_vm_hash is not None else [None] * len(volumes)
-        declared_mib = sum(volume.size_mib for volume in volumes)
-        held_mib = sum(hit.size_bytes for hit in held if hit is not None) // (1024 * 1024)
-        # The largest declared volume decides the per-pool check, and it is
-        # judged at its declared size: shrinking that figure by what is held
-        # elsewhere would let a discount from one volume excuse the placement
-        # of another. What the VM already holds *for that volume* is instead
-        # credited to the pool its file sits on, which is the only pool that
-        # would have to find room for it again.
-        largest = max(range(len(volumes)), key=lambda index: volumes[index].size_mib, default=None)
+        disk = discounted_disk(exclude_vm_hash, volumes)
         requirements = requirements_from_message(content, volumes)
         self.check_capacity(
             memory_mib=requirements.memory_mib,
             vcpus=requirements.vcpus,
-            disk_mib=max(declared_mib - held_mib, 0),
-            max_volume_mib=volumes[largest].size_mib if largest is not None else 0,
-            max_volume_credit=held[largest] if largest is not None else None,
+            disk_mib=disk.disk_mib,
+            max_volume_mib=disk.max_volume_mib,
+            max_volume_credit=disk.max_volume_credit,
             is_instance=requirements.is_instance,
             exclude_vm_hash=exclude_vm_hash,
         )
@@ -576,6 +610,11 @@ class CapacityManager:
         whether the roomiest pool could hold the largest volume, and which pool
         a volume lands on is a placement decision nothing models here.
 
+        A candidate is charged what it still has to allocate, not what it
+        declares: the volumes it already holds on this node are discounted the
+        way check_message discounts them, so a VM the plan re-lists is never
+        refused for space its own files occupy.
+
         A candidate's own registry record never counts against it. A hash can
         already be recorded here and still be a candidate: a recreate, or an
         owner record left by a create that failed part way. Counting both the
@@ -637,12 +676,14 @@ class CapacityManager:
         committed_disk = 0
         for vm_hash, requirements in candidates:
             refusal: tuple[str, str] | None = None
+            disk = self._candidate_disk(vm_hash, requirements)
             try:
                 self._check_against(
                     memory_mib=requirements.memory_mib,
                     vcpus=requirements.vcpus,
-                    disk_mib=requirements.disk_mib,
-                    max_volume_mib=requirements.max_volume_mib,
+                    disk_mib=disk.disk_mib,
+                    max_volume_mib=disk.max_volume_mib,
+                    max_volume_credit=disk.max_volume_credit,
                     is_instance=requirements.is_instance,
                     committed_instance_memory_mib=committed_instance,
                     committed_program_memory_mib=committed_program,
@@ -678,9 +719,27 @@ class CapacityManager:
             else:
                 committed_program += requirements.memory_mib
             committed_vcpus += requirements.vcpus
-            committed_disk += requirements.disk_mib
+            committed_disk += disk.disk_mib
             verdicts.append(AdmissionVerdict(vm_hash, True))
         return verdicts
+
+    @staticmethod
+    def _candidate_disk(vm_hash: ItemHash, requirements: ResourceRequirements) -> DiskRequest:
+        """The disk this candidate still has to find room for on this node.
+
+        A candidate can already hold its volumes here: the scheduler re-lists
+        a VM the supervisor is holding stopped, and a VM in that state is
+        sized as a candidate rather than read as unchanged. Charging it the
+        space its own files occupy refuses a VM the create path would have
+        admitted, and a refusal is what takes it out of the plan.
+
+        Requirements built from a message carry the volumes they were summed
+        from; requirements a caller assembled as bare scalars are judged as
+        given, since there is nothing to match a file against.
+        """
+        if not requirements.volumes:
+            return DiskRequest(requirements.disk_mib, requirements.max_volume_mib, None)
+        return discounted_disk(vm_hash, list(requirements.volumes))
 
     def _record_commitment(self, vm_hash: ItemHash) -> tuple[int, int, int] | None:
         """What this VM's registry record adds to (instance, program, vcpus).

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -650,6 +650,12 @@ class CapacityManager:
         allocate C onto B's card" is answered no even though doing it in that
         order would work.
 
+        Not free of blocking, though it is free of awaits: judging a candidate
+        walks the storage pools synchronously, once per candidate, so a large
+        plan holds the event loop for that many directory walks. check_message
+        does the same walk per create. Worth knowing here because the caller
+        must not yield while it holds this answer, which makes the window easy
+        to overlook.
         """
         candidate_hashes = {vm_hash for vm_hash, _ in candidates}
         committed_instance, committed_program, committed_vcpus = self._committed_resources(candidate_hashes)

--- a/tests/supervisor/test_agent_capacity.py
+++ b/tests/supervisor/test_agent_capacity.py
@@ -1408,6 +1408,67 @@ def test_a_colliding_stem_never_discounts_one_file_twice(mocker, tmp_path):
     assert "Disk: required 20480 MiB" in str(excinfo.value)
 
 
+# ── simulate: the same discount, for a whole plan ──────────────────────────
+
+
+def test_simulate_discounts_disk_the_candidate_already_holds(mocker, tmp_path):
+    """simulate charged every candidate its declared disk in full, while
+    check_message, the path that actually creates the VM, subtracts what the
+    VM's files already occupy. The advisory answer was the stricter of the
+    two, so a nearly full node refused a VM it was perfectly able to run, and
+    a refusal here is not free: the answer drops the VM from the plan the
+    reconciler converges on."""
+    _patch_host(mocker, memory_bytes=64 * 1024**3, cores=16, disk_bytes=1 * 1024**3)
+    pool = tmp_path / "pool0"
+    directory = _stage_volume_files(mocker, pool, {"rootfs.qcow2": 20 * 1024**3})
+    _patch_namespace_dirs(mocker, directory)
+    _patch_eligible_pools(mocker, (pool, 1 * 1024**3))
+    candidate = (_VM_HASH, requirements_from_message(_instance_content(rootfs_mib=20 * 1024)))
+
+    verdicts = _manager().simulate([candidate])
+
+    assert verdicts[0].accepted is True
+
+
+def test_simulate_still_charges_a_candidate_that_holds_nothing(mocker):
+    """The discount must not switch the disk check off. A VM whose volumes
+    are not on this node is charged them whole, and refused when they do not
+    fit."""
+    _patch_host(mocker, memory_bytes=64 * 1024**3, cores=16, disk_bytes=1 * 1024**3)
+    _patch_pools(mocker, 1 * 1024**3)
+    _hold_nothing(mocker)
+    candidate = (_VM_HASH, requirements_from_message(_instance_content(rootfs_mib=20 * 1024)))
+
+    verdicts = _manager().simulate([candidate])
+
+    assert verdicts[0].accepted is False
+    assert verdicts[0].code == "insufficient_capacity"
+
+
+def test_a_held_volume_is_not_charged_to_the_rest_of_the_plan(mocker, tmp_path):
+    """The batch accumulator has to charge what a candidate still has to
+    allocate, not what it declares: 20 GiB the first candidate already holds
+    is not 20 GiB the second one cannot have."""
+    _patch_host(mocker, memory_bytes=64 * 1024**3, cores=16, disk_bytes=20 * 1024**3)
+    pool = tmp_path / "pool0"
+    directory = _stage_volume_files(mocker, pool, {"rootfs.qcow2": 20 * 1024**3})
+    # Keyed on the namespace, unlike _patch_namespace_dirs: the second
+    # candidate must not find the first one's directory and be credited it.
+    mocker.patch(
+        "aleph.vm.agent.capacity.storage_pools.iter_namespace_dirs",
+        side_effect=lambda namespace: [directory] if namespace == str(_VM_HASH) else [],
+    )
+    _patch_eligible_pools(mocker, (pool, 20 * 1024**3))
+    candidates = [
+        (_VM_HASH, requirements_from_message(_instance_content(rootfs_mib=20 * 1024))),
+        (_HASH_B, requirements_from_message(_instance_content(rootfs_mib=None, volumes=(_volume("data", 15 * 1024),)))),
+    ]
+
+    verdicts = _manager().simulate(candidates)
+
+    assert [verdict.accepted for verdict in verdicts] == [True, True]
+
+
 # ── existing_volume_files ───────────────────────────────────────────────────
 
 

--- a/tests/supervisor/test_allocation_reconciler.py
+++ b/tests/supervisor/test_allocation_reconciler.py
@@ -48,8 +48,13 @@ def _record(*, stream=False, vprogram=False):
     )
 
 
-def _plan(*hashes):
-    return AllocationPlan(plan_id="sha256:test", received_at=NOW, entries={h: PlannedVm(vm_hash=h) for h in hashes})
+def _plan(*hashes, refused=()):
+    return AllocationPlan(
+        plan_id="sha256:test",
+        received_at=NOW,
+        entries={h: PlannedVm(vm_hash=h) for h in hashes},
+        refused=frozenset(refused),
+    )
 
 
 @pytest.fixture
@@ -416,6 +421,56 @@ async def test_a_dropped_vm_is_torn_down_even_if_it_already_died(reconciler, mon
     await reconciler._converge_once()
 
     assert reconciler_module.teardown_vm.await_args.args[0] == HASH_B
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [VmStatus.STOPPED, VmStatus.FAILED])
+async def test_a_vm_the_answer_only_refused_is_not_torn_down(reconciler, monkeypatch, status):
+    """A refused VM is not in the plan's entries, and that absence used to
+    read as "the scheduler dropped it": the pass retired it GONE, which drops
+    the record and the DB rows and reaps the volumes. The scheduler was told
+    the VM was rejected, which is not that it was deleted, and every refusal
+    the answer can give here is temporary: no room today, or a node that has
+    not learned its own hash back yet."""
+    _record_starts(reconciler, monkeypatch)
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_B, status=status)]
+    reconciler.submit(_plan(refused=[HASH_B]))
+
+    await reconciler._converge_once()
+
+    reconciler_module.teardown_vm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_does_not_spare_the_vms_the_push_left_out(reconciler, monkeypatch):
+    """The skip is exactly the hashes the push named. A VM it did not name is
+    still dropped, refusals elsewhere in the same push or not."""
+    _record_starts(reconciler, monkeypatch)
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_B, status=VmStatus.STOPPED), _info(HASH_C)]
+    reconciler.submit(_plan(refused=[HASH_B]))
+
+    await reconciler._converge_once()
+
+    assert [call.args[0] for call in reconciler_module.teardown_vm.await_args_list] == [HASH_C]
+
+
+@pytest.mark.asyncio
+async def test_a_vm_a_newer_plan_refused_is_not_torn_down(reconciler, monkeypatch):
+    """The mid-pass re-read covers a refusal like it covers a re-add: a push
+    that lands while the pass is parked in list_vms and refuses this VM has
+    still named it, so the pass must not carry on and delete it."""
+    _record_starts(reconciler, monkeypatch)
+    reconciler.submit(_plan())
+
+    async def list_vms():
+        reconciler.submit(_plan(refused=[HASH_B]))
+        return [_info(HASH_B)]
+
+    reconciler.supervisor.list_vms = list_vms
+
+    await reconciler._converge_once()
+
+    reconciler_module.teardown_vm.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -319,6 +319,38 @@ def test_an_entry_with_an_unusable_item_hash_is_rejected_not_raised():
     assert list(plan.entries) == [HASH_A]
     assert rejected["not-a-hash"]["code"] == "invalid_message"
     assert rejected["None"]["code"] == "invalid_message"
+    # Neither key names a VM this node could be running, so neither is worth
+    # protecting from the teardown pass.
+    assert plan.refused == frozenset()
+
+
+def test_a_hash_whose_message_will_not_verify_is_still_a_hash_the_push_named():
+    """The push named this VM; all we refused is the message it carried. The
+    convergence loop deletes what the push left out, so leaving the hash out
+    of the plan entirely means a corrupt entry, from a scheduler bug or a bad
+    CCN read, reaps the disks of a VM that is running here perfectly well."""
+    body = {"vms": [{"item_hash": str(HASH_A), "message": "not-an-object"}, {"item_hash": str(HASH_B)}]}
+
+    plan, rejected = build_plan(body, now=NOW)
+
+    assert rejected[HASH_A]["code"] == "invalid_message"
+    assert list(plan.entries) == [HASH_B]
+    assert plan.refused == frozenset({HASH_A})
+
+
+def test_narrowing_carries_the_refusals_the_plan_arrived_with():
+    """Two refusals reach the loop by different routes: build_plan's, over a
+    message it would not verify, and the answer's, over a host with no room.
+    Both name a VM the push listed, so both have to survive narrowing."""
+    plan, _ = build_plan(
+        {"vms": [{"item_hash": str(HASH_A), "message": "not-an-object"}, {"item_hash": str(HASH_B)}]}, now=NOW
+    )
+    verdict = PlanVerdict(rejected={HASH_B: {"code": "insufficient_capacity"}})
+
+    narrowed = narrow_plan(plan, verdict)
+
+    assert narrowed.entries == {}
+    assert narrowed.refused == frozenset({HASH_A, HASH_B})
 
 
 def test_a_pinned_vm_is_not_refused_when_we_do_not_know_our_own_hash():

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -119,6 +119,25 @@ def test_a_running_vm_absent_from_the_plan_is_removing():
     assert verdict.removing == [HASH_B]
 
 
+def test_a_running_vm_the_push_refused_is_retained_not_removing():
+    """A hash the push named and this node refused is not one the push took
+    away. The loop keeps that VM, so the answer has to say the same: told the
+    VM is going away, a scheduler that believes it and stops naming the hash
+    has the VM torn down on the very next push, which is the destruction
+    refusing it was supposed to avoid. Its memory is not being freed either,
+    so it must not reach simulate as released capacity and buy room for the
+    other candidates.
+    """
+    plan = AllocationPlan(plan_id="sha256:test", received_at=NOW, entries={}, refused=frozenset({HASH_B}))
+    capacity = _capacity([])
+
+    verdict = compute_verdict(plan, infos=[_info(HASH_B)], registry=_registry({HASH_B: _record()}), capacity=capacity)
+
+    assert verdict.removing == []
+    assert verdict.retained[HASH_B] == "refused"
+    assert capacity.simulate.call_args.kwargs["releasing"] == frozenset()
+
+
 def test_a_stream_paid_vm_absent_from_the_plan_is_retained_with_its_reason():
     verdict = compute_verdict(
         _plan(), infos=[_info(HASH_B)], registry=_registry({HASH_B: _record(stream=True)}), capacity=_capacity([])

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -500,3 +500,50 @@ def test_narrowing_drops_what_the_answer_refused_and_nothing_else():
     assert set(narrowed.entries) == {HASH_A, HASH_C}
     assert narrowed.entries[HASH_A] is plan.entries[HASH_A]
     assert (narrowed.plan_id, narrowed.received_at) == (plan.plan_id, plan.received_at)
+    assert narrowed.refused == frozenset({HASH_B})
+
+
+def test_a_stopped_vm_the_answer_refused_is_carried_as_refused():
+    """The chain the reconciler reads. The supervisor holds C stopped, so the
+    answer sizes it as a candidate instead of reading it as unchanged, and a
+    node with no room left refuses it. Narrowing has to keep it out of the
+    entries, or the loop would retry it forever, but dropping it silently is
+    what turned "rejected" into "deleted": to the loop a hash the plan does
+    not list is one the scheduler took away, and it reaps the disks of every
+    VM it takes away."""
+    plan = _plan(HASH_C)
+    capacity = _capacity([AdmissionVerdict(HASH_C, False, "insufficient_capacity", "not enough capacity on this CRN")])
+
+    verdict = compute_verdict(
+        plan,
+        infos=[_info(HASH_C, status=VmStatus.STOPPED)],
+        registry=_registry({HASH_C: _record()}),
+        capacity=capacity,
+    )
+    narrowed = narrow_plan(plan, verdict)
+
+    assert verdict.rejected[HASH_C]["code"] == "insufficient_capacity"
+    assert narrowed.entries == {}
+    assert narrowed.refused == frozenset({HASH_C})
+
+
+def test_a_vm_refused_for_an_undiscovered_node_hash_is_carried_as_refused():
+    """The same, for the refusal that is purely transient: right after a
+    restart the agent has not read its own hash back, so every VM the push
+    pins to this node is refused for that one pass. Reading those refusals as
+    deletions would make a restart wipe the node."""
+    content = _make_qemu_instance_message()
+    content.requirements = SimpleNamespace(node=SimpleNamespace(node_hash="some-node"), gpu=None)
+    plan = _plan(HASH_C, content=content)
+
+    verdict = compute_verdict(
+        plan,
+        infos=[_info(HASH_C, status=VmStatus.STOPPED)],
+        registry=_registry({HASH_C: _record()}),
+        capacity=_capacity([]),
+        node_hash=None,
+    )
+    narrowed = narrow_plan(plan, verdict)
+
+    assert verdict.rejected[HASH_C]["code"] == "node_hash_unknown"
+    assert narrowed.refused == frozenset({HASH_C})

--- a/tests/supervisor/test_allocations_v2.py
+++ b/tests/supervisor/test_allocations_v2.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import aiohttp
 import pytest
 from aleph_message.models import ItemHash
+from test_supervisor_translate import _make_qemu_instance_message
 
 from aleph.vm.agent.allocation import reconciler as reconciler_module
 from aleph.vm.agent.capacity import AdmissionVerdict, CapacityManager
@@ -22,7 +23,7 @@ from aleph.vm.agent.views.allocation_auth import (
     MAX_SIGNED_REQUEST_BODY_BYTES,
 )
 from aleph.vm.resources import GpuDevice, GpuDeviceClass
-from aleph.vm.supervisor_interface.types import HostInfo
+from aleph.vm.supervisor_interface.types import ConfidentialMode, HostInfo, VmStatus
 
 HASH_C = ItemHash("c" * 64)
 PLAN = "/v2/control/allocations"
@@ -69,6 +70,17 @@ def _card():
 
 def _entry(message):
     return {"item_hash": message["item_hash"], "message": message}
+
+
+def _running(vm_hash):
+    """What the supervisor reports for a VM of ours that is up."""
+    return SimpleNamespace(
+        vm_id=str(vm_hash),
+        status=VmStatus.RUNNING,
+        gpus=[],
+        confidential_mode=ConfidentialMode.NONE,
+        awaiting_confidential_init=False,
+    )
 
 
 @pytest.mark.asyncio
@@ -183,6 +195,39 @@ async def test_a_message_the_host_can_take_is_accepted_and_submitted(
     assert (await response.json())["accepted"] == [message["item_hash"]]
     submitted = app["allocation_reconciler"].submit.call_args.args[0]
     assert set(submitted.entries) == {ItemHash(message["item_hash"])}
+
+
+@pytest.mark.asyncio
+async def test_a_corrupt_message_for_a_running_vm_does_not_delete_it(
+    aiohttp_client, scheduler_auth, signed_message, monkeypatch
+):
+    """The rule the loop converges by: a hash the push named is never one the
+    push dropped. Here the push names a VM this node is running and carries a
+    message that will not verify, which is what a scheduler bug or a bad CCN
+    read looks like from here. The answer is invalid_message, so the hash is
+    not among the plan's entries, and the pass used to read that absence as a
+    deletion: it retired the VM GONE, dropping its record and its DB rows and
+    reaping its disks over one corrupt entry."""
+    message = signed_message()
+    content = json.loads(message["item_content"])
+    content["resources"]["vcpus"] = 64
+    message["item_content"] = json.dumps(content)
+    message["content"] = content
+    vm_hash = ItemHash(message["item_hash"])
+    teardown = AsyncMock()
+    monkeypatch.setattr(reconciler_module, "teardown_vm", teardown)
+    app = _app(real_reconciler=True)
+    app["supervisor"].list_vms.return_value = [_running(vm_hash)]
+    running = _make_qemu_instance_message()
+    app["vm_registry"].record(vm_hash, message=running, original=running, persistent=True)
+    client = await aiohttp_client(app)
+    body, headers = scheduler_auth({"vms": [_entry(message)]}, path=PLAN)
+
+    response = await client.post(PLAN, data=body, headers=headers)
+
+    assert (await response.json())["rejected"][str(vm_hash)]["code"] == "invalid_message"
+    await app["allocation_reconciler"]._converge_once()
+    teardown.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_allocations_v2.py
+++ b/tests/supervisor/test_allocations_v2.py
@@ -225,7 +225,14 @@ async def test_a_corrupt_message_for_a_running_vm_does_not_delete_it(
 
     response = await client.post(PLAN, data=body, headers=headers)
 
-    assert (await response.json())["rejected"][str(vm_hash)]["code"] == "invalid_message"
+    payload = await response.json()
+    assert payload["rejected"][str(vm_hash)]["code"] == "invalid_message"
+    # The answer and the loop say one thing. This payload used to carry the VM
+    # under "rejected" and under "removing" at once, so a scheduler that read
+    # the second half stopped naming the hash and the next push deleted the VM
+    # the first half had just protected.
+    assert payload["removing"] == []
+    assert payload["retained"][str(vm_hash)] == "refused"
     await app["allocation_reconciler"]._converge_once()
     teardown.assert_not_awaited()
 


### PR DESCRIPTION
## Summary
The convergence loop deletes every VM the plan does not list, so the rule it needs is that **a VM hash the push listed, in any form, is never one that push dropped**. Neither half of that rule held.

A planned VM the supervisor holds STOPPED or FAILED is not "unchanged", so `compute_verdict` sizes it as a capacity candidate; `simulate` charged it its full declared disk with none of the held-volume discount `check_message` applies, so a nearly full node answered `insufficient_capacity`. `narrow_plan` dropped the hash from the plan the reconciler converges on, and `_teardown_dropped` read that absence as a deletion: it retires the VM GONE, which drops the record and the DB rows and reaps the disks under the default `VOLUME_RETENTION=reap`. The scheduler had been told "rejected", which is not "deleted". `node_hash_unknown`, transient right after an agent restart, refuses every node-pinned VM the same way, so a restart on a busy node could wipe them.

The same held for an entry whose embedded message does not verify: `build_plan` rejects it and the hash never entered the plan at all, so one corrupt entry, from a scheduler bug or a bad CCN read, deleted a VM running here perfectly well.

Now every hash the push named is carried by the plan, refused or accepted, and a pass tears down only what the push never named. `simulate` applies the held-volume discount too, so a re-listed VM is not refused for disk it already occupies.

The answer had to say the same thing as the loop, and did not. A RUNNING VM whose embedded message `build_plan` refused is out of `plan.entries`, so `compute_verdict` fell through to the drop branch and listed it under `removing`, and the e2e test's own payload carried one hash under `rejected` and under `removing` at once. A scheduler that believes `removing` stops naming the hash, and the next push, naming it nowhere, is exactly the teardown this PR carries the refusals forward to prevent, so the protection was defeated one push later. The list also reached `simulate` as released capacity, crediting a still-running VM's memory to the other candidates and making the advisory answer more permissive than the enforced check. Any hash the plan `lists()` is now answered under `retained`, with `refused` as the reason, and never reaches `simulate` as released.

## Changes
- `allocation/plan.py`: `AllocationPlan` gains `refused` and a `lists()` predicate, so a plan can say whether the push named a VM at all, not just whether it wants it started.
- `allocation/verdict.py`: `build_plan` names the hashes it refused over a message it would not verify (an entry whose hash could not be parsed is left out: it names no VM here, so it has nothing to protect), `narrow_plan` carries those through and adds the ones the answer refused.
- `allocation/verdict.py`: `compute_verdict` answers a hash the plan lists under `retained` (`refused`) instead of `removing`, so the answer and the loop agree and the VM's memory is not credited to the rest of the plan.
- `allocation/reconciler.py`: `_teardown_dropped` skips any hash the push named, on the pass snapshot and on the mid-pass re-read alike.
- `allocation/reconciler.py` and `allocation/plan.py` comments: the refused set was described as holding transient refusals only. `node_mismatch` is permanent, so both now say the set holds every refusal and that waiting for the push to stop naming the VM is the safe reading of either kind. `simulate`'s docstring notes the synchronous storage-pool walk it does per candidate on the caller's await-free path.
- `agent/capacity.py`: the disk arithmetic `check_message` did inline moves into `discounted_disk`, and `simulate` goes through it per candidate. `ResourceRequirements` carries the declared volumes it was summed from so the lookup is possible; requirements built as bare scalars are judged as given. The batch disk accumulator charges the discounted figure, so space a candidate already holds is not taken from the rest of the plan.

## Test plan
- `tests/supervisor/test_allocations_v2.py`: end to end, a push naming a RUNNING VM with a corrupt embedded message answers `invalid_message` and the next reconcile pass does not tear the VM down (on the unfixed code the mock teardown is awaited twice). The same payload now asserts `removing == []` and `retained[hash] == "refused"`, pinning the answer and the loop to one story.
- `tests/supervisor/test_allocation_reconciler.py`: a VM the answer only refused is not torn down (STOPPED and FAILED), a refusal does not spare the VMs the push left out, and the mid-pass re-read covers a refusal like it covers a re-add.
- `tests/supervisor/test_allocation_verdict.py`: a RUNNING hash the plan refused is `retained` rather than `removing`, and `simulate` is called with an empty `releasing`; narrowing carries the refused hashes, for a stopped VM refused `insufficient_capacity`, for one refused `node_hash_unknown`, and for one `build_plan` refused over its message; an unparseable hash is refused without being protected.
- `tests/supervisor/test_agent_capacity.py`: `simulate` discounts disk the candidate already holds, still charges a candidate that holds nothing, and does not charge a held volume to the rest of the plan.
- Checks: `ruff format --diff` and `isort --check-only --profile black` on every changed file, and `mypy src/aleph/vm/ tests/` from the worktree root, all clean. The test suites are left to CI on this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZyMqLgxxVfeDwiNy34sfM

