### PR TITLE
fix(cli): give aleph-vm storage its config, logs and database

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -538,10 +538,9 @@ goes first", which is the only promise a node can honestly sell.
 ### CLI
 
 Storage is agent-side and readable from the filesystem plus the agent DB, so
-`aleph-vm storage ...` (`src/aleph/vm/agent/storage_cli.py`, dispatched by
-`agent/cli.py` before its own argument parser, which points at
-`storage --help` in its own `--help` epilog) needs no running *agent
-process*:
+`aleph-vm storage ...` (`src/aleph/vm/agent/storage_cli.py`, registered as a
+subparser on `agent/cli.py`'s own parser, which points at `storage --help`
+in its `--help` epilog) needs no running *agent process*:
 
 - `storage status`: per pool, live / reclaimable / cache / free bytes
   against the budgets. Read-only, registry live set only.
@@ -579,6 +578,34 @@ process*:
   (`remove_parent_device` per evicted ref, then `sweep_leaked_cache_loops`),
   so an evicted entry never leaves `/dev/mapper/<ref>` and its loop device
   pinning the deleted inode.
+
+Running with no agent process also means setting the process up the way the
+systemd units set it up for the daemon, which the CLI does before it reads
+anything:
+
+- **Configuration.** `EnvironmentFile=/etc/aleph-vm/supervisor.env` in the
+  units is what gives the daemon its settings; nothing gives them to an
+  operator's shell, and pydantic reads only the process environment and a
+  `.env` in the working directory. The CLI therefore loads that file itself
+  (`--env-file`, else `$ALEPH_VM_ENV_FILE`, else the packaged path) and
+  rebuilds the settings singleton from it, logging which file it used or
+  that there was none. Values already in the environment win, so a one-off
+  override on the command line still works, and a `--env-file` that does
+  not exist is an error rather than a silent fall back to the defaults: a
+  pass run with `VOLUME_RETENTION` at its `reap` default on a node
+  configured to keep would evict every retained directory.
+- **Logging.** Most of what a pass has to report it reports through the
+  logger the reconciler, the purge and the marker already write to, so the
+  CLI configures a stderr handler at `INFO` (`--loglevel`, or the agent
+  CLI's own `-v` / `-vv` / `--loglevel` placed before the verb). Without it
+  those lines are dropped and warnings arrive as bare last-resort lines.
+- **Database.** `cli.initialise_database()` (the tables, then the alembic
+  migrations) is shared with the daemon's startup and runs before the
+  registry is rehydrated: an unmigrated or absent database otherwise fails
+  with a raw sqlite error. `status` and `list` are the exception; being
+  read-only, they refuse a database that does not exist and exit `1` rather
+  than create an empty one, so an operator pointed at the wrong execution
+  root sees the mistake instead of an empty listing.
 
 `reconcile` and `reclaim` can purge, so they apply the same fail-closed rule
 `reconciler._startup_refusal` applies to the daemon's own startup pass: a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,8 +80,9 @@ allow-direct-references = true
 platforms = [ "linux" ]
 
 [tool.hatch.envs.default.scripts]
-# The aleph-vm console script (aleph.vm.agent.cli:main) is a flat argparse
-# CLI, no subcommands; the supervisor daemon is the Rust binary under rust/.
+# The aleph-vm console script (aleph.vm.agent.cli:main) runs the agent with
+# no subcommand; `aleph-vm storage <verb>` is its one subcommand. The
+# supervisor daemon is the Rust binary under rust/.
 agent = "aleph-vm {args:--help}"
 config = "aleph-vm --print-settings --do-not-run {args}"
 

--- a/src/aleph/vm/agent/cli.py
+++ b/src/aleph/vm/agent/cli.py
@@ -21,6 +21,12 @@ from .custom_logs import setup_handlers
 logger = logging.getLogger(__name__)
 
 
+# Validated against --loglevel, here and on the storage subcommand: an
+# unknown name must be a clean argparse usage error (exit 2), not a raw
+# ValueError traceback out of logging.Logger.setLevel further down.
+LOG_LEVEL_NAMES = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+
+
 def parse_args(args):
     parser = argparse.ArgumentParser(
         prog="aleph-vm",
@@ -127,11 +133,12 @@ def parse_args(args):
         "--loglevel",
         dest="loglevel",
         type=str.upper,
+        choices=LOG_LEVEL_NAMES,
         # -v/--verbose is registered first and already supplies the default,
         # so this one must not offer a second one: argparse would keep the
         # first anyway, and SUPPRESS says so out loud.
         default=argparse.SUPPRESS,
-        help="Log level by name (DEBUG, INFO, WARNING, ERROR)",
+        help="Log level by name (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
     )
     subparsers = parser.add_subparsers(dest="command")
     # Imported here rather than at module scope: storage_cli imports this

--- a/src/aleph/vm/agent/cli.py
+++ b/src/aleph/vm/agent/cli.py
@@ -123,6 +123,22 @@ def parse_args(args):
         default=False,
         help="Authorize the developer's SSH keys to connect instead of those specified in the message",
     )
+    parser.add_argument(
+        "--loglevel",
+        dest="loglevel",
+        type=str.upper,
+        # -v/--verbose is registered first and already supplies the default,
+        # so this one must not offer a second one: argparse would keep the
+        # first anyway, and SUPPRESS says so out loud.
+        default=argparse.SUPPRESS,
+        help="Log level by name (DEBUG, INFO, WARNING, ERROR)",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+    # Imported here rather than at module scope: storage_cli imports this
+    # module for the shared database setup below.
+    from aleph.vm.agent import storage_cli
+
+    storage_cli.add_subparser(subparsers)
     return parser.parse_args(args)
 
 
@@ -154,13 +170,29 @@ async def run_async_db_migrations():
         await conn.run_sync(run_db_migrations)
 
 
+def initialise_database() -> None:
+    """Create the agent database and bring it to the latest schema.
+
+    The tables come first, since a fresh install has no file at all, then
+    the migrations bring an older database forward. Every process that
+    reads the agent database has to do this, not only the daemon: reading
+    an unmigrated database fails with a raw sqlite error and leaves an
+    empty file behind.
+    """
+    logger.debug("Initialising the DB...")
+    engine = metrics.setup_engine()
+    asyncio.run(metrics.create_tables(engine))
+    asyncio.run(run_async_db_migrations())
+    logger.debug("DB up to date.")
+
+
 def main():
-    if len(sys.argv) > 1 and sys.argv[1] == "storage":
+    args = parse_args(sys.argv[1:])
+
+    if getattr(args, "command", None) == "storage":
         from aleph.vm.agent import storage_cli
 
-        sys.exit(storage_cli.main(sys.argv[2:]))
-
-    args = parse_args(sys.argv[1:])
+        sys.exit(storage_cli.run_parsed(args))
 
     log_format = (
         "%(relativeCreated)4f | %(levelname)s | %(message)s"
@@ -234,13 +266,7 @@ def main():
     storage_pools.setup_pools()
 
     if not args.do_not_run:
-        logger.debug("Initialising the DB...")
-        # Check and create execution database
-        engine = metrics.setup_engine()
-        asyncio.run(metrics.create_tables(engine))
-        # After creating it run the DB migrations
-        asyncio.run(run_async_db_migrations())
-        logger.debug("DB up to date.")
+        initialise_database()
 
     if args.do_not_run:
         logger.info("Option --do-not-run, exiting")

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -58,7 +58,7 @@ from pydantic import ValidationError
 
 from aleph.vm import storage_pools
 from aleph.vm.agent import metrics
-from aleph.vm.agent.cli import initialise_database
+from aleph.vm.agent.cli import LOG_LEVEL_NAMES, initialise_database
 from aleph.vm.agent.vm.cache import cache_budget_bytes, cache_entries, cache_roots
 from aleph.vm.agent.vm.purge import purge_vm_storage
 from aleph.vm.agent.vm.reclaimable import (
@@ -112,11 +112,6 @@ READ_ONLY_COMMANDS = frozenset({"status", "list"})
 # line.
 _LOG_HANDLER_NAME = "aleph-vm-storage-cli"
 
-# Validated against --loglevel: an unknown name must be a clean argparse
-# usage error (exit 2), not a raw ValueError traceback out of
-# logging.Logger.setLevel.
-_LOG_LEVEL_NAMES = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
-
 logger = logging.getLogger(__name__)
 
 
@@ -136,13 +131,13 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
         "--loglevel",
         dest="loglevel",
         type=str.upper,
-        choices=_LOG_LEVEL_NAMES,
+        choices=LOG_LEVEL_NAMES,
         # SUPPRESS, not a real default: this parser also runs as a subparser
         # of the agent CLI, whose own --loglevel and -v/-vv write the same
         # destination, and a subparser default overwrites what the parent
         # already parsed.
         default=argparse.SUPPRESS,
-        help="Log level by name (DEBUG, INFO, WARNING, ERROR); INFO by default",
+        help="Log level by name (DEBUG, INFO, WARNING, ERROR, CRITICAL); INFO by default",
     )
     sub = parser.add_subparsers(dest="storage_command", required=True)
     sub.add_parser("status", help="per-pool and per-cache usage against the budgets")

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -30,6 +30,15 @@ directory that vanished under them, markers are written exclusively), but
 it is one more reason the daemon's own pass (startup, periodic, at-GONE) is
 always preferred when the daemon is up; this command exists mainly for when
 it is not.
+
+Running with no agent process also means setting up the process the way the
+systemd units set it up for the daemon: the node's environment file is read
+here (nothing else injects it into an operator's shell, and running a pass
+on the built-in defaults would reconcile a node against a configuration it
+does not have), the log records go to stderr, and the agent database is
+created and migrated before anything reads it. The read-only verbs are the
+exception to the last one: they refuse a database that is not there rather
+than create it.
 """
 
 from __future__ import annotations
@@ -37,13 +46,18 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import os
 import shutil
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TextIO
+
+from dotenv import load_dotenv
 
 from aleph.vm import storage_pools
 from aleph.vm.agent import metrics
+from aleph.vm.agent.cli import initialise_database
 from aleph.vm.agent.vm.cache import cache_budget_bytes, cache_entries, cache_roots
 from aleph.vm.agent.vm.purge import purge_vm_storage
 from aleph.vm.agent.vm.reclaimable import (
@@ -62,7 +76,7 @@ from aleph.vm.agent.vm.reconciler import (
     supervisor_hashes,
 )
 from aleph.vm.agent.vm_registry import AgentVmRegistry, rehydrate_registry
-from aleph.vm.conf import settings
+from aleph.vm.conf import Settings, settings
 from aleph.vm.storage_budget import parse_budget
 from aleph.vm.storage_pools import iter_namespace_dirs
 from aleph.vm.supervisor_interface.abc import Supervisor
@@ -80,15 +94,50 @@ SUPERVISOR_CONNECT_TIMEOUT_SECS = 3.0
 # degraded pass from a bad argument without parsing stderr.
 DEGRADED_EXIT_CODE = 3
 
+# The systemd units hand the daemon its configuration with
+# EnvironmentFile=; nothing hands it to an operator's shell, so a hand-run
+# command reads the same file itself or runs on the built-in defaults.
+DEFAULT_ENV_FILE = Path("/etc/aleph-vm/supervisor.env")
+ENV_FILE_VARIABLE = "ALEPH_VM_ENV_FILE"
+
+# Verbs that only read. They must not bring an agent database into
+# existence: an operator who ran the command with the wrong execution root
+# has to see a refusal, not an empty listing backed by a file this very
+# process just created.
+READ_ONLY_COMMANDS = frozenset({"status", "list"})
+
+# Name given to the handler this CLI installs on the root logger, so a
+# second call in the same process replaces it instead of doubling every
+# line.
+_LOG_HANDLER_NAME = "aleph-vm-storage-cli"
+
 logger = logging.getLogger(__name__)
 
 
-def parse_args(argv: list[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        prog="aleph-vm storage",
-        description="VM storage reclamation: status, list, reclaim, reconcile.",
+def add_arguments(parser: argparse.ArgumentParser) -> None:
+    """Fill in the storage flags and verbs, on a standalone parser or on the
+    subparser the agent CLI registers."""
+    parser.add_argument(
+        "--env-file",
+        dest="env_file",
+        default=None,
+        help=(
+            f"Environment file to load before reading the settings "
+            f"(default: ${ENV_FILE_VARIABLE}, else {DEFAULT_ENV_FILE})"
+        ),
     )
-    sub = parser.add_subparsers(dest="command", required=True)
+    parser.add_argument(
+        "--loglevel",
+        dest="loglevel",
+        type=str.upper,
+        # SUPPRESS, not a real default: this parser also runs as a subparser
+        # of the agent CLI, whose own --loglevel and -v/-vv write the same
+        # destination, and a subparser default overwrites what the parent
+        # already parsed.
+        default=argparse.SUPPRESS,
+        help="Log level by name (DEBUG, INFO, WARNING, ERROR); INFO by default",
+    )
+    sub = parser.add_subparsers(dest="storage_command", required=True)
     sub.add_parser("status", help="per-pool and per-cache usage against the budgets")
     list_parser = sub.add_parser("list", help="VM directories on every pool")
     list_parser.add_argument("--reclaimable", action="store_true", help="only directories no VM owns")
@@ -119,6 +168,27 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="purge using the registry alone when the supervisor cannot be asked which VMs it runs",
     )
+
+
+def add_subparser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    """Register ``storage`` on the agent CLI's own parser, so the agent's
+    global flags placed before the verb parse instead of being handed to a
+    second, unrelated parser."""
+    parser = subparsers.add_parser(
+        "storage",
+        help="VM storage reclamation: status, list, reclaim, reconcile",
+        description="VM storage reclamation: status, list, reclaim, reconcile.",
+    )
+    add_arguments(parser)
+    return parser
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="aleph-vm storage",
+        description="VM storage reclamation: status, list, reclaim, reconcile.",
+    )
+    add_arguments(parser)
     return parser.parse_args(argv)
 
 
@@ -316,13 +386,13 @@ def _reconcile(registry: AgentVmRegistry, out: TextIO, *, dry_run: bool, trust_r
 
 
 def run(args: argparse.Namespace, registry: AgentVmRegistry, out: TextIO) -> int:
-    if args.command == "status":
+    if args.storage_command == "status":
         return _status(registry, out)
-    if args.command == "list":
+    if args.storage_command == "list":
         return _list(registry, out, reclaimable_only=args.reclaimable)
-    if args.command == "reclaim":
+    if args.storage_command == "reclaim":
         return _reclaim(registry, args.vm_hash, out, trust_registry=args.trust_registry)
-    if args.command == "reconcile":
+    if args.storage_command == "reconcile":
         return _reconcile(registry, out, dry_run=args.dry_run, trust_registry=args.trust_registry)
     return 2
 
@@ -334,9 +404,103 @@ async def _load_registry() -> AgentVmRegistry:
     return registry
 
 
-def main(argv: list[str]) -> int:
-    args = parse_args(argv)
+def _setup_logging(level: str | int) -> None:
+    """Send the log records of this process to stderr.
+
+    Most of what these commands have to report they report through the
+    logger the reconciler, the purge and the marker already write to
+    ("Deleted volume ...", "Removed volume directory ...", "Marked ...
+    reclaimable"). With no handler configured those INFO lines are dropped
+    and anything at WARNING or above reaches the terminal as a bare
+    last-resort line with no level and no logger name, so an operator
+    watching a purge sees almost nothing of what it did.
+
+    Adds a named handler rather than calling basicConfig, so that repeated
+    calls in one process replace it instead of stacking, and so that
+    handlers something else installed are left alone.
+    """
+    root = logging.getLogger()
+    root.setLevel(level)
+    for existing in list(root.handlers):
+        if getattr(existing, "name", None) == _LOG_HANDLER_NAME:
+            root.removeHandler(existing)
+    handler = logging.StreamHandler(sys.stderr)
+    handler.name = _LOG_HANDLER_NAME
+    handler.setFormatter(logging.Formatter("%(levelname)s | %(name)s | %(message)s"))
+    root.addHandler(handler)
+    # These two are chatty below WARNING and say nothing about storage, so
+    # --loglevel DEBUG stays readable.
+    logging.getLogger("aiosqlite").setLevel(logging.WARNING)
+    logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
+
+
+def _env_file_path(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit)
+    from_environment = os.environ.get(ENV_FILE_VARIABLE)
+    if from_environment:
+        return Path(from_environment)
+    return DEFAULT_ENV_FILE
+
+
+def _reload_settings() -> None:
+    """Rebuild the settings singleton from the current environment.
+
+    ``aleph.vm.conf`` builds its singleton when it is first imported, so
+    anything this process adds to the environment afterwards is invisible
+    to it. A second instance re-reads the environment, and copying its
+    values onto the singleton keeps every module that already imported
+    ``settings`` looking at the one object.
+    """
+    settings.__dict__.update(Settings().__dict__)
+
+
+def _load_env_file(explicit: str | None) -> bool:
+    """Load the node's environment file, if there is one. False when the
+    operator named a file that does not exist: running on the defaults they
+    were trying to override is worse than refusing.
+
+    Values already in the environment win, so a one-off override on the
+    command line still works.
+    """
+    path = _env_file_path(explicit)
+    if not path.is_file():
+        if explicit:
+            logger.error("No environment file at %s", path)
+            return False
+        logger.info("No environment file at %s; using the process environment alone", path)
+        return True
+    load_dotenv(path, override=False)
+    _reload_settings()
+    logger.info("Loaded the node configuration from %s", path)
+    return True
+
+
+def run_parsed(args: argparse.Namespace) -> int:
+    """Set up the process (configuration, logging, database) and run the
+    verb. Takes an already parsed namespace, so the agent CLI can hand over
+    the one its own parser produced."""
+    _setup_logging(getattr(args, "loglevel", None) or logging.INFO)
+    if not _load_env_file(getattr(args, "env_file", None)):
+        return 1
     settings.setup()
     storage_pools.setup_pools()
+
+    database = Path(str(settings.EXECUTION_DATABASE))
+    if not database.exists():
+        if args.storage_command in READ_ONLY_COMMANDS:
+            logger.error(
+                "No agent database at %s: nothing has run on this node yet, or the execution root is not the one "
+                "the agent uses",
+                database,
+            )
+            return 1
+        logger.info("Creating the agent database at %s", database)
+    initialise_database()
+
     registry = asyncio.run(_load_registry())
     return run(args, registry, sys.stdout)
+
+
+def main(argv: list[str]) -> int:
+    return run_parsed(parse_args(argv))

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -54,6 +54,7 @@ from pathlib import Path
 from typing import TextIO
 
 from dotenv import load_dotenv
+from pydantic import ValidationError
 
 from aleph.vm import storage_pools
 from aleph.vm.agent import metrics
@@ -111,6 +112,11 @@ READ_ONLY_COMMANDS = frozenset({"status", "list"})
 # line.
 _LOG_HANDLER_NAME = "aleph-vm-storage-cli"
 
+# Validated against --loglevel: an unknown name must be a clean argparse
+# usage error (exit 2), not a raw ValueError traceback out of
+# logging.Logger.setLevel.
+_LOG_LEVEL_NAMES = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+
 logger = logging.getLogger(__name__)
 
 
@@ -130,6 +136,7 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
         "--loglevel",
         dest="loglevel",
         type=str.upper,
+        choices=_LOG_LEVEL_NAMES,
         # SUPPRESS, not a real default: this parser also runs as a subparser
         # of the agent CLI, whose own --loglevel and -v/-vv write the same
         # destination, and a subparser default overwrites what the parent
@@ -434,13 +441,19 @@ def _setup_logging(level: str | int) -> None:
     logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
 
 
-def _env_file_path(explicit: str | None) -> Path:
+def _env_file_path(explicit: str | None) -> tuple[Path, bool]:
+    """The env file to load, and whether the operator named it (via
+    --env-file or $ALEPH_VM_ENV_FILE) rather than this falling back to the
+    node's default location. Both ways of naming a file are equally
+    explicit operator intent: a missing one must refuse rather than run on
+    defaults the operator did not choose.
+    """
     if explicit:
-        return Path(explicit)
+        return Path(explicit), True
     from_environment = os.environ.get(ENV_FILE_VARIABLE)
     if from_environment:
-        return Path(from_environment)
-    return DEFAULT_ENV_FILE
+        return Path(from_environment), True
+    return DEFAULT_ENV_FILE, False
 
 
 def _reload_settings() -> None:
@@ -457,15 +470,16 @@ def _reload_settings() -> None:
 
 def _load_env_file(explicit: str | None) -> bool:
     """Load the node's environment file, if there is one. False when the
-    operator named a file that does not exist: running on the defaults they
-    were trying to override is worse than refusing.
+    operator named a file, via --env-file or $ALEPH_VM_ENV_FILE, that does
+    not exist: running on the defaults they were trying to override is
+    worse than refusing.
 
     Values already in the environment win, so a one-off override on the
     command line still works.
     """
-    path = _env_file_path(explicit)
+    path, named = _env_file_path(explicit)
     if not path.is_file():
-        if explicit:
+        if named:
             logger.error("No environment file at %s", path)
             return False
         logger.info("No environment file at %s; using the process environment alone", path)
@@ -481,12 +495,18 @@ def run_parsed(args: argparse.Namespace) -> int:
     verb. Takes an already parsed namespace, so the agent CLI can hand over
     the one its own parser produced."""
     _setup_logging(getattr(args, "loglevel", None) or logging.INFO)
-    if not _load_env_file(getattr(args, "env_file", None)):
-        return 1
+    try:
+        if not _load_env_file(getattr(args, "env_file", None)):
+            return 1
+    except ValidationError as error:
+        for field_error in error.errors():
+            field = ".".join(str(part) for part in field_error["loc"])
+            print(f"Invalid node configuration for {field}: {field_error['msg']}", file=sys.stderr)
+        return 2
     settings.setup()
     storage_pools.setup_pools()
 
-    database = Path(str(settings.EXECUTION_DATABASE))
+    database = settings.EXECUTION_DATABASE
     if not database.exists():
         if args.storage_command in READ_ONLY_COMMANDS:
             logger.error(

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -463,7 +463,13 @@ def plumbing(tmp_path, monkeypatch, registry):
     database = tmp_path / "executions.sqlite3"
     database.touch()
     monkeypatch.setattr(settings, "EXECUTION_DATABASE", database)
-    return database
+    # An env file the CLI loads rebuilds every field of the settings
+    # singleton, not only the ones a test monkeypatched, so the whole
+    # namespace is put back rather than trusting the two patches to cover it.
+    snapshot = dict(settings.__dict__)
+    yield database
+    settings.__dict__.clear()
+    settings.__dict__.update(snapshot)
 
 
 def test_the_env_file_reaches_the_settings(tmp_path, monkeypatch, isolated_environ, plumbing):
@@ -622,3 +628,31 @@ def test_an_unknown_loglevel_is_a_usage_error_not_a_traceback(capsys):
 
     assert exit_info.value.code == 2
     assert "--loglevel" in capsys.readouterr().err
+
+
+def test_the_agent_level_loglevel_is_validated_the_same_way(capsys):
+    """The flag exists on the agent parser too, ahead of the subcommand, and
+    `aleph-vm --loglevel verbos storage status` reached the same setLevel
+    traceback after the storage parser's own flag had been fixed."""
+    with pytest.raises(SystemExit) as exit_info:
+        agent_cli.parse_args(["--loglevel", "verbos", "storage", "status"])
+
+    assert exit_info.value.code == 2
+    assert "--loglevel" in capsys.readouterr().err
+
+
+def test_a_write_verb_creates_a_missing_database(pools, tmp_path, monkeypatch, caplog):  # noqa: F811
+    """status and list refuse a missing database; reconcile creates it, since
+    a fresh node has no file at all and the pass has to record what it
+    does. This runs the real table creation and migrations."""
+    database = tmp_path / "executions.sqlite3"
+    monkeypatch.setattr(settings, "EXECUTION_DATABASE", database)
+    monkeypatch.setattr(cli, "DEFAULT_ENV_FILE", tmp_path / "no-such-file.env")
+    monkeypatch.setattr(type(settings), "setup", lambda _self: None)
+    monkeypatch.setattr(storage_pools, "setup_pools", lambda: None)
+
+    with caplog.at_level(logging.INFO, logger=cli.logger.name):
+        assert cli.main(["reconcile", "--dry-run"]) == 0
+
+    assert database.exists()
+    assert any("Creating the agent database" in record.message for record in caplog.records)

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import logging
 import os
 import time
 from datetime import datetime, timedelta, timezone
@@ -12,8 +13,10 @@ import pytest
 from aleph_message.models import ItemHash
 from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
 
+import aleph.vm.agent.cli as agent_cli
 import aleph.vm.agent.storage_cli as cli
 import aleph.vm.agent.vm.reconciler as reconciler_module
+from aleph.vm import storage_pools
 from aleph.vm.agent.vm.reclaimable import (
     ReclaimableMarker,
     mark_reclaimable,
@@ -355,14 +358,16 @@ def test_reconcile_dry_run_never_touches_cache_parent_devices(pools, registry, m
 
 
 def test_cli_main_dispatches_storage_subcommand(mocker):
-    from aleph.vm.agent import cli as agent_cli
-
-    storage_main = mocker.patch("aleph.vm.agent.storage_cli.main", return_value=7)
-    mocker.patch("sys.argv", ["aleph-vm", "storage", "status"])
+    run_parsed = mocker.patch("aleph.vm.agent.storage_cli.run_parsed", return_value=7)
+    mocker.patch("sys.argv", ["aleph-vm", "-vv", "storage", "status"])
     with pytest.raises(SystemExit) as exit_info:
         agent_cli.main()
     assert exit_info.value.code == 7
-    storage_main.assert_called_once_with(["status"])
+    args = run_parsed.call_args.args[0]
+    assert args.command == "storage"
+    assert args.storage_command == "status"
+    # A global flag placed before the verb reaches the storage command.
+    assert args.loglevel == logging.DEBUG
 
 
 def test_reconcile_tears_down_the_devices_of_an_orphan_namespace(pools, registry, monkeypatch, tmp_path):  # noqa: F811
@@ -417,3 +422,153 @@ def test_a_degraded_reconcile_leaves_orphan_devices_too(pools, registry, monkeyp
 
     assert code == cli.DEGRADED_EXIT_CODE
     assert torn == []
+
+
+# --- process-level plumbing: env file, logging, database migrations ---------
+
+
+@pytest.fixture(autouse=True)
+def _restore_root_logger():
+    """``main()`` configures the root logger, and pytest's own logging plugin
+    lives on that same logger: put back what was there when the test ends."""
+    root = logging.getLogger()
+    handlers = list(root.handlers)
+    level = root.level
+    yield
+    root.handlers[:] = handlers
+    root.setLevel(level)
+
+
+@pytest.fixture
+def isolated_environ(monkeypatch):
+    """A private copy of ``os.environ``: loading an environment file writes
+    into it, and a leak would change the settings of every later test."""
+    environ = dict(os.environ)
+    monkeypatch.setattr(os, "environ", environ)
+    return environ
+
+
+@pytest.fixture
+def plumbing(tmp_path, monkeypatch, registry):
+    """Drive ``main()`` end to end with the parts a test cannot provide
+    stubbed out: the pool setup the ``pools`` fixture already did by hand,
+    and the registry the agent DB would rehydrate. Returns the database path
+    the CLI will find, already present so the missing-DB refusal stays out of
+    the way of the tests that are about something else."""
+    monkeypatch.setattr(cli, "DEFAULT_ENV_FILE", tmp_path / "no-such-file.env")
+    monkeypatch.setattr(type(settings), "setup", lambda _self: None)
+    monkeypatch.setattr(storage_pools, "setup_pools", lambda: None)
+    monkeypatch.setattr(cli, "initialise_database", lambda: None)
+    monkeypatch.setattr(cli, "_load_registry", AsyncMock(return_value=registry))
+    database = tmp_path / "executions.sqlite3"
+    database.touch()
+    monkeypatch.setattr(settings, "EXECUTION_DATABASE", database)
+    return database
+
+
+def test_the_env_file_reaches_the_settings(tmp_path, monkeypatch, isolated_environ, plumbing):
+    """Only the systemd units inject /etc/aleph-vm/supervisor.env. Without
+    reading it here, a hand-run pass on a node configured to keep retained
+    volumes runs with the reap default and evicts every retained directory."""
+    env_file = tmp_path / "supervisor.env"
+    env_file.write_text(f"ALEPH_VM_VOLUME_RETENTION=keep\nALEPH_VM_EXECUTION_DATABASE={plumbing}\n")
+    isolated_environ.pop("ALEPH_VM_VOLUME_RETENTION", None)
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    seen: list[str] = []
+    monkeypatch.setattr(cli, "run", lambda *_: seen.append(settings.VOLUME_RETENTION) or 0)
+
+    code = cli.main(["--env-file", str(env_file), "status"])
+
+    assert code == 0
+    assert seen == ["keep"]
+
+
+def test_a_named_env_file_that_is_missing_is_an_error(tmp_path, monkeypatch, plumbing, capsys):
+    """Silently ignoring the file the operator named would run the command
+    with exactly the defaults they were trying to override."""
+    monkeypatch.setattr(cli, "run", lambda *_: 0)
+
+    code = cli.main(["--env-file", str(tmp_path / "typo.env"), "status"])
+
+    assert code == 1
+    assert "typo.env" in capsys.readouterr().err
+
+
+def test_status_refuses_a_missing_database_without_creating_one(tmp_path, monkeypatch, plumbing, capsys):
+    """A read-only command must not bring an agent DB into existence: an
+    operator who mistyped EXECUTION_ROOT has to see a refusal, not an empty
+    listing backed by a file this process just made."""
+    database = tmp_path / "gone.sqlite3"
+    monkeypatch.setattr(settings, "EXECUTION_DATABASE", database)
+    initialised: list[str] = []
+    monkeypatch.setattr(cli, "initialise_database", lambda: initialised.append("yes"))
+
+    code = cli.main(["status"])
+
+    assert code == 1
+    assert not database.exists()
+    assert initialised == []
+    assert str(database) in capsys.readouterr().err
+
+
+def test_the_database_is_migrated_before_the_registry_is_read(monkeypatch, plumbing, registry):
+    order: list[str] = []
+    monkeypatch.setattr(cli, "initialise_database", lambda: order.append("migrate"))
+
+    async def load() -> AgentVmRegistry:
+        order.append("load")
+        return registry
+
+    monkeypatch.setattr(cli, "_load_registry", load)
+    monkeypatch.setattr(cli, "run", lambda *_: 0)
+
+    assert cli.main(["status"]) == 0
+    assert order == ["migrate", "load"]
+
+
+def test_an_unmigrated_database_is_brought_up_to_date(pools, tmp_path, monkeypatch):  # noqa: F811
+    """An empty sqlite file (a fresh install, or a DB predating a migration)
+    used to reach rehydrate_registry with no ``executions`` table and crash
+    with a raw OperationalError. This runs the real migrations."""
+    database = tmp_path / "executions.sqlite3"
+    database.touch()
+    monkeypatch.setattr(settings, "EXECUTION_DATABASE", database)
+    monkeypatch.setattr(cli, "DEFAULT_ENV_FILE", tmp_path / "no-such-file.env")
+    monkeypatch.setattr(type(settings), "setup", lambda _self: None)
+    monkeypatch.setattr(storage_pools, "setup_pools", lambda: None)
+
+    assert cli.main(["list"]) == 0
+
+
+def test_reconcile_reports_its_purges_on_stderr(pools, monkeypatch, plumbing, capsys):  # noqa: F811
+    """The purge logs what it removed; with no handler configured those INFO
+    lines went nowhere and an operator watching a purge saw nothing."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    orphan = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    stamp = time.time() - 10_000
+    os.utime(orphan.parent, (stamp, stamp))
+
+    code = cli.main(["reconcile"])
+
+    assert code == 0
+    assert not orphan.exists()
+    assert "Deleted volume" in capsys.readouterr().err
+
+
+def test_global_flags_before_the_verb_parse():
+    """`aleph-vm --loglevel DEBUG storage status` used to be a usage error:
+    the dispatch sniffed sys.argv[1] before the agent parser ran."""
+    args = agent_cli.parse_args(["--loglevel", "debug", "storage", "list", "--reclaimable"])
+
+    assert args.command == "storage"
+    assert args.storage_command == "list"
+    assert args.reclaimable
+    # The subparser must not clobber the level the parent flag set.
+    assert args.loglevel == "DEBUG"
+
+
+def test_the_storage_subparser_keeps_its_own_loglevel_flag():
+    args = cli.parse_args(["--loglevel", "warning", "status"])
+
+    assert args.storage_command == "status"
+    assert args.loglevel == "WARNING"

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -473,6 +473,9 @@ def test_the_env_file_reaches_the_settings(tmp_path, monkeypatch, isolated_envir
     env_file = tmp_path / "supervisor.env"
     env_file.write_text(f"ALEPH_VM_VOLUME_RETENTION=keep\nALEPH_VM_EXECUTION_DATABASE={plumbing}\n")
     isolated_environ.pop("ALEPH_VM_VOLUME_RETENTION", None)
+    # This test's assertion is what the loaded file set, not what the
+    # process environment happened to already hold.
+    isolated_environ.pop("ALEPH_VM_EXECUTION_DATABASE", None)
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
     seen: list[str] = []
 
@@ -497,6 +500,38 @@ def test_a_named_env_file_that_is_missing_is_an_error(tmp_path, monkeypatch, plu
 
     assert code == 1
     assert "typo.env" in capsys.readouterr().err
+
+
+def test_an_env_file_named_by_the_environment_variable_that_is_missing_is_an_error(
+    tmp_path, monkeypatch, isolated_environ, plumbing, capsys
+):
+    """$ALEPH_VM_ENV_FILE is just as explicit as --env-file: a typo there
+    used to fall through to the built-in defaults with only an INFO line,
+    exactly the hazard the fail-closed --env-file behaviour exists for."""
+    monkeypatch.setattr(cli, "run", lambda *_: 0)
+    isolated_environ[cli.ENV_FILE_VARIABLE] = str(tmp_path / "typo.env")
+
+    code = cli.main(["status"])
+
+    assert code == 1
+    assert "typo.env" in capsys.readouterr().err
+
+
+def test_an_invalid_value_in_the_env_file_is_a_clean_usage_error(
+    tmp_path, monkeypatch, isolated_environ, plumbing, capsys
+):
+    """A typo'd value in the node's env file used to surface as a raw
+    pydantic ValidationError traceback; the operator should see which field
+    is wrong instead."""
+    env_file = tmp_path / "supervisor.env"
+    env_file.write_text("ALEPH_VM_VOLUME_RETENTION=sometimes\n")
+    isolated_environ.pop("ALEPH_VM_VOLUME_RETENTION", None)
+    monkeypatch.setattr(cli, "run", lambda *_: 0)
+
+    code = cli.main(["--env-file", str(env_file), "status"])
+
+    assert code == 2
+    assert "VOLUME_RETENTION" in capsys.readouterr().err
 
 
 def test_status_refuses_a_missing_database_without_creating_one(tmp_path, monkeypatch, plumbing, capsys):
@@ -577,3 +612,13 @@ def test_the_storage_subparser_keeps_its_own_loglevel_flag():
 
     assert args.storage_command == "status"
     assert args.loglevel == "WARNING"
+
+
+def test_an_unknown_loglevel_is_a_usage_error_not_a_traceback(capsys):
+    """`--loglevel verbos` used to reach logging.Logger.setLevel and die with
+    a raw ValueError traceback instead of a clean argparse usage error."""
+    with pytest.raises(SystemExit) as exit_info:
+        cli.parse_args(["--loglevel", "verbos", "status"])
+
+    assert exit_info.value.code == 2
+    assert "--loglevel" in capsys.readouterr().err

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -475,7 +475,12 @@ def test_the_env_file_reaches_the_settings(tmp_path, monkeypatch, isolated_envir
     isolated_environ.pop("ALEPH_VM_VOLUME_RETENTION", None)
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
     seen: list[str] = []
-    monkeypatch.setattr(cli, "run", lambda *_: seen.append(settings.VOLUME_RETENTION) or 0)
+
+    def record_retention(*_args: object) -> int:
+        seen.append(settings.VOLUME_RETENTION)
+        return 0
+
+    monkeypatch.setattr(cli, "run", record_retention)
 
     code = cli.main(["--env-file", str(env_file), "status"])
 


### PR DESCRIPTION
## Summary
A hand-run `aleph-vm storage` command was missing everything the systemd units set up for the agent daemon, so it ran against a configuration the node does not have. The units inject `/etc/aleph-vm/supervisor.env` with `EnvironmentFile=`, and pydantic reads only the process environment plus a cwd `.env`: on a node configured with `VOLUME_RETENTION=keep`, `aleph-vm storage reconcile` therefore ran with the `reap` default and evicted every retained directory (with non-default pools it died in `setup_pools`, with a non-default execution root it read an empty DB). `_load_registry` also skipped the table creation and alembic migrations the daemon's startup runs, so `status` / `list` on a fresh install crashed with a raw `OperationalError` and left an empty sqlite file behind. And nothing configured logging, so every "Deleted volume" / "Removed volume directory" / "Marked reclaimable" line was dropped.

This loads the node's environment file (`--env-file`, else `$ALEPH_VM_ENV_FILE`, else the packaged path) and rebuilds the settings singleton from it, shares the daemon's database setup, configures a stderr handler at INFO, and turns `storage` into a real argparse subparser so the agent's global flags placed before the verb parse.

## Changes
- `src/aleph/vm/agent/storage_cli.py`: `run_parsed()` sets the process up before any verb runs. It loads the env file (existing environment values still win; a file named explicitly, by `--env-file` or by `$ALEPH_VM_ENV_FILE`, that does not exist is an error rather than a silent fall back to the defaults), installs a named stderr log handler at INFO with `--loglevel` (validated against the known level names, so an unknown one is a clean usage error rather than a raw `ValueError` traceback), and runs the shared database setup before the registry is rehydrated. `status` and `list` are read-only, so they refuse a database that is not there and exit 1 rather than create one: an operator pointed at the wrong execution root sees the mistake instead of an empty listing. An invalid value in the env file (a `pydantic.ValidationError` from the settings reload) is caught and printed field by field to stderr with exit 2, instead of escaping as a traceback. The verb parser moved into `add_arguments()`, reused by the standalone parser and by the new `add_subparser()`; the verb's dest is `storage_command` now that `command` belongs to the agent parser.
- `src/aleph/vm/agent/cli.py`: the daemon's table creation plus migrations factored into `initialise_database()`, called from `main()` and from the storage CLI. `storage` registered as a subparser instead of being dispatched by sniffing `sys.argv[1]` before `parse_args`, and a `--loglevel LEVEL` global flag added alongside `-v` / `-vv`, validated against the same tuple of level names the storage subparser uses (the tuple lives here, since the storage module already imports this one), so `aleph-vm --loglevel verbos storage status` is a usage error too. The subparser's own `--loglevel` defaults to `SUPPRESS` so it does not clobber what the parent parsed.
- `pyproject.toml`: the comment claiming a flat CLI with no subcommands was wrong.
- `docs/architecture/storage.md`: the CLI section documents the env file, the logging, and the database rules.

## Test plan
- `tests/supervisor/test_storage_cli.py`: nine new or rewritten tests, plus five more from the Foxpatch review rounds: an unknown `--loglevel` value is a usage error and not a traceback on the storage parser and on the agent parser ahead of the subcommand, `reconcile` creates a missing database through the real table creation and migrations (the plumbing fixture now restores the whole settings namespace after each test, since an env file rebuilds every field), `$ALEPH_VM_ENV_FILE` naming a missing file refuses exactly as `--env-file` does, and an invalid value in the env file exits 2 with the offending field named on stderr. The env file reaches the settings when the CLI runs and a named file that is missing exits 1; `status` refuses a missing database, creates no file, and does not call the initialiser; the migrations run before the registry is read, and a real empty sqlite file is brought up to date end to end through the real alembic path; a `reconcile` purge reports its INFO lines on stderr; the agent parser accepts a global flag before the verb, and the storage subparser keeps its own `--loglevel`.
- `pytest tests/supervisor/test_storage_cli.py` 35 passed.
- `ruff format --diff`, `isort --check-only --profile black`, `mypy src/aleph/vm/ tests/`: all clean (exit 0). A whole-`tests/supervisor` collection currently fails on this checkout on two unrelated files (`test_snp_instance_run.py`, `test_vprogram_launch.py`: `ImportError: cannot import name 'ConfidentialGpuRequirement'`), from the confidential-GPU feature merged into `dev-2.1` after this chain was opened (#1200) needing a newer `aleph_message` than this venv has installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZyMqLgxxVfeDwiNy34sfM


