### PR TITLE
fix(agent): put the retained marker back when a create does not commit

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -332,6 +332,13 @@ purge is immediate.
 A create for the same hash adopts the directory (the marker is unlinked and
 the volumes are reused through the existing sticky placement in
 `volume_path_for`), which is what `reconciler.creating()` does on entry.
+Adoption is undone when the create does not commit: leaving the guard by
+raising puts the adopted markers back as they were, so a re-create that
+keeps failing (the allocation reconciler retries it every cycle) does not
+turn retained disks into an owner-less orphan directory with no parent-image
+pins and a timestamp that resets on every attempt. A directory the failed
+create's own teardown purged is not re-marked, and a marker written while
+the create ran (a retire of the same hash) is the newer record and stays.
 
 ### The reconciler
 
@@ -754,7 +761,8 @@ pass against an empty registry would call every running VM an orphan.
 - `src/aleph/vm/agent/vm/retire.py`: `retire_vm` and `RetireReason`, the one
   way a VM's storage is released.
 - `src/aleph/vm/agent/vm/reclaimable.py`: the `.reclaimable` marker
-  (`mark_reclaimable`, `adopt`, `iter_reclaimable`, `reclaimable_bytes`) and
+  (`mark_reclaimable`, `adopt`, `restore_markers`, `iter_reclaimable`,
+  `reclaimable_bytes`) and
   the one enumeration of the cache entries a message names
   (`iter_content_refs`, `refs_from_content`, `depends_on_from_content`).
 - `src/aleph/vm/agent/vm/cache.py`: the cache budget, LRU eviction

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -16,8 +16,8 @@ import json
 import logging
 import os
 import time
-from collections.abc import Iterator
-from dataclasses import asdict, dataclass
+from collections.abc import Iterator, Mapping
+from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
@@ -307,15 +307,54 @@ def mark_reclaimable(
     return written
 
 
-def adopt(namespace: str) -> int:
-    """A create for this hash takes its retained directories back."""
+def adopt(namespace: str) -> dict[Path, ReclaimableMarker]:
+    """A create for this hash takes its retained directories back.
+
+    Returns the markers it removed, keyed by directory, so a create that
+    does not commit can put them back (``restore_markers``). A directory
+    whose marker was unreadable or corrupt is adopted like any other and
+    simply has nothing to give back.
+    """
     namespace = _checked_namespace(namespace)
-    cleared = 0
+    adopted: dict[Path, ReclaimableMarker] = {}
     for directory in iter_namespace_dirs(namespace):
+        marker = read_marker(directory)
         if clear_marker(directory):
             logger.info("Adopted retained volumes in %s", directory)
-            cleared += 1
-    return cleared
+            if marker is not None:
+                adopted[directory] = marker
+    return adopted
+
+
+def restore_markers(adopted: Mapping[Path, ReclaimableMarker]) -> int:
+    """Put back the markers an adopt cleared, for a create that then failed.
+
+    Adoption happens before the create is known to succeed, and a failed
+    create must leave the directory as it found it. Left unmarked it is only
+    an orphan to the next pass, which re-marks it with no owner (so the
+    owner can no longer have their own retained data erased) and no
+    depends_on (so the cache may evict the parent image the retained volumes
+    are built on), and with a fresh timestamp that moves it to the back of
+    the eviction queue on every retry.
+
+    Restored exclusively: a marker written while the create ran is a newer
+    record of the same directory (a retire of this very hash) and stays. A
+    directory the failed create's own teardown purged is skipped rather than
+    recreated.
+    """
+    restored = 0
+    for directory, marker in adopted.items():
+        if not directory.is_dir():
+            continue
+        # size_bytes is a measurement of what the directory holds, and a
+        # create that failed part way may have left more or less than it
+        # found. The rest of the marker (since when, whose, what it is built
+        # on) is the record that has to survive unchanged.
+        current = replace(marker, size_bytes=directory_size_bytes(directory))
+        if write_marker(directory, current, exclusive=True):
+            logger.info("Restored the reclaimable marker in %s after a create that did not commit", directory)
+            restored += 1
+    return restored
 
 
 def retained_marker(namespace: str) -> ReclaimableMarker | None:

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -67,6 +67,7 @@ from aleph.vm.agent.vm.reclaimable import (
     iter_reclaimable,
     mark_reclaimable,
     read_marker,
+    restore_markers,
 )
 from aleph.vm.agent.vm.retire import teardown_namespace_devices
 from aleph.vm.agent.vm_registry import AgentVmRegistry
@@ -121,12 +122,14 @@ def creating(namespace: str) -> Iterator[None]:
     writes a session directory outside this context can have them removed
     from under it by the next pass.
 
-    Adoption happens on entry, before the create is known to succeed, so a
-    create that is then refused leaves the directory unmarked: the next pass
-    re-marks it as an orphan with a fresh ``reclaimable_since``, which moves
-    it to the back of the eviction queue. Retention is a budgeted cache, not
-    a promise, so a reset order is acceptable; adopting later would mean a
-    create racing the eviction of the very disks it is about to reuse.
+    Adoption happens on entry, before the create is known to succeed:
+    adopting later would mean a create racing the eviction of the very disks
+    it is about to reuse. A create that then fails leaves the context by
+    raising, and the markers the entry adopted go back exactly as they were,
+    so a retained directory keeps its owner (who may still ask for it to be
+    erased), the parent images its volumes depend on, and its place in the
+    eviction queue. That matters because a failing create is retried: the
+    allocation reconciler pushes it again on every cycle.
     """
     # Register before adopting: between clear_marker and the add there would
     # otherwise be an instant where the directory is protected by neither
@@ -135,12 +138,26 @@ def creating(namespace: str) -> Iterator[None]:
     # is_creating as False must have read it before this line, and then
     # still sees the marker adopt() has yet to clear.
     _creating[namespace] = _creating.get(namespace, 0) + 1
+    adopted: dict[Path, ReclaimableMarker] = {}
     try:
         # Inside the try: an adopt that raises (a marker that cannot be
         # unlinked) must not leave the guard up for good, which would exempt
         # the namespace from every future pass.
-        adopt(namespace)
+        adopted = adopt(namespace)
         yield
+    except BaseException:
+        # Any way out other than a normal return means the create did not
+        # commit: an exception, and a cancellation of the task running it.
+        # The restore runs before the guard comes down below, so no pass can
+        # see the directory unmarked and unguarded in between.
+        try:
+            restore_markers(adopted)
+        except Exception:
+            # Deliberately swallowed: the create's own failure is what the
+            # caller has to see. A directory left unmarked is picked up as an
+            # orphan by the next pass, which is what used to happen anyway.
+            logger.exception("Could not restore the reclaimable markers of %s", namespace)
+        raise
     finally:
         remaining = _creating[namespace] - 1
         if remaining:

--- a/tests/supervisor/test_reclaimable.py
+++ b/tests/supervisor/test_reclaimable.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -24,11 +25,13 @@ from aleph.vm.agent.vm.reclaimable import (
     read_marker,
     reclaimable_bytes,
     refs_from_content,
+    restore_markers,
     write_marker,
 )
 from aleph.vm.storage import get_message
 
 NOW = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
+OWNER = "0x1234567890123456789012345678901234567890"
 
 
 def test_marker_round_trips_through_json():
@@ -127,12 +130,59 @@ def test_adopt_clears_every_marker_of_the_namespace(pools):  # noqa: F811
     mark_reclaimable(VM_HASH, "gone", now=NOW)
     mark_reclaimable(OTHER_HASH, "gone", now=NOW)
 
-    assert adopt(VM_HASH) == 2
+    adopted = adopt(VM_HASH)
 
+    assert set(adopted) == {pools["pool0"] / VM_HASH, pools["pool1"] / VM_HASH}
     assert read_marker(pools["pool0"] / VM_HASH) is None
     assert read_marker(pools["pool1"] / VM_HASH) is None
     assert read_marker(pools["pool0"] / OTHER_HASH) is not None
-    assert adopt(VM_HASH) == 0
+    assert adopt(VM_HASH) == {}
+
+
+def test_restore_puts_every_adopted_marker_back(pools):  # noqa: F811
+    """What adopt returns is enough to undo it, on every pool the VM spans."""
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    volume(pools["pool1"], VM_HASH, "data.ext4")
+    mark_reclaimable(VM_HASH, "gone", ("parent-ref",), now=NOW, owner=OWNER)
+    adopted = adopt(VM_HASH)
+
+    assert restore_markers(adopted) == 2
+
+    for pool in (pools["pool0"], pools["pool1"]):
+        marker = read_marker(pool / VM_HASH)
+        assert marker is not None
+        assert marker.owner == OWNER and marker.depends_on == ("parent-ref",)
+        assert marker.reclaimable_since == NOW
+
+
+def test_restore_re_measures_what_the_directory_now_holds(pools):  # noqa: F811
+    """size_bytes says what is on disk, and a create that failed part way may
+    have left more than it found; everything else is the record it must not
+    change."""
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=4096)
+    mark_reclaimable(VM_HASH, "gone", now=NOW, owner=OWNER)
+    adopted = adopt(VM_HASH)
+    volume(pools["pool0"], VM_HASH, "half-written.qcow2", size=8192)
+
+    restore_markers(adopted)
+
+    marker = read_marker(pools["pool0"] / VM_HASH)
+    assert marker is not None
+    assert marker.size_bytes > adopted[pools["pool0"] / VM_HASH].size_bytes
+    assert marker.owner == OWNER and marker.reclaimable_since == NOW
+
+
+def test_restore_skips_a_directory_that_is_gone(pools):  # noqa: F811
+    """A create whose teardown purged the whole directory leaves nothing to
+    mark, and the marker is not what would bring it back."""
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW, owner=OWNER)
+    adopted = adopt(VM_HASH)
+    shutil.rmtree(pools["pool0"] / VM_HASH)
+
+    assert restore_markers(adopted) == 0
+
+    assert not (pools["pool0"] / VM_HASH).exists()
 
 
 def test_a_failed_marker_write_leaves_no_temp_file(pools, monkeypatch, caplog):  # noqa: F811
@@ -232,8 +282,6 @@ def test_reclaimable_bytes_is_cached_between_marker_changes(pools, monkeypatch):
     """Admission asks on every request; the walk must not happen every time,
     and must not be stale after a marker is written, cleared, or its whole
     directory removed."""
-    import shutil
-
     import aleph.vm.agent.vm.reclaimable as reclaimable_module
 
     walks = []

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -31,6 +31,8 @@ from aleph.vm.storage_pools import get_pools
 from aleph.vm.supervisor_interface.errors import SupervisorError
 
 LIVE = "dead" * 16
+OWNER = "0x1234567890123456789012345678901234567890"
+OTHER_OWNER = "0x9999999999999999999999999999999999999999"
 NOW = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
 GIB = 1024**3
 
@@ -135,6 +137,125 @@ def test_creating_adopts_retained_dirs(pools, monkeypatch):  # noqa: F811
     mark_reclaimable(VM_HASH, "gone", now=NOW)
 
     with creating(VM_HASH):
+        assert read_marker(pools["pool0"] / VM_HASH) is None
+
+
+def test_a_failed_create_puts_the_retained_marker_back(pools, monkeypatch):  # noqa: F811
+    """A create that does not commit leaves the directory as it found it.
+
+    The allocation reconciler retries a failed create, so a persistently
+    failing one adopts and fails over and over. Left unmarked, the next pass
+    re-marks the directory as an orphan with no owner (the operator API can
+    no longer authorize its owner's erase) and no depends_on (the cache may
+    evict the parent image the retained volumes are built on)."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", (OTHER_HASH,), now=NOW, owner=OWNER)
+
+    with pytest.raises(RuntimeError), creating(VM_HASH):
+        raise RuntimeError("the create failed after adoption")
+
+    restored = read_marker(pools["pool0"] / VM_HASH)
+    assert restored is not None
+    assert restored.owner == OWNER
+    assert restored.depends_on == (OTHER_HASH,)
+    assert restored.reason == "gone"
+    assert restored.reclaimable_since == NOW
+
+
+def test_a_failed_create_keeps_the_eviction_order_of_what_it_adopted(pools, monkeypatch):  # noqa: F811
+    """The restored marker is the one that was there, not a fresh one: a VM
+    whose create keeps failing must not keep moving to the back of the
+    eviction queue."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    since = NOW - timedelta(days=3)
+    mark_reclaimable(VM_HASH, "orphan", now=since)
+
+    for _attempt in range(2):
+        with pytest.raises(RuntimeError), creating(VM_HASH):
+            raise RuntimeError("the create failed again")
+
+    restored = read_marker(pools["pool0"] / VM_HASH)
+    assert restored is not None and restored.reclaimable_since == since
+
+
+def test_a_create_that_commits_leaves_the_directory_adopted(pools, monkeypatch):  # noqa: F811
+    """The guard against over-restoring: a create that returns normally owns
+    the directory, and a marker put back under a live VM would offer its
+    disks to the evictor."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW, owner=OWNER)
+
+    with creating(VM_HASH):
+        pass
+
+    assert read_marker(pools["pool0"] / VM_HASH) is None
+
+
+def test_a_failed_create_does_not_re_mark_a_directory_it_purged(pools, monkeypatch):  # noqa: F811
+    """A create that allocated fresh disks retires FAILED_CREATE, which purges
+    the whole directory before the failure leaves the guard. Nothing is put
+    back into a directory that is gone."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    disk = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW, owner=OWNER)
+
+    with pytest.raises(RuntimeError), creating(VM_HASH):
+        disk.unlink()
+        disk.parent.rmdir()
+        raise RuntimeError("the create failed and its teardown purged the directory")
+
+    assert not (pools["pool0"] / VM_HASH).exists()
+
+
+def test_a_marker_written_during_a_failed_create_survives_the_restore(pools, monkeypatch):  # noqa: F811
+    """A retire of the same hash while the create ran wrote a newer marker.
+    That one is the current record and the restore must not replace it."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW, owner=OWNER)
+    newer = NOW + timedelta(hours=1)
+
+    with pytest.raises(RuntimeError), creating(VM_HASH):
+        mark_reclaimable(VM_HASH, "gone", now=newer, owner=OTHER_OWNER)
+        raise RuntimeError("the create failed after the retire re-marked it")
+
+    restored = read_marker(pools["pool0"] / VM_HASH)
+    assert restored is not None
+    assert restored.reclaimable_since == newer and restored.owner == OTHER_OWNER
+
+
+def test_a_restore_that_fails_does_not_mask_the_create_failure(pools, monkeypatch):  # noqa: F811
+    """The caller has to see why its create failed, not why the marker could
+    not be put back."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW, owner=OWNER)
+
+    def refuse(_adopted):
+        raise PermissionError("the pool is read-only")
+
+    monkeypatch.setattr(reconciler_module, "restore_markers", refuse)
+
+    with pytest.raises(RuntimeError, match="the create failed"), creating(VM_HASH):
+        raise RuntimeError("the create failed")
+
+    assert not is_creating(VM_HASH)
+
+
+def test_a_failed_inner_create_does_not_re_mark_a_directory_the_outer_holds(pools, monkeypatch):  # noqa: F811
+    """Two creates of one hash can overlap. The inner one adopted nothing (the
+    outer already cleared the marker), so its failure must leave the directory
+    the outer create is still writing unmarked."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW, owner=OWNER)
+
+    with creating(VM_HASH):
+        with pytest.raises(RuntimeError), creating(VM_HASH):
+            raise RuntimeError("the second create failed")
         assert read_marker(pools["pool0"] / VM_HASH) is None
 
 

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -180,6 +180,37 @@ def test_a_failed_create_keeps_the_eviction_order_of_what_it_adopted(pools, monk
     assert restored is not None and restored.reclaimable_since == since
 
 
+@pytest.mark.asyncio
+async def test_a_cancelled_create_puts_the_retained_marker_back(pools, monkeypatch):  # noqa: F811
+    """A cancellation is the other way out of the context, and it is not an
+    ``Exception``: an agent shutting down or a create hitting its timeout
+    cancels the task, and the directory has to be left as the create found it
+    just the same. Only ``BaseException`` catches this half."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", (OTHER_HASH,), now=NOW, owner=OWNER)
+    adopted = asyncio.Event()
+
+    async def create():
+        with creating(VM_HASH):
+            adopted.set()
+            await asyncio.sleep(3600)
+
+    task = asyncio.create_task(create())
+    await adopted.wait()
+    assert read_marker(pools["pool0"] / VM_HASH) is None
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    restored = read_marker(pools["pool0"] / VM_HASH)
+    assert restored is not None
+    assert restored.owner == OWNER
+    assert restored.depends_on == (OTHER_HASH,)
+    assert restored.reclaimable_since == NOW
+    assert not is_creating(VM_HASH)
+
+
 def test_a_create_that_commits_leaves_the_directory_adopted(pools, monkeypatch):  # noqa: F811
     """The guard against over-restoring: a create that returns normally owns
     the directory, and a marker put back under a live VM would offer its

--- a/tests/supervisor/views/test_operator_retire.py
+++ b/tests/supervisor/views/test_operator_retire.py
@@ -17,13 +17,16 @@ from aiohttp.test_utils import TestClient
 from aleph_message.models import ItemHash
 from aleph_message.models.execution.environment import TrustedExecutionEnvironment
 
+import aleph.vm.storage_pools as storage_pools_module
 from aleph.vm.agent import metrics
 from aleph.vm.agent.supervisor import setup_webapp
 from aleph.vm.agent.views.operator import _security_aggregate_cache
-from aleph.vm.agent.vm.reclaimable import ReclaimableMarker
+from aleph.vm.agent.vm.reclaimable import ReclaimableMarker, mark_reclaimable
+from aleph.vm.agent.vm.reconciler import creating
 from aleph.vm.agent.vm.retire import RetireReason
 from aleph.vm.conf import settings
 from aleph.vm.storage import get_message
+from aleph.vm.storage_pools import MediaClass, StoragePool, reset_pools
 from aleph.vm.supervisor_interface.errors import VmNotFoundError
 from aleph.vm.supervisor_interface.types import (
     Backend,
@@ -244,6 +247,59 @@ async def test_operator_erase_of_a_marker_without_an_owner_is_403(aiohttp_client
 
     assert response.status == 403
     retire.assert_not_awaited()
+
+
+@pytest.fixture
+def retention_pool(tmp_path, monkeypatch):
+    """One real volume pool, so the marker machinery reads and writes files
+    rather than a mock."""
+    pool = tmp_path / "volumes" / "persistent"
+    pool.mkdir(parents=True)
+    monkeypatch.setattr(settings, "PERSISTENT_VOLUMES_DIR", pool)
+    monkeypatch.setattr(
+        storage_pools_module,
+        "_pools",
+        [StoragePool(path=pool, media_class=MediaClass.SSD, index=0)],
+    )
+    yield pool
+    reset_pools()
+
+
+@pytest.mark.asyncio
+async def test_operator_erase_still_works_after_a_failed_re_create(aiohttp_client, mocker, retention_pool):
+    """The owner of retained disks keeps their erase across a failed
+    re-create.
+
+    The allocation reconciler retries a create that keeps failing, and each
+    attempt adopts the retained directory on entry. If the failure left it
+    unmarked, the next storage pass would re-mark it as an orphan with no
+    owner, and this endpoint would refuse the owner their own data."""
+    owner = "0x1234567890123456789012345678901234567890"
+    settings.ENABLE_QEMU_SUPPORT = True
+    settings.setup()
+
+    vm_hash = ItemHash(settings.FAKE_INSTANCE_ID)
+    namespace = retention_pool / str(vm_hash)
+    namespace.mkdir()
+    (namespace / "rootfs.qcow2").write_bytes(b"x" * 4096)
+    mark_reclaimable(str(vm_hash), "gone", ("parent-image-ref",), owner=owner)
+
+    with pytest.raises(RuntimeError), creating(str(vm_hash)):
+        raise RuntimeError("the re-create failed after adoption")
+
+    mocker.patch("aleph.vm.agent.views.authentication.authenticate_jwk", return_value=owner)
+    mocker.patch.object(metrics, "get_last_record_for_vm", AsyncMock(return_value=None))
+    app = setup_webapp(supervisor=_fake_supervisor())
+    fake_sup = _fake_supervisor()
+    fake_sup.get_vm = AsyncMock(side_effect=VmNotFoundError(str(vm_hash)))
+    app["supervisor"] = fake_sup
+    retire = mocker.patch("aleph.vm.agent.views.operator.retire_vm", new_callable=AsyncMock)
+
+    client: TestClient = await aiohttp_client(app)
+    response = await client.post(f"/control/machine/{vm_hash}/erase")
+
+    assert response.status == 200
+    retire.assert_awaited_once_with(vm_hash, RetireReason.ERASE, supervisor=fake_sup, registry=app["vm_registry"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
`creating()` adopts a VM's retained directories on entry (clearing the `.reclaimable` marker) before the create is known to succeed, and a create that then failed left them unmarked. The failure path retires `RECREATE` when the volumes already existed, which touches no storage, so the next reconcile pass saw an unmarked directory and re-marked it as an orphan: no owner, no `depends_on`, and a fresh `reclaimable_since`. The owner could no longer erase their own retained data (the operator erase endpoint 404s while there is no marker, and refuses a marker with no owner once the pass writes one), the parent images the retained volumes are built on lost their pin against cache eviction, and the directory went to the back of the eviction queue on every attempt. The allocation reconciler retries a failed create every cycle, so one that keeps failing cycled this indefinitely.

`adopt()` now returns the markers it removed and `creating()` puts them back on any exit other than a normal return, so a failed re-create leaves the directory exactly as it found it: retained, with its owner, its parent-image pins and its place in the eviction queue.

Stacked on #1213.

## Changes
- `src/aleph/vm/agent/vm/reclaimable.py`: `adopt()` returns the markers it cleared, keyed by directory (it counted them before). New `restore_markers()` writes them back exclusively, so a marker written while the create ran (a retire of the same hash) is the newer record and stays, and a directory the failed create's own teardown purged is skipped rather than recreated. Only `size_bytes` is re-measured: a create that failed part way may have left more or less on disk than it found, while the rest of the marker is the record that has to survive unchanged.
- `src/aleph/vm/agent/vm/reconciler.py`: `creating()` keeps what `adopt()` returned and restores it on any exception (a cancellation of the task running the create included), before the create guard comes down, so no pass can see the directory unmarked and unguarded in between. A restore that itself fails is logged and swallowed: the create's own failure is what the caller has to see. The docstring now states the rule.
- `docs/architecture/storage.md`: the marker section says adoption is undone when a create does not commit, and what the two exceptions are.

## Test plan
- `tests/supervisor/test_reconciler.py`: a failed create puts the retained marker back with its owner, `depends_on`, reason and timestamp; the eviction order survives repeated failed attempts; a create that commits leaves the directory adopted; a purged directory is not re-marked; a marker written during the create survives; a failed inner create does not re-mark a directory the outer create still holds; a restore that raises does not mask the create failure.
- `tests/supervisor/test_reclaimable.py`: `adopt()`/`restore_markers()` round trip across both pools a VM spans, `size_bytes` is re-measured, a directory that is gone is skipped.
- `tests/supervisor/views/test_operator_retire.py`: end to end on the real marker machinery, an owner's erase of retained disks still returns 200 after a failed re-create (it was a 404 before the fix).
- Checks: `pytest tests/supervisor` (1207 passed, 1 skipped, 1 pre-existing journald failure in `test_log.py::test_make_logs_queue`, identical on the base commit), `ruff format --diff`, `isort --check-only --profile black`, `mypy` on the changed files and on `src/aleph/vm/` (all exit 0). No Rust touched.

## Review follow-up (rebased onto dev-2.1 at 973b8fd7)
- `tests/supervisor/test_reconciler.py`: a test that a create cancelled while inside the context also restores the markers it adopted, the half of the `BaseException` clause `Exception` does not cover. It fails when the clause is narrowed.
- Not changed: the partial-adopt corner (an `adopt` that raises after clearing one pool's marker). Those directories fall back to orphan recovery, which is what happened before this PR.
- Checks on the rebased branch: `ruff format --diff`, `isort --check-only --profile black`, `mypy` clean. Test suites are left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZyMqLgxxVfeDwiNy34sfM

