### PR TITLE
fix(agent): back off when a guest crash-loops after it reached RUNNING

### DIFF
--- a/src/aleph/vm/agent/allocation/plan.py
+++ b/src/aleph/vm/agent/allocation/plan.py
@@ -61,7 +61,12 @@ class AllocationState(str, Enum):
 
 @dataclass
 class FailureRecord:
-    """Why a planned VM is not running, and when we will try again.
+    """What it is taking to keep a planned VM running, and when we try again.
+
+    Two things are counted as one attempt: a start that raised, and a rebuild
+    of a VM the supervisor held dead, which is what puts a crash-looping guest
+    on the same backoff. So a record can outlive a successful start, and one
+    on a running VM means it has died recently, not that it is down now.
 
     Kept in the reconciler and NOT in AgentVmRegistry on purpose: the registry
     is what CapacityManager sums committed resources over, and a VM that failed

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -205,7 +205,18 @@ class AllocationReconciler:
             if info.status in LIVE_STATUSES or info.awaiting_confidential_init
         }
         now = self._now()
-        todo = [vm_hash for vm_hash in plan.entries if vm_hash not in live and self._retry_due(vm_hash, now)]
+        self._forget_settled(live, now)
+        todo: list[ItemHash] = []
+        for vm_hash in plan.entries:
+            if vm_hash in live:
+                continue
+            if not self._retry_due(vm_hash, now):
+                # Down and waiting out its backoff. Saying so is what lets the
+                # executions list report the wait and the time it ends, rather
+                # than a dead VM the agent appears to have no opinion about.
+                self._states[vm_hash] = AllocationState.FAILED
+                continue
+            todo.append(vm_hash)
         if not todo:
             return
 
@@ -213,7 +224,9 @@ class AllocationReconciler:
 
         async def start(vm_hash: ItemHash) -> None:
             async with semaphore:
-                await self._start_one(vm_hash)
+                # A VM the supervisor lists that is not live is one it holds
+                # dead: the loop started it before, so this start is a rebuild.
+                await self._start_one(vm_hash, known.get(vm_hash))
 
         await asyncio.gather(*(start(vm_hash) for vm_hash in todo), return_exceptions=True)
 
@@ -221,7 +234,24 @@ class AllocationReconciler:
         failure = self._failures.get(vm_hash)
         return failure is None or failure.next_retry_at <= now
 
-    async def _start_one(self, vm_hash: ItemHash) -> None:
+    def _forget_settled(self, live: set[ItemHash], now: datetime) -> None:
+        """Drop the record of a VM that has been up long enough to call healthy.
+
+        A rebuild after a death counts as an attempt, so the record has to
+        outlive the successful start that follows it, or nothing would gate
+        the next rebuild. It cannot be immortal either: a VM that crashed once
+        a month ago deserves its rebuild at once, not at the capped wait. The
+        longest wait the backoff can impose is the threshold, past which the
+        next death is a new problem rather than the tail of the old one.
+        """
+        settled = timedelta(seconds=settings.ALLOCATION_RETRY_MAX_INTERVAL)
+        for vm_hash, failure in list(self._failures.items()):
+            if vm_hash in live and now - failure.last_failed_at >= settled:
+                self._forget(vm_hash)
+
+    async def _start_one(self, vm_hash: ItemHash, down: VmInfo | None = None) -> None:
+        """Start a planned VM. `down` is what the supervisor holds for it when
+        it already has one, which makes this start a rebuild of a dead VM."""
         self._states[vm_hash] = AllocationState.DOWNLOADING
         try:
             await start_persistent_vm(
@@ -244,13 +274,47 @@ class AllocationReconciler:
                 return
             self._record_failure(vm_hash, error)
             return
-        self._forget(vm_hash)
+        if down is None or self._desired is None or vm_hash not in self._desired.entries:
+            # A first create, or one the plan dropped while it was in flight:
+            # submit() has already pruned that VM's records, and putting one
+            # back would leave state_for reporting on something nothing will
+            # retry until the next push clears it again.
+            self._forget(vm_hash)
+            return
+        # The rebuild of a VM the supervisor held dead counts as a failed
+        # attempt, on the same backoff a failing create climbs. Otherwise a
+        # guest that panics seconds after boot is rebuilt from scratch, disks
+        # and all, at boot speed: the successful start erases the record, the
+        # down event wakes the loop, and nothing gates the next pass. The
+        # record deliberately outlives this successful start, and is dropped
+        # once the VM has stayed up (see _forget_settled).
+        record = self._note_attempt(
+            vm_hash,
+            code=f"vm_{down.status.value}",
+            message=f"rebuilt after the supervisor reported it {down.status.value}",
+        )
+        logger.warning(
+            "Rebuilt %s after the supervisor reported it %s (attempt %d, next rebuild not before %s)",
+            vm_hash,
+            down.status.value,
+            record.attempts,
+            record.next_retry_at,
+        )
+        # The supervisor knows the VM again, so the agent has no phase of its
+        # own to report; only the count of what it took to get here.
+        self._states.pop(vm_hash, None)
 
     def _forget(self, vm_hash: ItemHash) -> None:
         self._failures.pop(vm_hash, None)
         self._states.pop(vm_hash, None)
 
     def _record_failure(self, vm_hash: ItemHash, error: Exception) -> None:
+        code = getattr(getattr(error, "code", None), "value", "") or type(error).__name__
+        record = self._note_attempt(vm_hash, code=code, message=str(error))
+        logger.warning("Starting %s failed (attempt %d): %s", vm_hash, record.attempts, error)
+        self._states[vm_hash] = AllocationState.FAILED
+
+    def _note_attempt(self, vm_hash: ItemHash, *, code: str, message: str) -> FailureRecord:
         # There is no terminal failure, on purpose. The plan is the authority
         # on what should run here, so a VM it still lists is still owed an
         # attempt, at the capped interval; giving up would leave a listed VM
@@ -264,14 +328,13 @@ class AllocationReconciler:
             settings.ALLOCATION_RETRY_BASE_INTERVAL * (2 ** (attempts - 1)),
             settings.ALLOCATION_RETRY_MAX_INTERVAL,
         )
-        code = getattr(getattr(error, "code", None), "value", "") or type(error).__name__
-        logger.warning("Starting %s failed (attempt %d): %s", vm_hash, attempts, error)
-        self._failures[vm_hash] = FailureRecord(
+        record = FailureRecord(
             code=code,
-            message=str(error)[:200],
+            message=message[:200],
             attempts=attempts,
             first_failed_at=previous.first_failed_at if previous else now,
             last_failed_at=now,
             next_retry_at=now + timedelta(seconds=delay),
         )
-        self._states[vm_hash] = AllocationState.FAILED
+        self._failures[vm_hash] = record
+        return record

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -254,12 +254,10 @@ class AllocationReconciler:
 
         `down` is what the supervisor holds for it when it already has one,
         which makes this start a rebuild and charges it on the backoff ladder.
-        Any status that is not live counts, not only the FAILED of a guest that
-        panicked: STOPPED is resumed in place, which is cheaper than a rebuild,
-        and STOPPING is waited out and then recreated, and both climb the same
-        ladder. A guest that halt loops needs the wait as much as one that
-        panics, and the cheaper resume is no reason to let it loop at boot
-        speed forever.
+        Whatever state the supervisor held the VM in is charged, not only the
+        FAILED of a guest that panicked: a guest that halt loops needs the wait
+        as much as one that panics, and a resume being cheaper than a rebuild
+        is no reason to let it loop at boot speed forever.
         """
         self._states[vm_hash] = AllocationState.DOWNLOADING
         try:

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -250,8 +250,17 @@ class AllocationReconciler:
                 self._forget(vm_hash)
 
     async def _start_one(self, vm_hash: ItemHash, down: VmInfo | None = None) -> None:
-        """Start a planned VM. `down` is what the supervisor holds for it when
-        it already has one, which makes this start a rebuild of a dead VM."""
+        """Start a planned VM.
+
+        `down` is what the supervisor holds for it when it already has one,
+        which makes this start a rebuild and charges it on the backoff ladder.
+        Any status that is not live counts, not only the FAILED of a guest that
+        panicked: STOPPED is resumed in place, which is cheaper than a rebuild,
+        and STOPPING is waited out and then recreated, and both climb the same
+        ladder. A guest that halt loops needs the wait as much as one that
+        panics, and the cheaper resume is no reason to let it loop at boot
+        speed forever.
+        """
         self._states[vm_hash] = AllocationState.DOWNLOADING
         try:
             await start_persistent_vm(

--- a/tests/supervisor/test_allocation_reconciler.py
+++ b/tests/supervisor/test_allocation_reconciler.py
@@ -327,6 +327,153 @@ async def test_a_successful_start_clears_a_previous_failure(reconciler, monkeypa
     assert reconciler.state_for(HASH_C) == (None, None)
 
 
+# ── A guest that dies after it started ─────────────────────────────────────
+
+
+def _boots_then(reconciler, monkeypatch, status=VmStatus.FAILED):
+    """A start that works, after which the supervisor holds the VM in `status`.
+
+    With FAILED that is a guest which boots and dies, the crash loop; with
+    RUNNING it is a VM that stays up. Returns the list the fake supervisor
+    answers with, so a test can change what the VM is doing afterwards.
+    """
+    listed: list = []
+
+    async def fake_start(vm_hash, _pubsub, **_kwargs):
+        reconciler.started.append(vm_hash)
+        listed[:] = [_info(vm_hash, status=status)]
+
+    async def list_vms():
+        return list(listed)
+
+    monkeypatch.setattr(reconciler_module, "start_persistent_vm", fake_start)
+    reconciler.supervisor.list_vms = list_vms
+    return listed
+
+
+@pytest.mark.asyncio
+async def test_a_guest_that_dies_after_it_started_is_rebuilt_on_the_backoff(reconciler, monkeypatch, clock):
+    """Rebuilding a VM the supervisor already holds dead is a retry like any
+    other, and used to be free: the successful start erased the failure
+    record, the FAILED event woke the loop, and the next pass found nothing to
+    gate it. A guest that panics on boot was rebuilt from scratch at boot
+    speed, disks and all, for as long as the plan listed it."""
+    _boots_then(reconciler, monkeypatch)
+    reconciler.submit(_plan(HASH_C))
+
+    await reconciler._converge_once()  # the first create
+    await reconciler._converge_once()  # it died: rebuilt at once, and counted
+
+    assert reconciler.started == [HASH_C, HASH_C]
+    _, failure = reconciler.state_for(HASH_C)
+    assert failure.attempts == 1
+    assert failure.next_retry_at == NOW + timedelta(seconds=settings.ALLOCATION_RETRY_BASE_INTERVAL)
+
+    await reconciler._converge_once()  # still dead, but not due yet
+    assert reconciler.started == [HASH_C, HASH_C]
+
+    clock.now = failure.next_retry_at
+    await reconciler._converge_once()
+
+    assert reconciler.started == [HASH_C, HASH_C, HASH_C]
+    _, failure = reconciler.state_for(HASH_C)
+    assert failure.attempts == 2
+    assert failure.next_retry_at == clock.now + timedelta(seconds=settings.ALLOCATION_RETRY_BASE_INTERVAL * 2)
+
+
+@pytest.mark.asyncio
+async def test_the_rebuild_backoff_doubles_and_is_capped(reconciler, monkeypatch, clock):
+    """The same ladder a failed create climbs, on the same two settings."""
+    _boots_then(reconciler, monkeypatch)
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()  # the first create
+    delays = []
+
+    for _ in range(8):
+        await reconciler._converge_once()
+        _, failure = reconciler.state_for(HASH_C)
+        delays.append((failure.next_retry_at - clock.now).total_seconds())
+        clock.now = failure.next_retry_at
+
+    assert delays[0] == settings.ALLOCATION_RETRY_BASE_INTERVAL
+    assert delays[1] == settings.ALLOCATION_RETRY_BASE_INTERVAL * 2
+    assert max(delays) == settings.ALLOCATION_RETRY_MAX_INTERVAL
+
+
+@pytest.mark.asyncio
+async def test_a_vm_that_stays_up_accumulates_no_attempts(reconciler, monkeypatch, clock):
+    """The rebuild count is charged for a death, not for existing."""
+    _boots_then(reconciler, monkeypatch, status=VmStatus.RUNNING)
+    reconciler.submit(_plan(HASH_C))
+
+    for _ in range(3):
+        await reconciler._converge_once()
+        clock.now += timedelta(seconds=settings.ALLOCATION_RECONCILE_INTERVAL)
+
+    assert reconciler.started == [HASH_C]
+    assert reconciler.state_for(HASH_C) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_a_rebuilt_vm_that_stays_up_loses_its_crash_record(reconciler, monkeypatch, clock):
+    """The count must not be immortal, or a VM that crashed once a month ago
+    would take the capped wait for a rebuild it deserves at once. It is
+    dropped once the VM has been up longer than the longest wait the backoff
+    can impose, past which the next death is a new problem rather than the
+    tail of the old one."""
+    listed = _boots_then(reconciler, monkeypatch)
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+    await reconciler._converge_once()
+    assert reconciler.state_for(HASH_C)[1].attempts == 1
+
+    listed[:] = [_info(HASH_C, status=VmStatus.RUNNING)]
+    clock.now = NOW + timedelta(seconds=settings.ALLOCATION_RETRY_MAX_INTERVAL - 1)
+    await reconciler._converge_once()
+    assert reconciler.state_for(HASH_C)[1].attempts == 1
+
+    clock.now = NOW + timedelta(seconds=settings.ALLOCATION_RETRY_MAX_INTERVAL)
+    await reconciler._converge_once()
+
+    assert reconciler.state_for(HASH_C) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_a_vm_waiting_out_its_rebuild_backoff_says_so(reconciler, monkeypatch):
+    """What the executions list has to report while a rebuild is held back:
+    the attempts and when it will happen, rather than a dead VM the agent
+    looks to have no opinion about."""
+    _boots_then(reconciler, monkeypatch)
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+    await reconciler._converge_once()
+
+    await reconciler._converge_once()
+
+    state, failure = reconciler.state_for(HASH_C)
+    assert state is AllocationState.FAILED
+    assert failure.attempts == 1
+    assert failure.next_retry_at == NOW + timedelta(seconds=settings.ALLOCATION_RETRY_BASE_INTERVAL)
+
+
+@pytest.mark.asyncio
+async def test_a_rebuild_the_plan_dropped_mid_flight_is_not_remembered(reconciler, monkeypatch):
+    """The same rule the failing create follows: submit() prunes the state of
+    a VM it drops, and a rebuild that lands afterwards must not put it back
+    for a VM nothing will retry."""
+
+    async def fake_start(vm_hash, _pubsub, **_kwargs):
+        reconciler.submit(_plan())
+
+    monkeypatch.setattr(reconciler_module, "start_persistent_vm", fake_start)
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_C, status=VmStatus.FAILED)]
+    reconciler.submit(_plan(HASH_C))
+
+    await reconciler._converge_once()
+
+    assert reconciler.state_for(HASH_C) == (None, None)
+
+
 def test_pending_hashes_are_the_entries_the_push_carried_no_message_for(reconciler):
     reconciler.submit(
         AllocationPlan(


### PR DESCRIPTION
## Summary
The allocation reconciler's backoff only covered a start that raised. A start that worked called `_forget`, erasing the record, so when the guest later died the FAILED event woke the loop, `_start_missing` found no record and read the retry as due, and `start_persistent_vm`'s FAILED branch retired the VM as RECREATE and rebuilt it from scratch. A guest that panics seconds after boot was therefore rebuilt at boot speed, disks and all, for as long as the plan listed it (v1 rebuilt the same guest once per scheduler push). This counts a post-RUNNING death as an attempt on the same exponential ladder, so the first rebuild is still immediate and each death after it waits longer, capped at `ALLOCATION_RETRY_MAX_INTERVAL`.

Stacked on #1209.

## Changes
- `allocation/reconciler.py`: `_start_one` takes the `VmInfo` the supervisor holds for the VM when it has one, which is what makes the start a rebuild rather than a first create. On success it now records that rebuild as an attempt instead of forgetting, on the same ladder a failing create climbs. The backoff bookkeeping moved out of `_record_failure` into `_note_attempt`, shared by both callers, so exactly one attempt is charged per pass either way.
- `allocation/reconciler.py`: `_forget_settled` drops the record of a VM that has been up longer than `ALLOCATION_RETRY_MAX_INTERVAL`, the longest wait the backoff can impose. The record has to outlive the successful start that follows a rebuild, or nothing would gate the next one, but it must not be immortal: a VM that crashed once a month ago deserves its rebuild at once, not at the cap.
- `allocation/reconciler.py`: a planned VM that is down and not yet due is reported `failed`, so the v2 executions list shows the attempts and `next_retry_at` instead of a dead VM the agent looks to have no opinion about. No change was needed in `_allocation_block`, which already renders that pair.
- `allocation/plan.py`: `FailureRecord`'s docstring says what a record on a running VM now means (it has died recently, not that it is down).

## Test plan
- `tests/supervisor/test_allocation_reconciler.py`: six tests, four of which failed before the fix. A guest that boots and dies is rebuilt at once, counted, and its next rebuild is gated by the base interval then by double; the ladder doubles and is capped at the max; a VM that stays up accumulates no attempts; a rebuilt VM that stays up loses its record once it has been up for the max interval (and keeps it a second before); a VM waiting out its rebuild reports `failed` with the attempts and the retry time; a rebuild the plan dropped mid-flight is not recorded, the rule the failing create already followed.
- pytest on the four files that import the touched modules plus `test_allocation_teardown.py` and `test_agent_capacity.py`: `197 passed`. The wider related set (15 files): `307 passed`.
- `ruff format --diff`, `isort --check-only --profile black`, `mypy` on the three changed files: exit 0, `Success: no issues found in 3 source files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZyMqLgxxVfeDwiNy34sfM
