### PR TITLE
fix(agent): hold a reserve, not the whole budget, for an unmeasured download

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -438,7 +438,8 @@ kilobytes of JSON each, so it never approaches a budget sized for runtime
 images, and one setting is one thing for an operator to reason about. A root's
 usage is its finished entries plus what it owes to downloads that have not
 finished (`in_flight_bytes`): the allocated blocks of `.part` and `.tmp`
-files, and the size any admitted download was promised.
+files, and the size any admitted download was promised (the greater of the
+two for a download still being written, never their sum).
 
 The pass evicts least recently used first, mtime being a real
 signal because the downloader touches an entry on every cache hit
@@ -502,9 +503,17 @@ ceiling for a runtime image and equally the ceiling for a few kilobytes of
 manifest, so charging it as a size would evict a whole cache root for a
 download that never needed the room. An unknown-length download therefore
 never evicts, is refused only when the root is already over its budget, and
-is charged `min(cap, budget)`: bounded, so a stream of them still runs the
-root over budget and the next one is refused, and never more than the budget
-itself. What is admitted is then charged to
+is charged `UNKNOWN_LENGTH_RESERVE` (2 GiB by default), never more than its
+own cap nor than the whole budget. The reserve is a modest, deliberately
+arbitrary figure: charging the budget itself let one chunked response hold a
+whole root, so every other download on it was refused for as long as that one
+ran. It is still charged against the next admission, so a stream of
+unknown-length downloads ends in a refusal, and it is reconciled against the
+truth as the body lands, since the bytes on disk are counted the moment they
+are written. A ceiling never sets the eviction target either: a root's usage
+counts a guessed reservation only at the bytes it has actually written when
+the question is how much to evict, and at the full figure when the question
+is whether the next download fits. What is admitted is then charged to
 the download's `.part` path (`reserve_download`) until `download_file`
 releases it, so a second create arriving while the first is still writing
 sees the room the first was promised rather than only the bytes it has
@@ -534,6 +543,7 @@ budget as it stands.
 | `VOLUME_RECONCILE_INTERVAL` | `3600` | Seconds between periodic passes |
 | `VOLUME_CREATE_GUARD` | `600` | Seconds a young directory or `.part` file is assumed to be an in-flight create |
 | `CACHE_BUDGET` | `20%` | Cap on each download cache (runtime, code, data, message) |
+| `UNKNOWN_LENGTH_RESERVE` | `2G` | Room held for a download whose response carries no `Content-Length` |
 
 `keep` is not a promise of "forever": reclaimable disks are unpaid storage,
 and an attacker does not need to stop paying to create them (create, forget,

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -799,10 +799,15 @@ def _unknown_length_charge(root: Path, budget: int, max_bytes: int | None) -> in
     """The room to hold for a body nobody measured: the smallest of the
     reserve, this download's own cap and the budget."""
     try:
-        reserve = parse_budget(settings.UNKNOWN_LENGTH_RESERVE, shutil.disk_usage(str(root)).total)
+        total = shutil.disk_usage(str(root)).total
     except OSError:
-        logger.warning("Cache directory %s is not accessible; holding its whole budget", root, exc_info=True)
-        return budget
+        # A disk nobody can measure must not resurrect the whole-budget hold:
+        # resolve the reserve against a zero total instead, which yields the
+        # configured size when it is written as an absolute one and nothing
+        # when it is a percentage of the disk that just failed to answer.
+        logger.warning("Cache directory %s is not accessible; holding only the reserve", root, exc_info=True)
+        total = 0
+    reserve = parse_budget(settings.UNKNOWN_LENGTH_RESERVE, total)
     figures = [reserve, budget] if max_bytes is None else [reserve, budget, max_bytes]
     return min(figures)
 

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -151,7 +151,7 @@ def cache_entries(root: Path) -> list[CacheEntry]:
     return entries
 
 
-def in_flight_bytes(root: Path) -> int:
+def in_flight_bytes(root: Path, *, count_ceilings: bool = True) -> int:
     """What ``root`` owes to downloads that have not finished.
 
     Two overlapping things, counted once. A ``.part`` or ``.tmp`` file holds
@@ -161,14 +161,23 @@ def in_flight_bytes(root: Path) -> int:
     disk yet: without it two creates arriving together are both told there is
     space only one of them can have. For a reservation still being written the
     bigger of the two is the honest figure, never their sum.
+
+    ``count_ceilings`` separates a reservation made from a ``Content-Length``
+    from one made from a cap. Both hold room against the next admission, since
+    a body nobody measured still has to be paid for if it turns out to be that
+    big. Only a measured one may cost an entry its place: a caller deciding
+    how much to evict passes ``count_ceilings=False``, and a ceiling then
+    counts only the bytes it has actually written, which is the part of it
+    that is a measurement.
     """
     reserved = reserved_downloads()
     total = 0
     counted: set[Path] = set()
-    for path, size_bytes in reserved.items():
+    for path, reservation in reserved.items():
         if path.parent != root:
             continue
-        total += max(size_bytes, file_size_bytes(path))
+        written = file_size_bytes(path)
+        total += max(reservation.size_bytes, written) if reservation.measured or count_ceilings else written
         counted.add(path)
     try:
         children = list(root.iterdir())
@@ -181,8 +190,8 @@ def in_flight_bytes(root: Path) -> int:
     return total
 
 
-def _root_usage(root: Path, entries: list[CacheEntry]) -> int:
-    return sum(entry.size_bytes for entry in entries) + in_flight_bytes(root)
+def _root_usage(root: Path, entries: list[CacheEntry], *, count_ceilings: bool = True) -> int:
+    return sum(entry.size_bytes for entry in entries) + in_flight_bytes(root, count_ceilings=count_ceilings)
 
 
 def _entry_refs(path: Path) -> set[str]:
@@ -509,7 +518,12 @@ def evict_caches(
         state = _RootBudget(
             root=root,
             budget=budget,
-            usage=_root_usage(root, entries) + needed.get(root, 0),
+            # A download whose size nobody stated holds room, but the figure it
+            # holds is a guess: unlinking a real entry to honour it would trade
+            # something the node has for something it may never need. Only the
+            # bytes such a download has actually written count here, so the
+            # eviction it does cause is the one its own body earned.
+            usage=_root_usage(root, entries, count_ceilings=False) + needed.get(root, 0),
             evicted=evicted,
             live_only=live_only,
             is_live=is_live,
@@ -723,7 +737,7 @@ def admit_download(
     except OSError:
         logger.warning("Cache directory %s is not accessible; admitting the download", root, exc_info=True)
         if content_length is not None:
-            reserve_download(tmp_path, content_length)
+            reserve_download(tmp_path, content_length, measured=True)
         return
     if content_length is None:
         _admit_unknown_length(tmp_path, root, budget, max_bytes)
@@ -734,7 +748,7 @@ def admit_download(
         )
     usage = _root_usage(root, cache_entries(root)) + content_length
     if usage <= budget:
-        reserve_download(tmp_path, content_length)
+        reserve_download(tmp_path, content_length, measured=True)
         return
     free = max(budget - (usage - content_length), 0)
     msg = f"Cache {root} cannot hold a {content_length} byte download within CACHE_BUDGET"
@@ -757,10 +771,18 @@ def _admit_unknown_length(tmp_path: Path, root: Path, budget: int, max_bytes: in
     download anyway.
 
     So: never evict for a figure that is only a ceiling, and refuse only what
-    a root that is already over its budget cannot start at all. What is
-    charged is ``min(cap, budget)``, enough that a handful of concurrent
-    unknown-length downloads still run the root over its budget and the next
-    one is refused, and never more than the budget itself.
+    a root that is already over its budget cannot start at all.
+
+    What is charged is a modest, deliberately arbitrary figure,
+    ``UNKNOWN_LENGTH_RESERVE`` (2 GiB by default), and never more than this
+    download's own cap nor than the whole budget. Charging the budget itself,
+    as this used to, made one chunked response hold the entire root: every
+    other download on it was refused for as long as that one ran, whatever
+    its real size turned out to be. A reserve leaves room beside it, is still
+    charged against the next admission so a stream of unknown-length
+    downloads ends in a refusal, and is reconciled against the truth as the
+    body lands, since the bytes on disk are counted the moment they are
+    written and outgrow the reserve when the body is bigger than it.
     """
     usage = _root_usage(root, cache_entries(root))
     if usage > budget:
@@ -770,8 +792,19 @@ def _admit_unknown_length(tmp_path: Path, root: Path, budget: int, max_bytes: in
             required={"disk_mib": (usage - budget) // MIB},
             available={"disk_mib": 0},
         )
-    charge = min(max_bytes, budget) if max_bytes is not None else budget
-    reserve_download(tmp_path, charge)
+    reserve_download(tmp_path, _unknown_length_charge(root, budget, max_bytes), measured=False)
+
+
+def _unknown_length_charge(root: Path, budget: int, max_bytes: int | None) -> int:
+    """The room to hold for a body nobody measured: the smallest of the
+    reserve, this download's own cap and the budget."""
+    try:
+        reserve = parse_budget(settings.UNKNOWN_LENGTH_RESERVE, shutil.disk_usage(str(root)).total)
+    except OSError:
+        logger.warning("Cache directory %s is not accessible; holding its whole budget", root, exc_info=True)
+        return budget
+    figures = [reserve, budget] if max_bytes is None else [reserve, budget, max_bytes]
+    return min(figures)
 
 
 def _deleted_cache_backings() -> list[tuple[str, Path]]:

--- a/src/aleph/vm/conf.py
+++ b/src/aleph/vm/conf.py
@@ -317,6 +317,12 @@ class Settings(BaseSettings):
         description="Cap on each download cache (runtime, code, data, message): a percentage of the "
         "filesystem the cache sits on or an absolute size.",
     )
+    UNKNOWN_LENGTH_RESERVE: str = Field(
+        default="2G",
+        description="Room held in a download cache for a response that carries no Content-Length, "
+        "as a percentage of the filesystem the cache sits on or an absolute size. Never more than "
+        "the download's own cap or the cache budget.",
+    )
 
     HOST_MEMORY_RESERVED_MIB: int = Field(
         default=2048,
@@ -616,7 +622,7 @@ class Settings(BaseSettings):
         if self.ENABLE_GPU_SUPPORT:
             assert self.ENABLE_QEMU_SUPPORT, "Qemu Support is needed for GPU support and it's disabled, "
 
-        for setting_name in ("VOLUME_RETENTION_BUDGET", "CACHE_BUDGET"):
+        for setting_name in ("VOLUME_RETENTION_BUDGET", "CACHE_BUDGET", "UNKNOWN_LENGTH_RESERVE"):
             try:
                 parse_budget(getattr(self, setting_name), 0)
             except ValueError as error:

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -12,6 +12,7 @@ import os
 import re
 import sys
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from shutil import make_archive
 from subprocess import CalledProcessError
@@ -116,13 +117,29 @@ async def file_downloaded_by_another_task(final_path: Path) -> None:
 CacheAdmission = Callable[[Path, int | None, int | None], None]
 _cache_admission: CacheAdmission | None = None
 
+
+@dataclass(frozen=True)
+class DownloadReservation:
+    """Room charged to an in-flight download, and what the figure is worth.
+
+    ``measured`` says the size came from a ``Content-Length``: it is this
+    body's size, so a cache may evict entries to make room for it. Anything
+    else is a ceiling, a guess bounded by the caller's cap and by the budget,
+    and a guess must never cost another entry its place. The bytes such a
+    download actually writes are a measurement again, and those do count.
+    """
+
+    size_bytes: int
+    measured: bool
+
+
 # Downloads that have been admitted and are still being written, by ``.part``
 # path. Nothing on disk says how big one is going to be, so an in-flight
 # download would otherwise be invisible to the next admission, and two
 # concurrent creates would both be told there is room only one of them can
 # have. Kept here rather than in the agent's cache module because this is
 # where the download ends, in ``download_file``'s finally.
-_reserved_downloads: dict[Path, int] = {}
+_reserved_downloads: dict[Path, DownloadReservation] = {}
 
 
 def set_cache_admission(fn: CacheAdmission | None) -> None:
@@ -130,16 +147,16 @@ def set_cache_admission(fn: CacheAdmission | None) -> None:
     _cache_admission = fn
 
 
-def reserve_download(tmp_path: Path, size_bytes: int) -> None:
+def reserve_download(tmp_path: Path, size_bytes: int, *, measured: bool) -> None:
     """Charge ``size_bytes`` to ``tmp_path`` until the download ends."""
-    _reserved_downloads[Path(tmp_path)] = size_bytes
+    _reserved_downloads[Path(tmp_path)] = DownloadReservation(size_bytes=size_bytes, measured=measured)
 
 
 def release_download(tmp_path: Path) -> None:
     _reserved_downloads.pop(Path(tmp_path), None)
 
 
-def reserved_downloads() -> dict[Path, int]:
+def reserved_downloads() -> dict[Path, DownloadReservation]:
     """What admission has charged for and not yet seen written."""
     return dict(_reserved_downloads)
 

--- a/tests/supervisor/test_cache_eviction.py
+++ b/tests/supervisor/test_cache_eviction.py
@@ -25,6 +25,7 @@ from aleph.vm.agent.vm.reclaimable import mark_reclaimable
 from aleph.vm.agent.vm_registry import AgentVmRegistry
 from aleph.vm.conf import settings
 from aleph.vm.resources import InsufficientResourcesError
+from aleph.vm.storage import DownloadReservation
 
 NOW = datetime(2026, 8, 24, tzinfo=timezone.utc)
 OLDER = datetime(2026, 8, 23, tzinfo=timezone.utc)
@@ -643,7 +644,9 @@ def test_an_unknown_length_download_evicts_nothing(pools, monkeypatch):
     admit_download(registry, pools["runtime"] / "new.part", None, 100 * 1024**3)
 
     assert old.exists()
-    assert storage_module.reserved_downloads() == {pools["runtime"] / "new.part": 8192}
+    assert storage_module.reserved_downloads() == {
+        pools["runtime"] / "new.part": DownloadReservation(8192, measured=False)
+    }
 
 
 def test_an_unknown_length_download_is_refused_on_a_root_over_budget(pools, monkeypatch):
@@ -672,7 +675,10 @@ def test_two_unknown_length_downloads_are_both_charged_the_capped_figure(pools, 
     admit_download(registry, first, None, 4096)
     admit_download(registry, second, None, 100 * 1024**3)
 
-    assert storage_module.reserved_downloads() == {first: 4096, second: 8192}
+    assert storage_module.reserved_downloads() == {
+        first: DownloadReservation(4096, measured=False),
+        second: DownloadReservation(8192, measured=False),
+    }
     with pytest.raises(InsufficientResourcesError):
         admit_download(registry, pools["runtime"] / "c.part", None, 4096)
 
@@ -688,3 +694,77 @@ def test_a_measured_download_still_evicts_to_make_room(pools, monkeypatch):
     admit_download(registry, pools["code"] / "new.part", 8000)
 
     assert not old.exists()
+
+
+def test_a_measured_download_fits_beside_an_unknown_length_one(pools, monkeypatch):
+    """The whole budget used to go to the chunked response, so the next
+    measured download found the root at its cap: it evicted every unreferenced
+    entry trying to make room that a guess was holding, and was refused
+    anyway."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "16384")
+    monkeypatch.setattr(settings, "UNKNOWN_LENGTH_RESERVE", "4096")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    root = pools["code"]
+    old = _entry(root, "old", size=4096, age=1000)
+    chunked = root / "chunked.part"
+
+    admit_download(registry, chunked, None, 100 * 1024**3)
+    admit_download(registry, root / "measured.part", 4096)
+
+    assert old.exists()
+    assert storage_module.reserved_downloads()[chunked] == DownloadReservation(4096, measured=False)
+
+
+def test_a_ceiling_reservation_never_drives_the_pass_to_evict(pools, monkeypatch):
+    """A guess may make a later download wait, never make an entry go: until
+    the chunked body writes bytes, the room it holds is hypothetical and the
+    eviction target leaves it out."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    monkeypatch.setattr(settings, "UNKNOWN_LENGTH_RESERVE", "4096")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    old = _entry(pools["code"], "old", size=8192, age=1000)
+
+    admit_download(registry, pools["code"] / "chunked.part", None, 100 * 1024**3)
+
+    assert evict_caches(registry) == []
+    assert old.exists()
+
+
+def test_the_bytes_a_ceiling_download_writes_are_counted_as_they_land(pools, monkeypatch):
+    """The reconciliation of the guess: what the ``.part`` actually holds is a
+    measurement, so it counts against the budget like any other blocks."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    monkeypatch.setattr(settings, "UNKNOWN_LENGTH_RESERVE", "4096")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    old = _entry(pools["code"], "old", size=8192, age=1000)
+    chunked = pools["code"] / "chunked.part"
+
+    admit_download(registry, chunked, None, 100 * 1024**3)
+    chunked.write_bytes(b"x" * 4096)
+
+    assert evict_caches(registry) == [old]
+
+
+def test_both_downloads_together_stay_inside_the_budget(pools, monkeypatch):
+    """The guess is a placeholder, not a licence: what the two downloads leave
+    behind once they land is still under the cap."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "16384")
+    monkeypatch.setattr(settings, "UNKNOWN_LENGTH_RESERVE", "4096")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    root = pools["code"]
+    _entry(root, "old", size=4096, age=1000)
+    chunked = root / "chunked.part"
+    measured = root / "measured.part"
+
+    admit_download(registry, chunked, None, 100 * 1024**3)
+    admit_download(registry, measured, 4096)
+    for part in (chunked, measured):
+        part.write_bytes(b"x" * 4096)
+        storage_module.release_download(part)
+        part.rename(part.with_suffix(""))
+
+    assert cache_module._root_usage(root, cache_entries(root)) <= 16384

--- a/tests/supervisor/test_cache_eviction.py
+++ b/tests/supervisor/test_cache_eviction.py
@@ -637,6 +637,9 @@ def test_an_unknown_length_download_evicts_nothing(pools, monkeypatch):
     charging that for a chunked response wiped every unreferenced entry in the
     root before refusing the download anyway."""
     monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    # Named so the 8192 below is the budget capping a larger reserve, not a
+    # coincidence of whatever the default reserve happens to be.
+    monkeypatch.setattr(settings, "UNKNOWN_LENGTH_RESERVE", "16384")
     registry = AgentVmRegistry()
     cache_module.record_live_snapshot(set())
     old = _entry(pools["runtime"], "old", size=4096, age=1000)
@@ -667,6 +670,9 @@ def test_two_unknown_length_downloads_are_both_charged_the_capped_figure(pools, 
     """Bounded, so a stream of them still runs the root over its budget and
     the next one is refused, but never charged more than the budget itself."""
     monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    # A reserve above the budget, so what caps each charge below is named here:
+    # the download's own 4096 for the first, the budget for the second.
+    monkeypatch.setattr(settings, "UNKNOWN_LENGTH_RESERVE", "16384")
     registry = AgentVmRegistry()
     cache_module.record_live_snapshot(set())
     first = pools["runtime"] / "a.part"
@@ -681,6 +687,36 @@ def test_two_unknown_length_downloads_are_both_charged_the_capped_figure(pools, 
     }
     with pytest.raises(InsufficientResourcesError):
         admit_download(registry, pools["runtime"] / "c.part", None, 4096)
+
+
+def test_an_unreadable_cache_disk_still_charges_only_the_reserve(pools, monkeypatch, caplog):
+    """The fallback must not be the bug it replaces: a disk whose total cannot
+    be read leaves an absolute reserve holding, never the whole budget."""
+    monkeypatch.setattr(settings, "UNKNOWN_LENGTH_RESERVE", "4096")
+
+    def unreadable(path):
+        raise OSError(13, "Permission denied")
+
+    monkeypatch.setattr(cache_module.shutil, "disk_usage", unreadable)
+
+    with caplog.at_level(logging.WARNING):
+        charge = cache_module._unknown_length_charge(pools["runtime"], 1024**3, None)
+
+    assert charge == 4096
+    assert "not accessible" in caplog.text
+
+
+def test_an_unreadable_cache_disk_holds_nothing_for_a_percentage_reserve(pools, monkeypatch):
+    """A percentage of a disk nobody could measure resolves to nothing, which
+    is still better than holding the root against every other download."""
+    monkeypatch.setattr(settings, "UNKNOWN_LENGTH_RESERVE", "10%")
+
+    def unreadable(path):
+        raise OSError(13, "Permission denied")
+
+    monkeypatch.setattr(cache_module.shutil, "disk_usage", unreadable)
+
+    assert cache_module._unknown_length_charge(pools["runtime"], 1024**3, None) == 0
 
 
 def test_a_measured_download_still_evicts_to_make_room(pools, monkeypatch):

--- a/tests/supervisor/test_storage_download_cap.py
+++ b/tests/supervisor/test_storage_download_cap.py
@@ -227,13 +227,13 @@ async def test_an_admitted_download_is_reserved_until_the_part_is_gone(tmp_path)
 
     async def fake_chunks(url, part, max_bytes=None):
         # What download_file_in_chunks does once the admission hook returns.
-        storage_module.reserve_download(part, max_bytes)
+        storage_module.reserve_download(part, max_bytes, measured=True)
         reserved_mid_download.update(storage_module.reserved_downloads())
 
     with patch("aleph.vm.storage.download_file_in_chunks", side_effect=fake_chunks):
         await download_file("http://x/f", tmp_path / "f", max_bytes=999)
 
-    assert reserved_mid_download == {tmp_path / "f.part": 999}
+    assert reserved_mid_download == {tmp_path / "f.part": storage_module.DownloadReservation(999, measured=True)}
     assert storage_module.reserved_downloads() == {}
 
 


### PR DESCRIPTION
## Summary
A download whose response carries no `Content-Length` was charged `min(cap, budget)`
against its cache root, and since `MAX_RUNTIME_ARCHIVE_SIZE` is 100 GiB that is the
whole budget on any realistic root. One chunked-encoding response then held the
entire root for its duration: a concurrent measured download saw usage already at
the cap, evicted every unreferenced entry in the root trying to free room that a
guess was holding, and was refused anyway. The cache was wiped and the create
failed, for a body that may have been a few kilobytes of manifest.
An unmeasured download is now charged `UNKNOWN_LENGTH_RESERVE` (2 GiB by default,
never more than its own cap nor than the budget), and a reservation records whether
its figure is a measurement or a ceiling: a ceiling never sets an eviction target.
Stacked on #1206.

## Changes
- `src/aleph/vm/storage.py`: reservations are a `DownloadReservation` (size plus
  `measured`), so the cache can tell a `Content-Length` from a cap after admission,
  not just during it. `reserve_download` takes `measured` as a keyword.
- `src/aleph/vm/agent/vm/cache.py`: `in_flight_bytes` takes `count_ceilings`. A
  ceiling reservation counts only the bytes it has actually written when the
  question is how much to evict (`evict_caches`), and in full when the question is
  whether the next download fits (`admit_download`). `_admit_unknown_length` charges
  `_unknown_length_charge`: the smallest of the reserve, the download's cap and the
  budget.
- `src/aleph/vm/conf.py`: `UNKNOWN_LENGTH_RESERVE`, defaulting to `2G`, validated
  through `parse_budget` alongside `CACHE_BUDGET`.
- `docs/architecture/storage.md`: the admission paragraph and the settings table.

## Test plan
- `tests/supervisor/test_cache_eviction.py`: a measured download admitted beside an
  unknown-length one with nothing evicted (the reported scenario, failing before);
  a ceiling reservation never driving the pass to evict; the bytes a ceiling
  download writes still counting as they land; total usage inside the budget once
  both downloads complete.
- `tests/supervisor/test_storage_download_cap.py`: the reservation assertions follow
  the new type.
- Checks: `pytest tests/supervisor` (only the pre-existing environment failure
  `test_log.py::test_make_logs_queue`, missing `systemd.journal.Reader`), `ruff
  format --diff`, `isort --check-only`, `mypy` on the five changed Python files, all
  exit 0.

## Review follow-up (rebased onto dev-2.1 at 973b8fd7)
- `cache.py`: the OSError fallback in `_unknown_length_charge` returned the whole budget, the hold this PR removes. It now resolves the reserve against a zero total, which yields the configured size when the reserve is absolute and nothing when it is a percentage of the disk that just refused to answer.
- `tests/supervisor/test_cache_eviction.py`: the two tests whose expected figure was really `min(reserve, budget)` under the 2 GiB default now set `UNKNOWN_LENGTH_RESERVE` explicitly, plus two tests for both shapes of the fallback.
- Checks on the rebased branch: `ruff format --diff`, `isort --check-only --profile black`, `mypy` clean. Test suites are left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZyMqLgxxVfeDwiNy34sfM

