### PR TITLE
fix(cli): keep aleph-vm storage from purging behind a running agent

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -625,20 +625,39 @@ Both "is it running" questions are answered fail-closed, and neither claims
 more than it can back up. The **agent** is called stopped only when nothing
 accepts a connection on its bind address; that is a loopback connect with a
 2 s timeout, it needs no privileges and no unit name, and anything listening
-there counts as the agent. A probe that fails any other way (a name that
-does not resolve, a socket this user may not open, the timeout) leaves the
-agent possibly running, and the refusal stands: being wrong that way costs
-an operator one refused command, being wrong the other way deletes the disks
-of a VM mid-create. The **supervisor** is called *down* only when its socket
-is missing (`os.stat`, not `Path.exists()`, which turns a stat this user may
-not make into a plain False) or refuses a connection. Every other failed
-dial (a socket this user may not open, the 3 s deadline, a reply that does
-not parse) leaves the daemon's state unknown. The difference is what the
+there counts as the agent. A wildcard bind (`0.0.0.0`, `::`, empty) is
+probed on *both* loopbacks and called stopped only when both refuse, because
+asyncio's `create_server` sets `IPV6_V6ONLY` on an `AF_INET6` socket: an
+agent bound to `::` accepts on `::1` and refuses on `127.0.0.1`, so a probe
+that asked only the IPv4 loopback would call a running agent stopped and
+purge behind it. An address family the kernel cannot reach at all
+(`EAFNOSUPPORT`, `ENETUNREACH` and friends) counts with the refusals, since
+nothing can be serving on a loopback that is not there. A probe that fails
+any other way (a name that does not resolve, a socket this user may not
+open, the timeout) leaves the agent possibly running, and the refusal
+stands: being wrong that way costs an operator one refused command, being
+wrong the other way deletes the disks of a VM mid-create. The **supervisor**
+is called *down* only when *its own socket* is missing (`os.stat`, not
+`Path.exists()`, which turns a stat this user may not make into a plain
+False) or refuses a connection. A refused connection in the dial's exception
+chain counts too, but a missing *file* there does not: the client opens more
+than its socket, and only a stat of the socket path can tell a stopped
+daemon from a running one that tripped over something else. Every other
+failed dial (a socket this user may not open, the 3 s deadline, a reply that
+does not parse) leaves the daemon's state unknown. The difference is what the
 operator is told: the exception class and message always, and the advice to
 pass `--trust-registry` only when the daemon is verified down, since on
 anything else it would invite exactly the purge the supervisor union exists
 to prevent. An explicit `--dry-run` is told its preview is registry-only
 instead, having asked for nothing that could be downgraded.
+
+Every verb writes what it found or achieved (the status table, the listing,
+the reconcile report, the "Purged ..." line) to stdout, and every warning,
+refusal and diagnostic to stderr, `reclaim` included: a wrapper parses one
+stream without filtering the other, and a refusal leaves stdout empty rather
+than mixing a reason into a report that does not exist. The verbs take both
+streams as arguments, so the tests read them apart without capturing the
+process's own.
 
 `--trust-registry` remains the sharpest tool here even so, and the narrow
 advice does not blunt it: a supervisor that is verifiably down has not

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -562,27 +562,62 @@ in its `--help` epilog) needs no running *agent process*:
   under `backup_old`) and a directory with no marker (it may belong to a
   live VM) are refused the same way. Then refuses a hash the agent registry
   or the supervisor considers live (see below), and refuses outright,
-  without `--trust-registry`, when the supervisor cannot be asked. Finally,
-  if the purge itself leaves the directory behind (a device-mapper target
-  still holds one of its volumes, the same guard `purge_vm_storage` always
-  applies), reclaim reports that and exits non-zero rather than claiming
-  success. `reclaim` never tears devices down itself: `storage reconcile`
-  is the CLI path that does, for every VM nothing owns, so the refusal
-  points the operator there.
+  without `--trust-registry`, when the supervisor is down. The marker is
+  read once more immediately before the purge: a re-create adopts its
+  retained directories by clearing their markers, and one that started
+  while the supervisor was being asked is in no answer this process holds,
+  so the second read is what keeps the purge off the disks a create is at
+  that moment building on. Finally, if the purge itself leaves the
+  directory behind (a device-mapper target still holds one of its volumes,
+  the same guard `purge_vm_storage` always applies), reclaim reports that
+  and exits non-zero rather than claiming success. `reclaim` never tears
+  devices down, and neither does any other CLI verb: the refusal points the
+  operator at the agent, whose own pass reclaims the device.
 - `storage reconcile [--dry-run] [--trust-registry]`: run one
-  `reconcile_storage()` pass with the daemon's two device steps around it,
-  or the CLI would keep refusing what the daemon reclaims. Before the pass,
-  `_teardown_orphan_devices` removes the dm devices of every namespace no
-  live VM owns, so the purge that follows is not refused on a volume file a
-  target still holds; that step needs the supervisor's answer and is skipped
-  under `--dry-run` and when the supervisor is unreachable, `--trust-registry`
-  included (it buys a purge on the registry's word, not a teardown). After
-  the pass, and printing what it removed (or, under `--dry-run`, what it
-  would remove), it tears down the devices of any evicted runtime cache
+  `reconcile_storage()` pass, with what the supervisor answers deciding
+  which passes are allowed to run at all:
+  - **The supervisor answers.** A real pass is refused (exit 3, the reason
+    on stderr, nothing written). The agent is running, and the set of
+    creates it has in flight is in-process state this command cannot see, so
+    a create that outlives `VOLUME_CREATE_GUARD` before its DB record exists
+    (a long migration import routinely does) would read as an orphan here.
+    A CLI pass also holds no lock against the agent's own. The agent runs
+    that pass itself at startup, periodically and after every VM goes away,
+    and it sees the creates too, so there is nothing here for a CLI pass to
+    add. `--dry-run` is still allowed and is how a running node is
+    inspected: it takes the supervisor's list into the live set exactly as a
+    real pass would.
+  - **The supervisor does not answer.** Nothing is being created, so the age
+    of the directory is a sound guard again and this is the command for a
+    node whose agent will not start. The live set is the registry alone,
+    which is not a safe one, so the pass runs dry, warns on stderr and exits
+    3 unless `--trust-registry` says to proceed on the registry's word.
+  After the pass, and printing what it removed (or, under `--dry-run`, what
+  it would remove), it tears down the devices of any evicted runtime cache
   parent the same way `reconcile_now` / `reconcile_at_startup` do
   (`remove_parent_device` per evicted ref, then `sweep_leaked_cache_loops`),
   so an evicted entry never leaves `/dev/mapper/<ref>` and its loop device
-  pinning the deleted inode.
+  pinning the deleted inode. The orphan-namespace teardown the daemon's
+  passes run first is not repeated here: tearing a device down takes the
+  disk of a VM that was merely unlisted, and the one answer that made it
+  safe (the supervisor's) is now the answer that refuses the pass outright.
+
+Both purge paths call the daemon's own `_startup_refusal` rather than
+restating its conditions, so a CLI pass and a daemon pass cannot drift
+apart: an empty registry while the supervisor runs VMs means the agent DB
+was lost, and both refuse on that alone.
+
+Whether the daemon is *down* is a claim the CLI only makes when it can back
+it up: a socket that is missing (`os.stat`, not `Path.exists()`, which turns
+a stat this user may not make into a plain False) or one that refuses a
+connection. Every other failed dial (a socket this user may not open, the
+3 s deadline, a reply that does not parse) leaves the daemon's state
+unknown. The difference is what the operator is told: the exception class
+and message always, and the advice to pass `--trust-registry` only when the
+daemon is verified down, since on anything else it would invite exactly the
+purge the supervisor union exists to prevent. An explicit `--dry-run` is
+told its preview is registry-only instead, having asked for nothing that
+could be downgraded.
 
 Running with no agent process also means setting the process up the way the
 systemd units set it up for the daemon, which the CLI does before it reads

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -557,12 +557,15 @@ in its `--help` epilog) needs no running *agent process*:
 - `storage reclaim <hash> [--trust-registry]`: purge one reclaimable
   directory now. Checks the name and the `.reclaimable` marker first, purely
   locally, so a typo or an unrelated hash fails instantly rather than
-  waiting on a supervisor dial that could only ever confirm what those
+  waiting on a probe or a dial that could only ever confirm what those
   checks already know; a name that is not a VM hash (a hand-made marker
   under `backup_old`) and a directory with no marker (it may belong to a
-  live VM) are refused the same way. Then refuses a hash the agent registry
-  or the supervisor considers live (see below), and refuses outright,
-  without `--trust-registry`, when the supervisor is down. The marker is
+  live VM) are refused the same way. Then refused outright (exit 3) while
+  the agent may be running, for the reason `reconcile` is: a marked
+  directory is not safe to purge merely because it is marked, since a
+  create adopts one by clearing its marker. Then refuses a hash the agent
+  registry or the supervisor considers live, and refuses without
+  `--trust-registry` when the supervisor cannot be asked. The marker is
   read once more immediately before the purge: a re-create adopts its
   retained directories by clearing their markers, and one that started
   while the supervisor was being asked is in no answer this process holds,
@@ -571,53 +574,78 @@ in its `--help` epilog) needs no running *agent process*:
   directory behind (a device-mapper target still holds one of its volumes,
   the same guard `purge_vm_storage` always applies), reclaim reports that
   and exits non-zero rather than claiming success. `reclaim` never tears
-  devices down, and neither does any other CLI verb: the refusal points the
-  operator at the agent, whose own pass reclaims the device.
+  devices down itself: `storage reconcile` is the CLI path that does, for
+  every VM nothing owns, so the refusal points the operator there.
 - `storage reconcile [--dry-run] [--trust-registry]`: run one
-  `reconcile_storage()` pass, with what the supervisor answers deciding
-  which passes are allowed to run at all:
-  - **The supervisor answers.** A real pass is refused (exit 3, the reason
-    on stderr, nothing written). The agent is running, and the set of
-    creates it has in flight is in-process state this command cannot see, so
-    a create that outlives `VOLUME_CREATE_GUARD` before its DB record exists
-    (a long migration import routinely does) would read as an orphan here.
-    A CLI pass also holds no lock against the agent's own. The agent runs
-    that pass itself at startup, periodically and after every VM goes away,
-    and it sees the creates too, so there is nothing here for a CLI pass to
-    add. `--dry-run` is still allowed and is how a running node is
-    inspected: it takes the supervisor's list into the live set exactly as a
-    real pass would.
-  - **The supervisor does not answer.** Nothing is being created, so the age
-    of the directory is a sound guard again and this is the command for a
-    node whose agent will not start. The live set is the registry alone,
+  `reconcile_storage()` pass. Two processes decide what it may do, and they
+  are not the same one. The **agent** is this Python service
+  (`aleph-vm-agent`, bound to `SUPERVISOR_HOST`/`SUPERVISOR_PORT`); it owns
+  the reconciler and the creates. The **supervisor** is the Rust daemon that
+  runs the VMs and answers `list_vms`. Either can be up without the other,
+  and the state an operator needs this command for is exactly the awkward
+  one: VMs running under a healthy supervisor while the agent is down or
+  will not start. Hence three states:
+  - **The agent is running, or cannot be ruled out as running.** A real pass
+    is refused (exit 3, the reason on stderr, nothing written). The set of
+    creates the agent has in flight is in-process state this command cannot
+    see, so a create that outlives `VOLUME_CREATE_GUARD` before its DB
+    record exists (a long migration import routinely does) would read as an
+    orphan here, and a CLI pass holds no lock against the agent's own. The
+    agent runs that pass itself at startup, periodically and after every VM
+    goes away, and it sees the creates too, so there is nothing here for a
+    CLI pass to add. `--dry-run` is still allowed and is how a running node
+    is inspected; it says on stderr that what it lists may include a
+    directory the agent is at that moment creating.
+  - **The agent is down and the supervisor answers.** The full pass runs.
+    Nothing is being created, so the age of the directory is a sound guard
+    again, and the live set is a known one (registry union `list_vms`), so
+    `_teardown_orphan_devices` removes the dm devices of every namespace no
+    live VM owns before the walk, or the purge that follows would be refused
+    on a volume file a target still holds.
+  - **The supervisor does not answer.** The live set is the registry alone,
     which is not a safe one, so the pass runs dry, warns on stderr and exits
-    3 unless `--trust-registry` says to proceed on the registry's word.
+    3 unless `--trust-registry` says to proceed on the registry's word. No
+    device is torn down on that path, `--trust-registry` included: it buys a
+    purge on the registry's word, not a teardown, and removing the device of
+    a VM that is merely unlisted takes that VM's disk with it.
   After the pass, and printing what it removed (or, under `--dry-run`, what
   it would remove), it tears down the devices of any evicted runtime cache
   parent the same way `reconcile_now` / `reconcile_at_startup` do
   (`remove_parent_device` per evicted ref, then `sweep_leaked_cache_loops`),
   so an evicted entry never leaves `/dev/mapper/<ref>` and its loop device
-  pinning the deleted inode. The orphan-namespace teardown the daemon's
-  passes run first is not repeated here: tearing a device down takes the
-  disk of a VM that was merely unlisted, and the one answer that made it
-  safe (the supervisor's) is now the answer that refuses the pass outright.
+  pinning the deleted inode.
 
 Both purge paths call the daemon's own `_startup_refusal` rather than
 restating its conditions, so a CLI pass and a daemon pass cannot drift
 apart: an empty registry while the supervisor runs VMs means the agent DB
-was lost, and both refuse on that alone.
+was lost, and both refuse on that alone (exit 3, not 1: nothing about the
+hash or the node's disks is wrong, the command simply may not run here).
 
-Whether the daemon is *down* is a claim the CLI only makes when it can back
-it up: a socket that is missing (`os.stat`, not `Path.exists()`, which turns
-a stat this user may not make into a plain False) or one that refuses a
-connection. Every other failed dial (a socket this user may not open, the
-3 s deadline, a reply that does not parse) leaves the daemon's state
-unknown. The difference is what the operator is told: the exception class
-and message always, and the advice to pass `--trust-registry` only when the
-daemon is verified down, since on anything else it would invite exactly the
-purge the supervisor union exists to prevent. An explicit `--dry-run` is
-told its preview is registry-only instead, having asked for nothing that
-could be downgraded.
+Both "is it running" questions are answered fail-closed, and neither claims
+more than it can back up. The **agent** is called stopped only when nothing
+accepts a connection on its bind address; that is a loopback connect with a
+2 s timeout, it needs no privileges and no unit name, and anything listening
+there counts as the agent. A probe that fails any other way (a name that
+does not resolve, a socket this user may not open, the timeout) leaves the
+agent possibly running, and the refusal stands: being wrong that way costs
+an operator one refused command, being wrong the other way deletes the disks
+of a VM mid-create. The **supervisor** is called *down* only when its socket
+is missing (`os.stat`, not `Path.exists()`, which turns a stat this user may
+not make into a plain False) or refuses a connection. Every other failed
+dial (a socket this user may not open, the 3 s deadline, a reply that does
+not parse) leaves the daemon's state unknown. The difference is what the
+operator is told: the exception class and message always, and the advice to
+pass `--trust-registry` only when the daemon is verified down, since on
+anything else it would invite exactly the purge the supervisor union exists
+to prevent. An explicit `--dry-run` is told its preview is registry-only
+instead, having asked for nothing that could be downgraded.
+
+`--trust-registry` remains the sharpest tool here even so, and the narrow
+advice does not blunt it: a supervisor that is verifiably down has not
+necessarily stopped its VMs (a supervisor process that dies leaves its QEMU
+processes running), so purging on the registry's word can still delete the
+disks under a live VM whose registry record was lost. It is the flag for an
+operator who knows what the node is doing, not a way to get past a warning.
 
 Running with no agent process also means setting the process up the way the
 systemd units set it up for the daemon, which the CLI does before it reads

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -12,32 +12,46 @@ supervisor daemon over the same gRPC socket the agent dials
 timeout, and union its answer into the live set. ``status`` and ``list``
 are read-only and never touch the supervisor.
 
-The answer decides what ``reconcile`` may do, and the two outcomes are
-opposite by design:
+Two processes matter here, and they are not the same one. The *agent* is
+this Python service (``aleph-vm-agent``, bound to
+``settings.SUPERVISOR_HOST``/``SUPERVISOR_PORT``); it owns the reconciler
+and the creates. The *supervisor* is the Rust daemon that runs the VMs and
+answers ``list_vms`` on the gRPC socket. Either can be up without the
+other, and the case an operator needs this command for is precisely the
+awkward one: VMs running under a supervisor that is perfectly healthy while
+the agent is down or will not start.
 
-* The supervisor answers. The agent is running, and the one thing this
-  process can never see is exactly the thing the running agent holds: the
-  set of creates it has in flight (``reconciler.creating()`` is in-process
-  state). A create that outlives ``VOLUME_CREATE_GUARD`` before its DB
-  record exists (a long migration import routinely does) is invisible here
-  and looks like an orphan, directory and devices alike. So a real pass is
-  refused: the agent runs its own pass at startup, periodically and after
-  every VM goes away, and that pass sees everything this one does plus the
-  creates. ``--dry-run`` is still allowed, and is how an operator inspects
-  a running node.
-* The supervisor does not answer. Nothing is being created, so the age of
-  the directory is a sound guard again, and this command becomes the way to
-  reconcile a node whose agent will not start. The live set is then the
-  registry alone, which is not a safe one, so the pass runs dry and exits
-  non-zero unless ``--trust-registry`` says to proceed on the registry's
-  word. ``reclaim`` refuses on the same terms.
+So a purge is decided in three states:
 
-Whether the daemon is down is a claim this module only makes when it can
-back it up: a socket that is missing or refuses a connection. A dial that
-failed for any other reason (a socket this user may not open, a deadline, a
-reply that does not parse) leaves the daemon's state unknown, and the
-advice to purge on the registry alone is then withheld: it would invite the
-one purge the union exists to prevent.
+* The agent is running (or cannot be ruled out as running). A real pass and
+  ``reclaim`` are refused. The one thing this process can never see is
+  exactly what the running agent holds: the set of creates it has in flight
+  (``reconciler.creating()`` is in-process state). A create that outlives
+  ``VOLUME_CREATE_GUARD`` before its DB record exists (a long migration
+  import routinely does) is invisible here and looks like an orphan,
+  directory and devices alike, and a CLI pass holds no lock against the
+  agent's own. The agent runs that pass itself at startup, periodically and
+  after every VM goes away, and its pass sees the creates too.
+  ``--dry-run`` is still allowed, and is how a running node is inspected.
+* The agent is stopped and the supervisor answers. Nothing is being
+  created, and the live set is a known one (registry union ``list_vms``), so
+  the full pass runs: the orphan-namespace device teardown first, exactly as
+  the agent's own passes do it, then the walk.
+* The supervisor does not answer. The live set is the registry alone, which
+  is not a safe one, so the pass runs dry, warns and exits non-zero unless
+  ``--trust-registry`` says to proceed on the registry's word, and no device
+  is torn down (that would take the disk of a VM that was merely unlisted).
+  ``reclaim`` refuses on the same terms.
+
+Both "is it running" questions are answered fail-closed, and neither claims
+more than it can back up. The agent is called stopped only when nothing
+accepts a connection on its bind address; a probe that fails any other way
+leaves it possibly running, and the refusal stands. The supervisor is
+called down only when its socket is missing or refuses a connection; a dial
+that failed for any other reason (a socket this user may not open, a
+deadline, a reply that does not parse) leaves its state unknown, and the
+advice to purge on the registry alone is then withheld, since it would
+invite the one purge the union exists to prevent.
 
 Running with no agent process also means setting up the process the way the
 systemd units set it up for the daemon: the node's environment file is read
@@ -84,6 +98,7 @@ from aleph.vm.agent.vm.reconciler import (
     _release_cache_devices,
     _startup_refusal,
     _still_on_disk,
+    _teardown_orphan_devices,
     live_hashes,
     reconcile_storage,
     supervisor_hashes,
@@ -98,6 +113,11 @@ from aleph.vm.supervisor_interface.abc import Supervisor
 # unreachable. Short on purpose: an operator running this by hand should not
 # sit through a 30 second RPC deadline just to learn the daemon is down.
 SUPERVISOR_CONNECT_TIMEOUT_SECS = 3.0
+
+# How long to wait for the agent's own bind address. Shorter still: it is a
+# loopback connect, and a node that does not answer it in two seconds is a
+# node this command must assume is alive anyway.
+AGENT_PROBE_TIMEOUT_SECS = 2.0
 
 # Exit code for a reconcile that did not reconcile: it was refused because
 # the agent is running (its own pass covers the node), or it silently
@@ -169,12 +189,13 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
         help="run one reconciler pass",
         description=(
             "Run one reconciler pass against the agent registry (unioned with the supervisor's "
-            "list_vms() when it can be reached). While the agent answers, only --dry-run runs: "
-            "this process cannot see a create the agent is in the middle of (that state lives in "
-            "the agent), so a create that has outlived VOLUME_CREATE_GUARD without reaching the "
-            "registry DB would read as an orphan here. The agent's own pass (at startup, "
-            "periodically, and after every VM goes away) covers a node whose agent is up. This "
-            "command is for a node whose agent is not."
+            "list_vms() when it can be reached). While the aleph-vm agent is running, or cannot be "
+            "ruled out as running, only --dry-run runs: this process cannot see a create the agent "
+            "is in the middle of (that state lives in the agent), so a create that has outlived "
+            "VOLUME_CREATE_GUARD without reaching the registry DB would read as an orphan here, and "
+            "the agent's own pass (at startup, periodically, and after every VM goes away) covers "
+            "that node anyway. This command is for a node whose agent is down, whether or not the "
+            "supervisor daemon under it still runs VMs."
         ),
     )
     reconcile_parser.add_argument("--dry-run", action="store_true")
@@ -234,6 +255,65 @@ def _open_supervisor() -> Supervisor:
     from aleph.vm.supervisor_interface.client import GrpcSupervisor
 
     return GrpcSupervisor(settings.SUPERVISOR_GRPC_SOCKET)
+
+
+class AgentReach(Enum):
+    """How much this process knows about the agent service."""
+
+    RUNNING = "running"
+    # Verified stopped: nothing accepts a connection on its bind address.
+    STOPPED = "stopped"
+    # Could not tell, which counts as running: see AgentProbe.may_be_running.
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class AgentProbe:
+    """Whether the agent service is up, and on what evidence."""
+
+    reach: AgentReach
+    detail: str
+
+    @property
+    def may_be_running(self) -> bool:
+        """Fail closed: only a refused connection rules the agent out.
+
+        Everything a wrong answer here costs is asymmetric. Calling a
+        stopped agent running costs an operator one refused command on a
+        node they can then look at; calling a running agent stopped purges
+        the disks of a VM it is at that moment creating.
+        """
+        return self.reach is not AgentReach.STOPPED
+
+
+def _probe_agent() -> AgentProbe:
+    """Ask the agent's own HTTP bind address whether it is there.
+
+    The cheapest evidence available, and it needs no privileges and no unit
+    name: the agent binds that address for as long as its process lives, and
+    this is a loopback connect that is either refused at once or accepted at
+    once. Anything listening there is treated as the agent, which is the
+    fail-closed reading; a socket configured but unreachable, a name that
+    does not resolve or a deadline all leave the question open, and open
+    counts as running.
+
+    The setting is spelled SUPERVISOR_HOST/PORT for historical reasons: it
+    is this Python service's own bind, not the Rust supervisor's socket.
+    """
+    host = str(settings.SUPERVISOR_HOST)
+    port = int(settings.SUPERVISOR_PORT)
+    address = f"{host}:{port}"
+    # A wildcard bind is not a connectable address: dial the loopback the
+    # agent necessarily also answers on.
+    target = "127.0.0.1" if host in {"", "0.0.0.0", "::", "*"} else host  # noqa: S104
+    try:
+        with socket.create_connection((target, port), timeout=AGENT_PROBE_TIMEOUT_SECS):
+            pass
+    except ConnectionRefusedError:
+        return AgentProbe(AgentReach.STOPPED, f"nothing accepts a connection on {address}")
+    except OSError as error:
+        return AgentProbe(AgentReach.UNKNOWN, f"{address} could not be probed ({type(error).__name__}: {error})")
+    return AgentProbe(AgentReach.RUNNING, f"something is listening on {address}")
 
 
 class SupervisorReach(Enum):
@@ -442,35 +522,49 @@ def _is_marked_reclaimable(vm_hash: str) -> bool:
     return any(directory.name == vm_hash for directory, _marker in iter_reclaimable())
 
 
-def _supervisor_reclaim_refusal(registry: AgentVmRegistry, vm_hash: str, *, trust_registry: bool) -> str | None:
+@dataclass(frozen=True)
+class Refusal:
+    """A reason not to purge, and the exit code that reports it.
+
+    Most refusals say "not this hash" and exit 1. A node whose agent is
+    live, or whose agent database was lost, is a different answer: nothing
+    about the hash is wrong, the command simply may not run here, and a
+    wrapper script has to be able to tell the two apart.
+    """
+
+    message: str
+    code: int = 1
+
+
+def _supervisor_reclaim_refusal(registry: AgentVmRegistry, vm_hash: str, *, trust_registry: bool) -> Refusal | None:
     """The half of the reclaim verdict that needs the daemon's answer."""
     answer = asyncio.run(_ask_supervisor())
     if answer.answered:
         if vm_hash in answer.running:
-            return f"{vm_hash} is running (the supervisor lists it); refusing to purge it"
+            return Refusal(f"{vm_hash} is running (the supervisor lists it); refusing to purge it")
         # The daemon's own reason to distrust a live set, asked here too: a
         # lost agent DB makes every marker on the node look purgeable, and
         # the supervisor's list is no second opinion on a VM it has not
         # started yet.
         lost_database = _startup_refusal(registry, len(answer.running))
         if lost_database is not None:
-            return f"Refusing to purge {vm_hash}: {lost_database}"
+            return Refusal(f"Refusing to purge {vm_hash}: {lost_database}", DEGRADED_EXIT_CODE)
         return None
     if trust_registry:
         return None
     if answer.reach is SupervisorReach.DOWN:
-        return (
+        return Refusal(
             f"Supervisor unreachable ({answer.problem}); cannot confirm {vm_hash} is not running. "
             "Pass --trust-registry to purge using the registry alone"
         )
-    return (
+    return Refusal(
         f"The supervisor could not be asked ({answer.problem}); cannot confirm {vm_hash} is not "
         "running. That error is no proof the daemon is stopped, so purging on the registry alone "
         "is not offered here: fix it and retry"
     )
 
 
-def _reclaim_refusal(registry: AgentVmRegistry, vm_hash: str, *, trust_registry: bool) -> str | None:
+def _reclaim_refusal(registry: AgentVmRegistry, vm_hash: str, *, trust_registry: bool) -> Refusal | None:
     """Why reclaim must not purge this hash, or None when it may.
 
     Cheapest, purely local checks first: a typo or an unrelated hash fails
@@ -481,23 +575,36 @@ def _reclaim_refusal(registry: AgentVmRegistry, vm_hash: str, *, trust_registry:
     purge_vm_storage after every other check passed.
     """
     if not _plausible(vm_hash):
-        return f"{vm_hash!r} is not a VM hash; refusing to purge a directory not named after a VM"
+        return Refusal(f"{vm_hash!r} is not a VM hash; refusing to purge a directory not named after a VM")
     if not _is_marked_reclaimable(vm_hash):
-        return f"{vm_hash} is not reclaimable (no .reclaimable marker); refusing to purge a directory a VM may own"
+        return Refusal(
+            f"{vm_hash} is not reclaimable (no .reclaimable marker); refusing to purge a directory a VM may own"
+        )
     if vm_hash in live_hashes(registry):
-        return f"{vm_hash} is a live VM in the agent registry; refusing to purge it"
+        return Refusal(f"{vm_hash} is a live VM in the agent registry; refusing to purge it")
+    probe = _probe_agent()
+    if probe.may_be_running:
+        # A marked directory is not safe to purge merely because it is
+        # marked: a create adopts it by clearing the marker, and this
+        # process would have to win a race with that to notice.
+        return Refusal(
+            f"Refusing to purge {vm_hash}: {_agent_at_work_reason(probe)}. {_agent_pass_note()}; "
+            "run 'storage list --reclaimable' to see what it will find",
+            DEGRADED_EXIT_CODE,
+        )
     return _supervisor_reclaim_refusal(registry, vm_hash, trust_registry=trust_registry)
 
 
 def _reclaim(registry: AgentVmRegistry, vm_hash: str, out: TextIO, *, trust_registry: bool) -> int:
     refusal = _reclaim_refusal(registry, vm_hash, trust_registry=trust_registry)
     if refusal is not None:
-        out.write(refusal + "\n")
-        return 1
-    # Asked again, after the dial: a re-create adopts its retained
-    # directories by clearing their markers, and a create that started while
-    # the supervisor was being asked is in no answer this process has. The
-    # marker is the one thing that says the disks are nobody's.
+        out.write(refusal.message + "\n")
+        return refusal.code
+    # Asked again, after the probe and the dial: a re-create adopts its
+    # retained directories by clearing their markers, and a create that
+    # started while the supervisor was being asked is in no answer this
+    # process has. The marker is the one thing that says the disks are
+    # nobody's.
     if not _is_marked_reclaimable(vm_hash):
         out.write(
             f"{vm_hash} is no longer marked reclaimable: a create adopted its directory while the "
@@ -508,25 +615,49 @@ def _reclaim(registry: AgentVmRegistry, vm_hash: str, out: TextIO, *, trust_regi
     if _still_on_disk(vm_hash):
         out.write(
             f"Purge of {vm_hash} left directories behind: a device-mapper target still holds its volumes. "
-            "Tearing a device down needs the certainty only the agent has, so start it and let its own "
-            "pass reclaim the device, then retry\n"
+            "Run 'storage reconcile' to tear down the devices of every VM nothing owns, then retry\n"
         )
         return 1
     out.write(f"Purged {vm_hash}: {deleted} volume file(s)\n")
     return 0
 
 
-def _running_daemon_refusal(live_set: LiveSet) -> str:
-    """What to tell an operator who asked for a real pass on a live node."""
-    reason = live_set.refusal or (
-        "the agent is running, and the creates it has in flight are invisible to this process "
-        "(that state lives in the agent itself), so a VM being built would read as an orphan here"
-    )
+def _agent_at_work_reason(probe: AgentProbe) -> str:
+    """Why a live agent takes the purge away from this command."""
+    if probe.reach is AgentReach.RUNNING:
+        opening = f"the agent is running ({probe.detail})"
+    else:
+        opening = f"the agent cannot be ruled out as running ({probe.detail})"
     return (
-        f"Refusing to reconcile: {reason}. The agent runs its own pass at startup, periodically, "
-        "and after every VM goes away, and that pass sees the creates too; use --dry-run to "
-        "preview what one would find.\n"
+        f"{opening}, and the creates it has in flight are invisible to this process (that state "
+        "lives in the agent itself), so a VM being built would read as an orphan here"
     )
+
+
+def _agent_pass_note() -> str:
+    return (
+        "The agent runs its own pass at startup, periodically, and after every VM goes away, and "
+        "that pass sees the creates too"
+    )
+
+
+def _pass_refusal(probe: AgentProbe, live_set: LiveSet) -> str | None:
+    """Why a real reconcile must not run at all, or None when it may."""
+    if probe.may_be_running:
+        return (
+            f"Refusing to reconcile: {_agent_at_work_reason(probe)}. {_agent_pass_note()}; use "
+            "--dry-run to preview what one would find.\n"
+        )
+    # The agent is out of the way, but the daemon's own reason to distrust a
+    # live set still applies: an empty registry while the supervisor runs VMs
+    # means the agent DB was lost, and every directory on the node then reads
+    # as an orphan.
+    if live_set.refusal is not None:
+        return (
+            f"Refusing to reconcile: {live_set.refusal}. Restore the agent database, or use "
+            "--dry-run to see what a pass would find.\n"
+        )
+    return None
 
 
 def _unanswered_warning(answer: SupervisorAnswer, *, dry_run: bool, trust_registry: bool) -> str:
@@ -553,18 +684,30 @@ def _unanswered_warning(answer: SupervisorAnswer, *, dry_run: bool, trust_regist
 def _reconcile(registry: AgentVmRegistry, out: TextIO, *, dry_run: bool, trust_registry: bool) -> int:
     live_set = _cli_live_set(registry)
     answer = live_set.supervisor
+    probe = _probe_agent()
+    if not dry_run:
+        refusal = _pass_refusal(probe, live_set)
+        if refusal is not None:
+            sys.stderr.write(refusal)
+            return DEGRADED_EXIT_CODE
+    elif probe.may_be_running:
+        sys.stderr.write(
+            f"Note: {_agent_at_work_reason(probe)}, so this preview can name a directory the "
+            "agent is at that moment creating\n"
+        )
     if not answer.answered:
         sys.stderr.write(_unanswered_warning(answer, dry_run=dry_run, trust_registry=trust_registry))
-    elif not dry_run:
-        # A running agent is the one state where this process is strictly
-        # less informed than the agent's own pass, so it does not get to
-        # purge. The preview still runs: it is how a node under load is
-        # inspected.
-        sys.stderr.write(_running_daemon_refusal(live_set))
-        return DEGRADED_EXIT_CODE
     downgraded = not answer.answered and not trust_registry
     effective_dry_run = dry_run or downgraded
     live = set(live_set.hashes)
+    # Mirrors reconcile_now: the devices of every namespace nothing owns go
+    # before the walk, or the purge that follows refuses those directories
+    # (a dm target still holds their volume files) exactly as the agent's
+    # passes used to. Only when the supervisor answered, since removing the
+    # device of a VM that is merely unlisted takes that VM's disk with it:
+    # --trust-registry buys a purge on the registry's word, not a teardown.
+    if not effective_dry_run and answer.answered:
+        asyncio.run(_teardown_orphan_devices(live))
     report = reconcile_storage(registry, dry_run=effective_dry_run, live=live, live_known=answer.answered)
     prefix = "Dry run: " if effective_dry_run else "Reconciled: "
     out.write(prefix + report.summary() + "\n")

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -45,13 +45,18 @@ So a purge is decided in three states:
 
 Both "is it running" questions are answered fail-closed, and neither claims
 more than it can back up. The agent is called stopped only when nothing
-accepts a connection on its bind address; a probe that fails any other way
-leaves it possibly running, and the refusal stands. The supervisor is
-called down only when its socket is missing or refuses a connection; a dial
-that failed for any other reason (a socket this user may not open, a
-deadline, a reply that does not parse) leaves its state unknown, and the
-advice to purge on the registry alone is then withheld, since it would
-invite the one purge the union exists to prevent.
+accepts a connection on its bind address, on every loopback a wildcard bind
+could be answering on; a probe that fails any other way leaves it possibly
+running, and the refusal stands. The supervisor is called down only when
+its own socket is missing or refuses a connection; a dial that failed for
+any other reason (a socket this user may not open, a deadline, a reply that
+does not parse) leaves its state unknown, and the advice to purge on the
+registry alone is then withheld, since it would invite the one purge the
+union exists to prevent.
+
+Every verb writes what it found or achieved to ``out`` and every warning,
+refusal and diagnostic to ``err``, so a wrapper can parse one without
+filtering the other.
 
 Running with no agent process also means setting up the process the way the
 systemd units set it up for the daemon: the node's environment file is read
@@ -67,6 +72,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import errno
 import logging
 import os
 import shutil
@@ -286,6 +292,28 @@ class AgentProbe:
         return self.reach is not AgentReach.STOPPED
 
 
+# Hosts that name no address to connect to. A wildcard bind is probed on
+# both loopbacks, never on one: asyncio's server sets IPV6_V6ONLY on an
+# AF_INET6 socket, so an agent bound to "::" accepts on ::1 and refuses on
+# 127.0.0.1, and a probe that asked only the IPv4 loopback would call a
+# running agent stopped and purge behind it.
+_WILDCARD_HOSTS = frozenset({"", "*", "0.0.0.0", "::", "::0"})  # noqa: S104
+_LOOPBACKS = ("127.0.0.1", "::1")
+
+# Errnos that say the address family itself is unusable on this host rather
+# than that the agent is up. Nothing can be serving on a loopback the kernel
+# cannot reach, so these count with the refusals: without that, the probe on
+# an IPv4-only node would answer "cannot tell" for ever and the command
+# would refuse every purge on a node that has none of the risk.
+_FAMILY_UNAVAILABLE = frozenset(
+    {errno.EAFNOSUPPORT, errno.EPFNOSUPPORT, errno.ENETUNREACH, errno.EHOSTUNREACH, errno.EADDRNOTAVAIL}
+)
+
+
+def _format_address(host: str, port: int) -> str:
+    return f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
+
+
 def _probe_agent() -> AgentProbe:
     """Ask the agent's own HTTP bind address whether it is there.
 
@@ -295,25 +323,34 @@ def _probe_agent() -> AgentProbe:
     once. Anything listening there is treated as the agent, which is the
     fail-closed reading; a socket configured but unreachable, a name that
     does not resolve or a deadline all leave the question open, and open
-    counts as running.
+    counts as running. A wildcard bind is stopped only when every loopback
+    it could be answering on refuses.
 
     The setting is spelled SUPERVISOR_HOST/PORT for historical reasons: it
     is this Python service's own bind, not the Rust supervisor's socket.
     """
     host = str(settings.SUPERVISOR_HOST)
     port = int(settings.SUPERVISOR_PORT)
-    address = f"{host}:{port}"
-    # A wildcard bind is not a connectable address: dial the loopback the
-    # agent necessarily also answers on.
-    target = "127.0.0.1" if host in {"", "0.0.0.0", "::", "*"} else host  # noqa: S104
-    try:
-        with socket.create_connection((target, port), timeout=AGENT_PROBE_TIMEOUT_SECS):
-            pass
-    except ConnectionRefusedError:
-        return AgentProbe(AgentReach.STOPPED, f"nothing accepts a connection on {address}")
-    except OSError as error:
-        return AgentProbe(AgentReach.UNKNOWN, f"{address} could not be probed ({type(error).__name__}: {error})")
-    return AgentProbe(AgentReach.RUNNING, f"something is listening on {address}")
+    targets = _LOOPBACKS if host in _WILDCARD_HOSTS else (host,)
+    silent: list[str] = []
+    problems: list[str] = []
+    for target in targets:
+        address = _format_address(target, port)
+        try:
+            with socket.create_connection((target, port), timeout=AGENT_PROBE_TIMEOUT_SECS):
+                pass
+        except ConnectionRefusedError:
+            silent.append(address)
+        except OSError as error:
+            if error.errno in _FAMILY_UNAVAILABLE:
+                silent.append(f"{address} ({type(error).__name__}: {error})")
+            else:
+                problems.append(f"{address} ({type(error).__name__}: {error})")
+        else:
+            return AgentProbe(AgentReach.RUNNING, f"something is listening on {address}")
+    if problems:
+        return AgentProbe(AgentReach.UNKNOWN, "could not be probed: " + "; ".join(problems))
+    return AgentProbe(AgentReach.STOPPED, "nothing accepts a connection on " + " or ".join(silent))
 
 
 class SupervisorReach(Enum):
@@ -397,13 +434,17 @@ def _reach_from_failure(error: BaseException) -> SupervisorReach:
 
     The gRPC client rebuilds transport failures into its own error classes,
     so the exception alone rarely says whether the daemon is stopped; when
-    it does not, the socket itself is asked. A refusal or a missing socket
-    anywhere in the chain is proof enough; a permission error never is, and
-    neither is a deadline (a daemon that is up but wedged is the textbook
-    way to time out).
+    it does not, the socket itself is asked. A refused connection anywhere
+    in the chain is proof enough. A missing *file* is not, whatever the
+    chain says: the client opens more than its socket (a TLS material path,
+    a config file), and only a stat of the socket path itself can tell a
+    stopped daemon from a running one that tripped over something else, so
+    that case falls through to _socket_reach. A permission error is never
+    proof, and neither is a deadline (a daemon that is up but wedged is the
+    textbook way to time out).
     """
     for cause in _exception_chain(error):
-        if isinstance(cause, FileNotFoundError | ConnectionRefusedError):
+        if isinstance(cause, ConnectionRefusedError):
             return SupervisorReach.DOWN
         if isinstance(cause, PermissionError):
             return SupervisorReach.UNKNOWN
@@ -595,10 +636,13 @@ def _reclaim_refusal(registry: AgentVmRegistry, vm_hash: str, *, trust_registry:
     return _supervisor_reclaim_refusal(registry, vm_hash, trust_registry=trust_registry)
 
 
-def _reclaim(registry: AgentVmRegistry, vm_hash: str, out: TextIO, *, trust_registry: bool) -> int:
+def _reclaim(registry: AgentVmRegistry, vm_hash: str, out: TextIO, err: TextIO, *, trust_registry: bool) -> int:
+    # Every refusal and every diagnostic goes to err, as in reconcile: stdout
+    # carries what the command achieved and nothing else, so a wrapper can
+    # read it without filtering.
     refusal = _reclaim_refusal(registry, vm_hash, trust_registry=trust_registry)
     if refusal is not None:
-        out.write(refusal.message + "\n")
+        err.write(refusal.message + "\n")
         return refusal.code
     # Asked again, after the probe and the dial: a re-create adopts its
     # retained directories by clearing their markers, and a create that
@@ -606,14 +650,14 @@ def _reclaim(registry: AgentVmRegistry, vm_hash: str, out: TextIO, *, trust_regi
     # process has. The marker is the one thing that says the disks are
     # nobody's.
     if not _is_marked_reclaimable(vm_hash):
-        out.write(
+        err.write(
             f"{vm_hash} is no longer marked reclaimable: a create adopted its directory while the "
             "supervisor was being asked. Refusing to purge it\n"
         )
         return 1
     deleted = purge_vm_storage(vm_hash)
     if _still_on_disk(vm_hash):
-        out.write(
+        err.write(
             f"Purge of {vm_hash} left directories behind: a device-mapper target still holds its volumes. "
             "Run 'storage reconcile' to tear down the devices of every VM nothing owns, then retry\n"
         )
@@ -641,23 +685,24 @@ def _agent_pass_note() -> str:
     )
 
 
-def _pass_refusal(probe: AgentProbe, live_set: LiveSet) -> str | None:
-    """Why a real reconcile must not run at all, or None when it may."""
-    if probe.may_be_running:
-        return (
-            f"Refusing to reconcile: {_agent_at_work_reason(probe)}. {_agent_pass_note()}; use "
-            "--dry-run to preview what one would find.\n"
-        )
-    # The agent is out of the way, but the daemon's own reason to distrust a
-    # live set still applies: an empty registry while the supervisor runs VMs
-    # means the agent DB was lost, and every directory on the node then reads
-    # as an orphan.
-    if live_set.refusal is not None:
-        return (
-            f"Refusing to reconcile: {live_set.refusal}. Restore the agent database, or use "
-            "--dry-run to see what a pass would find.\n"
-        )
-    return None
+def _agent_pass_refusal(probe: AgentProbe) -> str:
+    return (
+        f"Refusing to reconcile: {_agent_at_work_reason(probe)}. {_agent_pass_note()}; use "
+        "--dry-run to preview what one would find.\n"
+    )
+
+
+def _lost_database_refusal(live_set: LiveSet) -> str | None:
+    """The daemon's own reason to distrust a live set, once the agent is out
+    of the way: an empty registry while the supervisor runs VMs means the
+    agent DB was lost, and every directory on the node then reads as an
+    orphan."""
+    if live_set.refusal is None:
+        return None
+    return (
+        f"Refusing to reconcile: {live_set.refusal}. Restore the agent database, or use "
+        "--dry-run to see what a pass would find.\n"
+    )
 
 
 def _unanswered_warning(answer: SupervisorAnswer, *, dry_run: bool, trust_registry: bool) -> str:
@@ -681,22 +726,29 @@ def _unanswered_warning(answer: SupervisorAnswer, *, dry_run: bool, trust_regist
     )
 
 
-def _reconcile(registry: AgentVmRegistry, out: TextIO, *, dry_run: bool, trust_registry: bool) -> int:
-    live_set = _cli_live_set(registry)
-    answer = live_set.supervisor
+def _reconcile(registry: AgentVmRegistry, out: TextIO, err: TextIO, *, dry_run: bool, trust_registry: bool) -> int:
+    # The agent probe comes before the supervisor dial: it is a loopback
+    # connect that answers at once, and it can refuse the whole pass, so a
+    # refused pass should not first sit through a three second deadline for
+    # an answer it then throws away.
     probe = _probe_agent()
-    if not dry_run:
-        refusal = _pass_refusal(probe, live_set)
-        if refusal is not None:
-            sys.stderr.write(refusal)
+    if probe.may_be_running:
+        if not dry_run:
+            err.write(_agent_pass_refusal(probe))
             return DEGRADED_EXIT_CODE
-    elif probe.may_be_running:
-        sys.stderr.write(
+        err.write(
             f"Note: {_agent_at_work_reason(probe)}, so this preview can name a directory the "
             "agent is at that moment creating\n"
         )
+    live_set = _cli_live_set(registry)
+    answer = live_set.supervisor
+    if not dry_run:
+        lost_database = _lost_database_refusal(live_set)
+        if lost_database is not None:
+            err.write(lost_database)
+            return DEGRADED_EXIT_CODE
     if not answer.answered:
-        sys.stderr.write(_unanswered_warning(answer, dry_run=dry_run, trust_registry=trust_registry))
+        err.write(_unanswered_warning(answer, dry_run=dry_run, trust_registry=trust_registry))
     downgraded = not answer.answered and not trust_registry
     effective_dry_run = dry_run or downgraded
     live = set(live_set.hashes)
@@ -723,15 +775,18 @@ def _reconcile(registry: AgentVmRegistry, out: TextIO, *, dry_run: bool, trust_r
     return DEGRADED_EXIT_CODE if downgraded and not dry_run else 0
 
 
-def run(args: argparse.Namespace, registry: AgentVmRegistry, out: TextIO) -> int:
+def run(args: argparse.Namespace, registry: AgentVmRegistry, out: TextIO, err: TextIO) -> int:
+    """Run one verb. ``out`` carries what the command found or achieved,
+    ``err`` every warning, refusal and diagnostic, so a wrapper can parse one
+    without filtering the other."""
     if args.storage_command == "status":
         return _status(registry, out)
     if args.storage_command == "list":
         return _list(registry, out, reclaimable_only=args.reclaimable)
     if args.storage_command == "reclaim":
-        return _reclaim(registry, args.vm_hash, out, trust_registry=args.trust_registry)
+        return _reclaim(registry, args.vm_hash, out, err, trust_registry=args.trust_registry)
     if args.storage_command == "reconcile":
-        return _reconcile(registry, out, dry_run=args.dry_run, trust_registry=args.trust_registry)
+        return _reconcile(registry, out, err, dry_run=args.dry_run, trust_registry=args.trust_registry)
     return 2
 
 
@@ -850,7 +905,7 @@ def run_parsed(args: argparse.Namespace) -> int:
     initialise_database()
 
     registry = asyncio.run(_load_registry())
-    return run(args, registry, sys.stdout)
+    return run(args, registry, sys.stdout, sys.stderr)
 
 
 def main(argv: list[str]) -> int:

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -47,12 +47,15 @@ Both "is it running" questions are answered fail-closed, and neither claims
 more than it can back up. The agent is called stopped only when nothing
 accepts a connection on its bind address, on every loopback a wildcard bind
 could be answering on; a probe that fails any other way leaves it possibly
-running, and the refusal stands. The supervisor is called down only when
-its own socket is missing or refuses a connection; a dial that failed for
-any other reason (a socket this user may not open, a deadline, a reply that
-does not parse) leaves its state unknown, and the advice to purge on the
-registry alone is then withheld, since it would invite the one purge the
-union exists to prevent.
+running, and the refusal stands. One gap this cannot close: aiohttp runs
+the agent's on_startup hooks, including the reconciler launch, before its
+listener binds, so a starting agent can read as stopped for a moment; the
+create guard covers most of that window. The supervisor is called down
+only when its own socket is missing or refuses a connection; a dial that
+failed for any other reason (a socket this user may not open, a deadline,
+a reply that does not parse) leaves its state unknown, and the advice to
+purge on the registry alone is then withheld, since it would invite the
+one purge the union exists to prevent.
 
 Every verb writes what it found or achieved to ``out`` and every warning,
 refusal and diagnostic to ``err``, so a wrapper can parse one without
@@ -435,19 +438,22 @@ def _reach_from_failure(error: BaseException) -> SupervisorReach:
     The gRPC client rebuilds transport failures into its own error classes,
     so the exception alone rarely says whether the daemon is stopped; when
     it does not, the socket itself is asked. A refused connection anywhere
-    in the chain is proof enough. A missing *file* is not, whatever the
-    chain says: the client opens more than its socket (a TLS material path,
-    a config file), and only a stat of the socket path itself can tell a
-    stopped daemon from a running one that tripped over something else, so
-    that case falls through to _socket_reach. A permission error is never
-    proof, and neither is a deadline (a daemon that is up but wedged is the
-    textbook way to time out).
+    in the chain is proof enough, checked across the whole chain before
+    anything else: a PermissionError closer to the head of the chain must
+    not hide a ConnectionRefusedError sitting deeper in it. A missing
+    *file* is not proof, whatever the chain says: the client opens more
+    than its socket (a TLS material path, a config file), and only a stat
+    of the socket path itself can tell a stopped daemon from a running one
+    that tripped over something else, so that case falls through to
+    _socket_reach. A permission error on its own is never proof, and
+    neither is a deadline (a daemon that is up but wedged is the textbook
+    way to time out).
     """
-    for cause in _exception_chain(error):
-        if isinstance(cause, ConnectionRefusedError):
-            return SupervisorReach.DOWN
-        if isinstance(cause, PermissionError):
-            return SupervisorReach.UNKNOWN
+    chain = list(_exception_chain(error))
+    if any(isinstance(cause, ConnectionRefusedError) for cause in chain):
+        return SupervisorReach.DOWN
+    if any(isinstance(cause, PermissionError) for cause in chain):
+        return SupervisorReach.UNKNOWN
     if isinstance(error, TimeoutError):
         return SupervisorReach.UNKNOWN
     return _socket_reach(settings.SUPERVISOR_GRPC_SOCKET)
@@ -630,7 +636,7 @@ def _reclaim_refusal(registry: AgentVmRegistry, vm_hash: str, *, trust_registry:
         # process would have to win a race with that to notice.
         return Refusal(
             f"Refusing to purge {vm_hash}: {_agent_at_work_reason(probe)}. {_agent_pass_note()}; "
-            "run 'storage list --reclaimable' to see what it will find",
+            "run 'storage reconcile --dry-run' to preview what the agent's own pass will find",
             DEGRADED_EXIT_CODE,
         )
     return _supervisor_reclaim_refusal(registry, vm_hash, trust_registry=trust_registry)

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -4,32 +4,40 @@ Storage is agent-side and, by design, readable from the filesystem plus the
 agent DB, so these commands need no *agent process* running. They run the
 same code the reconciler runs, including the same safety rule: a live set
 built from the registry alone purges the disks of VMs the supervisor still
-runs (that was PR A's Critical 1, guarded on the daemon side by
-``reconciler._startup_refusal``). A CLI process holding only the registry is
-exactly that state, so ``reconcile`` and ``reclaim`` ask the supervisor
-daemon over the same gRPC socket the agent dials (``GrpcSupervisor``,
-``settings.SUPERVISOR_GRPC_SOCKET``), with a short timeout, and union its
-answer into the live set. When the daemon cannot be reached, both commands
-fail closed: ``reconcile`` runs dry, warns on stderr and exits non-zero,
-``reclaim`` refuses, unless ``--trust-registry`` says to proceed on the
-registry alone. ``status`` and ``list`` are read-only and never touch the
-supervisor.
+runs (guarded on the daemon side by ``reconciler._startup_refusal``, which
+this module calls rather than restates). A CLI process holding only the
+registry is exactly that state, so ``reconcile`` and ``reclaim`` ask the
+supervisor daemon over the same gRPC socket the agent dials
+(``GrpcSupervisor``, ``settings.SUPERVISOR_GRPC_SOCKET``), with a short
+timeout, and union its answer into the live set. ``status`` and ``list``
+are read-only and never touch the supervisor.
 
-What this process still cannot see, even with the supervisor reachable: a
-create the daemon is in the middle of. ``reconciler.is_creating()`` is an
-in-process set the running agent populates for the duration of a create; a
-CLI invocation is a separate process and never sees it. What protects such
-a create here is only the age of its directory: the directory purge and the
-orphan-device teardown both leave a namespace whose directory is younger
-than ``VOLUME_CREATE_GUARD`` alone, so a create that has outlived the guard
-and has not yet landed in the registry DB or in ``list_vms`` looks exactly
-like an orphan to a real ``reconcile`` here, directory and devices alike.
-A CLI pass also shares no lock with the daemon's own passes and can run
-concurrently with one; that is benign (purges are idempotent and tolerate a
-directory that vanished under them, markers are written exclusively), but
-it is one more reason the daemon's own pass (startup, periodic, at-GONE) is
-always preferred when the daemon is up; this command exists mainly for when
-it is not.
+The answer decides what ``reconcile`` may do, and the two outcomes are
+opposite by design:
+
+* The supervisor answers. The agent is running, and the one thing this
+  process can never see is exactly the thing the running agent holds: the
+  set of creates it has in flight (``reconciler.creating()`` is in-process
+  state). A create that outlives ``VOLUME_CREATE_GUARD`` before its DB
+  record exists (a long migration import routinely does) is invisible here
+  and looks like an orphan, directory and devices alike. So a real pass is
+  refused: the agent runs its own pass at startup, periodically and after
+  every VM goes away, and that pass sees everything this one does plus the
+  creates. ``--dry-run`` is still allowed, and is how an operator inspects
+  a running node.
+* The supervisor does not answer. Nothing is being created, so the age of
+  the directory is a sound guard again, and this command becomes the way to
+  reconcile a node whose agent will not start. The live set is then the
+  registry alone, which is not a safe one, so the pass runs dry and exits
+  non-zero unless ``--trust-registry`` says to proceed on the registry's
+  word. ``reclaim`` refuses on the same terms.
+
+Whether the daemon is down is a claim this module only makes when it can
+back it up: a socket that is missing or refuses a connection. A dial that
+failed for any other reason (a socket this user may not open, a deadline, a
+reply that does not parse) leaves the daemon's state unknown, and the
+advice to purge on the registry alone is then withheld: it would invite the
+one purge the union exists to prevent.
 
 Running with no agent process also means setting up the process the way the
 systemd units set it up for the daemon: the node's environment file is read
@@ -48,8 +56,12 @@ import asyncio
 import logging
 import os
 import shutil
+import socket
 import sys
+from collections.abc import Iterator
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from typing import TextIO
 
@@ -70,8 +82,8 @@ from aleph.vm.agent.vm.reclaimable import (
 from aleph.vm.agent.vm.reconciler import (
     _plausible,
     _release_cache_devices,
+    _startup_refusal,
     _still_on_disk,
-    _teardown_orphan_devices,
     live_hashes,
     reconcile_storage,
     supervisor_hashes,
@@ -87,12 +99,14 @@ from aleph.vm.supervisor_interface.abc import Supervisor
 # sit through a 30 second RPC deadline just to learn the daemon is down.
 SUPERVISOR_CONNECT_TIMEOUT_SECS = 3.0
 
-# Exit code for a reconcile that silently downgraded to a dry run because the
-# supervisor could not be asked and --trust-registry was not given. Distinct
-# from an explicit --dry-run, which is a success (exit 0): nothing was
-# downgraded, the caller asked for a preview and got one. Not 2, which
-# argparse uses for a usage error: a wrapper script must be able to tell a
-# degraded pass from a bad argument without parsing stderr.
+# Exit code for a reconcile that did not reconcile: it was refused because
+# the agent is running (its own pass covers the node), or it silently
+# downgraded to a dry run because the supervisor could not be asked and
+# --trust-registry was not given. Distinct from an explicit --dry-run, which
+# is a success (exit 0): nothing was refused or downgraded, the caller asked
+# for a preview and got one. Not 2, which argparse uses for a usage error: a
+# wrapper script must be able to tell a pass that did not run from a bad
+# argument without parsing stderr.
 DEGRADED_EXIT_CODE = 3
 
 # The systemd units hand the daemon its configuration with
@@ -155,20 +169,19 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
         help="run one reconciler pass",
         description=(
             "Run one reconciler pass against the agent registry (unioned with the supervisor's "
-            "list_vms() when it can be reached). This process cannot see a create the daemon is "
-            "currently in the middle of: is_creating() is in-process state of the running agent, "
-            "and only the age of the directory protects such a create here, so a create that has "
-            "outlived VOLUME_CREATE_GUARD and is not yet in the registry DB or list_vms looks like "
-            "an orphan and a real pass can remove its directory and its devices. Prefer the "
-            "daemon's own pass (it runs at startup, periodically, and after every GONE) when the "
-            "daemon is up; use this command mainly when it is not."
+            "list_vms() when it can be reached). While the agent answers, only --dry-run runs: "
+            "this process cannot see a create the agent is in the middle of (that state lives in "
+            "the agent), so a create that has outlived VOLUME_CREATE_GUARD without reaching the "
+            "registry DB would read as an orphan here. The agent's own pass (at startup, "
+            "periodically, and after every VM goes away) covers a node whose agent is up. This "
+            "command is for a node whose agent is not."
         ),
     )
     reconcile_parser.add_argument("--dry-run", action="store_true")
     reconcile_parser.add_argument(
         "--trust-registry",
         action="store_true",
-        help="purge using the registry alone when the supervisor cannot be asked which VMs it runs",
+        help="purge using the registry alone when the supervisor is down and cannot say which VMs it runs",
     )
 
 
@@ -223,9 +236,104 @@ def _open_supervisor() -> Supervisor:
     return GrpcSupervisor(settings.SUPERVISOR_GRPC_SOCKET)
 
 
-async def _supervisor_running_hashes(timeout: float = SUPERVISOR_CONNECT_TIMEOUT_SECS) -> set[str] | None:
-    """The item hashes the supervisor lists as running, or None when it could
-    not be asked (unreachable, timed out, or answered with an error).
+class SupervisorReach(Enum):
+    """How much this process knows about the daemon after asking it."""
+
+    ANSWERED = "answered"
+    # Verified stopped: its socket is missing, or refuses a connection.
+    DOWN = "down"
+    # Could not be asked, and that is all: the daemon may well be running.
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class SupervisorAnswer:
+    """What ``list_vms`` gave back, or why it gave nothing back."""
+
+    reach: SupervisorReach
+    running: frozenset[str] = frozenset()
+    # Exception class and message, for the operator. Empty when the
+    # supervisor answered.
+    problem: str = ""
+
+    @property
+    def answered(self) -> bool:
+        return self.reach is SupervisorReach.ANSWERED
+
+
+@dataclass(frozen=True)
+class LiveSet:
+    """The hashes no CLI pass may touch, and what backs them."""
+
+    hashes: frozenset[str]
+    supervisor: SupervisorAnswer
+    # The daemon's own reason to distrust its live set, when the supervisor
+    # answered. None when it did not answer: the "unanswered" half of that
+    # verdict is what the --trust-registry gate already covers.
+    refusal: str | None
+
+
+def _exception_chain(error: BaseException) -> Iterator[BaseException]:
+    seen: set[int] = set()
+    current: BaseException | None = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
+
+
+def _socket_reach(path: Path | None) -> SupervisorReach:
+    """Whether the daemon's socket says it is stopped.
+
+    Only two answers prove it: no socket at all, or one that refuses the
+    connection (a stale file the daemon left behind). A connection that is
+    accepted, one the kernel will not let this user attempt, or a path that
+    cannot even be resolved all leave the daemon's state unknown.
+    """
+    if path is None:
+        return SupervisorReach.UNKNOWN
+    # os.stat rather than Path.exists(), which turns every error into a
+    # plain False: a socket this user may not stat would then be reported as
+    # a stopped daemon, which is the one mistake this function must not make.
+    try:
+        os.stat(path)
+    except FileNotFoundError:
+        return SupervisorReach.DOWN
+    except OSError:
+        return SupervisorReach.UNKNOWN
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+            probe.settimeout(SUPERVISOR_CONNECT_TIMEOUT_SECS)
+            probe.connect(str(path))
+    except ConnectionRefusedError:
+        return SupervisorReach.DOWN
+    except OSError:
+        return SupervisorReach.UNKNOWN
+    return SupervisorReach.UNKNOWN
+
+
+def _reach_from_failure(error: BaseException) -> SupervisorReach:
+    """Classify a failed dial, conservatively.
+
+    The gRPC client rebuilds transport failures into its own error classes,
+    so the exception alone rarely says whether the daemon is stopped; when
+    it does not, the socket itself is asked. A refusal or a missing socket
+    anywhere in the chain is proof enough; a permission error never is, and
+    neither is a deadline (a daemon that is up but wedged is the textbook
+    way to time out).
+    """
+    for cause in _exception_chain(error):
+        if isinstance(cause, FileNotFoundError | ConnectionRefusedError):
+            return SupervisorReach.DOWN
+        if isinstance(cause, PermissionError):
+            return SupervisorReach.UNKNOWN
+    if isinstance(error, TimeoutError):
+        return SupervisorReach.UNKNOWN
+    return _socket_reach(settings.SUPERVISOR_GRPC_SOCKET)
+
+
+async def _ask_supervisor(timeout: float = SUPERVISOR_CONNECT_TIMEOUT_SECS) -> SupervisorAnswer:
+    """Ask the supervisor which VMs it runs, and classify the answer.
 
     Reuses ``reconciler.supervisor_hashes`` for the id-to-hash mapping, so a
     CLI pass and a daemon pass never disagree on what counts as a plausible
@@ -233,9 +341,20 @@ async def _supervisor_running_hashes(timeout: float = SUPERVISOR_CONNECT_TIMEOUT
     """
     supervisor = _open_supervisor()
     try:
-        return await asyncio.wait_for(supervisor_hashes(supervisor), timeout=timeout)
-    except Exception:
-        return None
+        running = await asyncio.wait_for(supervisor_hashes(supervisor), timeout=timeout)
+    # Broad on purpose: every way this can fail (a transport error, a
+    # deadline, a reply that does not parse) means the same thing here, that
+    # there is no answer to union in, and the caller must fail closed. What
+    # differs is only what the operator is told, which is why the exception
+    # is kept rather than swallowed.
+    except Exception as error:
+        logger.debug("The supervisor could not be asked which VMs it runs", exc_info=True)
+        return SupervisorAnswer(
+            reach=_reach_from_failure(error),
+            problem=f"{type(error).__name__}: {error}",
+        )
+    else:
+        return SupervisorAnswer(SupervisorReach.ANSWERED, frozenset(running))
     finally:
         close = getattr(supervisor, "close", None)
         if close is not None:
@@ -245,19 +364,27 @@ async def _supervisor_running_hashes(timeout: float = SUPERVISOR_CONNECT_TIMEOUT
                 logger.debug("Failed to close the supervisor handle", exc_info=True)
 
 
-def _cli_live_set(registry: AgentVmRegistry) -> tuple[set[str], bool]:
-    """(live hashes, whether the supervisor could be asked).
+def _cli_live_set(registry: AgentVmRegistry) -> LiveSet:
+    """The live set for a CLI pass, and everything that qualifies it.
 
     The registry alone is never enough here: it is the same fail-closed
     reasoning ``reconciler._startup_refusal`` applies to the daemon's own
     startup pass, applied to a CLI process that by construction never has
-    more than the registry unless it asks the daemon itself.
+    more than the registry unless it asks the daemon itself. That refusal is
+    called, not restated, so the two passes cannot drift apart: an empty
+    registry while the supervisor runs VMs means the agent DB was lost, and
+    the union then hides nothing, since it is the registry half that would
+    have named the VMs the supervisor has not started yet.
     """
-    running = asyncio.run(_supervisor_running_hashes())
+    answer = asyncio.run(_ask_supervisor())
     live = live_hashes(registry)
-    if running is None:
-        return live, False
-    return live | running, True
+    if not answer.answered:
+        return LiveSet(frozenset(live), answer, None)
+    return LiveSet(
+        frozenset(live | set(answer.running)),
+        answer,
+        _startup_refusal(registry, len(answer.running)),
+    )
 
 
 def _status(registry: AgentVmRegistry, out: TextIO) -> int:
@@ -311,6 +438,38 @@ def _list(registry: AgentVmRegistry, out: TextIO, *, reclaimable_only: bool) -> 
     return 0
 
 
+def _is_marked_reclaimable(vm_hash: str) -> bool:
+    return any(directory.name == vm_hash for directory, _marker in iter_reclaimable())
+
+
+def _supervisor_reclaim_refusal(registry: AgentVmRegistry, vm_hash: str, *, trust_registry: bool) -> str | None:
+    """The half of the reclaim verdict that needs the daemon's answer."""
+    answer = asyncio.run(_ask_supervisor())
+    if answer.answered:
+        if vm_hash in answer.running:
+            return f"{vm_hash} is running (the supervisor lists it); refusing to purge it"
+        # The daemon's own reason to distrust a live set, asked here too: a
+        # lost agent DB makes every marker on the node look purgeable, and
+        # the supervisor's list is no second opinion on a VM it has not
+        # started yet.
+        lost_database = _startup_refusal(registry, len(answer.running))
+        if lost_database is not None:
+            return f"Refusing to purge {vm_hash}: {lost_database}"
+        return None
+    if trust_registry:
+        return None
+    if answer.reach is SupervisorReach.DOWN:
+        return (
+            f"Supervisor unreachable ({answer.problem}); cannot confirm {vm_hash} is not running. "
+            "Pass --trust-registry to purge using the registry alone"
+        )
+    return (
+        f"The supervisor could not be asked ({answer.problem}); cannot confirm {vm_hash} is not "
+        "running. That error is no proof the daemon is stopped, so purging on the registry alone "
+        "is not offered here: fix it and retry"
+    )
+
+
 def _reclaim_refusal(registry: AgentVmRegistry, vm_hash: str, *, trust_registry: bool) -> str | None:
     """Why reclaim must not purge this hash, or None when it may.
 
@@ -323,20 +482,11 @@ def _reclaim_refusal(registry: AgentVmRegistry, vm_hash: str, *, trust_registry:
     """
     if not _plausible(vm_hash):
         return f"{vm_hash!r} is not a VM hash; refusing to purge a directory not named after a VM"
-    if not any(directory.name == vm_hash for directory, _marker in iter_reclaimable()):
+    if not _is_marked_reclaimable(vm_hash):
         return f"{vm_hash} is not reclaimable (no .reclaimable marker); refusing to purge a directory a VM may own"
     if vm_hash in live_hashes(registry):
         return f"{vm_hash} is a live VM in the agent registry; refusing to purge it"
-    running = asyncio.run(_supervisor_running_hashes())
-    if running is not None:
-        if vm_hash in running:
-            return f"{vm_hash} is running (the supervisor lists it); refusing to purge it"
-    elif not trust_registry:
-        return (
-            f"Supervisor unreachable; cannot confirm {vm_hash} is not running. "
-            "Pass --trust-registry to purge using the registry alone"
-        )
-    return None
+    return _supervisor_reclaim_refusal(registry, vm_hash, trust_registry=trust_registry)
 
 
 def _reclaim(registry: AgentVmRegistry, vm_hash: str, out: TextIO, *, trust_registry: bool) -> int:
@@ -344,35 +494,78 @@ def _reclaim(registry: AgentVmRegistry, vm_hash: str, out: TextIO, *, trust_regi
     if refusal is not None:
         out.write(refusal + "\n")
         return 1
+    # Asked again, after the dial: a re-create adopts its retained
+    # directories by clearing their markers, and a create that started while
+    # the supervisor was being asked is in no answer this process has. The
+    # marker is the one thing that says the disks are nobody's.
+    if not _is_marked_reclaimable(vm_hash):
+        out.write(
+            f"{vm_hash} is no longer marked reclaimable: a create adopted its directory while the "
+            "supervisor was being asked. Refusing to purge it\n"
+        )
+        return 1
     deleted = purge_vm_storage(vm_hash)
     if _still_on_disk(vm_hash):
         out.write(
             f"Purge of {vm_hash} left directories behind: a device-mapper target still holds its volumes. "
-            "Run 'storage reconcile' to tear down the devices of every VM nothing owns, then retry\n"
+            "Tearing a device down needs the certainty only the agent has, so start it and let its own "
+            "pass reclaim the device, then retry\n"
         )
         return 1
     out.write(f"Purged {vm_hash}: {deleted} volume file(s)\n")
     return 0
 
 
-def _reconcile(registry: AgentVmRegistry, out: TextIO, *, dry_run: bool, trust_registry: bool) -> int:
-    live, reachable = _cli_live_set(registry)
-    downgraded = not reachable and not trust_registry
-    effective_dry_run = dry_run or downgraded
-    if downgraded:
-        sys.stderr.write(
-            "Warning: supervisor unreachable; showing what a registry-only pass would purge; "
-            "pass --trust-registry to purge using the registry alone\n"
+def _running_daemon_refusal(live_set: LiveSet) -> str:
+    """What to tell an operator who asked for a real pass on a live node."""
+    reason = live_set.refusal or (
+        "the agent is running, and the creates it has in flight are invisible to this process "
+        "(that state lives in the agent itself), so a VM being built would read as an orphan here"
+    )
+    return (
+        f"Refusing to reconcile: {reason}. The agent runs its own pass at startup, periodically, "
+        "and after every VM goes away, and that pass sees the creates too; use --dry-run to "
+        "preview what one would find.\n"
+    )
+
+
+def _unanswered_warning(answer: SupervisorAnswer, *, dry_run: bool, trust_registry: bool) -> str:
+    """Say what failed, then say what that does and does not license."""
+    if answer.reach is SupervisorReach.DOWN:
+        opening = f"Warning: the supervisor is unreachable ({answer.problem})\n"
+    else:
+        opening = f"Warning: the supervisor could not be asked which VMs it runs ({answer.problem})\n"
+    if dry_run:
+        return opening + "This preview is registry-only: a VM the registry has forgotten reads as an orphan here\n"
+    if trust_registry:
+        return opening + "Purging on the registry alone, as --trust-registry asked\n"
+    if answer.reach is SupervisorReach.DOWN:
+        return opening + (
+            "Showing what a registry-only pass would purge; pass --trust-registry to purge using "
+            "the registry alone\n"
         )
-    # Mirrors reconcile_now: the devices of every namespace nothing owns go
-    # before the walk, or the purge that follows refuses those directories
-    # (a dm target still holds their volume files) exactly as the daemon's
-    # passes used to. Only when the supervisor answered, since removing the
-    # device of a VM that is merely unlisted takes that VM's disk with it:
-    # --trust-registry buys a purge on the registry's word, not a teardown.
-    if not effective_dry_run and reachable:
-        asyncio.run(_teardown_orphan_devices(live))
-    report = reconcile_storage(registry, dry_run=effective_dry_run, live=live, live_known=reachable)
+    return opening + (
+        "Showing what a registry-only pass would purge. That error is no proof the daemon is "
+        "stopped, so purging on the registry alone is not offered here: fix it and retry\n"
+    )
+
+
+def _reconcile(registry: AgentVmRegistry, out: TextIO, *, dry_run: bool, trust_registry: bool) -> int:
+    live_set = _cli_live_set(registry)
+    answer = live_set.supervisor
+    if not answer.answered:
+        sys.stderr.write(_unanswered_warning(answer, dry_run=dry_run, trust_registry=trust_registry))
+    elif not dry_run:
+        # A running agent is the one state where this process is strictly
+        # less informed than the agent's own pass, so it does not get to
+        # purge. The preview still runs: it is how a node under load is
+        # inspected.
+        sys.stderr.write(_running_daemon_refusal(live_set))
+        return DEGRADED_EXIT_CODE
+    downgraded = not answer.answered and not trust_registry
+    effective_dry_run = dry_run or downgraded
+    live = set(live_set.hashes)
+    report = reconcile_storage(registry, dry_run=effective_dry_run, live=live, live_known=answer.answered)
     prefix = "Dry run: " if effective_dry_run else "Reconciled: "
     out.write(prefix + report.summary() + "\n")
     for name in report.purged_orphans + report.evicted:

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -109,10 +109,12 @@ def _supervisor_reachable(monkeypatch):
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor())
 
 
-def _run(argv: list[str], registry) -> tuple[int, str]:
-    out = io.StringIO()
-    code = cli.run(cli.parse_args(argv), registry, out)
-    return code, out.getvalue()
+def _run(argv: list[str], registry) -> tuple[int, str, str]:
+    """(exit code, stdout, stderr). The verbs write to the streams they are
+    handed, so a test reads the two apart without capsys."""
+    out, err = io.StringIO(), io.StringIO()
+    code = cli.run(cli.parse_args(argv), registry, out, err)
+    return code, out.getvalue(), err.getvalue()
 
 
 def test_status_lists_pools_and_caches(pools, registry, monkeypatch):  # noqa: F811
@@ -121,7 +123,7 @@ def test_status_lists_pools_and_caches(pools, registry, monkeypatch):  # noqa: F
     volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=4096)
     mark_reclaimable(VM_HASH, "gone", now=NOW)
 
-    code, out = _run(["status"], registry)
+    code, out, err = _run(["status"], registry)
 
     assert code == 0
     assert "POOL" in out and str(pools["pool0"]) in out and str(pools["pool1"]) in out
@@ -134,14 +136,14 @@ def test_list_shows_every_vm_dir_and_reclaimable_filters(pools, registry):  # no
     volume(pools["pool1"], OTHER_HASH, "rootfs.qcow2")
     mark_reclaimable(VM_HASH, "orphan", now=NOW - timedelta(days=3))
 
-    code, out = _run(["list"], registry)
+    code, out, err = _run(["list"], registry)
     assert code == 0
     rows = {line.split("\t")[0]: line.split("\t")[3] for line in out.splitlines()[1:]}
     # An unmarked directory is "live" only on the registry's word; an
     # unmarked orphan no pass has reached yet must not read as a live VM.
     assert rows == {LIVE: "live", VM_HASH: "orphan", OTHER_HASH: "unmarked"}
 
-    code, out = _run(["list", "--reclaimable"], registry)
+    code, out, err = _run(["list", "--reclaimable"], registry)
     assert LIVE not in out and VM_HASH in out and "orphan" in out
 
 
@@ -150,15 +152,16 @@ def test_reclaim_purges_a_reclaimable_dir_only(pools, registry):  # noqa: F811
     unmarked = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2")
     mark_reclaimable(VM_HASH, "gone", now=NOW)
 
-    code, out = _run(["reclaim", VM_HASH], registry)
+    code, out, err = _run(["reclaim", VM_HASH], registry)
     assert code == 0 and "Purged" in out
     assert not gone.exists()
 
     # OTHER_HASH is on disk, unmarked, unknown to the registry and to the
     # (fake, reachable) supervisor: reclaim refuses it for lack of a marker,
     # not because anything claims to own it.
-    code, out = _run(["reclaim", OTHER_HASH], registry)
-    assert code == 1 and "not reclaimable" in out
+    code, out, err = _run(["reclaim", OTHER_HASH], registry)
+    assert code == 1 and "not reclaimable" in err
+    assert out == ""  # a refusal achieved nothing, so stdout stays empty
     assert unmarked.exists()
 
 
@@ -173,11 +176,11 @@ def test_reclaim_checks_the_marker_before_dialing_the_supervisor(pools, registry
 
     monkeypatch.setattr(cli, "_open_supervisor", open_supervisor)
 
-    code, out = _run(["reclaim", "not-a-real-hash"], registry)
-    assert code == 1 and "not a VM hash" in out
+    code, out, err = _run(["reclaim", "not-a-real-hash"], registry)
+    assert code == 1 and "not a VM hash" in err
 
-    code, out = _run(["reclaim", "f" * 64], registry)
-    assert code == 1 and "not reclaimable" in out
+    code, out, err = _run(["reclaim", "f" * 64], registry)
+    assert code == 1 and "not reclaimable" in err
 
     assert dialed == []
 
@@ -189,9 +192,9 @@ def test_reclaim_refuses_a_marked_directory_not_named_after_a_vm(pools, registry
     kept = volume(pools["pool0"], "backup_old", "rootfs.qcow2")
     write_marker(kept.parent, ReclaimableMarker(reclaimable_since=NOW, reason="gone", size_bytes=0))
 
-    code, out = _run(["reclaim", "backup_old"], registry)
+    code, out, err = _run(["reclaim", "backup_old"], registry)
 
-    assert code == 1 and "not a VM hash" in out
+    assert code == 1 and "not a VM hash" in err
     assert kept.exists()
 
 
@@ -200,9 +203,9 @@ def test_reclaim_refuses_an_unmarked_live_directory(pools, registry):  # noqa: F
     check alone already refuses it."""
     live = volume(pools["pool0"], LIVE, "rootfs.qcow2")
 
-    code, out = _run(["reclaim", LIVE], registry)
+    code, out, err = _run(["reclaim", LIVE], registry)
 
-    assert code == 1 and "not reclaimable" in out
+    assert code == 1 and "not reclaimable" in err
     assert live.exists()
 
 
@@ -213,9 +216,9 @@ def test_reclaim_refuses_a_marked_but_still_live_registry_hash(pools, registry):
     live = volume(pools["pool0"], LIVE, "rootfs.qcow2")
     mark_reclaimable(LIVE, "orphan", now=NOW)
 
-    code, out = _run(["reclaim", LIVE], registry)
+    code, out, err = _run(["reclaim", LIVE], registry)
 
-    assert code == 1 and "live VM in the agent registry" in out
+    assert code == 1 and "live VM in the agent registry" in err
     assert live.exists()
 
 
@@ -224,9 +227,9 @@ def test_reclaim_refuses_a_hash_the_supervisor_lists_as_running(pools, registry,
     mark_reclaimable(VM_HASH, "gone", now=NOW)
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(VM_HASH))
 
-    code, out = _run(["reclaim", VM_HASH], registry)
+    code, out, err = _run(["reclaim", VM_HASH], registry)
 
-    assert code == 1 and "running" in out
+    assert code == 1 and "running" in err
     assert gone.exists()
 
 
@@ -235,11 +238,11 @@ def test_reclaim_refuses_unless_trust_registry_when_supervisor_unreachable(pools
     mark_reclaimable(VM_HASH, "gone", now=NOW)
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(fails=True))
 
-    code, out = _run(["reclaim", VM_HASH], registry)
-    assert code == 1 and "unreachable" in out
+    code, out, err = _run(["reclaim", VM_HASH], registry)
+    assert code == 1 and "unreachable" in err
     assert gone.exists()
 
-    code, out = _run(["reclaim", "--trust-registry", VM_HASH], registry)
+    code, out, err = _run(["reclaim", "--trust-registry", VM_HASH], registry)
     assert code == 0 and "Purged" in out
     assert not gone.exists()
 
@@ -252,11 +255,11 @@ def test_reclaim_does_not_advise_the_registry_when_the_daemon_may_be_up(pools, r
     denied = PermissionError(13, "Permission denied")
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(error=denied))
 
-    code, out = _run(["reclaim", VM_HASH], registry)
+    code, out, err = _run(["reclaim", VM_HASH], registry)
 
     assert code == 1
-    assert "PermissionError" in out and "Permission denied" in out
-    assert "--trust-registry" not in out
+    assert "PermissionError" in err and "Permission denied" in err
+    assert "--trust-registry" not in err
     assert gone.exists()
 
 
@@ -268,9 +271,9 @@ def test_reclaim_refuses_an_empty_registry_the_supervisor_contradicts(pools, mon
     mark_reclaimable(VM_HASH, "gone", now=NOW)
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(LIVE))
 
-    code, out = _run(["reclaim", VM_HASH], AgentVmRegistry())
+    code, out, err = _run(["reclaim", VM_HASH], AgentVmRegistry())
 
-    assert code == cli.DEGRADED_EXIT_CODE and "registry is empty" in out
+    assert code == cli.DEGRADED_EXIT_CODE and "registry is empty" in err
     assert gone.exists()
 
 
@@ -288,9 +291,9 @@ def test_reclaim_refuses_a_marker_that_vanished_during_the_dial(pools, registry,
 
     monkeypatch.setattr(cli, "_open_supervisor", open_supervisor)
 
-    code, out = _run(["reclaim", VM_HASH], registry)
+    code, out, err = _run(["reclaim", VM_HASH], registry)
 
-    assert code == 1 and "no longer marked reclaimable" in out
+    assert code == 1 and "no longer marked reclaimable" in err
     assert adopted.exists()
 
 
@@ -301,10 +304,10 @@ def test_reclaim_refuses_when_the_purge_leaves_a_dm_held_directory(pools, regist
     real_is_block_device = Path.is_block_device
     monkeypatch.setattr(Path, "is_block_device", lambda self: self == dm_path or real_is_block_device(self))
 
-    code, out = _run(["reclaim", VM_HASH], registry)
+    code, out, err = _run(["reclaim", VM_HASH], registry)
 
     assert code == 1
-    assert "device-mapper" in out
+    assert "device-mapper" in err
     assert held.exists()
 
 
@@ -314,19 +317,19 @@ def test_reconcile_dry_run_reports_without_changing(pools, registry, monkeypatch
     stamp = time.time() - 10_000
     os.utime(orphan.parent, (stamp, stamp))
 
-    code, out = _run(["reconcile", "--dry-run"], registry)
+    code, out, err = _run(["reconcile", "--dry-run"], registry)
 
     assert code == 0 and "Dry run" in out and "purged=1" in out
     assert orphan.exists()
 
     # The agent is down (the autouse fixture) and the supervisor is
     # reachable and lists nothing running, so a real pass may purge.
-    code, out = _run(["reconcile"], registry)
+    code, out, err = _run(["reconcile"], registry)
     assert code == 0 and not orphan.exists()
 
 
 @pytest.mark.parametrize("reach", [None, "unknown"])
-def test_reconcile_refuses_a_real_pass_while_the_agent_may_be_running(pools, registry, monkeypatch, capsys, reach):  # noqa: F811
+def test_reconcile_refuses_a_real_pass_while_the_agent_may_be_running(pools, registry, monkeypatch, reach):  # noqa: F811
     """The agent holds the one thing this process cannot see: the set of
     creates it has in flight. A long import outlives VOLUME_CREATE_GUARD
     before its DB record exists, and a CLI pass would purge it as an orphan.
@@ -338,21 +341,39 @@ def test_reconcile_refuses_a_real_pass_while_the_agent_may_be_running(pools, reg
     os.utime(orphan.parent, (stamp, stamp))
     monkeypatch.setattr(cli, "_probe_agent", _agent_up(cli.AgentReach.UNKNOWN if reach else None))
 
-    code, out = _run(["reconcile"], registry)
+    code, out, err = _run(["reconcile"], registry)
 
     assert code == cli.DEGRADED_EXIT_CODE
     assert orphan.exists()
     assert out == ""  # nothing was reconciled, so there is no report to print
-    err = capsys.readouterr().err
     assert "Refusing to reconcile" in err and "--dry-run" in err
     assert ("cannot be ruled out" in err) is bool(reach)
 
     # The preview is still available, still sees the orphan, and says what
     # the running agent does to its reading.
-    code, out = _run(["reconcile", "--dry-run"], registry)
+    code, out, err = _run(["reconcile", "--dry-run"], registry)
     assert code == 0 and "purged=1" in out
     assert orphan.exists()
-    assert "creating" in capsys.readouterr().err
+    assert "creating" in err
+
+
+def test_a_refused_pass_never_dials_the_supervisor(pools, registry, monkeypatch):  # noqa: F811, ARG001
+    """The agent probe answers at once and can refuse the whole pass; the
+    dial can take the full three second deadline and would be discarded."""
+    dialed: list[bool] = []
+    monkeypatch.setattr(cli, "_probe_agent", _agent_up())
+
+    def open_supervisor():
+        dialed.append(True)
+        return _fake_supervisor()
+
+    monkeypatch.setattr(cli, "_open_supervisor", open_supervisor)
+
+    code, _out, err = _run(["reconcile"], registry)
+
+    assert code == cli.DEGRADED_EXIT_CODE
+    assert "Refusing to reconcile" in err
+    assert dialed == []
 
 
 def test_reclaim_refuses_while_the_agent_may_be_running(pools, registry, monkeypatch):  # noqa: F811
@@ -363,24 +384,24 @@ def test_reclaim_refuses_while_the_agent_may_be_running(pools, registry, monkeyp
     mark_reclaimable(VM_HASH, "gone", now=NOW)
     monkeypatch.setattr(cli, "_probe_agent", _agent_up())
 
-    code, out = _run(["reclaim", VM_HASH], registry)
+    code, out, err = _run(["reclaim", VM_HASH], registry)
 
     assert code == cli.DEGRADED_EXIT_CODE
-    assert "the agent is running" in out
+    assert "the agent is running" in err
+    assert out == ""
     assert gone.exists()
 
 
-def test_reconcile_refuses_an_empty_registry_the_supervisor_contradicts(pools, monkeypatch, capsys):  # noqa: F811, ARG001
+def test_reconcile_refuses_an_empty_registry_the_supervisor_contradicts(pools, monkeypatch):  # noqa: F811, ARG001
     """The daemon's own startup refusal, applied here: an empty registry
     while the supervisor runs VMs means the agent DB was lost, and every
     directory on the node then reads as an orphan."""
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(LIVE))
 
-    code, out = _run(["reconcile"], AgentVmRegistry())
+    code, out, err = _run(["reconcile"], AgentVmRegistry())
 
     assert code == cli.DEGRADED_EXIT_CODE
     assert out == ""
-    err = capsys.readouterr().err
     assert "registry is empty" in err and "1 VM(s)" in err
 
 
@@ -394,48 +415,46 @@ def test_reconcile_leaves_a_supervisor_known_vm_the_registry_does_not(pools, reg
     os.utime(unknown.parent, (stamp, stamp))
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(OTHER_HASH))
 
-    code, out = _run(["reconcile"], registry)
+    code, out, err = _run(["reconcile"], registry)
 
     assert code == 0
     assert unknown.exists()
 
 
-def test_reconcile_unreachable_exits_nonzero_and_warns_on_stderr(pools, registry, monkeypatch, capsys):  # noqa: F811
+def test_reconcile_unreachable_exits_nonzero_and_warns_on_stderr(pools, registry, monkeypatch):  # noqa: F811
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
     orphan = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
     stamp = time.time() - 10_000
     os.utime(orphan.parent, (stamp, stamp))
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(fails=True))
 
-    code, out = _run(["reconcile"], registry)
+    code, out, err = _run(["reconcile"], registry)
 
     assert code == cli.DEGRADED_EXIT_CODE
     assert "Dry run" in out
     assert "unreachable" not in out  # the warning must not land in the parseable report
-    err = capsys.readouterr().err
     assert "unreachable" in err and "registry-only" in err
     assert orphan.exists()
 
 
-def test_reconcile_explicit_dry_run_stays_exit_zero_when_unreachable(pools, registry, monkeypatch, capsys):  # noqa: F811
+def test_reconcile_explicit_dry_run_stays_exit_zero_when_unreachable(pools, registry, monkeypatch):  # noqa: F811
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
     orphan = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
     stamp = time.time() - 10_000
     os.utime(orphan.parent, (stamp, stamp))
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(fails=True))
 
-    code, out = _run(["reconcile", "--dry-run"], registry)
+    code, out, err = _run(["reconcile", "--dry-run"], registry)
 
     assert code == 0
     assert "Dry run" in out
     assert orphan.exists()
     # Nothing was downgraded: the operator asked for a preview and got one,
     # so advising the flag that turns a pass into a purge is noise.
-    err = capsys.readouterr().err
     assert "registry-only" in err and "--trust-registry" not in err
 
 
-def test_a_dial_that_is_no_proof_the_daemon_is_down_advises_no_purge(pools, registry, monkeypatch, capsys):  # noqa: F811
+def test_a_dial_that_is_no_proof_the_daemon_is_down_advises_no_purge(pools, registry, monkeypatch):  # noqa: F811
     """A socket this user may not open, a deadline, a reply that does not
     parse: none of them says the daemon is stopped, and purging on the
     registry alone while it runs is the very thing the union prevents. The
@@ -447,24 +466,22 @@ def test_a_dial_that_is_no_proof_the_daemon_is_down_advises_no_purge(pools, regi
     denied = PermissionError(13, "Permission denied")
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(error=denied))
 
-    code, out = _run(["reconcile"], registry)
+    code, out, err = _run(["reconcile"], registry)
 
     assert code == cli.DEGRADED_EXIT_CODE
     assert orphan.exists()
-    err = capsys.readouterr().err
     assert "PermissionError" in err and "Permission denied" in err
     assert "--trust-registry" not in err
 
 
-def test_a_timeout_is_never_reported_as_a_stopped_daemon(pools, registry, monkeypatch, capsys):  # noqa: F811
+def test_a_timeout_is_never_reported_as_a_stopped_daemon(pools, registry, monkeypatch):  # noqa: F811
     """asyncio.wait_for gives up on a daemon that is up but wedged."""
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(error=TimeoutError("timed out")))
 
-    code, _out = _run(["reconcile"], registry)
+    code, _out, err = _run(["reconcile"], registry)
 
     assert code == cli.DEGRADED_EXIT_CODE
-    err = capsys.readouterr().err
     assert "TimeoutError" in err
     assert "--trust-registry" not in err
 
@@ -480,6 +497,48 @@ def test_the_agent_probe_reads_a_listening_socket_as_running(monkeypatch):
 
     assert probe.reach is cli.AgentReach.RUNNING
     assert probe.may_be_running
+
+
+@pytest.fixture
+def ipv6_loopback():
+    """A listening socket on ::1 alone, or a skip on a host without one."""
+    server = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    try:
+        server.bind(("::1", 0))
+    except OSError as error:  # no IPv6 loopback on this host
+        server.close()
+        pytest.skip(f"no IPv6 loopback: {error}")
+    server.listen(1)
+    try:
+        yield server.getsockname()[1]
+    finally:
+        server.close()
+
+
+def test_the_agent_probe_finds_a_wildcard_agent_on_the_ipv6_loopback(monkeypatch, ipv6_loopback):
+    """asyncio's server sets IPV6_V6ONLY, so an agent bound to "::" refuses
+    on 127.0.0.1 and accepts on ::1 alone. A probe that asked only the IPv4
+    loopback would call it stopped and purge behind a running agent."""
+    monkeypatch.setattr(settings, "SUPERVISOR_HOST", "::")
+    monkeypatch.setattr(settings, "SUPERVISOR_PORT", ipv6_loopback)
+
+    probe = REAL_PROBE_AGENT()
+
+    assert probe.reach is cli.AgentReach.RUNNING
+    assert "[::1]" in probe.detail
+
+
+def test_a_wildcard_bind_is_stopped_only_when_every_loopback_refuses(monkeypatch):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as bound:
+        bound.bind(("127.0.0.1", 0))
+        port = bound.getsockname()[1]
+    monkeypatch.setattr(settings, "SUPERVISOR_HOST", "0.0.0.0")  # noqa: S104
+    monkeypatch.setattr(settings, "SUPERVISOR_PORT", port)
+
+    probe = REAL_PROBE_AGENT()
+
+    assert probe.reach is cli.AgentReach.STOPPED
+    assert "127.0.0.1" in probe.detail and "::1" in probe.detail
 
 
 def test_the_agent_probe_reads_a_refused_port_as_stopped(monkeypatch):
@@ -511,6 +570,27 @@ def test_an_agent_probe_that_cannot_answer_counts_as_running(monkeypatch):
     assert "PermissionError" in probe.detail
 
 
+def test_a_missing_file_that_is_not_the_socket_is_no_proof_the_daemon_is_down(pools, registry, monkeypatch, tmp_path):  # noqa: F811, ARG001
+    """The gRPC client opens more than its socket. A FileNotFoundError from
+    somewhere else in the dial must not end in the advice to purge on the
+    registry alone while the daemon is answering on a socket that is there."""
+    path = tmp_path / "sup.sock"
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(str(path))
+    server.listen(1)
+    monkeypatch.setattr(settings, "SUPERVISOR_GRPC_SOCKET", path)
+    missing = FileNotFoundError(2, "No such file or directory: '/etc/aleph-vm/credentials'")
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(error=missing))
+    try:
+        code, _out, err = _run(["reconcile"], registry)
+    finally:
+        server.close()
+
+    assert code == cli.DEGRADED_EXIT_CODE
+    assert "FileNotFoundError" in err
+    assert "--trust-registry" not in err
+
+
 def test_a_socket_that_accepts_is_never_read_as_a_stopped_daemon(tmp_path):
     """The fallback classification, on its own: a daemon that is listening
     but would not answer must never end in the advice to purge without it."""
@@ -530,14 +610,13 @@ def test_an_unset_socket_path_says_nothing_about_the_daemon():
     assert cli._socket_reach(None) is cli.SupervisorReach.UNKNOWN
 
 
-def test_a_refused_socket_is_reported_as_a_stopped_daemon(pools, registry, monkeypatch, capsys):  # noqa: F811
+def test_a_refused_socket_is_reported_as_a_stopped_daemon(pools, registry, monkeypatch):  # noqa: F811
     refused = ConnectionRefusedError(111, "Connection refused")
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(error=refused))
 
-    code, _out = _run(["reconcile"], registry)
+    code, _out, err = _run(["reconcile"], registry)
 
     assert code == cli.DEGRADED_EXIT_CODE
-    err = capsys.readouterr().err
     assert "unreachable" in err and "ConnectionRefusedError" in err
     assert "--trust-registry" in err
 
@@ -549,14 +628,14 @@ def test_reconcile_trust_registry_purges_when_supervisor_unreachable(pools, regi
     os.utime(orphan.parent, (stamp, stamp))
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(fails=True))
 
-    code, out = _run(["reconcile", "--trust-registry"], registry)
+    code, out, err = _run(["reconcile", "--trust-registry"], registry)
 
     assert code == 0 and not orphan.exists()
 
     # --dry-run still wins even with --trust-registry.
     other = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2")
     os.utime(other.parent, (time.time() - 10_000, time.time() - 10_000))
-    code, out = _run(["reconcile", "--dry-run", "--trust-registry"], registry)
+    code, out, err = _run(["reconcile", "--dry-run", "--trust-registry"], registry)
     assert code == 0 and "Dry run" in out
     assert other.exists()
 
@@ -567,7 +646,7 @@ def test_reconcile_passes_live_known_false_when_supervisor_unreachable(pools, re
     spy = MagicMock(return_value=fake_report)
     monkeypatch.setattr(cli, "reconcile_storage", spy)
 
-    code, out = _run(["reconcile", "--trust-registry"], registry)
+    code, out, err = _run(["reconcile", "--trust-registry"], registry)
 
     assert code == 0
     assert spy.call_args.kwargs["live_known"] is False
@@ -580,7 +659,7 @@ def test_reconcile_passes_live_known_true_when_supervisor_reachable(pools, regis
     spy = MagicMock(return_value=fake_report)
     monkeypatch.setattr(cli, "reconcile_storage", spy)
 
-    code, out = _run(["reconcile"], registry)
+    code, out, err = _run(["reconcile"], registry)
 
     assert code == 0
     assert spy.call_args.kwargs["live_known"] is True
@@ -593,7 +672,7 @@ def test_reconcile_tears_down_devices_of_evicted_cache_parents(pools, registry, 
     removed: list[str] = []
     monkeypatch.setattr(reconciler_module, "remove_parent_device", AsyncMock(side_effect=removed.append))
 
-    code, out = _run(["reconcile"], registry)
+    code, out, err = _run(["reconcile"], registry)
 
     assert code == 0
     assert not stale.exists()
@@ -609,7 +688,7 @@ def test_reconcile_touches_no_cache_entry_while_the_agent_is_running(pools, regi
     removed: list[str] = []
     monkeypatch.setattr(reconciler_module, "remove_parent_device", AsyncMock(side_effect=removed.append))
 
-    code, out = _run(["reconcile"], registry)
+    code, out, err = _run(["reconcile"], registry)
 
     assert code == cli.DEGRADED_EXIT_CODE
     assert stale.exists()
@@ -623,7 +702,7 @@ def test_reconcile_dry_run_never_touches_cache_parent_devices(pools, registry, m
     removed: list[str] = []
     monkeypatch.setattr(reconciler_module, "remove_parent_device", AsyncMock(side_effect=removed.append))
 
-    code, out = _run(["reconcile", "--dry-run"], registry)
+    code, out, err = _run(["reconcile", "--dry-run"], registry)
 
     assert code == 0
     assert stale.exists()
@@ -652,7 +731,7 @@ def test_reconcile_tears_down_the_devices_of_an_orphan_namespace(pools, registry
     torn: list[str] = []
     monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
 
-    code, _out = _run(["reconcile"], registry)
+    code, _out, err = _run(["reconcile"], registry)
 
     assert code == 0
     assert torn == [VM_HASH]
@@ -664,7 +743,7 @@ def test_no_device_is_torn_down_while_the_agent_is_running(pools, registry, monk
     torn: list[str] = []
     monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
 
-    code, _out = _run(["reconcile"], registry)
+    code, _out, err = _run(["reconcile"], registry)
 
     assert code == cli.DEGRADED_EXIT_CODE
     assert torn == []
@@ -675,7 +754,7 @@ def test_reconcile_dry_run_never_touches_orphan_devices(pools, registry, monkeyp
     torn: list[str] = []
     monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
 
-    code, _out = _run(["reconcile", "--dry-run"], registry)
+    code, _out, err = _run(["reconcile", "--dry-run"], registry)
 
     assert code == 0
     assert torn == []
@@ -690,7 +769,7 @@ def test_reconcile_leaves_orphan_devices_when_the_supervisor_is_unreachable(pool
     monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(fails=True))
 
-    code, _out = _run(["reconcile", "--trust-registry"], registry)
+    code, _out, err = _run(["reconcile", "--trust-registry"], registry)
 
     assert code == 0
     assert torn == []
@@ -705,7 +784,7 @@ def test_a_degraded_reconcile_leaves_orphan_devices_too(pools, registry, monkeyp
     monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(fails=True))
 
-    code, _out = _run(["reconcile"], registry)
+    code, _out, err = _run(["reconcile"], registry)
 
     assert code == cli.DEGRADED_EXIT_CODE
     assert torn == []

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -610,6 +610,16 @@ def test_an_unset_socket_path_says_nothing_about_the_daemon():
     assert cli._socket_reach(None) is cli.SupervisorReach.UNKNOWN
 
 
+def test_a_refusal_behind_a_permission_error_is_still_proof_of_down():
+    """The chain is walked front to back; a PermissionError closer to the
+    head must not hide a ConnectionRefusedError deeper in the same chain."""
+    refused = ConnectionRefusedError(111, "Connection refused")
+    denied = PermissionError(13, "Permission denied")
+    denied.__cause__ = refused
+
+    assert cli._reach_from_failure(denied) is cli.SupervisorReach.DOWN
+
+
 def test_a_refused_socket_is_reported_as_a_stopped_daemon(pools, registry, monkeypatch):  # noqa: F811
     refused = ConnectionRefusedError(111, "Connection refused")
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(error=refused))

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -29,6 +29,9 @@ from aleph.vm.conf import settings
 
 LIVE = "dead" * 16
 NOW = datetime(2026, 8, 24, tzinfo=timezone.utc)
+# Captured before the autouse fixture below replaces it, for the tests that
+# are about the probe itself rather than about what a verb does with it.
+REAL_PROBE_AGENT = cli._probe_agent
 
 
 @pytest.fixture
@@ -76,6 +79,26 @@ def _fake_supervisor(*vm_ids: str, fails: bool = False, error: Exception | None 
     if fails:
         return SimpleNamespace(list_vms=AsyncMock(side_effect=RuntimeError("no answer")))
     return SimpleNamespace(list_vms=AsyncMock(return_value=[SimpleNamespace(vm_id=vm_id) for vm_id in vm_ids]))
+
+
+@pytest.fixture(autouse=True)
+def _agent_stopped(monkeypatch):
+    """By default the aleph-vm agent is down, which is the node this command
+    is for: the tests that care about a live agent say so themselves."""
+    monkeypatch.setattr(
+        cli,
+        "_probe_agent",
+        lambda: cli.AgentProbe(cli.AgentReach.STOPPED, "nothing accepts a connection on 127.0.0.1:4020"),
+    )
+
+
+def _agent_up(reach=None):
+    """A probe that says the agent is running, or that it cannot be ruled
+    out as running (which counts as running)."""
+    reach = reach or cli.AgentReach.RUNNING
+    if reach is cli.AgentReach.RUNNING:
+        return lambda: cli.AgentProbe(reach, "something is listening on 127.0.0.1:4020")
+    return lambda: cli.AgentProbe(reach, "127.0.0.1:4020 could not be probed (PermissionError: denied)")
 
 
 @pytest.fixture(autouse=True)
@@ -247,7 +270,7 @@ def test_reclaim_refuses_an_empty_registry_the_supervisor_contradicts(pools, mon
 
     code, out = _run(["reclaim", VM_HASH], AgentVmRegistry())
 
-    assert code == 1 and "registry is empty" in out
+    assert code == cli.DEGRADED_EXIT_CODE and "registry is empty" in out
     assert gone.exists()
 
 
@@ -296,16 +319,24 @@ def test_reconcile_dry_run_reports_without_changing(pools, registry, monkeypatch
     assert code == 0 and "Dry run" in out and "purged=1" in out
     assert orphan.exists()
 
+    # The agent is down (the autouse fixture) and the supervisor is
+    # reachable and lists nothing running, so a real pass may purge.
+    code, out = _run(["reconcile"], registry)
+    assert code == 0 and not orphan.exists()
 
-def test_reconcile_refuses_a_real_pass_while_the_daemon_answers(pools, registry, monkeypatch, capsys):  # noqa: F811
-    """The daemon holds the one thing this process cannot see: the set of
+
+@pytest.mark.parametrize("reach", [None, "unknown"])
+def test_reconcile_refuses_a_real_pass_while_the_agent_may_be_running(pools, registry, monkeypatch, capsys, reach):  # noqa: F811
+    """The agent holds the one thing this process cannot see: the set of
     creates it has in flight. A long import outlives VOLUME_CREATE_GUARD
-    before its DB record exists, and a CLI pass would purge it as an orphan,
-    so a real pass is refused for as long as the daemon answers."""
+    before its DB record exists, and a CLI pass would purge it as an orphan.
+    A probe that could not answer counts as a running agent: the cost of
+    being wrong is one refused command against a deleted disk."""
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
     orphan = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
     stamp = time.time() - 10_000
     os.utime(orphan.parent, (stamp, stamp))
+    monkeypatch.setattr(cli, "_probe_agent", _agent_up(cli.AgentReach.UNKNOWN if reach else None))
 
     code, out = _run(["reconcile"], registry)
 
@@ -314,11 +345,29 @@ def test_reconcile_refuses_a_real_pass_while_the_daemon_answers(pools, registry,
     assert out == ""  # nothing was reconciled, so there is no report to print
     err = capsys.readouterr().err
     assert "Refusing to reconcile" in err and "--dry-run" in err
+    assert ("cannot be ruled out" in err) is bool(reach)
 
-    # The preview is still available, and still sees the orphan.
+    # The preview is still available, still sees the orphan, and says what
+    # the running agent does to its reading.
     code, out = _run(["reconcile", "--dry-run"], registry)
     assert code == 0 and "purged=1" in out
     assert orphan.exists()
+    assert "creating" in capsys.readouterr().err
+
+
+def test_reclaim_refuses_while_the_agent_may_be_running(pools, registry, monkeypatch):  # noqa: F811
+    """Same rule, no --dry-run to fall back on: a marked directory is not
+    safe to purge merely because it is marked, since a create adopts one by
+    clearing its marker."""
+    gone = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+    monkeypatch.setattr(cli, "_probe_agent", _agent_up())
+
+    code, out = _run(["reclaim", VM_HASH], registry)
+
+    assert code == cli.DEGRADED_EXIT_CODE
+    assert "the agent is running" in out
+    assert gone.exists()
 
 
 def test_reconcile_refuses_an_empty_registry_the_supervisor_contradicts(pools, monkeypatch, capsys):  # noqa: F811, ARG001
@@ -336,19 +385,18 @@ def test_reconcile_refuses_an_empty_registry_the_supervisor_contradicts(pools, m
 
 
 def test_reconcile_leaves_a_supervisor_known_vm_the_registry_does_not(pools, registry, monkeypatch):  # noqa: F811
-    """The union with the supervisor's list, visible in the one mode a
-    reachable daemon still allows: OTHER_HASH is not in the registry, so
-    only that union keeps it out of the report."""
+    """The agent is down but the supervisor still runs VMs: the case this
+    command exists for. OTHER_HASH is not in the registry, so only the union
+    with list_vms keeps its disks."""
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
     unknown = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2")
     stamp = time.time() - 10_000
     os.utime(unknown.parent, (stamp, stamp))
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(OTHER_HASH))
 
-    code, out = _run(["reconcile", "--dry-run"], registry)
+    code, out = _run(["reconcile"], registry)
 
     assert code == 0
-    assert "purged=0" in out and OTHER_HASH not in out
     assert unknown.exists()
 
 
@@ -421,6 +469,48 @@ def test_a_timeout_is_never_reported_as_a_stopped_daemon(pools, registry, monkey
     assert "--trust-registry" not in err
 
 
+def test_the_agent_probe_reads_a_listening_socket_as_running(monkeypatch):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        monkeypatch.setattr(settings, "SUPERVISOR_HOST", "127.0.0.1")
+        monkeypatch.setattr(settings, "SUPERVISOR_PORT", server.getsockname()[1])
+
+        probe = REAL_PROBE_AGENT()
+
+    assert probe.reach is cli.AgentReach.RUNNING
+    assert probe.may_be_running
+
+
+def test_the_agent_probe_reads_a_refused_port_as_stopped(monkeypatch):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as bound:
+        bound.bind(("127.0.0.1", 0))
+        port = bound.getsockname()[1]
+    monkeypatch.setattr(settings, "SUPERVISOR_HOST", "127.0.0.1")
+    monkeypatch.setattr(settings, "SUPERVISOR_PORT", port)
+
+    probe = REAL_PROBE_AGENT()
+
+    assert probe.reach is cli.AgentReach.STOPPED
+    assert not probe.may_be_running
+
+
+def test_an_agent_probe_that_cannot_answer_counts_as_running(monkeypatch):
+    """Fail closed: being wrong the other way purges the disks of a VM the
+    agent is at that moment creating."""
+
+    def denied(*_args, **_kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(socket, "create_connection", denied)
+
+    probe = REAL_PROBE_AGENT()
+
+    assert probe.reach is cli.AgentReach.UNKNOWN
+    assert probe.may_be_running
+    assert "PermissionError" in probe.detail
+
+
 def test_a_socket_that_accepts_is_never_read_as_a_stopped_daemon(tmp_path):
     """The fallback classification, on its own: a daemon that is listening
     but would not answer must never end in the advice to purge without it."""
@@ -484,22 +574,36 @@ def test_reconcile_passes_live_known_false_when_supervisor_unreachable(pools, re
 
 
 def test_reconcile_passes_live_known_true_when_supervisor_reachable(pools, registry, monkeypatch):  # noqa: F811
-    # The autouse fixture already installs a reachable fake supervisor, and a
-    # reachable one leaves --dry-run as the only mode that reaches the pass.
+    # The autouse fixtures already install a reachable fake supervisor and a
+    # stopped agent.
     fake_report = reconciler_module.ReconcileReport()
     spy = MagicMock(return_value=fake_report)
     monkeypatch.setattr(cli, "reconcile_storage", spy)
 
-    code, out = _run(["reconcile", "--dry-run"], registry)
+    code, out = _run(["reconcile"], registry)
 
     assert code == 0
     assert spy.call_args.kwargs["live_known"] is True
 
 
-def test_reconcile_evicts_no_cache_entry_while_the_daemon_answers(pools, registry, monkeypatch):  # noqa: F811
-    """The cache pass runs inside the reconcile the daemon's presence
-    refuses, devices included: what the daemon is up for, the daemon does."""
+def test_reconcile_tears_down_devices_of_evicted_cache_parents(pools, registry, monkeypatch):  # noqa: F811
     monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    stale = pools["runtime"] / "stale"
+    stale.write_bytes(b"x" * 4096)
+    removed: list[str] = []
+    monkeypatch.setattr(reconciler_module, "remove_parent_device", AsyncMock(side_effect=removed.append))
+
+    code, out = _run(["reconcile"], registry)
+
+    assert code == 0
+    assert not stale.exists()
+    assert removed == ["stale"]
+
+
+def test_reconcile_touches_no_cache_entry_while_the_agent_is_running(pools, registry, monkeypatch):  # noqa: F811
+    """The cache pass runs inside the pass a live agent refuses."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    monkeypatch.setattr(cli, "_probe_agent", _agent_up())
     stale = pools["runtime"] / "stale"
     stale.write_bytes(b"x" * 4096)
     removed: list[str] = []
@@ -539,12 +643,24 @@ def test_cli_main_dispatches_storage_subcommand(mocker):
     assert args.loglevel == logging.DEBUG
 
 
-def test_a_cli_pass_never_tears_down_an_orphan_namespace_device(pools, registry, monkeypatch, tmp_path):  # noqa: F811
-    """Tearing a device down takes the VM's disk with it if the VM was only
-    unlisted rather than gone. The one answer that made that safe (the
-    supervisor's) is now the answer that refuses the pass outright, so the
-    devices of an orphan namespace are the daemon's own pass to reclaim."""
+def test_reconcile_tears_down_the_devices_of_an_orphan_namespace(pools, registry, monkeypatch, tmp_path):  # noqa: F811
+    """Same parity as the cache devices: without this the CLI keeps refusing
+    the dm-held directories the agent's own pass reclaims. The live set is a
+    known one here (the agent is down, the supervisor answered), which is
+    what makes a teardown safe."""
     _fake_mapper(monkeypatch, tmp_path, f"{VM_HASH}_rootfs", f"{LIVE}_rootfs")
+    torn: list[str] = []
+    monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
+
+    code, _out = _run(["reconcile"], registry)
+
+    assert code == 0
+    assert torn == [VM_HASH]
+
+
+def test_no_device_is_torn_down_while_the_agent_is_running(pools, registry, monkeypatch, tmp_path):  # noqa: F811
+    _fake_mapper(monkeypatch, tmp_path, f"{VM_HASH}_rootfs")
+    monkeypatch.setattr(cli, "_probe_agent", _agent_up())
     torn: list[str] = []
     monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
 
@@ -759,15 +875,13 @@ def test_an_unmigrated_database_is_brought_up_to_date(pools, tmp_path, monkeypat
 
 def test_reconcile_reports_its_purges_on_stderr(pools, monkeypatch, plumbing, capsys):  # noqa: F811
     """The purge logs what it removed; with no handler configured those INFO
-    lines went nowhere and an operator watching a purge saw nothing. A real
-    purge needs a daemon that is down, which is the case this command is for."""
+    lines went nowhere and an operator watching a purge saw nothing."""
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
-    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(fails=True))
     orphan = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
     stamp = time.time() - 10_000
     os.utime(orphan.parent, (stamp, stamp))
 
-    code = cli.main(["reconcile", "--trust-registry"])
+    code = cli.main(["reconcile"])
 
     assert code == 0
     assert not orphan.exists()

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import logging
 import os
+import socket
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -19,6 +20,7 @@ import aleph.vm.agent.vm.reconciler as reconciler_module
 from aleph.vm import storage_pools
 from aleph.vm.agent.vm.reclaimable import (
     ReclaimableMarker,
+    clear_marker,
     mark_reclaimable,
     write_marker,
 )
@@ -60,9 +62,17 @@ def _fake_mapper(monkeypatch, tmp_path, *names: str) -> Path:
     return mapper
 
 
-def _fake_supervisor(*vm_ids: str, fails: bool = False):
+def _fake_supervisor(*vm_ids: str, fails: bool = False, error: Exception | None = None):
     """A supervisor handle that lists ``vm_ids``, or cannot be asked at all
-    (an unreachable daemon: a connection error, a timeout, any of it)."""
+    (an unreachable daemon: a connection error, a timeout, any of it).
+
+    ``fails`` raises a generic error, which the CLI then classifies by
+    probing the socket itself (absent under the tests, so: verified down).
+    ``error`` raises exactly what the caller passes, for the classes the CLI
+    reads off the exception alone.
+    """
+    if error is not None:
+        return SimpleNamespace(list_vms=AsyncMock(side_effect=error))
     if fails:
         return SimpleNamespace(list_vms=AsyncMock(side_effect=RuntimeError("no answer")))
     return SimpleNamespace(list_vms=AsyncMock(return_value=[SimpleNamespace(vm_id=vm_id) for vm_id in vm_ids]))
@@ -211,6 +221,56 @@ def test_reclaim_refuses_unless_trust_registry_when_supervisor_unreachable(pools
     assert not gone.exists()
 
 
+def test_reclaim_does_not_advise_the_registry_when_the_daemon_may_be_up(pools, registry, monkeypatch):  # noqa: F811
+    """A dial that failed for a reason other than a stopped daemon must not
+    end in an invitation to purge on the registry alone."""
+    gone = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+    denied = PermissionError(13, "Permission denied")
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(error=denied))
+
+    code, out = _run(["reclaim", VM_HASH], registry)
+
+    assert code == 1
+    assert "PermissionError" in out and "Permission denied" in out
+    assert "--trust-registry" not in out
+    assert gone.exists()
+
+
+def test_reclaim_refuses_an_empty_registry_the_supervisor_contradicts(pools, monkeypatch):  # noqa: F811
+    """A lost agent DB makes every marker on the node look purgeable, and
+    the supervisor's list is no second opinion on a VM it has not started
+    yet."""
+    gone = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(LIVE))
+
+    code, out = _run(["reclaim", VM_HASH], AgentVmRegistry())
+
+    assert code == 1 and "registry is empty" in out
+    assert gone.exists()
+
+
+def test_reclaim_refuses_a_marker_that_vanished_during_the_dial(pools, registry, monkeypatch):  # noqa: F811
+    """A re-create adopts its retained directory by clearing the marker. If
+    that happens while the supervisor is being asked, the hash is not yet in
+    any answer, and a purge on the checks made before the dial would delete
+    the disks of a VM the daemon is at that moment building on them."""
+    adopted = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+
+    def open_supervisor():
+        clear_marker(adopted.parent)
+        return _fake_supervisor()
+
+    monkeypatch.setattr(cli, "_open_supervisor", open_supervisor)
+
+    code, out = _run(["reclaim", VM_HASH], registry)
+
+    assert code == 1 and "no longer marked reclaimable" in out
+    assert adopted.exists()
+
+
 def test_reclaim_refuses_when_the_purge_leaves_a_dm_held_directory(pools, registry, monkeypatch):  # noqa: F811
     held = volume(pools["pool0"], VM_HASH, "data.btrfs")
     mark_reclaimable(VM_HASH, "gone", now=NOW)
@@ -236,22 +296,59 @@ def test_reconcile_dry_run_reports_without_changing(pools, registry, monkeypatch
     assert code == 0 and "Dry run" in out and "purged=1" in out
     assert orphan.exists()
 
-    # The fake supervisor (installed by the autouse fixture) is reachable and
-    # lists nothing running, so a real pass is allowed to purge.
+
+def test_reconcile_refuses_a_real_pass_while_the_daemon_answers(pools, registry, monkeypatch, capsys):  # noqa: F811
+    """The daemon holds the one thing this process cannot see: the set of
+    creates it has in flight. A long import outlives VOLUME_CREATE_GUARD
+    before its DB record exists, and a CLI pass would purge it as an orphan,
+    so a real pass is refused for as long as the daemon answers."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    orphan = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    stamp = time.time() - 10_000
+    os.utime(orphan.parent, (stamp, stamp))
+
     code, out = _run(["reconcile"], registry)
-    assert code == 0 and not orphan.exists()
+
+    assert code == cli.DEGRADED_EXIT_CODE
+    assert orphan.exists()
+    assert out == ""  # nothing was reconciled, so there is no report to print
+    err = capsys.readouterr().err
+    assert "Refusing to reconcile" in err and "--dry-run" in err
+
+    # The preview is still available, and still sees the orphan.
+    code, out = _run(["reconcile", "--dry-run"], registry)
+    assert code == 0 and "purged=1" in out
+    assert orphan.exists()
+
+
+def test_reconcile_refuses_an_empty_registry_the_supervisor_contradicts(pools, monkeypatch, capsys):  # noqa: F811, ARG001
+    """The daemon's own startup refusal, applied here: an empty registry
+    while the supervisor runs VMs means the agent DB was lost, and every
+    directory on the node then reads as an orphan."""
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(LIVE))
+
+    code, out = _run(["reconcile"], AgentVmRegistry())
+
+    assert code == cli.DEGRADED_EXIT_CODE
+    assert out == ""
+    err = capsys.readouterr().err
+    assert "registry is empty" in err and "1 VM(s)" in err
 
 
 def test_reconcile_leaves_a_supervisor_known_vm_the_registry_does_not(pools, registry, monkeypatch):  # noqa: F811
+    """The union with the supervisor's list, visible in the one mode a
+    reachable daemon still allows: OTHER_HASH is not in the registry, so
+    only that union keeps it out of the report."""
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
     unknown = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2")
     stamp = time.time() - 10_000
     os.utime(unknown.parent, (stamp, stamp))
     monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(OTHER_HASH))
 
-    code, out = _run(["reconcile"], registry)
+    code, out = _run(["reconcile", "--dry-run"], registry)
 
     assert code == 0
+    assert "purged=0" in out and OTHER_HASH not in out
     assert unknown.exists()
 
 
@@ -272,7 +369,7 @@ def test_reconcile_unreachable_exits_nonzero_and_warns_on_stderr(pools, registry
     assert orphan.exists()
 
 
-def test_reconcile_explicit_dry_run_stays_exit_zero_when_unreachable(pools, registry, monkeypatch):  # noqa: F811
+def test_reconcile_explicit_dry_run_stays_exit_zero_when_unreachable(pools, registry, monkeypatch, capsys):  # noqa: F811
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
     orphan = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
     stamp = time.time() - 10_000
@@ -284,6 +381,75 @@ def test_reconcile_explicit_dry_run_stays_exit_zero_when_unreachable(pools, regi
     assert code == 0
     assert "Dry run" in out
     assert orphan.exists()
+    # Nothing was downgraded: the operator asked for a preview and got one,
+    # so advising the flag that turns a pass into a purge is noise.
+    err = capsys.readouterr().err
+    assert "registry-only" in err and "--trust-registry" not in err
+
+
+def test_a_dial_that_is_no_proof_the_daemon_is_down_advises_no_purge(pools, registry, monkeypatch, capsys):  # noqa: F811
+    """A socket this user may not open, a deadline, a reply that does not
+    parse: none of them says the daemon is stopped, and purging on the
+    registry alone while it runs is the very thing the union prevents. The
+    error itself has to reach the operator, named."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    orphan = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    stamp = time.time() - 10_000
+    os.utime(orphan.parent, (stamp, stamp))
+    denied = PermissionError(13, "Permission denied")
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(error=denied))
+
+    code, out = _run(["reconcile"], registry)
+
+    assert code == cli.DEGRADED_EXIT_CODE
+    assert orphan.exists()
+    err = capsys.readouterr().err
+    assert "PermissionError" in err and "Permission denied" in err
+    assert "--trust-registry" not in err
+
+
+def test_a_timeout_is_never_reported_as_a_stopped_daemon(pools, registry, monkeypatch, capsys):  # noqa: F811
+    """asyncio.wait_for gives up on a daemon that is up but wedged."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(error=TimeoutError("timed out")))
+
+    code, _out = _run(["reconcile"], registry)
+
+    assert code == cli.DEGRADED_EXIT_CODE
+    err = capsys.readouterr().err
+    assert "TimeoutError" in err
+    assert "--trust-registry" not in err
+
+
+def test_a_socket_that_accepts_is_never_read_as_a_stopped_daemon(tmp_path):
+    """The fallback classification, on its own: a daemon that is listening
+    but would not answer must never end in the advice to purge without it."""
+    path = tmp_path / "sup.sock"
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+        server.bind(str(path))
+        server.listen(1)
+
+        assert cli._socket_reach(path) is not cli.SupervisorReach.DOWN
+
+
+def test_a_missing_socket_is_read_as_a_stopped_daemon(tmp_path):
+    assert cli._socket_reach(tmp_path / "nothing.sock") is cli.SupervisorReach.DOWN
+
+
+def test_an_unset_socket_path_says_nothing_about_the_daemon():
+    assert cli._socket_reach(None) is cli.SupervisorReach.UNKNOWN
+
+
+def test_a_refused_socket_is_reported_as_a_stopped_daemon(pools, registry, monkeypatch, capsys):  # noqa: F811
+    refused = ConnectionRefusedError(111, "Connection refused")
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(error=refused))
+
+    code, _out = _run(["reconcile"], registry)
+
+    assert code == cli.DEGRADED_EXIT_CODE
+    err = capsys.readouterr().err
+    assert "unreachable" in err and "ConnectionRefusedError" in err
+    assert "--trust-registry" in err
 
 
 def test_reconcile_trust_registry_purges_when_supervisor_unreachable(pools, registry, monkeypatch):  # noqa: F811
@@ -318,18 +484,21 @@ def test_reconcile_passes_live_known_false_when_supervisor_unreachable(pools, re
 
 
 def test_reconcile_passes_live_known_true_when_supervisor_reachable(pools, registry, monkeypatch):  # noqa: F811
-    # The autouse fixture already installs a reachable fake supervisor.
+    # The autouse fixture already installs a reachable fake supervisor, and a
+    # reachable one leaves --dry-run as the only mode that reaches the pass.
     fake_report = reconciler_module.ReconcileReport()
     spy = MagicMock(return_value=fake_report)
     monkeypatch.setattr(cli, "reconcile_storage", spy)
 
-    code, out = _run(["reconcile"], registry)
+    code, out = _run(["reconcile", "--dry-run"], registry)
 
     assert code == 0
     assert spy.call_args.kwargs["live_known"] is True
 
 
-def test_reconcile_tears_down_devices_of_evicted_cache_parents(pools, registry, monkeypatch):  # noqa: F811
+def test_reconcile_evicts_no_cache_entry_while_the_daemon_answers(pools, registry, monkeypatch):  # noqa: F811
+    """The cache pass runs inside the reconcile the daemon's presence
+    refuses, devices included: what the daemon is up for, the daemon does."""
     monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
     stale = pools["runtime"] / "stale"
     stale.write_bytes(b"x" * 4096)
@@ -338,9 +507,9 @@ def test_reconcile_tears_down_devices_of_evicted_cache_parents(pools, registry, 
 
     code, out = _run(["reconcile"], registry)
 
-    assert code == 0
-    assert not stale.exists()
-    assert removed == ["stale"]
+    assert code == cli.DEGRADED_EXIT_CODE
+    assert stale.exists()
+    assert removed == []
 
 
 def test_reconcile_dry_run_never_touches_cache_parent_devices(pools, registry, monkeypatch):  # noqa: F811
@@ -370,17 +539,19 @@ def test_cli_main_dispatches_storage_subcommand(mocker):
     assert args.loglevel == logging.DEBUG
 
 
-def test_reconcile_tears_down_the_devices_of_an_orphan_namespace(pools, registry, monkeypatch, tmp_path):  # noqa: F811
-    """Same parity as the cache devices: without this the CLI keeps refusing
-    the dm-held directories the daemon's own pass now reclaims."""
+def test_a_cli_pass_never_tears_down_an_orphan_namespace_device(pools, registry, monkeypatch, tmp_path):  # noqa: F811
+    """Tearing a device down takes the VM's disk with it if the VM was only
+    unlisted rather than gone. The one answer that made that safe (the
+    supervisor's) is now the answer that refuses the pass outright, so the
+    devices of an orphan namespace are the daemon's own pass to reclaim."""
     _fake_mapper(monkeypatch, tmp_path, f"{VM_HASH}_rootfs", f"{LIVE}_rootfs")
     torn: list[str] = []
     monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
 
     code, _out = _run(["reconcile"], registry)
 
-    assert code == 0
-    assert torn == [VM_HASH]
+    assert code == cli.DEGRADED_EXIT_CODE
+    assert torn == []
 
 
 def test_reconcile_dry_run_never_touches_orphan_devices(pools, registry, monkeypatch, tmp_path):  # noqa: F811
@@ -588,13 +759,15 @@ def test_an_unmigrated_database_is_brought_up_to_date(pools, tmp_path, monkeypat
 
 def test_reconcile_reports_its_purges_on_stderr(pools, monkeypatch, plumbing, capsys):  # noqa: F811
     """The purge logs what it removed; with no handler configured those INFO
-    lines went nowhere and an operator watching a purge saw nothing."""
+    lines went nowhere and an operator watching a purge saw nothing. A real
+    purge needs a daemon that is down, which is the case this command is for."""
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    monkeypatch.setattr(cli, "_open_supervisor", lambda: _fake_supervisor(fails=True))
     orphan = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
     stamp = time.time() - 10_000
     os.utime(orphan.parent, (stamp, stamp))
 
-    code = cli.main(["reconcile"])
+    code = cli.main(["reconcile", "--trust-registry"])
 
     assert code == 0
     assert not orphan.exists()


### PR DESCRIPTION
## Summary
A real `aleph-vm storage reconcile` ran the reconciler's walk from a process
that cannot see the one thing the agent holds: the creates it has in flight
(`reconciler.creating()` is in-process state). A migration import that
outlives `VOLUME_CREATE_GUARD` before its DB record exists therefore read as
an orphan, and the pass removed the directory the create was building on,
plus its devices, with no lock against the agent's own pass. This PR turns
that documented caveat into a rule keyed on the agent process, and fixes
three smaller safety gaps in the same file: the CLI live set mirrored only
half of the daemon's `_startup_refusal` (an empty registry plus a reachable
supervisor purged on the supervisor's list alone), every failed dial became a
silent `None` that ended in the advice to purge on the registry alone (on a
permission error, on the 3 s deadline, on a malformed reply, and even on an
explicit `--dry-run`), and `reclaim` checked the `.reclaimable` marker before
the supervisor dial and purged afterwards without looking again.

The two processes are independent and the distinction matters: the **agent**
is this Python service, which owns the reconciler and the creates; the
**supervisor** is the Rust daemon that runs the VMs and answers `list_vms`.
The node an operator needs this command for is the awkward one, VMs running
under a healthy supervisor while the agent is down.

Stacked on #1210.

## Changes
- `storage_cli.py`, three-way purge rule in `_reconcile` and `_reclaim`:
  - the agent is running, or cannot be ruled out as running: a real pass and
    `reclaim` are refused, reason on stderr, exit 3. `--dry-run` still runs
    and notes that its listing may name a directory the agent is creating.
  - the agent is down and the supervisor answers: the full pass, including
    `_teardown_orphan_devices` before the walk (nothing is creating, and the
    live set is registry union `list_vms`).
  - the supervisor does not answer: the existing `--trust-registry` gate,
    unchanged, and no device teardown on that path.
- `storage_cli.py`, agent probe: `_probe_agent` connects to the agent's own
  HTTP bind (`SUPERVISOR_HOST`/`SUPERVISOR_PORT`, that setting's legacy name)
  with a 2 s timeout. It needs no privileges and no unit name. Only a refused
  connection returns `STOPPED`; anything else is `UNKNOWN`, which counts as
  running (`AgentProbe.may_be_running`). Being wrong that way costs one
  refused command; being wrong the other way deletes the disks of a VM
  mid-create. A wildcard bind is probed on both loopbacks and called stopped
  only when both refuse: asyncio's `create_server` sets `IPV6_V6ONLY`, so an
  agent bound to `::` accepts on `::1` and refuses on `127.0.0.1`. An address
  family the kernel cannot reach counts with the refusals, or an IPv4-only
  node would answer "cannot tell" for ever.
- `storage_cli.py`, streams: `run()` and the verbs take `out` and `err`.
  What the command found or achieved goes to stdout, every warning, refusal
  and diagnostic to stderr, `reclaim` included, so a refusal leaves stdout
  empty rather than mixing a reason into a report that does not exist.
- `storage_cli.py`, ordering: `_reconcile` probes the agent before dialling
  the supervisor, so a pass the agent refuses does not first sit through the
  3 s deadline for an answer it discards.
- `storage_cli.py`, live set: `_cli_live_set` returns a `LiveSet` carrying
  the daemon's own `_startup_refusal` verdict, imported rather than restated,
  so the registry-empty case ("the agent DB was lost") refuses in the CLI
  exactly as it does in the daemon. `_reclaim_refusal` asks it too.
- `storage_cli.py`, diagnostics: `_ask_supervisor` returns a
  `SupervisorAnswer` (`ANSWERED` / `DOWN` / `UNKNOWN`, plus the exception
  class and message) instead of `None`. `DOWN` is only claimed when it can be
  backed up: *its own* socket is missing (`os.stat`, since `Path.exists()`
  turns a stat this user may not make into a plain `False`) or refuses a
  connection. A refused connection in the exception chain counts too, but a
  missing file there does not (the client opens more than its socket): that
  case falls through to the stat. Fixed in the Foxpatch review round: the
  chain was walked one cause at a time and returned as soon as it found a
  `PermissionError`, so a `ConnectionRefusedError` sitting deeper in a chain
  whose head is a `PermissionError` went unnoticed; the whole chain is now
  checked for a refusal before it is checked for a permission error, so a
  refusal anywhere in the chain is proof of `DOWN` regardless of what comes
  before it.
  The `--trust-registry` advice is printed only then; a permission error, a
  deadline or a malformed reply say so and stop, and an explicit `--dry-run`
  is told its preview is registry-only.
- `storage_cli.py`, reclaim race: the marker is read once more immediately
  before `purge_vm_storage`, since a re-create adopts its retained
  directories by clearing their markers and one that started during the dial
  is in no answer this process holds.
- `storage_cli.py`, exit codes: refusals carry theirs (`Refusal`). "Not this
  hash" stays 1; a node whose agent is live or whose agent database was lost
  is 3, since nothing about the hash is wrong and a wrapper has to tell the
  two apart.
- `docs/architecture/storage.md`: the CLI section states the three states,
  both fail-closed probes, and the caveat that `--trust-registry` on a
  verified-down supervisor can still purge under a live VM (a supervisor
  process that dies leaves its QEMU processes running).
- `storage_cli.py`, wording (Foxpatch): the reclaim refusal used to point at
  `storage list --reclaimable` to preview a purge, but that verb does not run
  a reconcile pass; it now points at `storage reconcile --dry-run`, which
  does. The module docstring also now notes that aiohttp runs the agent's
  `on_startup` hooks before its listener binds, so a starting agent can
  briefly read as stopped; the create guard covers most of that window.

## Test plan
- `tests/supervisor/test_storage_cli.py`: the three states (a live agent and
  an unprobeable one refuse `reconcile` and `reclaim` at exit 3 while
  `--dry-run` still lists and warns; an agent that is down with the
  supervisor answering runs the full pass, tears down the orphan namespace's
  devices and evicts cache parents; an unanswered supervisor keeps the
  `--trust-registry` gate and tears nothing down). Plus: the probe itself on
  a listening socket, a refused port and a probe that raises; the
  registry-empty refusal on both verbs; `PermissionError` and `TimeoutError`
  dials named on stderr with no `--trust-registry` advice while
  `ConnectionRefusedError` gets it; an explicit `--dry-run` on a down daemon
  told its preview is registry-only; a marker cleared during the dial making
  `reclaim` refuse; and `_socket_reach` on a listening socket, a missing one
  and an unset path.
- Review follow-ups pinned: an agent bound to `::1` alone is found through a
  `::` wildcard; a wildcard is stopped only when both loopbacks refuse; a
  `FileNotFoundError` from elsewhere in the dial does not advise
  `--trust-registry` while the socket is answering; a refused pass never
  dials the supervisor; and every reclaim refusal is asserted on stderr with
  stdout empty.
- Foxpatch review round: a `ConnectionRefusedError` deeper in the chain than
  a `PermissionError` still classifies the daemon as `DOWN`.
- `pytest tests/supervisor/test_storage_cli.py` 58 passed; with the
  reconciler and reclaimable files, 145 passed.
- `ruff format --diff`, `isort --check-only --profile black`, and `mypy
  src/aleph/vm/ tests/` all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZyMqLgxxVfeDwiNy34sfM

