### PR TITLE
fix(agent): drop a retired VM from the live set the retire forgets it

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -534,6 +534,14 @@ message means the referenced set is incomplete. Before the first pass there is
 no live set, so admission evicts nothing and simply admits or refuses on the
 budget as it stands.
 
+A pass is not the only thing that changes the published set: `retire_vm` drops
+the VM it retires from it, right where it forgets the registry record. The two
+halves have to move together, and under `reap` no pass follows a retire, so a
+hash left behind would read as a live VM with no record until the next periodic
+pass (an hour by default) and stop admission evicting for that whole window. A
+retire never turns an unset live set into an empty one: only a pass may say
+that nothing is live.
+
 ### Settings
 
 | Setting | Default | What it does |

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -96,6 +96,28 @@ def record_live_snapshot(live: Collection[str]) -> None:
     _live_snapshot = frozenset(str(namespace) for namespace in live)
 
 
+def forget_live(namespace: str) -> None:
+    """Drop a VM the agent has just retired from the live set.
+
+    A retire quiesces the VM in the supervisor and forgets its registry
+    record, so the two halves the pass reconciles both stop naming it. Until
+    the next pass republishes the set, a hash left here reads to admission as
+    a live VM with no record, which is precisely the doubt that stops it
+    evicting anything: every download then logs an error and one that does
+    not fit is refused with the cache full of evictable entries. Retiring
+    under the retention that keeps volumes runs a pass straight after, but
+    reaping does not, and the periodic pass can be an hour away.
+
+    An unset snapshot stays unset: "no pass has run yet" is a different
+    answer from "nothing is live", and only the pass may turn one into the
+    other.
+    """
+    global _live_snapshot  # noqa: PLW0603
+    if _live_snapshot is None:
+        return
+    _live_snapshot = _live_snapshot - {str(namespace)}
+
+
 def live_snapshot() -> frozenset[str] | None:
     return _live_snapshot
 

--- a/src/aleph/vm/agent/vm/retire.py
+++ b/src/aleph/vm/agent/vm/retire.py
@@ -31,6 +31,7 @@ from aleph_message.models import ItemHash
 
 from aleph.vm.agent.metrics import delete_records_for_vm
 from aleph.vm.agent.vm.backup import purge_vm_backups
+from aleph.vm.agent.vm.cache import forget_live
 from aleph.vm.agent.vm.purge import (
     _checked_namespace,
     purge_vm_side_dirs,
@@ -192,6 +193,12 @@ async def retire_vm(
     item_hash = vm_hash if isinstance(vm_hash, ItemHash) else ItemHash(str(vm_hash))
     record = registry.get(item_hash)
     registry.forget(item_hash)
+    # The cache's live set is the other half of what admission checks a record
+    # against, and it is only refreshed by a storage pass: leaving a retired
+    # hash in it makes every download until the next pass look like it is
+    # racing a live VM the agent has no message for, so nothing is evicted and
+    # a download that needs room is refused.
+    forget_live(str(vm_hash))
     await delete_records_for_vm(str(vm_hash))
     # Before the storage pass: a volume file held by a live dm target cannot
     # be unlinked usefully, and the marker written for a kept volume would

--- a/tests/supervisor/test_retire.py
+++ b/tests/supervisor/test_retire.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 import json
+import os
+import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aleph_message.models import InstanceContent, ItemHash
-from reclaim_fixtures import VM_HASH, pools, volume  # noqa: F401
+from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
 
+import aleph.vm.agent.vm.cache as cache_module
 import aleph.vm.agent.vm.retire as retire_module
+import aleph.vm.storage as storage_module
+from aleph.vm.agent.vm.cache import admit_download
 from aleph.vm.agent.vm.reclaimable import MARKER_NAME, read_marker
 from aleph.vm.agent.vm.retire import RetireReason, retire_vm
 from aleph.vm.agent.vm_registry import AgentVmRegistry
@@ -18,6 +23,14 @@ from aleph.vm.supervisor_interface.errors import VmNotFoundError
 from aleph.vm.supervisor_interface.types import VmId
 
 OWNER = "0x1234567890123456789012345678901234567890"
+
+
+@pytest.fixture(autouse=True)
+def _clean_module_state(monkeypatch):
+    """The live-set snapshot and the reserved downloads are module state: no
+    test inherits another's."""
+    monkeypatch.setattr(cache_module, "_live_snapshot", None)
+    monkeypatch.setattr(storage_module, "_reserved_downloads", {})
 
 
 @pytest.fixture
@@ -353,3 +366,63 @@ async def test_a_retire_with_a_record_reads_the_volumes_from_the_message(env, mo
 
     fallback.assert_not_awaited()
     remove.assert_awaited_once_with(VM_HASH, "data")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reason", [RetireReason.GONE, RetireReason.ERASE, RetireReason.FAILED_CREATE])
+async def test_a_record_dropping_retire_drops_the_vm_from_the_live_snapshot(env, monkeypatch, reason):
+    """The snapshot is what admission checks the registry against: a hash left
+    in it after its record is forgotten reads as a live VM the agent knows
+    nothing about."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    cache_module.record_live_snapshot({VM_HASH, OTHER_HASH})
+
+    await retire_vm(VM_HASH, reason, supervisor=env["supervisor"], registry=env["registry"])
+
+    assert cache_module.live_snapshot() == frozenset({OTHER_HASH})
+
+
+@pytest.mark.asyncio
+async def test_recreate_leaves_the_live_snapshot_alone(env):
+    """RECREATE keeps the record and the VM comes straight back."""
+    cache_module.record_live_snapshot({VM_HASH})
+
+    await retire_vm(VM_HASH, RetireReason.RECREATE, supervisor=env["supervisor"], registry=env["registry"])
+
+    assert cache_module.live_snapshot() == frozenset({VM_HASH})
+
+
+@pytest.mark.asyncio
+async def test_a_retire_before_the_first_pass_leaves_the_snapshot_unset(env, monkeypatch):
+    """No pass has run, so nothing is known about the live set: that is not
+    the same answer as "nothing is live", and admission must keep refusing to
+    evict."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+
+    await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
+
+    assert cache_module.live_snapshot() is None
+
+
+@pytest.mark.asyncio
+async def test_a_download_after_a_reaping_retire_may_still_evict(env, monkeypatch, pools, caplog):  # noqa: F811
+    """The failure this pins: under reap nothing re-runs a pass after a
+    retire, so the retired hash sat in the snapshot without a record for up to
+    a whole reconcile interval, and every download in between was admitted
+    without evicting, or refused outright with the cache full of evictable
+    entries."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    cache_module.record_live_snapshot({VM_HASH})
+    old = pools["code"] / "old"
+    old.write_bytes(b"x" * 4096)
+    stamp = time.time() - 1000
+    os.utime(old, (stamp, stamp))
+
+    await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
+
+    with caplog.at_level("ERROR"):
+        admit_download(env["registry"], pools["code"] / "new.part", 8000)
+
+    assert not old.exists()
+    assert "no registry record" not in caplog.text


### PR DESCRIPTION
## Summary
The download admission hook evicts only when it can trust the live set a storage pass published: a hash in that set with no registry record means a running VM whose message nobody can read, so admission fails closed and evicts nothing. `retire_vm` forgot the registry record but left the retired hash in the published set, and under the default `VOLUME_RETENTION=reap` no pass follows a retire. Every retired VM therefore read as a live VM without a record until the next periodic pass (up to `VOLUME_RECONCILE_INTERVAL`, an hour): in that window every download logged an ERROR and a download that did not fit the budget was refused with a 503 while the cache was full of evictable entries.

The fix keeps one owner of the set. `cache.py` gains `forget_live`, and `retire_vm` calls it where it calls `registry.forget`, so both halves move together for every reason that drops the record. An unset set stays unset: "no pass has run yet" is still not "nothing is live", and only a pass may turn one into the other.

Stacked on #1211.

## Changes
- `src/aleph/vm/agent/vm/cache.py`: new `forget_live(namespace)` next to `record_live_snapshot`, the only other writer of `_live_snapshot`. It removes one hash and returns without touching an unset snapshot.
- `src/aleph/vm/agent/vm/retire.py`: `retire_vm` calls `forget_live` immediately after `registry.forget`, so it runs for GONE, ERASE and FAILED_CREATE and not for RECREATE (which keeps the record and brings the VM straight back).
- `docs/architecture/storage.md`: the admission section now says a pass is not the only writer of the published live set, and why a retire has to drop its hash.

## Test plan
- `tests/supervisor/test_retire.py`: four new tests. A record-dropping retire (parametrized over the three reasons) removes the hash and leaves the rest of the set alone; RECREATE leaves the set untouched; a retire before the first pass leaves the set unset; and the end to end pin, a reaping GONE retire followed by a download that needs room, which now evicts the stale entry with no "no registry record" ERROR and no `InsufficientResourcesError`. The three parametrizations and the end to end test failed on the base commit (the last one with the 503).
- An autouse fixture in that file resets the two module-level pieces of state the file now touches (the live snapshot and the reserved downloads), matching the convention in `test_cache_eviction.py`.
- Checks: `pytest tests/supervisor/test_retire.py tests/supervisor/test_cache_eviction.py tests/supervisor/test_reconciler.py` (146 passed, 1 skipped) and the whole `tests/supervisor` suite (1196 passed, 1 pre-existing journald failure in `test_log.py`, identical to the base). `ruff format --diff`, `isort --check-only --profile black` and `mypy` all clean on the three Python files. No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZyMqLgxxVfeDwiNy34sfM
