### PR TITLE
fix(agent): leave a VM its owner stopped alone; a push acknowledges it, never restarts it

### DIFF
--- a/docs/architecture/vm-lifecycle.md
+++ b/docs/architecture/vm-lifecycle.md
@@ -253,6 +253,37 @@ have to restart. `StopVm` and `StartVm` on an ephemeral program are flatly
 "stopped but still defined" state for a program (no on-disk config, no
 systemd unit to restart), so the daemon refuses rather than faking one.
 
+The agent's allocation loop respects that stop, and respects it for good.
+The loop converges the node onto the scheduler's plan, and a planned VM that
+is down is normally started again on the next pass, but a VM that was stopped
+is a decision somebody made: the owner's through
+`/control/machine/{ref}/stop`, or the guest's own shutdown. The loop
+therefore treats STOPPED and STOPPING as terminal, full stop. A stop event
+does not wake it, its backstop pass leaves the VM alone, and a plan naming
+the VM does not restart it either: the owner stopped it, and the owner is who
+starts it again, through the same operator API. The executions list carries
+no allocation block for it, since the supervisor already reports STOPPED and
+the agent has nothing to add. It does keep reporting a start it was asked to
+make and could not: a VM left stopped because its create failed still carries
+the failure and the attempt count, which is the node's news rather than the
+owner's. FAILED is the opposite case, nobody's decision, so the loop rebuilds
+it on the event, damped by the retry backoff. Without the split an owner
+could not keep a planned VM stopped at all, since the plan is level-triggered
+and re-pushed for as long as the VM is allocated here.
+
+What the scheduler is told is that the VM is here. A plan entry for a stopped
+VM is answered `unchanged`, the same answer a running one gets, because the
+scheduler's belief that the VM is allocated to this node is exactly what has
+not changed. The node keeps committing its memory, vCPUs and disk for it too:
+the definition and the volumes are still allocated, and forgetting them would
+let the node promise the same room twice. Unallocating a stopped VM stays the
+scheduler's own move, made by dropping the hash from the plan, which the loop
+reads as a teardown like any other.
+
+This diverges from v1, where an allocation push restarted a stopped VM. The
+node answered every push by starting whatever it held down, so an owner's
+stop lasted until the next push and no longer.
+
 ### Idle expiry
 
 Idle teardown is agent policy, not something the supervisor knows about: the

--- a/src/aleph/vm/agent/allocation/plan.py
+++ b/src/aleph/vm/agent/allocation/plan.py
@@ -22,6 +22,14 @@ logger = logging.getLogger(__name__)
 # again would be a second VM under the same hash.
 LIVE_STATUSES = (VmStatus.RUNNING, VmStatus.BOOTING, VmStatus.DEFINED)
 
+# States a VM only reaches because it was told to: the owner's stop through the
+# operator API, or a guest shutting itself down. The definition and the disks
+# survive, so the VM is down rather than lost, and starting it again is the
+# owner's call and nobody else's. STOPPING is here too because a stop caught
+# mid-flight is still a stop: a caller that read it as work to do would wait
+# the VM out and then recreate it from scratch.
+STOPPED_STATUSES = (VmStatus.STOPPING, VmStatus.STOPPED)
+
 
 def by_hash(infos: list[VmInfo]) -> dict[ItemHash, VmInfo]:
     """The supervisor's VMs, keyed by item hash.

--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -6,6 +6,22 @@ an empty diff and a plan arriving mid-convergence simply wins at the next step
 boundary. This is the seam pull mode plugs into: replacing "the scheduler
 pushed a plan" with "the agent fetched a plan" is a change to submit()'s
 caller and nothing else.
+
+One asymmetry runs through the loop: a VM that is stopped and a VM that is
+dead are not the same thing. A stop is somebody's decision, the owner's
+through the operator API or the guest's own, and only its owner undoes it:
+the loop never starts a stopped VM, not on a down event, not on its own
+backstop interval, and not because a plan lists it. A VM that failed is
+nobody's decision, so the loop rebuilds it on the event, damped by the
+backoff. Without that split the owner could not keep a planned VM down at
+all, since the plan is level-triggered and re-pushed for as long as the VM is
+allocated here.
+
+What the scheduler is told about a stopped VM is that it is here: the plan
+naming it is answered "unchanged", and the node goes on committing its
+memory, vCPUs and disk for it, because the definition and the volumes are
+still allocated. Unallocating it stays the scheduler's own move, made by
+dropping the hash from the plan, which the loop reads as a teardown.
 """
 
 import asyncio
@@ -18,6 +34,7 @@ from aleph_message.models import ItemHash
 
 from aleph.vm.agent.allocation.plan import (
     LIVE_STATUSES,
+    STOPPED_STATUSES,
     AllocationPlan,
     AllocationState,
     FailureRecord,
@@ -97,9 +114,18 @@ class AllocationReconciler:
                 self._forget(vm_hash)
         self._wakeup.set()
 
-    def notify_vm_down(self, vm_id: str) -> None:
-        """A VM went STOPPED or FAILED. If the plan still wants it, converge."""
+    def notify_vm_down(self, vm_id: str, status: VmStatus | None) -> None:
+        """A VM went down. If the plan still wants it up, converge now.
+
+        `status` is what the supervisor reported, or None when the VM is gone
+        from its list entirely. A stop is not a death: the loop has nothing to
+        do about a VM somebody stopped, so a stop does not wake it, while a VM
+        that failed or vanished is rebuilt at once rather than at the backstop
+        interval.
+        """
         if self._desired is None:
+            return
+        if status in STOPPED_STATUSES:
             return
         try:
             vm_hash = ItemHash(str(vm_id))
@@ -210,6 +236,25 @@ class AllocationReconciler:
         for vm_hash in plan.entries:
             if vm_hash in live:
                 continue
+            info = known.get(vm_hash)
+            if info is not None and info.status in STOPPED_STATUSES:
+                # Somebody stopped this VM, so it stays stopped: the plan
+                # listing it says the scheduler still holds it here, not that
+                # the node should overrule the owner. What the agent still has
+                # to report is whether its last attempt failed: a stop is not
+                # the agent's news to tell, since the supervisor already says
+                # STOPPED, but a start the node was asked to make and could
+                # not is. Only the phase is cleared, and the failure record is
+                # deliberately left standing: it is the attempt history, and a
+                # VM that failed twice, sat stopped a while and then crashed
+                # should climb the ladder from where it was rather than from
+                # the bottom. _forget_settled drops it once the VM has been up
+                # long enough to call healthy.
+                if vm_hash in self._failures:
+                    self._states[vm_hash] = AllocationState.FAILED
+                else:
+                    self._states.pop(vm_hash, None)
+                continue
             if not self._retry_due(vm_hash, now):
                 # Down and waiting out its backoff. Saying so is what lets the
                 # executions list report the wait and the time it ends, rather
@@ -254,10 +299,9 @@ class AllocationReconciler:
 
         `down` is what the supervisor holds for it when it already has one,
         which makes this start a rebuild and charges it on the backoff ladder.
-        Whatever state the supervisor held the VM in is charged, not only the
-        FAILED of a guest that panicked: a guest that halt loops needs the wait
-        as much as one that panics, and a resume being cheaper than a rebuild
-        is no reason to let it loop at boot speed forever.
+        Only a VM the supervisor holds FAILED reaches here with one: a live VM
+        needs nothing done to it, and one that is stopped or stopping is left
+        alone by _start_missing, since nobody but its owner restarts it.
         """
         self._states[vm_hash] = AllocationState.DOWNLOADING
         try:

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -14,6 +14,7 @@ from aleph_message.models import ExecutableContent, ItemHash
 
 from aleph.vm.agent.allocation.plan import (
     LIVE_STATUSES,
+    STOPPED_STATUSES,
     AllocationPlan,
     PlannedVm,
     PlanVerdict,
@@ -176,7 +177,15 @@ def compute_verdict(
 
     for vm_hash, info in known.items():
         if vm_hash in plan.entries:
-            if info.status in LIVE_STATUSES or info.awaiting_confidential_init:
+            # A VM this node already holds, up or stopped, is acknowledged
+            # rather than sized: what the answer reports is that the
+            # scheduler's belief the VM is allocated here still holds. A
+            # stopped VM stays that way until its owner starts it, and its
+            # registry record goes on committing its memory and vCPUs, so
+            # sizing it as a candidate would let a node that is tight on room
+            # refuse a VM it is already holding, and a refusal is what takes
+            # the VM out of the plan the loop converges on.
+            if info.status in LIVE_STATUSES or info.status in STOPPED_STATUSES or info.awaiting_confidential_init:
                 unchanged.add(vm_hash)
                 verdict.unchanged.append(vm_hash)
             # A planned VM the supervisor holds dead is about to be created

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -734,10 +734,10 @@ class CapacityManager:
         """The disk this candidate still has to find room for on this node.
 
         A candidate can already hold its volumes here: the scheduler re-lists
-        a VM the supervisor is holding stopped, and a VM in that state is
-        sized as a candidate rather than read as unchanged. Charging it the
-        space its own files occupy refuses a VM the create path would have
-        admitted, and a refusal is what takes it out of the plan.
+        a VM the supervisor is holding dead, and a VM in that state is sized
+        as a candidate to be rebuilt rather than read as unchanged. Charging
+        it the space its own files occupy refuses a VM the create path would
+        have admitted, and a refusal is what takes it out of the plan.
 
         Requirements built from a message carry the volumes they were summed
         from; requirements a caller assembled as bare scalars are judged as

--- a/src/aleph/vm/agent/supervisor.py
+++ b/src/aleph/vm/agent/supervisor.py
@@ -207,7 +207,9 @@ async def _reconcile_after_event_gap(app: web.Application) -> None:
             await _drop_vm_state(app, vm_id)
             # Same nudge the live stream gives: a VM that died during the gap
             # is still planned, and should not wait out the backstop interval.
-            app["allocation_reconciler"].notify_vm_down(vm_id)
+            # The status goes with it, since the reconciler leaves a VM that
+            # was stopped alone and rebuilds one that failed or vanished.
+            app["allocation_reconciler"].notify_vm_down(vm_id, status)
 
 
 async def watch_supervisor_events(app: web.Application) -> None:
@@ -236,9 +238,11 @@ async def watch_supervisor_events(app: web.Application) -> None:
             async for event in supervisor.watch_events():
                 if event.new_status in (VmStatus.STOPPED, VmStatus.FAILED):
                     await _drop_vm_state(app, event.vm_id)
-                    # If the plan still wants this VM, converge now rather than
-                    # waiting out the reconciler's backstop interval.
-                    app["allocation_reconciler"].notify_vm_down(event.vm_id)
+                    # If the plan still wants this VM up, converge now rather
+                    # than waiting out the reconciler's backstop interval. The
+                    # new status decides whether it does: a VM somebody
+                    # stopped waits for its owner to start it again.
+                    app["allocation_reconciler"].notify_vm_down(event.vm_id, event.new_status)
         except NotImplementedSupervisorError:
             logger.info("Supervisor does not implement WatchEvents; agent state relies on its own reaps only")
             return

--- a/tests/supervisor/test_allocation_reconciler.py
+++ b/tests/supervisor/test_allocation_reconciler.py
@@ -474,6 +474,219 @@ async def test_a_rebuild_the_plan_dropped_mid_flight_is_not_remembered(reconcile
     assert reconciler.state_for(HASH_C) == (None, None)
 
 
+# ── A VM the owner stopped ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_an_owner_stopped_vm_stays_stopped_until_the_next_push(reconciler, monkeypatch):
+    """Stop means stop. The operator API leaves a persistent VM STOPPED and
+    still defined, and the loop used to read that as a VM it owed a start: the
+    down event woke it and the next pass started the VM again, so the owner
+    could not keep a planned VM down for more than a few seconds. Only a
+    scheduler push starts a stopped VM."""
+    listed = _boots_then(reconciler, monkeypatch, status=VmStatus.RUNNING)
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+    assert reconciler.started == [HASH_C]
+
+    listed[:] = [_info(HASH_C, status=VmStatus.STOPPED)]
+    await reconciler._converge_once()
+
+    assert reconciler.started == [HASH_C]
+
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+
+    assert reconciler.started == [HASH_C, HASH_C]
+
+
+@pytest.mark.asyncio
+async def test_a_stop_does_not_wake_the_loop_but_a_failure_does(reconciler):
+    """The watcher reports both, and the loop has work to do for one of them:
+    a stopped VM waits for the next push, a failed one is rebuilt now."""
+    reconciler.submit(_plan(HASH_C))
+    reconciler._wakeup.clear()
+
+    reconciler.notify_vm_down(str(HASH_C), VmStatus.STOPPED)
+    assert reconciler._wakeup.is_set() is False
+
+    reconciler.notify_vm_down(str(HASH_C), VmStatus.FAILED)
+    assert reconciler._wakeup.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_a_vm_that_died_is_still_rebuilt_on_a_nudge(reconciler, monkeypatch):
+    """The complement: only a stop is the owner's word. A guest that crashed
+    is rebuilt on the event, without waiting for a push."""
+    listed = _boots_then(reconciler, monkeypatch, status=VmStatus.RUNNING)
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+    reconciler._wakeup.clear()
+
+    listed[:] = [_info(HASH_C, status=VmStatus.FAILED)]
+    reconciler.notify_vm_down(str(HASH_C), VmStatus.FAILED)
+    assert reconciler._wakeup.is_set() is True
+
+    await reconciler._converge_once()
+
+    assert reconciler.started == [HASH_C, HASH_C]
+
+
+@pytest.mark.asyncio
+async def test_restarting_a_stopped_vm_on_a_push_costs_no_attempt(reconciler, monkeypatch):
+    """A stop is not a failure. Charging the push-driven restart like a crash
+    would put an owner who stops and starts a VM on the crash-loop backoff,
+    and label the VM failed in the executions list on the way."""
+    listed = _boots_then(reconciler, monkeypatch, status=VmStatus.RUNNING)
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+
+    listed[:] = [_info(HASH_C, status=VmStatus.STOPPED)]
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+
+    assert reconciler.started == [HASH_C, HASH_C]
+    assert reconciler.state_for(HASH_C) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_a_stopped_vm_waiting_for_a_push_reports_nothing(reconciler, monkeypatch):
+    """What the executions list renders while the VM waits. The supervisor
+    already says STOPPED, and the agent has no plan of its own for it, so an
+    allocation block would have to claim the VM is failing or being worked on,
+    and neither is true."""
+    listed = _boots_then(reconciler, monkeypatch, status=VmStatus.RUNNING)
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+
+    listed[:] = [_info(HASH_C, status=VmStatus.STOPPED)]
+    await reconciler._converge_once()
+
+    assert reconciler.state_for(HASH_C) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_a_vm_caught_mid_stop_is_left_alone_until_a_push_asks(reconciler, monkeypatch):
+    """A stop caught in flight is still a stop. Read as work to do, STOPPING
+    sends the loop down start_persistent_vm's wait-until-gone path and the VM
+    is recreated from scratch, so a pass that owes nothing has to leave it be
+    and a push has to be able to ask for it all the same."""
+    listed = _boots_then(reconciler, monkeypatch, status=VmStatus.RUNNING)
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+    assert reconciler.started == [HASH_C]
+
+    listed[:] = [_info(HASH_C, status=VmStatus.STOPPING)]
+    await reconciler._converge_once()
+
+    assert reconciler.started == [HASH_C]
+    assert reconciler.state_for(HASH_C) == (None, None)
+
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+
+    assert reconciler.started == [HASH_C, HASH_C]
+
+
+@pytest.mark.asyncio
+async def test_a_push_start_that_failed_is_not_retried_by_the_next_pass(reconciler, monkeypatch):
+    """One start per push, on the failing path too. The ask is spent when the
+    start is made, not when it succeeds, so a guest that cannot be started is
+    tried once and then waits for the next push. Spending it on success
+    instead would have the loop retry at pass cadence, which is the loop
+    starting a stopped VM on its own."""
+    _record_starts(reconciler, monkeypatch, fail=True)
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_C, status=VmStatus.STOPPED)]
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+
+    attempts = _record_starts(reconciler, monkeypatch, fail=True)
+    await reconciler._converge_once()
+    await reconciler._converge_once()
+
+    assert attempts.attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_a_push_restarts_a_stopped_vm_even_with_a_backoff_pending(reconciler, monkeypatch):
+    """A push is the authority on a stopped VM, so it is answered on the pass
+    it arrives, not at the next slot an earlier failure left. The backoff
+    exists to bound what the loop does on its own; a push is not that."""
+    _record_starts(reconciler, monkeypatch, fail=True)
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+    _, failure = reconciler.state_for(HASH_C)
+    assert failure.next_retry_at > NOW
+
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_C, status=VmStatus.STOPPED)]
+    _record_starts(reconciler, monkeypatch)
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+
+    assert reconciler.started == [HASH_C]
+
+
+@pytest.mark.asyncio
+async def test_a_push_landing_mid_pass_is_not_answered_by_that_pass(reconciler, monkeypatch):
+    """A pass works off the list it was handed, which a push arriving while it
+    was parked in list_vms has already made stale. The VM is stopped and the
+    push wants it back, but this pass still sees it running, so it has nothing
+    to do about it: marking the push answered here would swallow it, and the
+    VM would stay stopped until the push after next."""
+    _record_starts(reconciler, monkeypatch)
+    listed = [_info(HASH_C, status=VmStatus.RUNNING)]
+
+    async def list_vms():
+        snapshot = list(listed)
+        if listed[0].status is VmStatus.RUNNING:
+            # The owner stops the VM and the scheduler re-pushes the plan
+            # while the pass is parked here.
+            listed[0] = _info(HASH_C, status=VmStatus.STOPPED)
+            reconciler.submit(_plan(HASH_C))
+        return snapshot
+
+    reconciler.supervisor.list_vms = list_vms
+    reconciler.submit(_plan(HASH_C))
+
+    await reconciler._converge_once()
+    assert reconciler.started == []
+
+    await reconciler._converge_once()
+
+    assert reconciler.started == [HASH_C]
+
+
+@pytest.mark.asyncio
+async def test_a_stopped_vm_whose_push_start_failed_still_says_why(reconciler, monkeypatch):
+    """The push bought a start and it raised, so the VM is stopped and waiting
+    for the next push. The scheduler still has to be told the node tried and
+    what went wrong, rather than reading a plain stopped VM the agent appears
+    to have no opinion about."""
+    _record_starts(reconciler, monkeypatch, fail=True)
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_C, status=VmStatus.STOPPED)]
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
+
+    await reconciler._converge_once()
+
+    state, failure = reconciler.state_for(HASH_C)
+    assert state is AllocationState.FAILED
+    assert failure.code == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_a_vm_stopped_before_any_push_is_started_by_the_first_one(reconciler, monkeypatch):
+    """The other side of the gate: a plan that lists a VM this node happens to
+    hold stopped is still a plan to run it."""
+    _record_starts(reconciler, monkeypatch)
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_C, status=VmStatus.STOPPED)]
+    reconciler.submit(_plan(HASH_C))
+
+    await reconciler._converge_once()
+
+    assert reconciler.started == [HASH_C]
+
+
 def test_pending_hashes_are_the_entries_the_push_carried_no_message_for(reconciler):
     reconciler.submit(
         AllocationPlan(
@@ -540,7 +753,9 @@ async def test_the_event_watcher_nudges_the_reconciler_when_a_vm_goes_down():
     task.cancel()
     await asyncio.gather(task, return_exceptions=True)
 
-    app["allocation_reconciler"].notify_vm_down.assert_called_once_with(vm_id)
+    # The status travels with the nudge: what the reconciler owes a VM that
+    # went down depends on whether somebody stopped it or it died.
+    app["allocation_reconciler"].notify_vm_down.assert_called_once_with(vm_id, VmStatus.STOPPED)
 
 
 @pytest.mark.asyncio
@@ -550,10 +765,10 @@ async def test_notify_vm_down_wakes_the_loop_only_for_a_planned_vm(reconciler):
     reconciler.submit(_plan(HASH_C))
     reconciler._wakeup.clear()
 
-    reconciler.notify_vm_down(str(HASH_B))
+    reconciler.notify_vm_down(str(HASH_B), VmStatus.FAILED)
     assert reconciler._wakeup.is_set() is False
 
-    reconciler.notify_vm_down(str(HASH_C))
+    reconciler.notify_vm_down(str(HASH_C), VmStatus.FAILED)
     assert reconciler._wakeup.is_set() is True
 
 

--- a/tests/supervisor/test_allocation_reconciler.py
+++ b/tests/supervisor/test_allocation_reconciler.py
@@ -478,12 +478,14 @@ async def test_a_rebuild_the_plan_dropped_mid_flight_is_not_remembered(reconcile
 
 
 @pytest.mark.asyncio
-async def test_an_owner_stopped_vm_stays_stopped_until_the_next_push(reconciler, monkeypatch):
+async def test_an_owner_stopped_vm_is_left_alone_even_when_the_plan_lists_it(reconciler, monkeypatch):
     """Stop means stop. The operator API leaves a persistent VM STOPPED and
     still defined, and the loop used to read that as a VM it owed a start: the
-    down event woke it and the next pass started the VM again, so the owner
-    could not keep a planned VM down for more than a few seconds. Only a
-    scheduler push starts a stopped VM."""
+    down event woke it and the next pass started the VM again. A push does not
+    override it either, which is the whole of the rule: the plan is
+    level-triggered and re-pushed for as long as the VM is allocated here, so
+    a push that restarted it would leave the owner unable to keep the VM down
+    at all. Whoever stopped it is who starts it again."""
     listed = _boots_then(reconciler, monkeypatch, status=VmStatus.RUNNING)
     reconciler.submit(_plan(HASH_C))
     await reconciler._converge_once()
@@ -491,19 +493,16 @@ async def test_an_owner_stopped_vm_stays_stopped_until_the_next_push(reconciler,
 
     listed[:] = [_info(HASH_C, status=VmStatus.STOPPED)]
     await reconciler._converge_once()
-
-    assert reconciler.started == [HASH_C]
-
     reconciler.submit(_plan(HASH_C))
     await reconciler._converge_once()
 
-    assert reconciler.started == [HASH_C, HASH_C]
+    assert reconciler.started == [HASH_C]
 
 
 @pytest.mark.asyncio
 async def test_a_stop_does_not_wake_the_loop_but_a_failure_does(reconciler):
     """The watcher reports both, and the loop has work to do for one of them:
-    a stopped VM waits for the next push, a failed one is rebuilt now."""
+    a stopped VM is left where its owner put it, a failed one is rebuilt now."""
     reconciler.submit(_plan(HASH_C))
     reconciler._wakeup.clear()
 
@@ -516,8 +515,8 @@ async def test_a_stop_does_not_wake_the_loop_but_a_failure_does(reconciler):
 
 @pytest.mark.asyncio
 async def test_a_vm_that_died_is_still_rebuilt_on_a_nudge(reconciler, monkeypatch):
-    """The complement: only a stop is the owner's word. A guest that crashed
-    is rebuilt on the event, without waiting for a push."""
+    """The complement: only a stop is somebody's decision. A guest that
+    crashed is rebuilt on the event, without waiting for anything."""
     listed = _boots_then(reconciler, monkeypatch, status=VmStatus.RUNNING)
     reconciler.submit(_plan(HASH_C))
     await reconciler._converge_once()
@@ -533,25 +532,8 @@ async def test_a_vm_that_died_is_still_rebuilt_on_a_nudge(reconciler, monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_restarting_a_stopped_vm_on_a_push_costs_no_attempt(reconciler, monkeypatch):
-    """A stop is not a failure. Charging the push-driven restart like a crash
-    would put an owner who stops and starts a VM on the crash-loop backoff,
-    and label the VM failed in the executions list on the way."""
-    listed = _boots_then(reconciler, monkeypatch, status=VmStatus.RUNNING)
-    reconciler.submit(_plan(HASH_C))
-    await reconciler._converge_once()
-
-    listed[:] = [_info(HASH_C, status=VmStatus.STOPPED)]
-    reconciler.submit(_plan(HASH_C))
-    await reconciler._converge_once()
-
-    assert reconciler.started == [HASH_C, HASH_C]
-    assert reconciler.state_for(HASH_C) == (None, None)
-
-
-@pytest.mark.asyncio
-async def test_a_stopped_vm_waiting_for_a_push_reports_nothing(reconciler, monkeypatch):
-    """What the executions list renders while the VM waits. The supervisor
+async def test_a_stopped_vm_reports_nothing_of_its_own(reconciler, monkeypatch):
+    """What the executions list renders for a stopped VM. The supervisor
     already says STOPPED, and the agent has no plan of its own for it, so an
     allocation block would have to claim the VM is failing or being worked on,
     and neither is true."""
@@ -566,11 +548,11 @@ async def test_a_stopped_vm_waiting_for_a_push_reports_nothing(reconciler, monke
 
 
 @pytest.mark.asyncio
-async def test_a_vm_caught_mid_stop_is_left_alone_until_a_push_asks(reconciler, monkeypatch):
+async def test_a_vm_caught_mid_stop_is_left_alone_too(reconciler, monkeypatch):
     """A stop caught in flight is still a stop. Read as work to do, STOPPING
-    sends the loop down start_persistent_vm's wait-until-gone path and the VM
-    is recreated from scratch, so a pass that owes nothing has to leave it be
-    and a push has to be able to ask for it all the same."""
+    sends the loop down start_persistent_vm's wait-until-gone path, so it
+    would wait the VM out and recreate from scratch the one the owner is only
+    stopping."""
     listed = _boots_then(reconciler, monkeypatch, status=VmStatus.RUNNING)
     reconciler.submit(_plan(HASH_C))
     await reconciler._converge_once()
@@ -578,95 +560,41 @@ async def test_a_vm_caught_mid_stop_is_left_alone_until_a_push_asks(reconciler, 
 
     listed[:] = [_info(HASH_C, status=VmStatus.STOPPING)]
     await reconciler._converge_once()
+    reconciler.submit(_plan(HASH_C))
+    await reconciler._converge_once()
 
     assert reconciler.started == [HASH_C]
     assert reconciler.state_for(HASH_C) == (None, None)
 
-    reconciler.submit(_plan(HASH_C))
-    await reconciler._converge_once()
-
-    assert reconciler.started == [HASH_C, HASH_C]
-
 
 @pytest.mark.asyncio
-async def test_a_push_start_that_failed_is_not_retried_by_the_next_pass(reconciler, monkeypatch):
-    """One start per push, on the failing path too. The ask is spent when the
-    start is made, not when it succeeds, so a guest that cannot be started is
-    tried once and then waits for the next push. Spending it on success
-    instead would have the loop retry at pass cadence, which is the loop
-    starting a stopped VM on its own."""
-    _record_starts(reconciler, monkeypatch, fail=True)
+async def test_a_vm_this_node_already_holds_stopped_is_not_started_by_a_plan(reconciler, monkeypatch):
+    """The rule does not rest on the loop remembering that it started the VM.
+    After an agent restart the loop knows nothing about who stopped what, and
+    a plan listing a VM this node holds stopped says the VM is allocated here,
+    not that the node should boot it."""
+    _record_starts(reconciler, monkeypatch)
     reconciler.supervisor.list_vms.return_value = [_info(HASH_C, status=VmStatus.STOPPED)]
     reconciler.submit(_plan(HASH_C))
-    await reconciler._converge_once()
-
-    attempts = _record_starts(reconciler, monkeypatch, fail=True)
-    await reconciler._converge_once()
-    await reconciler._converge_once()
-
-    assert attempts.attempts == 0
-
-
-@pytest.mark.asyncio
-async def test_a_push_restarts_a_stopped_vm_even_with_a_backoff_pending(reconciler, monkeypatch):
-    """A push is the authority on a stopped VM, so it is answered on the pass
-    it arrives, not at the next slot an earlier failure left. The backoff
-    exists to bound what the loop does on its own; a push is not that."""
-    _record_starts(reconciler, monkeypatch, fail=True)
-    reconciler.submit(_plan(HASH_C))
-    await reconciler._converge_once()
-    _, failure = reconciler.state_for(HASH_C)
-    assert failure.next_retry_at > NOW
-
-    reconciler.supervisor.list_vms.return_value = [_info(HASH_C, status=VmStatus.STOPPED)]
-    _record_starts(reconciler, monkeypatch)
-    reconciler.submit(_plan(HASH_C))
-    await reconciler._converge_once()
-
-    assert reconciler.started == [HASH_C]
-
-
-@pytest.mark.asyncio
-async def test_a_push_landing_mid_pass_is_not_answered_by_that_pass(reconciler, monkeypatch):
-    """A pass works off the list it was handed, which a push arriving while it
-    was parked in list_vms has already made stale. The VM is stopped and the
-    push wants it back, but this pass still sees it running, so it has nothing
-    to do about it: marking the push answered here would swallow it, and the
-    VM would stay stopped until the push after next."""
-    _record_starts(reconciler, monkeypatch)
-    listed = [_info(HASH_C, status=VmStatus.RUNNING)]
-
-    async def list_vms():
-        snapshot = list(listed)
-        if listed[0].status is VmStatus.RUNNING:
-            # The owner stops the VM and the scheduler re-pushes the plan
-            # while the pass is parked here.
-            listed[0] = _info(HASH_C, status=VmStatus.STOPPED)
-            reconciler.submit(_plan(HASH_C))
-        return snapshot
-
-    reconciler.supervisor.list_vms = list_vms
-    reconciler.submit(_plan(HASH_C))
 
     await reconciler._converge_once()
+
     assert reconciler.started == []
-
-    await reconciler._converge_once()
-
-    assert reconciler.started == [HASH_C]
+    assert reconciler.state_for(HASH_C) == (None, None)
 
 
 @pytest.mark.asyncio
-async def test_a_stopped_vm_whose_push_start_failed_still_says_why(reconciler, monkeypatch):
-    """The push bought a start and it raised, so the VM is stopped and waiting
-    for the next push. The scheduler still has to be told the node tried and
-    what went wrong, rather than reading a plain stopped VM the agent appears
-    to have no opinion about."""
+async def test_a_stopped_vm_whose_last_start_failed_still_says_why(reconciler, monkeypatch):
+    """A start the node was asked to make and could not is its own news, and
+    it survives the VM turning up stopped: the create got as far as defining
+    the VM and then raised. An owner's stop is nothing for the agent to
+    report, since the supervisor already says STOPPED, but the failure and the
+    attempt count behind it are."""
     _record_starts(reconciler, monkeypatch, fail=True)
-    reconciler.supervisor.list_vms.return_value = [_info(HASH_C, status=VmStatus.STOPPED)]
     reconciler.submit(_plan(HASH_C))
     await reconciler._converge_once()
 
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_C, status=VmStatus.STOPPED)]
     await reconciler._converge_once()
 
     state, failure = reconciler.state_for(HASH_C)
@@ -675,16 +603,18 @@ async def test_a_stopped_vm_whose_push_start_failed_still_says_why(reconciler, m
 
 
 @pytest.mark.asyncio
-async def test_a_vm_stopped_before_any_push_is_started_by_the_first_one(reconciler, monkeypatch):
-    """The other side of the gate: a plan that lists a VM this node happens to
-    hold stopped is still a plan to run it."""
+async def test_a_stopped_vm_the_plan_stops_naming_is_still_torn_down(reconciler, monkeypatch):
+    """The scheduler's own move, and the only one that ends a stop. Refusing
+    to restart a stopped VM is not holding on to it forever: dropping the hash
+    unallocates it, and the sweep reaps a stopped VM the way it reaps a
+    running one."""
     _record_starts(reconciler, monkeypatch)
-    reconciler.supervisor.list_vms.return_value = [_info(HASH_C, status=VmStatus.STOPPED)]
-    reconciler.submit(_plan(HASH_C))
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_B, status=VmStatus.STOPPED)]
+    reconciler.submit(_plan())
 
     await reconciler._converge_once()
 
-    assert reconciler.started == [HASH_C]
+    assert reconciler_module.teardown_vm.await_args.args[0] == HASH_B
 
 
 def test_pending_hashes_are_the_entries_the_push_carried_no_message_for(reconciler):

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -70,6 +70,38 @@ def test_a_running_vm_still_in_the_plan_is_unchanged():
     assert verdict.accepted == []
 
 
+def test_a_stopped_vm_still_in_the_plan_is_unchanged_and_never_sized():
+    """A VM this node holds stopped is a VM this node holds. The scheduler's
+    belief that it is allocated here is exactly what has not changed, so the
+    answer says so instead of sizing it: sized as a candidate, a node that is
+    tight on room refuses a VM it is already holding, and a refusal is what
+    takes the VM out of the plan the loop converges on."""
+    capacity = _capacity([])
+
+    verdict = compute_verdict(
+        _plan(HASH_A),
+        infos=[_info(HASH_A, status=VmStatus.STOPPED)],
+        registry=_registry({HASH_A: _record()}),
+        capacity=capacity,
+    )
+
+    assert verdict.unchanged == [HASH_A]
+    assert verdict.accepted == []
+    assert capacity.simulate.call_args.args[0] == []
+
+
+def test_a_vm_caught_mid_stop_is_unchanged_too():
+    """STOPPING is a stop in flight, not a VM to rebuild."""
+    verdict = compute_verdict(
+        _plan(HASH_A),
+        infos=[_info(HASH_A, status=VmStatus.STOPPING)],
+        registry=_registry({HASH_A: _record()}),
+        capacity=_capacity([]),
+    )
+
+    assert verdict.unchanged == [HASH_A]
+
+
 def test_a_new_vm_that_fits_is_accepted():
     verdict = compute_verdict(
         _plan(HASH_C), infos=[], registry=_registry({}), capacity=_capacity([AdmissionVerdict(HASH_C, True)])
@@ -422,6 +454,55 @@ def _registry_holding(vm_hash, memory_mib):
     return registry
 
 
+def test_a_stopped_vm_keeps_its_capacity_committed(mocker):
+    """Not restarting a stopped VM is not forgetting it. The definition and
+    the volumes are still allocated, so its memory and vCPUs stay committed
+    and the headroom the node advertises stays reduced by them. Freeing them
+    on a stop is how a node over-provisions: it would promise the same room
+    to somebody else and then have nowhere to put the VM when its owner
+    starts it again."""
+    _tight_host(mocker)
+    registry = _registry_holding(HASH_C, 16384)
+    capacity = _real_capacity(mocker, memory_gib=40, registry=registry)
+
+    verdict = compute_verdict(
+        _plan(HASH_C),
+        infos=[_info(HASH_C, status=VmStatus.STOPPED)],
+        registry=registry,
+        capacity=capacity,
+    )
+
+    assert verdict.unchanged == [HASH_C]
+    # 40 GiB less the two reservations is a 30720 MiB bucket, less the
+    # stopped VM's 16384 MiB.
+    assert capacity.headroom()["instance_memory_mib"] == 30720 - 16384
+
+
+def test_a_newcomer_is_refused_the_room_a_stopped_vm_holds(mocker):
+    """The same guarantee from the other side. A is only admissible if C's
+    memory has been handed back, and it has not been: C is stopped, not gone.
+    The answer has to be no, or the node ends up with two VMs claiming one
+    bucket the moment C's owner starts it again."""
+    _tight_host(mocker)
+    registry = _registry_holding(HASH_C, 16384)
+    capacity = _real_capacity(mocker, memory_gib=40, registry=registry)
+    plan = AllocationPlan(
+        plan_id="sha256:test",
+        received_at=NOW,
+        entries={
+            HASH_C: PlannedVm(vm_hash=HASH_C, verified=_verified(_make_qemu_instance_message(memory=16384))),
+            HASH_A: PlannedVm(vm_hash=HASH_A, verified=_verified(_make_qemu_instance_message(memory=16384))),
+        },
+    )
+
+    verdict = compute_verdict(
+        plan, infos=[_info(HASH_C, status=VmStatus.STOPPED)], registry=registry, capacity=capacity
+    )
+
+    assert verdict.unchanged == [HASH_C]
+    assert verdict.rejected[HASH_A]["code"] == "insufficient_capacity"
+
+
 def test_compute_verdict_drives_the_real_capacity_manager(mocker):
     """Every other test here hands compute_verdict a double, so the shape of
     CapacityManager.simulate is never exercised: when the candidate tuple lost
@@ -447,7 +528,7 @@ def test_a_recreate_is_not_judged_against_its_own_stale_record(mocker):
 
     verdict = compute_verdict(
         _plan(HASH_C, content=_make_qemu_instance_message(memory=16384)),
-        infos=[_info(HASH_C, status=VmStatus.STOPPED)],
+        infos=[_info(HASH_C, status=VmStatus.FAILED)],
         registry=registry,
         capacity=capacity,
     )
@@ -473,9 +554,7 @@ def test_a_recreate_still_waiting_on_its_message_frees_nothing(mocker):
         },
     )
 
-    verdict = compute_verdict(
-        plan, infos=[_info(HASH_C, status=VmStatus.STOPPED)], registry=registry, capacity=capacity
-    )
+    verdict = compute_verdict(plan, infos=[_info(HASH_C, status=VmStatus.FAILED)], registry=registry, capacity=capacity)
 
     assert verdict.pending == [HASH_C]
     assert verdict.rejected[HASH_A]["code"] == "insufficient_capacity"
@@ -554,10 +633,10 @@ def test_narrowing_drops_what_the_answer_refused_and_nothing_else():
     assert narrowed.refused == frozenset({HASH_B})
 
 
-def test_a_stopped_vm_the_answer_refused_is_carried_as_refused():
-    """The chain the reconciler reads. The supervisor holds C stopped, so the
-    answer sizes it as a candidate instead of reading it as unchanged, and a
-    node with no room left refuses it. Narrowing has to keep it out of the
+def test_a_dead_vm_the_answer_refused_is_carried_as_refused():
+    """The chain the reconciler reads. The supervisor holds C dead, so the
+    answer sizes it as a candidate to rebuild instead of reading it as
+    unchanged, and a node with no room left refuses it. Narrowing has to keep it out of the
     entries, or the loop would retry it forever, but dropping it silently is
     what turned "rejected" into "deleted": to the loop a hash the plan does
     not list is one the scheduler took away, and it reaps the disks of every
@@ -567,7 +646,7 @@ def test_a_stopped_vm_the_answer_refused_is_carried_as_refused():
 
     verdict = compute_verdict(
         plan,
-        infos=[_info(HASH_C, status=VmStatus.STOPPED)],
+        infos=[_info(HASH_C, status=VmStatus.FAILED)],
         registry=_registry({HASH_C: _record()}),
         capacity=capacity,
     )
@@ -589,7 +668,7 @@ def test_a_vm_refused_for_an_undiscovered_node_hash_is_carried_as_refused():
 
     verdict = compute_verdict(
         plan,
-        infos=[_info(HASH_C, status=VmStatus.STOPPED)],
+        infos=[_info(HASH_C, status=VmStatus.FAILED)],
         registry=_registry({HASH_C: _record()}),
         capacity=_capacity([]),
         node_hash=None,

--- a/tests/supervisor/test_executions_list_allocation.py
+++ b/tests/supervisor/test_executions_list_allocation.py
@@ -162,6 +162,21 @@ async def test_a_vm_the_supervisor_holds_dead_still_carries_the_agents_failure(a
 
 
 @pytest.mark.asyncio
+async def test_a_planned_vm_the_owner_stopped_reports_only_the_supervisors_word(aiohttp_client):
+    """A VM waiting for the next push to be started again is not failing and
+    is not being worked on, so the agent has nothing to add: the reconciler
+    keeps no state for it and the listing renders no allocation block. Saying
+    "failed" here would report an owner's stop as a fault of the node."""
+    reconciler = _reconciler(planned=[HASH_A])
+
+    body = await _listing(aiohttp_client, _app(infos=[_info(HASH_A, VmStatus.STOPPED)], reconciler=reconciler))
+
+    assert body[str(HASH_A)]["state"] == "stopped"
+    assert body[str(HASH_A)]["allocation"] is None
+    assert body[str(HASH_A)]["running"] is False
+
+
+@pytest.mark.asyncio
 async def test_a_vm_the_supervisor_holds_dead_shows_the_recreate_in_flight(aiohttp_client):
     """The other half of the same claim: the loop is downloading for a VM
     the supervisor still lists as dead, so both words are out at once."""


### PR DESCRIPTION
## Summary
Stopping a persistent VM through the operator API leaves it STOPPED and still
defined, and the allocation loop read that as a VM it owed a start: the
supervisor's down event nudged the reconciler, STOPPED is not a live status,
and the next pass called `start_persistent_vm`, whose STOPPED branch resumes
the VM in place. The owner's stop came undone within seconds, and since the
crash backoff landed it also cost a rebuild attempt, so a VM the owner stopped
and started climbed the crash ladder and showed up as `failed` in the
executions list on the way.

The rule this PR settles on is that a VM this node already holds is
acknowledged by a push, in any state, and only its owner starts it again. A
push never restarts a VM in STOPPED or STOPPING, a stop event no longer wakes
the loop, and `compute_verdict` answers such a hash under `unchanged` instead
of sizing it through `simulate`: the scheduler's belief that the VM is
allocated here is exactly what has not changed. Sizing it would let a node
that is tight on room refuse a VM it is already holding, and a refusal is
what takes the VM out of the plan the loop converges on.

Accounting does not move. The stopped VM keeps its registry record, so its
memory, vCPUs and disk stay committed and the headroom advertised to the
scheduler stays reduced by them. Forgetting them on a stop is how a node
over-provisions: it would promise the same room to somebody else and have
nowhere to put the VM when its owner starts it again.

Teardown is unchanged, and it is how the scheduler unallocates a stopped VM:
a push that stops naming the hash tears it down like any other. FAILED is
unchanged too, nobody's decision, so the loop still rebuilds it under the
crash-loop backoff of #1214.

This diverges from v1 deliberately. In v1 an allocation push restarted a
stopped VM, so an owner's stop lasted until the next push and no longer. In
2.1 the push acknowledges the stop and the owner is the only one who ends it.

Stacked on #1214.

## Changes
- `allocation/plan.py`: new `STOPPED_STATUSES` (STOPPING, STOPPED), next to
  `LIVE_STATUSES`, because the verdict needs it as much as the loop does.
- `allocation/reconciler.py`: `notify_vm_down` takes the status (required:
  both callers have one) and does not wake the loop for a stop.
  `_start_missing` skips a planned hash the supervisor reports STOPPED or
  STOPPING, clearing its allocation phase and keeping any failure record as
  attempt history, so a VM that failed twice and then sat stopped climbs the
  ladder from where it was. `_start_one` documents that only a VM held FAILED
  now reaches it with a `down` info.
- `allocation/verdict.py`: a planned hash the supervisor holds stopped or
  stopping is answered `unchanged` and never reaches `simulate`.
- `supervisor.py`: the event watcher and the post-outage reconcile pass the
  status along with the nudge (None when the VM is gone from the list
  entirely, which still wakes the loop).
- `capacity.py`: `_candidate_disk`'s docstring said a re-listed stopped VM is
  sized as a candidate, which is now FAILED's case and not STOPPED's.
- `docs/architecture/vm-lifecycle.md`: the paragraph in "Stop, start, reboot"
  states the rule, the capacity guarantee and the v1 divergence.

STOPPING is treated as a stop as well: a pass that caught a stop in flight
would take `start_persistent_vm`'s wait-until-gone path and recreate the VM
from scratch, the same failure through a slower door.

## Test plan
- `tests/supervisor/test_allocation_reconciler.py`: an owner-stopped VM is
  left alone by a pass and by a re-pushed plan; a stop does not wake the loop
  while a failure does; a VM that died is still rebuilt on a nudge; a stopped
  VM reports no allocation state of its own; a VM caught mid-stop is left
  alone too; a VM this node already holds stopped is not started by a first
  plan either; a stopped VM whose last start failed still reports why; a
  stopped VM the plan stops naming is still torn down. The watcher test pins
  the status travelling with the nudge.
- `tests/supervisor/test_allocation_verdict.py`: a stopped or stopping entry
  is `unchanged` and `simulate` is called with no candidates; the headroom
  the node advertises stays reduced by a stopped VM's memory; a newcomer that
  would only fit if that VM were forgotten is refused
  `insufficient_capacity`. The recreate fixtures that used STOPPED as a
  stand-in for "a VM to build again" now use FAILED, the only status that
  still means that.
- `tests/supervisor/test_executions_list_allocation.py`: a planned VM the
  owner stopped renders `state: stopped` and no allocation block.
- Checks: `ruff format --diff` (exit 0), `isort --check-only --profile black`
  (exit 0), `mypy src/aleph/vm/ tests/` from the worktree root (Success, exit
  0). The test suites are left to CI on this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZyMqLgxxVfeDwiNy34sfM
