### PR TITLE
fix(daemon): resume a suspended GPU before the CC probe and cache the answer

### DIFF
--- a/docs/architecture/confidential.md
+++ b/docs/architecture/confidential.md
@@ -301,9 +301,18 @@ Blackwell, `0x1182cc` on Hopper, bits `[1:0]`), through the card's sysfs
 runs only against cards no VM's world-view entry currently attaches, reads
 the attached set fresh on the blocking task immediately before probing (a
 stale snapshot could otherwise race a concurrent `CreateVm`), and caches
-each card's mode until its attachment state changes; a card a guest owns is
-never read. A probe error or an unrecognized device id leaves the card's
-mode unknown, which advertises nothing.
+each card's answer; a card a guest owns is never read. A probe error or an
+unrecognized device id leaves the card's mode unknown, which advertises
+nothing. The cache is dropped for a card when its attachment state changes
+(a stop or a delete forgets it), and otherwise ages out on two windows: an
+hour for an answer that decoded to a mode, `ALEPH_VM_GPU_CC_MODE_TTL`
+seconds where an operator wants it shorter, and a fixed minute for an
+answer that carries none, so a card read while it was being reset (all
+ones, cached as unreadable) comes back within the minute rather than
+staying hidden for the hour. Reading the register wakes an idle card out
+of runtime suspend, so the windows are also what keeps the unauthenticated
+`/about` path from driving register reads at the request rate; the create
+and start gates never trust the cache and read the card themselves.
 
 **Gate.** `snp_config_slice` (`rust/crates/supervisor-daemon/src/lifecycle.rs`)
 admits a GPU onto an SEV-SNP spec only when the probed mode is exactly `On`

--- a/rust/crates/supervisor-daemon/src/config.rs
+++ b/rust/crates/supervisor-daemon/src/config.rs
@@ -186,6 +186,16 @@ pub struct Settings {
     /// unset bounds the reservation by total RAM minus the per-node headroom.
     /// Only read when `numa_hugepages` is on. Rust-only (no Python oracle).
     pub numa_hugepages_limit_mb: Option<u64>,
+
+    /// ALEPH_VM_GPU_CC_MODE_TTL, in SECONDS, default
+    /// [`crate::gpu_cc::DEFAULT_CC_MODE_TTL_SECS`] (3600). How long a GPU
+    /// confidential-computing mode that was read successfully is served
+    /// from the cache before the card is read again. The read wakes an idle
+    /// card out of runtime suspend, so this is the rate at which host-info
+    /// polling touches idle hardware; shorten it on a node whose cards are
+    /// re-moded often. An answer that carries no mode is held for a fixed
+    /// minute instead, whatever this says. Rust-only (no Python oracle).
+    pub gpu_cc_mode_ttl: u64,
 }
 
 /// conf.py DnsResolver: how DNS_NAMESERVERS is derived when unset.
@@ -374,6 +384,9 @@ impl Settings {
             .get_u32("NUMA_HUGEPAGES_HEADROOM_MB")?
             .unwrap_or(crate::hugepages::DEFAULT_HEADROOM_MB);
         let numa_hugepages_limit_mb = env.get_u64("NUMA_HUGEPAGES_LIMIT_MB")?;
+        let gpu_cc_mode_ttl = env
+            .get_u64("GPU_CC_MODE_TTL")?
+            .unwrap_or(crate::gpu_cc::DEFAULT_CC_MODE_TTL_SECS);
         let dns_resolution = match env.get("DNS_RESOLUTION") {
             None => DnsResolution::Detect,
             Some(value) if value == "detect" => DnsResolution::Detect,
@@ -428,6 +441,7 @@ impl Settings {
             numa_hugepages,
             numa_hugepages_headroom_mb,
             numa_hugepages_limit_mb,
+            gpu_cc_mode_ttl,
         })
     }
 

--- a/rust/crates/supervisor-daemon/src/config.rs
+++ b/rust/crates/supervisor-daemon/src/config.rs
@@ -657,6 +657,27 @@ mod tests {
     }
 
     #[test]
+    fn the_gpu_cc_mode_ttl_defaults_to_an_hour_and_is_tunable() {
+        // The long tier is the only one an operator sets: a node whose
+        // cards are re-moded often can shorten it, and the short tier for
+        // an answer with no mode is fixed in the probe module.
+        assert_eq!(
+            Settings::from_vars(vars(&[])).unwrap().gpu_cc_mode_ttl,
+            crate::gpu_cc::DEFAULT_CC_MODE_TTL_SECS
+        );
+        assert_eq!(
+            Settings::from_vars(vars(&[("ALEPH_VM_GPU_CC_MODE_TTL", "120")]))
+                .unwrap()
+                .gpu_cc_mode_ttl,
+            120
+        );
+        // A non-integer (or negative) value is a hard error, like the
+        // other int settings.
+        assert!(Settings::from_vars(vars(&[("ALEPH_VM_GPU_CC_MODE_TTL", "often")])).is_err());
+        assert!(Settings::from_vars(vars(&[("ALEPH_VM_GPU_CC_MODE_TTL", "-1")])).is_err());
+    }
+
+    #[test]
     fn defaults_mirror_conf_py() {
         let settings = Settings::from_vars(vars(&[])).unwrap();
         assert_eq!(settings.execution_root, PathBuf::from("/var/lib/aleph/vm"));

--- a/rust/crates/supervisor-daemon/src/error.rs
+++ b/rust/crates/supervisor-daemon/src/error.rs
@@ -41,6 +41,19 @@ pub enum DaemonError {
     #[error("GPU probe failed: {0}")]
     GpuProbe(String),
 
+    #[error("cannot read the confidential-computing register of the GPU at {pci_host}: {source}")]
+    GpuRegisterRead {
+        pci_host: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error(
+        "the GPU at {pci_host} answers 0xffffffff: it is powered down or off the bus, so its \
+         confidential-computing mode cannot be read"
+    )]
+    GpuUnreadable { pci_host: String },
+
     #[error("Device vendor not compatible")]
     IncompatibleGpuVendor,
 

--- a/rust/crates/supervisor-daemon/src/gpu_cc.rs
+++ b/rust/crates/supervisor-daemon/src/gpu_cc.rs
@@ -691,19 +691,44 @@ mod tests {
         );
     }
 
+    /// An answer of `mode` that a probe gave `age` ago.
+    fn aged(mode: Option<CcMode>, age: Duration) -> ProbedCcMode {
+        ProbedCcMode {
+            mode,
+            probed_at: Instant::now()
+                .checked_sub(age)
+                .expect("the process started after the ages used here"),
+        }
+    }
+
     #[test]
-    fn a_probe_answer_is_fresh_only_inside_its_window() {
+    fn a_decoded_mode_outlives_an_answer_that_carries_none() {
+        // The two tiers, at the ages that separate them: a mode is still
+        // served a minute in and only expires at the long window, while an
+        // answer with no mode (a card read during its reset, say) is read
+        // again after the short one, so a blink hides a card for a minute
+        // and not for an hour.
+        let windows = CcCacheWindows::with_mode_ttl(Duration::from_secs(3600));
+        assert_eq!(windows.unreadable, UNREADABLE_CC_MODE_TTL);
+        assert_eq!(windows.shortest(), UNREADABLE_CC_MODE_TTL);
+
         let answer = ProbedCcMode::now(Some(CcMode::On));
-        assert!(
-            answer.is_fresh(CcCacheWindows::with_mode_ttl(Duration::from_secs(
-                DEFAULT_CC_MODE_TTL_SECS
-            )))
-        );
-        assert!(!answer.is_fresh(CcCacheWindows {
+        assert_eq!(answer.mode, Some(CcMode::On));
+        assert!(answer.is_fresh(windows));
+
+        assert!(aged(Some(CcMode::On), Duration::from_secs(61)).is_fresh(windows));
+        assert!(!aged(Some(CcMode::On), Duration::from_secs(3601)).is_fresh(windows));
+        assert!(aged(None, Duration::from_secs(30)).is_fresh(windows));
+        assert!(!aged(None, Duration::from_secs(61)).is_fresh(windows));
+
+        // A zero-length pair expires everything, which is how the refresh
+        // tests force a read.
+        let expired = CcCacheWindows {
             mode: Duration::ZERO,
             unreadable: Duration::ZERO,
-        }));
-        assert_eq!(answer.mode, Some(CcMode::On));
+        };
+        assert!(!ProbedCcMode::now(Some(CcMode::On)).is_fresh(expired));
+        assert!(!ProbedCcMode::now(None).is_fresh(expired));
     }
 
     #[test]

--- a/rust/crates/supervisor-daemon/src/gpu_cc.rs
+++ b/rust/crates/supervisor-daemon/src/gpu_cc.rs
@@ -270,9 +270,9 @@ impl Drop for RuntimePowerHold {
 /// Pin a runtime-suspended card awake for a probe. vfio-pci lets a device
 /// nobody has opened runtime-suspend, and MMIO reads to a function in
 /// D3hot come back as all ones, which the register decoder cannot tell
-/// from a real answer. Returns `None`, having written nothing, when the
-/// device exposes no runtime PM or is already active. Waits up to
-/// `timeout` for the kernel to report it active.
+/// from a real answer. Returns `None`, having written nothing, unless the
+/// kernel reports the device on its way into or out of runtime suspend.
+/// Waits up to `timeout` for the kernel to report it active.
 ///
 /// Never fails the probe: a device whose runtime-PM files cannot be read
 /// or written is read as it is, exactly as it was before there was a
@@ -289,7 +289,15 @@ fn hold_runtime_power_on(device_dir: &Path, timeout: Duration) -> Option<Runtime
             return None;
         }
     };
-    if status.trim() == "active" {
+    // Only a device on its way into or out of D3 is worth holding. An
+    // "active" one is already awake, and a device with no runtime PM says
+    // "unsupported" (some drivers report other words still): it is powered,
+    // it will never report "active", so writing "on" would change the
+    // host's setting for nothing and then burn the whole resume budget
+    // waiting for a transition that cannot come. "resuming" stays in: a
+    // device mid-resume is exactly what the budget is there to wait for.
+    let status = status.trim();
+    if !matches!(status, "suspended" | "suspending" | "resuming") {
         return None;
     }
     let control_path = device_dir.join("power/control");
@@ -533,6 +541,36 @@ mod tests {
                 .unwrap()
                 .trim(),
             "auto"
+        );
+    }
+
+    #[test]
+    fn a_card_whose_runtime_pm_is_unsupported_is_neither_written_to_nor_waited_for() {
+        // A device the kernel does not runtime-manage is powered and stays
+        // powered, and its status will never turn "active". Writing "on"
+        // there would change the host's setting for nothing and then wait
+        // out the whole resume budget, once per probe.
+        let dir = tempfile::tempdir().unwrap();
+        let device_dir = fake_card(dir.path(), Some("unsupported"), 0x0000_0001);
+        let started = Instant::now();
+        assert!(
+            hold_runtime_power_on(&device_dir, Duration::from_secs(3)).is_none(),
+            "a device without runtime PM needs no hold"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "and must not wait for a resume that cannot happen"
+        );
+        assert_eq!(
+            std::fs::read_to_string(device_dir.join("power/control"))
+                .unwrap()
+                .trim(),
+            "auto"
+        );
+        assert_eq!(
+            probe_cc_mode_in(&device_dir, "06:00.0", "10de:2b85", Duration::from_secs(3)).unwrap(),
+            Some(CcMode::On),
+            "the register is read straight away"
         );
     }
 

--- a/rust/crates/supervisor-daemon/src/gpu_cc.rs
+++ b/rust/crates/supervisor-daemon/src/gpu_cc.rs
@@ -17,13 +17,61 @@ use std::time::{Duration, Instant};
 
 use crate::error::DaemonError;
 
-/// How long a probed mode is served from the cache before the card is read
-/// again. The mode only changes when an operator runs NVIDIA's tool against
-/// an idle card, so a minute of staleness in the advertised inventory costs
-/// nothing, while probing on demand would let anyone who can reach the
-/// agent's capability endpoint make the host mmap device memory on every
-/// NVIDIA card it has, as often as they like.
-pub const CC_MODE_TTL: Duration = Duration::from_secs(60);
+/// Default length, in seconds, of the window a cached answer that decoded
+/// to a mode is served for. A card's mode only changes when an operator
+/// runs NVIDIA's tool against an idle card, a handful of times in the life
+/// of a node, and nothing the daemon decides rests on the cache being
+/// current: the create and start gates read the hardware themselves, a stop
+/// or a delete forgets the card's entry, and a restart begins with an empty
+/// cache. So the window only has to cover "an idle card was re-moded and
+/// nothing on this node stopped or was deleted since", and an hour of that
+/// costs far less than waking every idle card out of runtime suspend once a
+/// minute for the rest of the node's life. Operators who re-mode cards
+/// often can shorten it with `ALEPH_VM_GPU_CC_MODE_TTL`.
+pub const DEFAULT_CC_MODE_TTL_SECS: u64 = 3600;
+
+/// How long an answer that carries no mode (the probe errored, the register
+/// read all ones, the encoding is reserved) is served before the card is
+/// read again. Deliberately not a setting: this is transient handling
+/// rather than an operator policy. An operator's mode change ends in a card
+/// reset, and a sweep landing during the reset reads all ones and caches
+/// "unreadable"; held for the long window, that one blink would hide a
+/// perfectly good card for an hour. A minute is still long enough to serve
+/// the reason failed answers are cached at all, which is to keep a card
+/// that cannot be read from being probed again on every request.
+pub const UNREADABLE_CC_MODE_TTL: Duration = Duration::from_secs(60);
+
+/// How long each kind of cached answer is served before its card is read
+/// again. Both windows do the same job for the unauthenticated host-info
+/// path: a card is read at most once per window whatever the request rate,
+/// so nobody who can reach the agent's capability endpoint can make the
+/// host mmap device memory on demand. Only the length differs, because a
+/// decoded mode stays true far longer than a failed read stays worth
+/// believing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CcCacheWindows {
+    /// For an answer that decoded to a mode.
+    pub mode: Duration,
+    /// For an answer that carries no mode.
+    pub unreadable: Duration,
+}
+
+impl CcCacheWindows {
+    /// The windows a running daemon serves under: the configured long one
+    /// for a decoded mode, the fixed short one for an answer without one.
+    pub fn with_mode_ttl(mode: Duration) -> Self {
+        Self {
+            mode,
+            unreadable: UNREADABLE_CC_MODE_TTL,
+        }
+    }
+
+    /// The shortest window any cached answer can be held under, which is
+    /// how long a decision taken over the whole cache at once stays true.
+    pub fn shortest(self) -> Duration {
+        self.mode.min(self.unreadable)
+    }
+}
 
 /// How long a runtime-suspended card gets to come back before the register
 /// is read anyway. A card that has not resumed reads as all ones, which
@@ -240,9 +288,18 @@ impl ProbedCcMode {
     }
 
     /// Whether this answer is young enough to serve without reading the
-    /// card again.
-    pub fn is_fresh(&self, ttl: Duration) -> bool {
-        self.probed_at.elapsed() < ttl
+    /// card again. Which window applies is the answer's own business: a
+    /// decoded mode gets the long one, an answer with no mode the short
+    /// one, so a card that read as unreadable while it was being reset
+    /// comes back on its own within the minute instead of staying hidden
+    /// for the length of the long window.
+    pub fn is_fresh(&self, windows: CcCacheWindows) -> bool {
+        let window = if self.mode.is_some() {
+            windows.mode
+        } else {
+            windows.unreadable
+        };
+        self.probed_at.elapsed() < window
     }
 }
 
@@ -635,10 +692,17 @@ mod tests {
     }
 
     #[test]
-    fn a_probe_answer_is_fresh_only_inside_its_ttl() {
+    fn a_probe_answer_is_fresh_only_inside_its_window() {
         let answer = ProbedCcMode::now(Some(CcMode::On));
-        assert!(answer.is_fresh(CC_MODE_TTL));
-        assert!(!answer.is_fresh(Duration::ZERO));
+        assert!(
+            answer.is_fresh(CcCacheWindows::with_mode_ttl(Duration::from_secs(
+                DEFAULT_CC_MODE_TTL_SECS
+            )))
+        );
+        assert!(!answer.is_fresh(CcCacheWindows {
+            mode: Duration::ZERO,
+            unreadable: Duration::ZERO,
+        }));
         assert_eq!(answer.mode, Some(CcMode::On));
     }
 

--- a/rust/crates/supervisor-daemon/src/gpu_cc.rs
+++ b/rust/crates/supervisor-daemon/src/gpu_cc.rs
@@ -7,11 +7,31 @@
 //! on Hopper, bits [1:0]). Reading it needs no driver: the card is bound to
 //! vfio-pci, and the register is reachable through the sysfs resource file.
 //! The read only ever runs on a card no VM owns, so it never races a guest.
+//! An idle card is usually runtime-suspended, and a suspended function
+//! answers MMIO with all ones, so the probe pins it awake first and treats
+//! an all-ones answer as no answer at all.
 
 use std::fmt;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use crate::error::DaemonError;
+
+/// How long a probed mode is served from the cache before the card is read
+/// again. The mode only changes when an operator runs NVIDIA's tool against
+/// an idle card, so a minute of staleness in the advertised inventory costs
+/// nothing, while probing on demand would let anyone who can reach the
+/// agent's capability endpoint make the host mmap device memory on every
+/// NVIDIA card it has, as often as they like.
+pub const CC_MODE_TTL: Duration = Duration::from_secs(60);
+
+/// How long a runtime-suspended card gets to come back before the register
+/// is read anyway. A card that has not resumed reads as all ones, which
+/// fails closed, so the wait is a courtesy and not a correctness bound.
+const RESUME_TIMEOUT: Duration = Duration::from_millis(200);
+
+/// How often `power/runtime_status` is re-read while waiting to resume.
+const RESUME_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -112,43 +132,51 @@ pub fn sysfs_device_dir_under(devices_dir: &Path, pci_host: &str) -> PathBuf {
     devices_dir.join(full)
 }
 
+/// An io error with the file it came from, so the caller's message names
+/// the register file and not just the errno.
+fn at_path(path: &Path, error: std::io::Error) -> std::io::Error {
+    std::io::Error::new(error.kind(), format!("{}: {error}", path.display()))
+}
+
 /// Read one 32-bit register from a BAR0 mapping. sysfs `resourceN` files
 /// only support mmap (read() is refused for memory BARs), so map the page
 /// holding the offset and do a volatile read.
-pub fn read_bar0_u32(resource0: &Path, offset: u64) -> Result<u32, DaemonError> {
+pub fn read_bar0_u32(resource0: &Path, offset: u64) -> Result<u32, std::io::Error> {
+    use std::io::{Error, ErrorKind};
     use std::os::fd::AsRawFd as _;
 
     if !offset.is_multiple_of(4) {
-        return Err(DaemonError::GpuProbe(format!(
-            "register offset {offset:#x} is not 4-byte aligned"
-        )));
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!("register offset {offset:#x} is not 4-byte aligned"),
+        ));
     }
 
-    let file = std::fs::File::open(resource0).map_err(|error| {
-        DaemonError::GpuProbe(format!("cannot open {}: {error}", resource0.display()))
-    })?;
+    let file = std::fs::File::open(resource0).map_err(|error| at_path(resource0, error))?;
     let len = file
         .metadata()
-        .map_err(|error| {
-            DaemonError::GpuProbe(format!("cannot stat {}: {error}", resource0.display()))
-        })?
+        .map_err(|error| at_path(resource0, error))?
         .len();
     let end = offset.checked_add(4).ok_or_else(|| {
-        DaemonError::GpuProbe(format!(
-            "register offset {offset:#x} + 4 would overflow u64"
-        ))
+        Error::new(
+            ErrorKind::InvalidInput,
+            format!("register offset {offset:#x} + 4 would overflow u64"),
+        )
     })?;
     if end > len {
-        return Err(DaemonError::GpuProbe(format!(
-            "register offset {offset:#x} is past the end of {} ({len} bytes)",
-            resource0.display()
-        )));
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!(
+                "register offset {offset:#x} is past the end of {} ({len} bytes)",
+                resource0.display()
+            ),
+        ));
     }
     // SAFETY: sysconf reads a constant and has no preconditions.
     let page = u64::try_from(unsafe { libc::sysconf(libc::_SC_PAGESIZE) })
         .ok()
         .filter(|page| page.is_power_of_two())
-        .ok_or_else(|| DaemonError::GpuProbe("cannot determine the page size".to_string()))?;
+        .ok_or_else(|| Error::other("cannot determine the page size"))?;
     let base = offset & !(page - 1);
     let within = (offset - base) as usize;
     // SAFETY: a read-only shared mapping of one page of an open file; the
@@ -165,11 +193,14 @@ pub fn read_bar0_u32(resource0: &Path, offset: u64) -> Result<u32, DaemonError> 
             base as libc::off_t,
         );
         if mapped == libc::MAP_FAILED {
-            return Err(DaemonError::GpuProbe(format!(
-                "mmap of {} at {base:#x} failed: {}",
-                resource0.display(),
-                std::io::Error::last_os_error()
-            )));
+            let error = std::io::Error::last_os_error();
+            return Err(Error::new(
+                error.kind(),
+                format!(
+                    "mmap of {} at {base:#x} failed: {error}",
+                    resource0.display()
+                ),
+            ));
         }
         let value = std::ptr::read_volatile(mapped.cast::<u8>().add(within).cast::<u32>());
         libc::munmap(mapped, page as usize);
@@ -188,14 +219,140 @@ pub fn no_probe(_pci_host: &str, _device_id: &str) -> Result<Option<CcMode>, Dae
     Ok(None)
 }
 
+/// What the last probe of one card read: the mode, or `None` when the
+/// probe failed or the register held an encoding with no mode, plus when
+/// it ran. The `None` answers are cached like the modes are: they are what
+/// keeps a card that cannot be read from being probed again on every
+/// request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProbedCcMode {
+    pub mode: Option<CcMode>,
+    pub probed_at: Instant,
+}
+
+impl ProbedCcMode {
+    /// The answer a probe has just given.
+    pub fn now(mode: Option<CcMode>) -> Self {
+        Self {
+            mode,
+            probed_at: Instant::now(),
+        }
+    }
+
+    /// Whether this answer is young enough to serve without reading the
+    /// card again.
+    pub fn is_fresh(&self, ttl: Duration) -> bool {
+        self.probed_at.elapsed() < ttl
+    }
+}
+
+/// A card held out of runtime suspend for the length of one probe. The
+/// previous `power/control` value goes back on drop, so the card idles
+/// again exactly as the host had it configured.
+struct RuntimePowerHold {
+    control: PathBuf,
+    previous: String,
+}
+
+impl Drop for RuntimePowerHold {
+    fn drop(&mut self) {
+        if let Err(error) = std::fs::write(&self.control, format!("{}\n", self.previous)) {
+            tracing::warn!(
+                path = %self.control.display(),
+                previous = %self.previous,
+                %error,
+                "cannot restore the GPU runtime-PM setting; the card stays powered on"
+            );
+        }
+    }
+}
+
+/// Pin a runtime-suspended card awake for a probe. vfio-pci lets a device
+/// nobody has opened runtime-suspend, and MMIO reads to a function in
+/// D3hot come back as all ones, which the register decoder cannot tell
+/// from a real answer. Returns `None`, having written nothing, when the
+/// device exposes no runtime PM or is already active. Waits up to
+/// `timeout` for the kernel to report it active.
+fn hold_runtime_power_on(
+    device_dir: &Path,
+    timeout: Duration,
+) -> Result<Option<RuntimePowerHold>, std::io::Error> {
+    let status_path = device_dir.join("power/runtime_status");
+    let status = match std::fs::read_to_string(&status_path) {
+        Ok(status) => status,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(at_path(&status_path, error)),
+    };
+    if status.trim() == "active" {
+        return Ok(None);
+    }
+    let control_path = device_dir.join("power/control");
+    let previous = std::fs::read_to_string(&control_path)
+        .map_err(|error| at_path(&control_path, error))?
+        .trim()
+        .to_string();
+    std::fs::write(&control_path, "on\n").map_err(|error| at_path(&control_path, error))?;
+    // From here on the hold owns the restore, whatever the wait does.
+    let hold = RuntimePowerHold {
+        control: control_path,
+        previous,
+    };
+    let deadline = Instant::now() + timeout;
+    loop {
+        if std::fs::read_to_string(&status_path).is_ok_and(|status| status.trim() == "active") {
+            break;
+        }
+        if Instant::now() >= deadline {
+            tracing::warn!(
+                path = %device_dir.display(),
+                "the GPU did not leave runtime suspend in time; reading its register anyway"
+            );
+            break;
+        }
+        std::thread::sleep(RESUME_POLL_INTERVAL);
+    }
+    Ok(Some(hold))
+}
+
 /// The CC mode of one vfio-bound NVIDIA card, `None` for cards without a
 /// CC mode (other vendors, pre-Hopper) or a reserved register encoding.
 pub fn probe_cc_mode(pci_host: &str, device_id: &str) -> Result<Option<CcMode>, DaemonError> {
+    probe_cc_mode_in(
+        &sysfs_device_dir(pci_host),
+        pci_host,
+        device_id,
+        RESUME_TIMEOUT,
+    )
+}
+
+/// `probe_cc_mode` against an explicit device directory and resume budget,
+/// so a fixture tree can stand in for sysfs.
+fn probe_cc_mode_in(
+    device_dir: &Path,
+    pci_host: &str,
+    device_id: &str,
+    resume_timeout: Duration,
+) -> Result<Option<CcMode>, DaemonError> {
     let Some(arch) = arch_from_device_id(device_id) else {
         return Ok(None);
     };
-    let resource0 = sysfs_device_dir(pci_host).join("resource0");
-    let value = read_bar0_u32(&resource0, bar0_register_offset(arch))?;
+    let read_error = |source: std::io::Error| DaemonError::GpuRegisterRead {
+        pci_host: pci_host.to_string(),
+        source,
+    };
+    let _resumed = hold_runtime_power_on(device_dir, resume_timeout).map_err(read_error)?;
+    let value = read_bar0_u32(&device_dir.join("resource0"), bar0_register_offset(arch))
+        .map_err(read_error)?;
+    // A function that cannot answer (still in D3hot, a reset in flight, the
+    // card gone off the bus) reads back as all ones, and the low two bits
+    // of that are the devtools encoding. Reporting devtools for a card
+    // nobody could read would advertise confidential capacity the host has
+    // no evidence for, so an unreachable card is an error and not a mode.
+    if value == u32::MAX {
+        return Err(DaemonError::GpuUnreadable {
+            pci_host: pci_host.to_string(),
+        });
+    }
     Ok(cc_mode_from_register(value))
 }
 
@@ -284,6 +441,134 @@ mod tests {
         assert!(err.to_string().contains("aligned"));
         // Aligned offset still reads correctly.
         assert_eq!(read_bar0_u32(&path, 0x590).unwrap(), 0x101);
+    }
+
+    /// A fixture card directory: the sysfs files the probe touches.
+    fn fake_card(dir: &Path, runtime_status: Option<&str>, register: u32) -> PathBuf {
+        let device_dir = dir.join("0000:06:00.0");
+        std::fs::create_dir_all(device_dir.join("power")).unwrap();
+        if let Some(status) = runtime_status {
+            std::fs::write(
+                device_dir.join("power/runtime_status"),
+                format!("{status}\n"),
+            )
+            .unwrap();
+            std::fs::write(device_dir.join("power/control"), "auto\n").unwrap();
+        }
+        let mut bytes = vec![0u8; 0x1000];
+        bytes[0x590..0x594].copy_from_slice(&register.to_le_bytes());
+        std::fs::write(device_dir.join("resource0"), &bytes).unwrap();
+        device_dir
+    }
+
+    #[test]
+    fn an_all_ones_register_is_unreadable_rather_than_devtools() {
+        // A card in D3hot answers every MMIO read with all ones, and the
+        // low two bits of that answer are the devtools encoding. The
+        // decoder cannot tell the difference, so the probe must: an idle
+        // card would otherwise be advertised as confidential capacity in
+        // devtools mode and then refused at create.
+        assert_eq!(cc_mode_from_register(0xffff_ffff), Some(CcMode::Devtools));
+        let dir = tempfile::tempdir().unwrap();
+        let device_dir = fake_card(dir.path(), None, 0xffff_ffff);
+        let error = probe_cc_mode_in(&device_dir, "06:00.0", "10de:2b85", Duration::ZERO)
+            .expect_err("all ones must not decode to a mode");
+        let message = error.to_string();
+        assert!(message.contains("06:00.0"), "{message}");
+        assert!(message.contains("ffffffff"), "{message}");
+    }
+
+    #[test]
+    fn a_suspended_card_is_pinned_awake_and_released_afterwards() {
+        // vfio-pci lets a card nobody has opened runtime-suspend. The
+        // probe pins it awake for the read and hands the host's own
+        // setting back, so the card can idle again once the daemon is
+        // done with it.
+        let dir = tempfile::tempdir().unwrap();
+        let device_dir = fake_card(dir.path(), Some("suspended"), 0x0000_0001);
+        let control = device_dir.join("power/control");
+        {
+            let hold = hold_runtime_power_on(&device_dir, Duration::ZERO)
+                .unwrap()
+                .expect("a suspended card must be held awake");
+            assert_eq!(std::fs::read_to_string(&control).unwrap().trim(), "on");
+            drop(hold);
+        }
+        assert_eq!(
+            std::fs::read_to_string(&control).unwrap().trim(),
+            "auto",
+            "the host's runtime-PM setting must survive the probe"
+        );
+    }
+
+    #[test]
+    fn an_active_card_is_never_written_to() {
+        let dir = tempfile::tempdir().unwrap();
+        let device_dir = fake_card(dir.path(), Some("active"), 0x0000_0001);
+        assert!(
+            hold_runtime_power_on(&device_dir, Duration::ZERO)
+                .unwrap()
+                .is_none(),
+            "an active card needs no hold"
+        );
+        assert_eq!(
+            std::fs::read_to_string(device_dir.join("power/control"))
+                .unwrap()
+                .trim(),
+            "auto"
+        );
+    }
+
+    #[test]
+    fn a_device_without_runtime_pm_files_probes_as_before() {
+        let dir = tempfile::tempdir().unwrap();
+        let device_dir = fake_card(dir.path(), None, 0x0000_0001);
+        assert_eq!(
+            probe_cc_mode_in(&device_dir, "06:00.0", "10de:2b85", Duration::ZERO).unwrap(),
+            Some(CcMode::On)
+        );
+    }
+
+    #[test]
+    fn a_suspended_card_is_resumed_before_its_register_is_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let device_dir = fake_card(dir.path(), Some("suspended"), 0x0000_0003);
+        assert_eq!(
+            probe_cc_mode_in(&device_dir, "06:00.0", "10de:2b85", Duration::ZERO).unwrap(),
+            Some(CcMode::Devtools)
+        );
+        assert_eq!(
+            std::fs::read_to_string(device_dir.join("power/control"))
+                .unwrap()
+                .trim(),
+            "auto"
+        );
+    }
+
+    #[test]
+    fn a_card_without_a_cc_architecture_is_never_touched() {
+        // The device-id check comes first: no runtime-PM write and no
+        // register read for a card that has no CC mode to read.
+        let dir = tempfile::tempdir().unwrap();
+        let device_dir = fake_card(dir.path(), Some("suspended"), 0xffff_ffff);
+        assert_eq!(
+            probe_cc_mode_in(&device_dir, "06:00.0", "10de:20f1", Duration::ZERO).unwrap(),
+            None
+        );
+        assert_eq!(
+            std::fs::read_to_string(device_dir.join("power/control"))
+                .unwrap()
+                .trim(),
+            "auto"
+        );
+    }
+
+    #[test]
+    fn a_probe_answer_is_fresh_only_inside_its_ttl() {
+        let answer = ProbedCcMode::now(Some(CcMode::On));
+        assert!(answer.is_fresh(CC_MODE_TTL));
+        assert!(!answer.is_fresh(Duration::ZERO));
+        assert_eq!(answer.mode, Some(CcMode::On));
     }
 
     #[test]

--- a/rust/crates/supervisor-daemon/src/gpu_cc.rs
+++ b/rust/crates/supervisor-daemon/src/gpu_cc.rs
@@ -273,25 +273,45 @@ impl Drop for RuntimePowerHold {
 /// from a real answer. Returns `None`, having written nothing, when the
 /// device exposes no runtime PM or is already active. Waits up to
 /// `timeout` for the kernel to report it active.
-fn hold_runtime_power_on(
-    device_dir: &Path,
-    timeout: Duration,
-) -> Result<Option<RuntimePowerHold>, std::io::Error> {
+///
+/// Never fails the probe: a device whose runtime-PM files cannot be read
+/// or written is read as it is, exactly as it was before there was a
+/// resume step. The register still decides, and an all-ones answer from a
+/// card that stayed asleep fails closed.
+fn hold_runtime_power_on(device_dir: &Path, timeout: Duration) -> Option<RuntimePowerHold> {
     let status_path = device_dir.join("power/runtime_status");
     let status = match std::fs::read_to_string(&status_path) {
         Ok(status) => status,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(at_path(&status_path, error)),
+        Err(error) => {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(path = %status_path.display(), %error, "cannot read the GPU runtime-PM state");
+            }
+            return None;
+        }
     };
     if status.trim() == "active" {
-        return Ok(None);
+        return None;
     }
     let control_path = device_dir.join("power/control");
-    let previous = std::fs::read_to_string(&control_path)
-        .map_err(|error| at_path(&control_path, error))?
-        .trim()
-        .to_string();
-    std::fs::write(&control_path, "on\n").map_err(|error| at_path(&control_path, error))?;
+    let previous = match std::fs::read_to_string(&control_path) {
+        Ok(previous) => previous.trim().to_string(),
+        Err(error) => {
+            tracing::warn!(
+                path = %control_path.display(),
+                %error,
+                "cannot read the GPU runtime-PM setting; reading its register without resuming it"
+            );
+            return None;
+        }
+    };
+    if let Err(error) = std::fs::write(&control_path, "on\n") {
+        tracing::warn!(
+            path = %control_path.display(),
+            %error,
+            "cannot pin the GPU awake; reading its register anyway"
+        );
+        return None;
+    }
     // From here on the hold owns the restore, whatever the wait does.
     let hold = RuntimePowerHold {
         control: control_path,
@@ -311,7 +331,7 @@ fn hold_runtime_power_on(
         }
         std::thread::sleep(RESUME_POLL_INTERVAL);
     }
-    Ok(Some(hold))
+    Some(hold)
 }
 
 /// The CC mode of one vfio-bound NVIDIA card, `None` for cards without a
@@ -327,7 +347,7 @@ pub fn probe_cc_mode(pci_host: &str, device_id: &str) -> Result<Option<CcMode>, 
 
 /// `probe_cc_mode` against an explicit device directory and resume budget,
 /// so a fixture tree can stand in for sysfs.
-fn probe_cc_mode_in(
+pub(crate) fn probe_cc_mode_in(
     device_dir: &Path,
     pci_host: &str,
     device_id: &str,
@@ -336,13 +356,13 @@ fn probe_cc_mode_in(
     let Some(arch) = arch_from_device_id(device_id) else {
         return Ok(None);
     };
-    let read_error = |source: std::io::Error| DaemonError::GpuRegisterRead {
-        pci_host: pci_host.to_string(),
-        source,
-    };
-    let _resumed = hold_runtime_power_on(device_dir, resume_timeout).map_err(read_error)?;
-    let value = read_bar0_u32(&device_dir.join("resource0"), bar0_register_offset(arch))
-        .map_err(read_error)?;
+    let _resumed = hold_runtime_power_on(device_dir, resume_timeout);
+    let value = read_bar0_u32(&device_dir.join("resource0"), bar0_register_offset(arch)).map_err(
+        |source| DaemonError::GpuRegisterRead {
+            pci_host: pci_host.to_string(),
+            source,
+        },
+    )?;
     // A function that cannot answer (still in D3hot, a reset in flight, the
     // card gone off the bus) reads back as all ones, and the low two bits
     // of that are the devtools encoding. Reporting devtools for a card
@@ -489,7 +509,6 @@ mod tests {
         let control = device_dir.join("power/control");
         {
             let hold = hold_runtime_power_on(&device_dir, Duration::ZERO)
-                .unwrap()
                 .expect("a suspended card must be held awake");
             assert_eq!(std::fs::read_to_string(&control).unwrap().trim(), "on");
             drop(hold);
@@ -506,9 +525,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let device_dir = fake_card(dir.path(), Some("active"), 0x0000_0001);
         assert!(
-            hold_runtime_power_on(&device_dir, Duration::ZERO)
-                .unwrap()
-                .is_none(),
+            hold_runtime_power_on(&device_dir, Duration::ZERO).is_none(),
             "an active card needs no hold"
         );
         assert_eq!(
@@ -560,6 +577,22 @@ mod tests {
                 .unwrap()
                 .trim(),
             "auto"
+        );
+    }
+
+    #[test]
+    fn an_unreadable_power_control_still_reads_the_register() {
+        // The resume step is an improvement on the read, not a condition
+        // of it: a device whose runtime-PM files cannot be read must probe
+        // exactly as it did before the step existed. Here the card claims
+        // to be suspended but has no power/control at all.
+        let dir = tempfile::tempdir().unwrap();
+        let device_dir = fake_card(dir.path(), Some("suspended"), 0x0000_0001);
+        std::fs::remove_file(device_dir.join("power/control")).unwrap();
+        assert!(hold_runtime_power_on(&device_dir, Duration::ZERO).is_none());
+        assert_eq!(
+            probe_cc_mode_in(&device_dir, "06:00.0", "10de:2b85", Duration::ZERO).unwrap(),
+            Some(CcMode::On)
         );
     }
 

--- a/rust/crates/supervisor-daemon/src/lifecycle.rs
+++ b/rust/crates/supervisor-daemon/src/lifecycle.rs
@@ -4818,6 +4818,37 @@ mod tests {
     }
 
     #[test]
+    fn stopping_a_vm_forgets_what_the_cache_knew_about_its_cards() {
+        // A stopped VM keeps claiming its cards, so the refresh sweep will
+        // never read them again, and the seed only covers a running VM. If
+        // the stop left the create gate's answer in the cache the card
+        // would keep being advertised CC-on with no guest holding its mode
+        // still, which an operator can change on an idle card.
+        let harness = harness_with_gpus(vec![nvidia_card("06:00.0")]);
+        let state = &harness.state;
+        let root = state.host.settings.execution_root.clone();
+        let vm_id = hash('c');
+        let mut request = spec(&vm_id, &root);
+        request.gpus = vec![pb::GpuConfig {
+            pci_host: "06:00.0".to_string(),
+            supports_x_vga: true,
+        }];
+        create_vm(state, request).unwrap();
+        state.gpu_cc_modes.lock().unwrap().insert(
+            "06:00.0".into(),
+            crate::gpu_cc::ProbedCcMode::now(Some(crate::gpu_cc::CcMode::On)),
+        );
+
+        stop_vm(state, &vm_id).unwrap();
+
+        assert_eq!(
+            crate::service::cc_mode_of(state, "06:00.0"),
+            None,
+            "a stopped VM's card advertises nothing, in the inventory as in VmInfo"
+        );
+    }
+
+    #[test]
     fn discarding_an_untracked_snp_vm_tears_down_the_dhcp_server() {
         // A live SNP VM whose adoption failed (untracked, config still on disk)
         // ran a per-tap DHCP server. The discard_failed_reattach delete path

--- a/rust/crates/supervisor-daemon/src/lifecycle.rs
+++ b/rust/crates/supervisor-daemon/src/lifecycle.rs
@@ -2119,11 +2119,11 @@ fn snp_config_slice_with(
             ))
         })?;
         {
-            let mut cache = state.gpu_cc_modes.lock().expect("gpu_cc_modes poisoned");
-            match mode {
-                Some(mode) => cache.insert(gpu.pci_host.clone(), mode),
-                None => cache.remove(&gpu.pci_host),
-            };
+            state
+                .gpu_cc_modes
+                .lock()
+                .expect("gpu_cc_modes poisoned")
+                .insert(gpu.pci_host.clone(), crate::gpu_cc::ProbedCcMode::now(mode));
         }
         if mode != Some(crate::gpu_cc::CcMode::On) {
             return Err(RpcError::InvalidBackend(format!(
@@ -4965,11 +4965,10 @@ mod tests {
             Some(crate::gpu_cc::CcMode::Off),
             Some(crate::gpu_cc::CcMode::Devtools),
         ] {
-            state
-                .gpu_cc_modes
-                .lock()
-                .unwrap()
-                .insert("06:00.0".into(), crate::gpu_cc::CcMode::On);
+            state.gpu_cc_modes.lock().unwrap().insert(
+                "06:00.0".into(),
+                crate::gpu_cc::ProbedCcMode::now(Some(crate::gpu_cc::CcMode::On)),
+            );
             let root = state.host.settings.execution_root.clone();
             let firmware = root.join("OVMF.fd");
             std::fs::write(&firmware, b"ovmf").unwrap();
@@ -5048,11 +5047,10 @@ mod tests {
         // must not admit the card: the gate reads the hardware.
         let harness = harness_with_gpus(vec![nvidia_card("06:00.0")]);
         let state = &harness.state;
-        state
-            .gpu_cc_modes
-            .lock()
-            .unwrap()
-            .insert("06:00.0".into(), crate::gpu_cc::CcMode::On);
+        state.gpu_cc_modes.lock().unwrap().insert(
+            "06:00.0".into(),
+            crate::gpu_cc::ProbedCcMode::now(Some(crate::gpu_cc::CcMode::On)),
+        );
         let root = state.host.settings.execution_root.clone();
         let firmware = root.join("OVMF.fd");
         std::fs::write(&firmware, b"ovmf").unwrap();

--- a/rust/crates/supervisor-daemon/src/lifecycle.rs
+++ b/rust/crates/supervisor-daemon/src/lifecycle.rs
@@ -1318,6 +1318,17 @@ fn delete_tracked_vm(
     state.events.emit(vm_id, old_status, pb::VmStatus::Stopped);
 
     state.world.blocking_write().entries.remove(vm_id);
+    // The cards are free again, so nothing the CC cache holds about them
+    // still stands on its own: neither a probe from before they were
+    // attached nor the mode the create gate vouched for while the guest
+    // held them. Forget them so the next refresh reads the hardware
+    // instead of serving an answer about a card in a different state.
+    if !entry.config.gpus.is_empty() {
+        let mut cache = state.gpu_cc_modes.lock().expect("gpu_cc_modes poisoned");
+        for gpu in &entry.config.gpus {
+            cache.remove(&gpu.pci_host);
+        }
+    }
     // Release the NUMA reservation alongside the other teardown (increment
     // C1). No-op for an unpinned or program VM (numa_node is None).
     if let Some(node) = entry.numa_node {
@@ -4751,6 +4762,38 @@ mod tests {
             harness.dhcp.stopped().is_empty(),
             "a plain VM teardown touches no DHCP server, got {:?}",
             harness.dhcp.stopped()
+        );
+    }
+
+    #[test]
+    fn deleting_a_vm_forgets_what_the_cache_knew_about_its_cards() {
+        // While a VM holds a card the cache keeps whatever was last known
+        // about it, and for a confidential VM that is the mode the create
+        // gate vouched for. Once the VM is gone the card is free hardware
+        // again and an operator can switch its mode, so the entry has to
+        // go with the VM: leaving it would advertise the old answer for
+        // the rest of its freshness window.
+        let harness = harness_with_gpus(vec![nvidia_card("06:00.0")]);
+        let state = &harness.state;
+        let root = state.host.settings.execution_root.clone();
+        let vm_id = hash('c');
+        let mut request = spec(&vm_id, &root);
+        request.gpus = vec![pb::GpuConfig {
+            pci_host: "06:00.0".to_string(),
+            supports_x_vga: true,
+        }];
+        create_vm(state, request).unwrap();
+        state.gpu_cc_modes.lock().unwrap().insert(
+            "06:00.0".into(),
+            crate::gpu_cc::ProbedCcMode::now(Some(crate::gpu_cc::CcMode::On)),
+        );
+
+        delete_vm(state, &vm_id, false).unwrap();
+
+        assert_eq!(
+            crate::service::cc_mode_of(state, "06:00.0"),
+            None,
+            "a freed card advertises nothing until it is read again"
         );
     }
 

--- a/rust/crates/supervisor-daemon/src/lifecycle.rs
+++ b/rust/crates/supervisor-daemon/src/lifecycle.rs
@@ -773,6 +773,23 @@ fn guest_ipv4(state: &DaemonState, entry: &VmEntry) -> String {
     .unwrap_or_default()
 }
 
+/// Drop everything the CC-mode cache holds about a VM's cards. Whatever is
+/// in there was learned either before the cards were attached or from the
+/// create gate that read them on the way in, and neither answer outlives
+/// the guest: once QEMU is gone the cards are idle hardware an operator can
+/// re-mode with NVIDIA's tool, so the host can no longer vouch for a mode
+/// it read earlier. Forgetting them makes the next reader take the card as
+/// it finds it instead of serving a mode from another era.
+fn forget_cc_modes(state: &DaemonState, gpus: &[crate::controller_config::QemuGpu]) {
+    if gpus.is_empty() {
+        return;
+    }
+    let mut cache = state.gpu_cc_modes.lock().expect("gpu_cc_modes poisoned");
+    for gpu in gpus {
+        cache.remove(&gpu.pci_host);
+    }
+}
+
 /// Python `VmExecution.stop()`: idempotent; stop the unit, wait for the
 /// graceful shutdown, drop the port redirects, tear down nftables and the
 /// tap.
@@ -857,6 +874,12 @@ fn stop_vm_execution(state: &DaemonState, vm_id: &str) -> Result<(), RpcError> {
     // addresses of a stopped VM (bug-for-bug; the proto says they should
     // empty once the tap is gone).
     with_entry_mut(state, vm_id, |entry| entry.times.stopped_at_ns = now_ns());
+    // The entry keeps claiming the cards, so the refresh sweep will not
+    // read them, and it seeds a mode only for a VM that is running. Without
+    // this the mode the create gate vouched for would sit in the cache and
+    // keep being advertised for a card that no longer has a guest holding
+    // its mode still.
+    forget_cc_modes(state, &entry.config.gpus);
     tracing::info!(vm_id, "VM stopped");
     Ok(())
 }
@@ -929,6 +952,11 @@ fn stop_program_execution(state: &DaemonState, vm_id: &str) -> Result<(), RpcErr
     }
 
     with_entry_mut(state, vm_id, |entry| entry.times.stopped_at_ns = now_ns());
+    // Same reason as the persistent stop: no guest holds the cards any
+    // more, so nothing the cache says about them still stands. A program
+    // spec carries no GPUs today, which makes this a no-op, but the rule
+    // belongs on every path that stamps a stop.
+    forget_cc_modes(state, &entry.config.gpus);
     tracing::info!(vm_id, "ephemeral program stopped");
     Ok(())
 }
@@ -1318,17 +1346,9 @@ fn delete_tracked_vm(
     state.events.emit(vm_id, old_status, pb::VmStatus::Stopped);
 
     state.world.blocking_write().entries.remove(vm_id);
-    // The cards are free again, so nothing the CC cache holds about them
-    // still stands on its own: neither a probe from before they were
-    // attached nor the mode the create gate vouched for while the guest
-    // held them. Forget them so the next refresh reads the hardware
+    // The cards are free again, so the next refresh reads the hardware
     // instead of serving an answer about a card in a different state.
-    if !entry.config.gpus.is_empty() {
-        let mut cache = state.gpu_cc_modes.lock().expect("gpu_cc_modes poisoned");
-        for gpu in &entry.config.gpus {
-            cache.remove(&gpu.pci_host);
-        }
-    }
+    forget_cc_modes(state, &entry.config.gpus);
     // Release the NUMA reservation alongside the other teardown (increment
     // C1). No-op for an unpinned or program VM (numa_node is None).
     if let Some(node) = entry.numa_node {

--- a/rust/crates/supervisor-daemon/src/lifecycle.rs
+++ b/rust/crates/supervisor-daemon/src/lifecycle.rs
@@ -2126,6 +2126,15 @@ fn snp_config_slice_with(
     // world write lock with creation serialized, so no guest can own the
     // card before this VM does. Any other answer, including a card that
     // cannot be read, fails closed. The cache learns the answer either way.
+    //
+    // That write lock is what the read costs: an idle card is usually
+    // runtime-suspended, and pinning it awake takes up to the probe's
+    // 200 ms resume budget, so a spec with several suspended cards holds
+    // the world write lock for that many times 200 ms and every reader
+    // behind it (GetHostInfo, ListVms, Health) waits. It is bounded, it is
+    // once per creation rather than once per request, and the alternative
+    // is trusting a cached mode for hardware about to be handed to a
+    // guest, so the wait stays here.
     for gpu in &spec.gpus {
         // The inventory-membership check runs FIRST and is what makes
         // `gpu.pci_host` safe to interpolate into the vfio-pci argv and into

--- a/rust/crates/supervisor-daemon/src/main.rs
+++ b/rust/crates/supervisor-daemon/src/main.rs
@@ -223,6 +223,21 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
             .map_err(|error| anyhow::anyhow!("the NUMA reconcile task failed: {error}"))?;
         }
 
+        // Read the CC mode of every free NVIDIA card once before the
+        // socket exists, so the first capability request is answered from
+        // the cache instead of waiting on device memory. Cards a VM
+        // already owns are left alone: their registers belong to the
+        // guest, so an adopted VM's cards carry no mode until they come
+        // back free.
+        {
+            let gpu_state = state.clone();
+            tokio::task::spawn_blocking(move || {
+                supervisor_daemon::service::refresh_cc_modes(&gpu_state);
+            })
+            .await
+            .map_err(|error| anyhow::anyhow!("the GPU CC probe task failed: {error}"))?;
+        }
+
         // Base ruleset + adoption step 5 inside the runtime (the ndppd
         // debounce and the blocking-pool hops need it), still before the
         // socket exists, like the Python network.setup() +

--- a/rust/crates/supervisor-daemon/src/main.rs
+++ b/rust/crates/supervisor-daemon/src/main.rs
@@ -203,6 +203,7 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
         gpu_cc_modes: std::sync::Mutex::new(std::collections::HashMap::new()),
         gpu_cc_probe: supervisor_daemon::gpu_cc::probe_cc_mode,
         gpu_cc_sweep: std::sync::Mutex::new(Default::default()),
+        gpu_cc_refresh: std::sync::Mutex::new(()),
     });
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -225,10 +226,13 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
 
         // Read the CC mode of every free NVIDIA card once before the
         // socket exists, so the first capability request is answered from
-        // the cache instead of waiting on device memory. Cards a VM
-        // already owns are left alone: their registers belong to the
-        // guest, so an adopted VM's cards carry no mode until they come
-        // back free.
+        // the cache instead of waiting on device memory. A card that is
+        // runtime-suspended costs up to the 200 ms resume budget, so this
+        // delays the bind by (free suspended cards) x 200 ms in the worst
+        // case, which is the same work the first request would otherwise
+        // have paid for. Cards a VM already owns are not read: their
+        // registers belong to the guest, and a confidential VM's cards get
+        // their mode from the gate that admitted them.
         {
             let gpu_state = state.clone();
             tokio::task::spawn_blocking(move || {

--- a/rust/crates/supervisor-daemon/src/service.rs
+++ b/rust/crates/supervisor-daemon/src/service.rs
@@ -175,12 +175,14 @@ pub struct DaemonState {
     /// tracking for `AllowedCPUs` pinning. In-memory; rebuilt at boot from
     /// each adopted VM's effective placement (its `AllowedCPUs` drop-in).
     pub numa_ledger: std::sync::Mutex<crate::numa::NumaAllocator>,
-    /// The cached NVIDIA CC mode of each probed card, keyed by pci_host.
-    /// Populated by `refresh_cc_modes` (called from `get_host_info`) for
-    /// every NVIDIA card no VM currently owns, and by the SEV-SNP GPU gate
-    /// when a create probes its cards; a card never probed, or whose last
-    /// probe failed, has no entry.
-    pub gpu_cc_modes: std::sync::Mutex<HashMap<String, crate::gpu_cc::CcMode>>,
+    /// The last CC mode probe of each card, keyed by pci_host. Populated
+    /// at startup and by `refresh_cc_modes` (called from `get_host_info`)
+    /// for every NVIDIA card no VM currently owns, and by the SEV-SNP GPU
+    /// gate when a create probes its cards. A card never probed has no
+    /// entry; a card whose last probe failed has an entry with no mode,
+    /// which advertises nothing and holds the retry off until the entry
+    /// goes stale.
+    pub gpu_cc_modes: std::sync::Mutex<HashMap<String, crate::gpu_cc::ProbedCcMode>>,
     /// How a card's CC mode is read: the BAR0 register in production,
     /// `gpu_cc::no_probe` on hermetic state so tests never open sysfs.
     pub gpu_cc_probe: crate::gpu_cc::CcProbe,
@@ -190,18 +192,14 @@ pub struct DaemonState {
     pub gpu_cc_sweep: std::sync::Mutex<CcSweep>,
 }
 
-/// The attached set the last CC-mode sweep saw, and when it ran.
+/// The attached set the last CC-mode sweep saw, and when it ran. A sweep
+/// against an unchanged set within `gpu_cc::CC_MODE_TTL` is skipped whole,
+/// which is the cheap outer gate over the per-card freshness check inside.
 #[derive(Debug, Default)]
 pub struct CcSweep {
     pub attached: HashSet<String>,
     pub at: Option<std::time::Instant>,
 }
-
-/// How long a CC-mode sweep stays good for when no card changed hands. A
-/// card's mode only changes through an operator running gpu-admin-tools on
-/// an idle card, so a minute of staleness on the advertisement is fine; the
-/// create-time gate reads the register itself and never trusts the sweep.
-pub const CC_PROBE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// See [`DaemonState::log_follows`].
 pub const MAX_CONCURRENT_LOG_FOLLOWS: usize = 64;
@@ -293,15 +291,20 @@ impl SupervisorService {
                 .flat_map(|entry| entry.config.gpus.iter().map(|gpu| gpu.pci_host.clone()))
                 .collect()
         };
-        // Probe every unattached NVIDIA card's CC mode before reporting the
-        // inventory, so a freshly-idled card's mode is current. mmap of a
-        // BAR is a blocking syscall; run it off the tokio worker.
+        // Refresh every unattached NVIDIA card whose CC mode has gone
+        // stale before reporting the inventory, so a freshly-idled card's
+        // mode is current. Cards answered within the freshness window are
+        // served from the cache and not read at all, which matters because
+        // the agent calls this for every unauthenticated capability
+        // request. mmap of a BAR is a blocking syscall; run it off the
+        // tokio worker.
         // refresh_cc_modes takes its own world read guard and keeps it for
         // the whole probe: the `attached` snapshot above can go stale the
         // moment a concurrent CreateVm registers a card, and the probe gate
         // must never trust a snapshot it no longer holds the lock for. It
-        // also skips the sweep when nothing changed hands within
-        // CC_PROBE_TTL, so a public poller cannot turn every request into a
+        // also skips the sweep when nothing changed hands within the
+        // freshness window, and reads no card whose own answer is still
+        // fresh, so a public poller cannot turn every request into a
         // register read.
         {
             let state = self.state.clone();
@@ -429,29 +432,31 @@ fn gpu_json(gpus: &[GpuDevice]) -> Result<String, DaemonError> {
     })
 }
 
-/// The cached CC mode of one card, if it has been probed.
+/// The cached CC mode of one card, if it has been probed successfully.
 pub fn cc_mode_of(state: &DaemonState, pci_host: &str) -> Option<crate::gpu_cc::CcMode> {
     state
         .gpu_cc_modes
         .lock()
         .expect("gpu_cc_modes poisoned")
         .get(pci_host)
-        .copied()
+        .and_then(|probed| probed.mode)
 }
 
-/// Probe every NVIDIA card no VM owns and remember the answer. A card that
-/// becomes attached keeps its last value (the register is never read under
-/// a guest). A probe that errors, or that reads a register encoding with no
-/// mode, forgets the card: whatever it advertised before is no longer known
-/// to be true, and an unknown card advertises nothing. Runs on the blocking
-/// pool: mmap of a BAR is a syscall against device memory.
-fn refresh_cc_modes(state: &DaemonState) {
-    refresh_cc_modes_with(state, state.gpu_cc_probe, CC_PROBE_TTL);
+/// Probe every NVIDIA card no VM owns whose last answer has gone stale, and
+/// remember what it said. A card that becomes attached keeps its last value
+/// (the register is never read under a guest). A probe that errors, or that
+/// reads a register encoding with no mode, replaces the card's answer with
+/// "no mode": whatever it advertised before is no longer known to be true,
+/// and an unknown card advertises nothing. Runs on the blocking pool: mmap
+/// of a BAR is a syscall against device memory.
+pub fn refresh_cc_modes(state: &DaemonState) {
+    refresh_cc_modes_with(state, state.gpu_cc_probe, crate::gpu_cc::CC_MODE_TTL);
 }
 
-/// `refresh_cc_modes` over an explicit probe and sweep lifetime, so unit
+/// `refresh_cc_modes` over an explicit probe and freshness window, so unit
 /// tests can hand in a closure that records what was probed and decide
-/// whether the last sweep counts as fresh. The world read
+/// whether the last sweep and each card's last answer count as fresh. The
+/// world read
 /// guard is held across the whole loop, not just while the attached set is
 /// collected: CreateVm registers a VM's cards in the world view under the
 /// write lock before it boots anything, so under this guard a card is
@@ -460,9 +465,17 @@ fn refresh_cc_modes(state: &DaemonState) {
 /// rather than merely likely. Each probe is a sysfs open and a one-page
 /// mmap, microseconds, so a writer waiting on the guard barely notices.
 ///
-/// A sweep younger than `ttl` that ran against the same attached set is
-/// not repeated: the answer cannot have changed by anything the daemon
-/// does, and the alternative is a register read per public request.
+/// Two gates share the one `ttl`. The outer one skips the sweep whole when
+/// it last ran against the same attached set less than `ttl` ago: nothing
+/// the daemon does can have changed an answer since. The inner one skips
+/// any single card whose own last answer is younger than `ttl`, which is
+/// what covers a sweep the outer gate let through because some other card
+/// changed hands. Host info is served on an unauthenticated path, and
+/// reading device memory once per request is both a needless cost and a
+/// lever an outsider gets to pull; the mode itself only changes when an
+/// operator runs NVIDIA's tool against an idle card, which no request can
+/// do. The create gate does not come through here: it always reads the
+/// card.
 fn refresh_cc_modes_with(
     state: &DaemonState,
     probe: impl Fn(&str, &str) -> Result<Option<crate::gpu_cc::CcMode>, DaemonError>,
@@ -487,6 +500,15 @@ fn refresh_cc_modes_with(
         if attached.contains(&gpu.pci_host) || gpu.vendor != "NVIDIA" {
             continue;
         }
+        let fresh = state
+            .gpu_cc_modes
+            .lock()
+            .expect("gpu_cc_modes poisoned")
+            .get(&gpu.pci_host)
+            .is_some_and(|probed| probed.is_fresh(ttl));
+        if fresh {
+            continue;
+        }
         let mode = match probe(&gpu.pci_host, &gpu.device_id) {
             Ok(mode) => mode,
             Err(error) => {
@@ -494,15 +516,11 @@ fn refresh_cc_modes_with(
                 None
             }
         };
-        let mut cache = state.gpu_cc_modes.lock().expect("gpu_cc_modes poisoned");
-        match mode {
-            Some(mode) => {
-                cache.insert(gpu.pci_host.clone(), mode);
-            }
-            None => {
-                cache.remove(&gpu.pci_host);
-            }
-        }
+        state
+            .gpu_cc_modes
+            .lock()
+            .expect("gpu_cc_modes poisoned")
+            .insert(gpu.pci_host.clone(), crate::gpu_cc::ProbedCcMode::now(mode));
     }
     let mut sweep = state.gpu_cc_sweep.lock().expect("gpu_cc_sweep poisoned");
     sweep.attached = attached;
@@ -1551,7 +1569,7 @@ mod tests {
                 probed.lock().unwrap().push(pci_host.to_string());
                 Ok(Some(crate::gpu_cc::CcMode::On))
             },
-            std::time::Duration::ZERO,
+            crate::gpu_cc::CC_MODE_TTL,
         );
 
         assert_eq!(
@@ -1561,7 +1579,10 @@ mod tests {
         );
         let cache = state.gpu_cc_modes.lock().unwrap();
         assert_eq!(cache.len(), 1);
-        assert_eq!(cache.get("07:00.0"), Some(&crate::gpu_cc::CcMode::On));
+        assert_eq!(
+            cache.get("07:00.0").map(|probed| probed.mode),
+            Some(Some(crate::gpu_cc::CcMode::On))
+        );
         assert_eq!(cache.get("06:00.0"), None);
     }
 
@@ -1596,32 +1617,34 @@ mod tests {
         );
         {
             let mut cache = state.gpu_cc_modes.lock().unwrap();
-            cache.insert("06:00.0".to_string(), crate::gpu_cc::CcMode::On);
-            cache.insert("07:00.0".to_string(), crate::gpu_cc::CcMode::On);
+            let on = crate::gpu_cc::ProbedCcMode::now(Some(crate::gpu_cc::CcMode::On));
+            cache.insert("06:00.0".to_string(), on);
+            cache.insert("07:00.0".to_string(), on);
         }
 
         refresh_cc_modes_with(
             &state,
             |pci_host, _device_id| match pci_host {
-                "06:00.0" => Err(DaemonError::GpuProbe("BAR0 went away".to_string())),
+                "06:00.0" => Err(DaemonError::GpuUnreadable {
+                    pci_host: pci_host.to_string(),
+                }),
                 _ => Ok(None),
             },
+            // The cached answers are seconds old, so only a zero window
+            // makes the refresh read the cards again.
             std::time::Duration::ZERO,
         );
 
         let cache = state.gpu_cc_modes.lock().unwrap();
         assert!(
-            cache.is_empty(),
-            "a failed or modeless probe must evict the stale entry: {cache:?}"
+            cache.values().all(|probed| probed.mode.is_none()),
+            "a failed or modeless probe must drop the stale mode: {cache:?}"
         );
     }
 
-    #[test]
-    fn refresh_cc_modes_repeats_a_sweep_only_when_a_card_changed_hands_or_the_ttl_passed() {
-        // A public poller hitting GetHostInfo must not turn every request
-        // into a register read: a sweep against the same attached set
-        // within the TTL is skipped. A card changing hands, or the TTL
-        // passing, brings the next sweep back.
+    /// Two free NVIDIA cards and nothing attached: the fixture both
+    /// freshness tests below build on.
+    fn two_free_cards() -> DaemonState {
         let card = |pci_host: &str| GpuDevice {
             vendor: "NVIDIA".to_string(),
             device_name: "GB202 [GeForce RTX 5090]".to_string(),
@@ -1638,12 +1661,22 @@ mod tests {
             gpus: vec![card("06:00.0"), card("07:00.0")],
             dns_nameservers: None,
         };
-        let state = DaemonState::hermetic(
+        DaemonState::hermetic(
             host,
             WorldView::default(),
             Arc::new(crate::units::StaticUnitStates::default()),
             Arc::new(crate::logs::StaticLogSource::new(Vec::new())),
-        );
+        )
+    }
+
+    #[test]
+    fn refresh_cc_modes_repeats_a_sweep_only_when_a_card_changed_hands_or_the_ttl_passed() {
+        // A public poller hitting GetHostInfo must not turn every request
+        // into a register read: a sweep against the same attached set
+        // within the TTL is skipped whole, before any card is looked at. A
+        // card changing hands, or the TTL passing, brings the next sweep
+        // back.
+        let state = two_free_cards();
         let probes = std::sync::atomic::AtomicUsize::new(0);
         let counting = |_: &str, _: &str| {
             probes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -1659,7 +1692,9 @@ mod tests {
             "the second sweep within the TTL against the same attached set is skipped"
         );
 
-        // A card changes hands: the sweep runs again, over the free card only.
+        // A card changes hands: the sweep runs again, over the free card
+        // only, and that card's own answer is an hour fresh, so nothing is
+        // read.
         let mut entry = fixture_entry(test_fixtures::QEMU_HASH, true);
         entry.config.gpus = vec![crate::controller_config::QemuGpu {
             pci_host: "06:00.0".to_string(),
@@ -1667,11 +1702,65 @@ mod tests {
         }];
         state.world.blocking_write().insert_entry(entry);
         refresh_cc_modes_with(&state, counting, hour);
-        assert_eq!(probes.load(std::sync::atomic::Ordering::SeqCst), 3);
+        assert_eq!(probes.load(std::sync::atomic::Ordering::SeqCst), 2);
 
-        // A zero TTL means every sweep runs.
+        // A zero TTL means every sweep runs and every card is read.
         refresh_cc_modes_with(&state, counting, std::time::Duration::ZERO);
-        assert_eq!(probes.load(std::sync::atomic::Ordering::SeqCst), 4);
+        assert_eq!(probes.load(std::sync::atomic::Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn refresh_cc_modes_serves_a_fresh_answer_without_reading_the_card() {
+        // GetHostInfo refreshes on every call and the agent calls it for
+        // every unauthenticated /about/capability request. Without a TTL
+        // any internet client could make the host mmap the BAR of every
+        // idle NVIDIA card it has, as often as it likes. A probe that
+        // failed is remembered too: a card that cannot be read must not be
+        // retried on every request either. The per-card window is what
+        // holds when the sweep gate lets a pass through, so the sweep is
+        // forced to run every time here.
+        let state = two_free_cards();
+
+        let probed: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+        let probe = |pci_host: &str, _device_id: &str| {
+            probed.lock().unwrap().push(pci_host.to_string());
+            match pci_host {
+                "06:00.0" => Ok(Some(crate::gpu_cc::CcMode::On)),
+                _ => Err(DaemonError::GpuUnreadable {
+                    pci_host: pci_host.to_string(),
+                }),
+            }
+        };
+
+        refresh_cc_modes_with(&state, probe, crate::gpu_cc::CC_MODE_TTL);
+        force_next_sweep(&state);
+        refresh_cc_modes_with(&state, probe, crate::gpu_cc::CC_MODE_TTL);
+        let after_two_refreshes = probed.lock().unwrap().clone();
+        assert_eq!(
+            after_two_refreshes.len(),
+            2,
+            "the second refresh must be served from the cache: {after_two_refreshes:?}"
+        );
+        assert_eq!(
+            cc_mode_of(&state, "06:00.0"),
+            Some(crate::gpu_cc::CcMode::On)
+        );
+        assert_eq!(
+            cc_mode_of(&state, "07:00.0"),
+            None,
+            "a card whose probe failed advertises nothing"
+        );
+
+        // An entry past its TTL is read again, both the mode and the failure.
+        refresh_cc_modes_with(&state, probe, std::time::Duration::ZERO);
+        assert_eq!(probed.into_inner().unwrap().len(), 4);
+    }
+
+    /// Drop the record of the last sweep so the next `refresh_cc_modes_with`
+    /// walks the cards whatever its `ttl` is, leaving only the per-card
+    /// freshness check between a card and its register.
+    fn force_next_sweep(state: &DaemonState) {
+        state.gpu_cc_sweep.lock().unwrap().at = None;
     }
 
     #[test]

--- a/rust/crates/supervisor-daemon/src/service.rs
+++ b/rust/crates/supervisor-daemon/src/service.rs
@@ -512,17 +512,24 @@ fn refresh_cc_modes_with(
         .expect("gpu_cc_refresh poisoned");
     let world = state.world.blocking_read();
     let mut attached: HashSet<String> = HashSet::new();
-    // The subset a confidential guest owns. Those cards have a known mode
-    // without any read: a card enters an SEV-SNP VM only after the create
-    // gate has read CC-on from it, and the mode cannot change while the
-    // guest holds the card (switching it takes a reset of a free card). A
-    // daemon that adopts such a VM at boot has an empty cache and will
+    // The subset a live confidential guest owns. Those cards have a known
+    // mode without any read: a card enters an SEV-SNP VM only after the
+    // create gate has read CC-on from it, and the mode cannot change while
+    // the guest holds the card (switching it takes a reset of a free card).
+    // A daemon that adopts such a VM at boot has an empty cache and will
     // never probe the card, so without this its mode would stay empty for
     // the VM's whole life. Plain passthrough VMs went through no gate and
     // get nothing.
+    //
+    // A stopped VM gets nothing either, even an SEV-SNP one: its QEMU is
+    // gone, so the card is idle hardware an operator can re-mode, and the
+    // gate's word about it has expired. The card stays out of the sweep
+    // (it is still in `attached`, the config still claims it), so a
+    // stopped VM's card simply advertises nothing until the VM is deleted
+    // and the card is read as free.
     let mut known_cc_on: HashSet<String> = HashSet::new();
     for entry in world.entries.values() {
-        let confidential = entry.config.snp().is_some();
+        let confidential = entry.config.snp().is_some() && entry.times.stopped_at_ns == 0;
         for gpu in &entry.config.gpus {
             attached.insert(gpu.pci_host.clone());
             if confidential {
@@ -1992,6 +1999,49 @@ mod tests {
         assert_eq!(
             info.gpus[0].arch, "blackwell",
             "the architecture comes from the device id, not from a probe"
+        );
+    }
+
+    #[test]
+    fn a_stopped_snp_vms_card_is_not_seeded_cc_on() {
+        // The seed rests on the card being under a live guest: nothing can
+        // switch its mode there, so the create gate's reading still holds.
+        // A stopped VM's QEMU is gone and the card is idle hardware an
+        // operator can re-mode, so the gate's word has expired and the
+        // card must advertise nothing rather than a mode the host cannot
+        // vouch for. It is still claimed by the entry's config, so it is
+        // not read either.
+        let mut snp_entry = adopted_entry_holding(test_fixtures::QEMU_HASH, "06:00.0", true);
+        snp_entry.times.started_at_ns = 0;
+        snp_entry.times.stopped_at_ns = snp_entry.times.defined_at_ns;
+        let host = HostState {
+            settings: crate::config::Settings::from_vars(std::iter::empty()).unwrap(),
+            host_ipv4: String::new(),
+            network_interface: None,
+            gpus: vec![nvidia_card("06:00.0")],
+            dns_nameservers: None,
+        };
+        let mut world = WorldView::default();
+        world.insert_entry(snp_entry);
+        let state = DaemonState::hermetic(
+            host,
+            world,
+            Arc::new(crate::units::StaticUnitStates::default()),
+            Arc::new(crate::logs::StaticLogSource::new(Vec::new())),
+        );
+
+        refresh_cc_modes_with(
+            &state,
+            |pci_host: &str, _device_id: &str| {
+                panic!("a card an entry still claims must never be probed: {pci_host}")
+            },
+            crate::gpu_cc::CC_MODE_TTL,
+        );
+
+        assert_eq!(
+            cc_mode_of(&state, "06:00.0"),
+            None,
+            "a stopped confidential VM's card advertises nothing"
         );
     }
 

--- a/rust/crates/supervisor-daemon/src/service.rs
+++ b/rust/crates/supervisor-daemon/src/service.rs
@@ -191,6 +191,12 @@ pub struct DaemonState {
     /// (reachable from the public `/about` endpoints) cannot drive an
     /// unbounded rate of register reads: see `refresh_cc_modes`.
     pub gpu_cc_sweep: std::sync::Mutex<CcSweep>,
+    /// Held for the length of one CC mode refresh pass, so a burst of
+    /// GetHostInfo calls costs one pass and the callers behind it read
+    /// what it wrote. Two passes running at once would also corrupt the
+    /// host's runtime-PM setting: both can read `power/control` before
+    /// either writes it, and the second would then restore "on".
+    pub gpu_cc_refresh: std::sync::Mutex<()>,
 }
 
 /// The attached set the last CC-mode sweep saw, and when it ran. A sweep
@@ -241,6 +247,7 @@ impl DaemonState {
             gpu_cc_modes: std::sync::Mutex::new(HashMap::new()),
             gpu_cc_probe: crate::gpu_cc::no_probe,
             gpu_cc_sweep: std::sync::Mutex::new(CcSweep::default()),
+            gpu_cc_refresh: std::sync::Mutex::new(()),
         }
     }
 
@@ -458,15 +465,30 @@ pub fn refresh_cc_modes(state: &DaemonState) {
 
 /// `refresh_cc_modes` over an explicit probe and freshness window, so unit
 /// tests can hand in a closure that records what was probed and decide
-/// whether the last sweep and each card's last answer count as fresh. The
-/// world read
-/// guard is held across the whole loop, not just while the attached set is
-/// collected: CreateVm registers a VM's cards in the world view under the
-/// write lock before it boots anything, so under this guard a card is
-/// either already attached (and skipped) or cannot become attached until
-/// the probe is done. That is what makes "never read under a guest" hold
-/// rather than merely likely. Each probe is a sysfs open and a one-page
-/// mmap, microseconds, so a writer waiting on the guard barely notices.
+/// whether the last sweep and each card's last answer count as fresh.
+///
+/// One pass at a time. The pass lock is taken before the world guard (a
+/// waiter must not sit on a read guard), so a burst of GetHostInfo calls
+/// costs one pass and the callers behind it find the entries it wrote.
+/// Overlapping passes would be worse than wasteful: both can read
+/// `power/control` before either writes it, and the second would then
+/// remember "on" as the value to put back, pinning the card awake for
+/// good.
+///
+/// The world read guard is held across the whole loop, not just while the
+/// attached set is collected: CreateVm registers a VM's cards in the world
+/// view under the write lock before it boots anything, so under this guard
+/// a card is either already attached (and skipped) or cannot become
+/// attached until the probe is done. That is what makes "never read under
+/// a guest" hold rather than merely likely, and it is why the probes
+/// cannot be moved outside the guard.
+///
+/// The guard is not cheap to hold any more: resuming a runtime-suspended
+/// card costs up to the 200 ms resume budget, so a pass can hold it for
+/// (stale suspended cards) x 200 ms, and tokio's RwLock is
+/// write-preferring, so a CreateVm arriving mid-pass waits that long. What
+/// keeps that off the hot path is the freshness window below: a given card
+/// is read at most once a minute, whatever the request rate.
 ///
 /// Two gates share the one `ttl`. The outer one skips the sweep whole when
 /// it last ran against the same attached set less than `ttl` ago: nothing
@@ -484,6 +506,10 @@ fn refresh_cc_modes_with(
     probe: impl Fn(&str, &str) -> Result<Option<crate::gpu_cc::CcMode>, DaemonError>,
     ttl: std::time::Duration,
 ) {
+    let _pass = state
+        .gpu_cc_refresh
+        .lock()
+        .expect("gpu_cc_refresh poisoned");
     let world = state.world.blocking_read();
     let mut attached: HashSet<String> = HashSet::new();
     // The subset a confidential guest owns. Those cards have a known mode
@@ -1802,6 +1828,74 @@ mod tests {
     /// An adopted VM holding one card: SNP (measured-boot slice present)
     /// or plain QEMU passthrough, which is the distinction the seeding
     /// turns on.
+    #[test]
+    fn concurrent_refreshes_read_a_card_once_and_leave_its_power_setting_alone() {
+        // Two GetHostInfo calls landing together used to run two full
+        // passes over the same cards. Both could read power/control before
+        // either wrote it, so the second remembered "on" as the value to
+        // restore and the card stayed pinned awake after the probes, with
+        // the host's own runtime-PM setting lost.
+        let sysfs = tempfile::tempdir().unwrap();
+        let device_dir = sysfs.path().join("0000:06:00.0");
+        std::fs::create_dir_all(device_dir.join("power")).unwrap();
+        // The fixture card never actually resumes, so a probe holds the
+        // pass for its whole (short) resume budget: plenty of overlap for
+        // a second pass to start if anything let it.
+        std::fs::write(device_dir.join("power/runtime_status"), "suspended\n").unwrap();
+        std::fs::write(device_dir.join("power/control"), "auto\n").unwrap();
+        let mut bytes = vec![0u8; 0x1000];
+        bytes[0x590..0x594].copy_from_slice(&1u32.to_le_bytes());
+        std::fs::write(device_dir.join("resource0"), &bytes).unwrap();
+
+        let host = HostState {
+            settings: crate::config::Settings::from_vars(std::iter::empty()).unwrap(),
+            host_ipv4: String::new(),
+            network_interface: None,
+            gpus: vec![nvidia_card("06:00.0")],
+            dns_nameservers: None,
+        };
+        let state = DaemonState::hermetic(
+            host,
+            WorldView::default(),
+            Arc::new(crate::units::StaticUnitStates::default()),
+            Arc::new(crate::logs::StaticLogSource::new(Vec::new())),
+        );
+
+        let reads = std::sync::atomic::AtomicUsize::new(0);
+        let devices_dir = sysfs.path().to_path_buf();
+        let probe = |pci_host: &str, device_id: &str| {
+            reads.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            crate::gpu_cc::probe_cc_mode_in(
+                &crate::gpu_cc::sysfs_device_dir_under(&devices_dir, pci_host),
+                pci_host,
+                device_id,
+                std::time::Duration::from_millis(50),
+            )
+        };
+        std::thread::scope(|scope| {
+            for _ in 0..2 {
+                scope.spawn(|| refresh_cc_modes_with(&state, probe, crate::gpu_cc::CC_MODE_TTL));
+            }
+        });
+
+        assert_eq!(
+            reads.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the second pass must wait for the first and then find the answer fresh"
+        );
+        assert_eq!(
+            std::fs::read_to_string(device_dir.join("power/control"))
+                .unwrap()
+                .trim(),
+            "auto",
+            "the host's runtime-PM setting must survive concurrent passes"
+        );
+        assert_eq!(
+            cc_mode_of(&state, "06:00.0"),
+            Some(crate::gpu_cc::CcMode::On)
+        );
+    }
+
     fn adopted_entry_holding(vm_hash: &str, pci_host: &str, snp: bool) -> VmEntry {
         let mut entry = fixture_entry(vm_hash, true);
         if snp {

--- a/rust/crates/supervisor-daemon/src/service.rs
+++ b/rust/crates/supervisor-daemon/src/service.rs
@@ -530,9 +530,17 @@ fn refresh_cc_modes_with(
     // it here again, on the gate's reading plus the guest's own attestation
     // of the card at every boot) or the VM is deleted and the card is read
     // as free.
+    //
+    // "Live" is a start with no stop after it, not just the absence of a
+    // stop: an entry that was never started (a Defined one, or one adopted
+    // while the systemd bus was unreachable, where no stage timestamp but
+    // defined_at is set) has no guest holding its card either, and the
+    // adopted case is precisely where the daemon cannot tell whether the
+    // guest is alive. Both would otherwise read as live and be seeded.
     let mut known_cc_on: HashSet<String> = HashSet::new();
     for entry in world.entries.values() {
-        let confidential = entry.config.snp().is_some() && entry.times.stopped_at_ns == 0;
+        let live = entry.times.started_at_ns != 0 && entry.times.stopped_at_ns == 0;
+        let confidential = entry.config.snp().is_some() && live;
         for gpu in &entry.config.gpus {
             attached.insert(gpu.pci_host.clone());
             if confidential {
@@ -2045,6 +2053,49 @@ mod tests {
             cc_mode_of(&state, "06:00.0"),
             None,
             "a stopped confidential VM's card advertises nothing"
+        );
+    }
+
+    #[test]
+    fn a_never_started_snp_vms_card_is_not_seeded_cc_on() {
+        // An entry adopted while the systemd bus was unreachable carries no
+        // stop stamp, but no start either, and the daemon does not know
+        // whether its guest is alive. A never-started Defined entry looks
+        // the same. Neither is proof that a guest is holding the card's
+        // mode still, so neither gets the seed.
+        let mut snp_entry = adopted_entry_holding(test_fixtures::QEMU_HASH, "06:00.0", true);
+        snp_entry.times = crate::world::VmTimes {
+            defined_at_ns: snp_entry.times.defined_at_ns,
+            ..Default::default()
+        };
+        let host = HostState {
+            settings: crate::config::Settings::from_vars(std::iter::empty()).unwrap(),
+            host_ipv4: String::new(),
+            network_interface: None,
+            gpus: vec![nvidia_card("06:00.0")],
+            dns_nameservers: None,
+        };
+        let mut world = WorldView::default();
+        world.insert_entry(snp_entry);
+        let state = DaemonState::hermetic(
+            host,
+            world,
+            Arc::new(crate::units::StaticUnitStates::default()),
+            Arc::new(crate::logs::StaticLogSource::new(Vec::new())),
+        );
+
+        refresh_cc_modes_with(
+            &state,
+            |pci_host: &str, _device_id: &str| {
+                panic!("a card an entry still claims must never be probed: {pci_host}")
+            },
+            crate::gpu_cc::CC_MODE_TTL,
+        );
+
+        assert_eq!(
+            cc_mode_of(&state, "06:00.0"),
+            None,
+            "a card whose guest may never have run advertises nothing"
         );
     }
 

--- a/rust/crates/supervisor-daemon/src/service.rs
+++ b/rust/crates/supervisor-daemon/src/service.rs
@@ -524,9 +524,12 @@ fn refresh_cc_modes_with(
     // A stopped VM gets nothing either, even an SEV-SNP one: its QEMU is
     // gone, so the card is idle hardware an operator can re-mode, and the
     // gate's word about it has expired. The card stays out of the sweep
-    // (it is still in `attached`, the config still claims it), so a
-    // stopped VM's card simply advertises nothing until the VM is deleted
-    // and the card is read as free.
+    // (it is still in `attached`, the config still claims it), and the
+    // stop itself dropped whatever the cache held about it, so a stopped
+    // VM's card advertises nothing until it is started again (which seeds
+    // it here again, on the gate's reading plus the guest's own attestation
+    // of the card at every boot) or the VM is deleted and the card is read
+    // as free.
     let mut known_cc_on: HashSet<String> = HashSet::new();
     for entry in world.entries.values() {
         let confidential = entry.config.snp().is_some() && entry.times.stopped_at_ns == 0;

--- a/rust/crates/supervisor-daemon/src/service.rs
+++ b/rust/crates/supervisor-daemon/src/service.rs
@@ -182,7 +182,8 @@ pub struct DaemonState {
     /// VM owns is entered as CC-on without a read, on the gate's word. A
     /// card never probed has no entry; a card whose last probe failed has
     /// an entry with no mode, which advertises nothing and holds the retry
-    /// off until the entry goes stale.
+    /// off until the entry goes stale, which happens sooner than it does
+    /// for a decoded mode (see `gpu_cc::CcCacheWindows`).
     pub gpu_cc_modes: std::sync::Mutex<HashMap<String, crate::gpu_cc::ProbedCcMode>>,
     /// How a card's CC mode is read: the BAR0 register in production,
     /// `gpu_cc::no_probe` on hermetic state so tests never open sysfs.
@@ -200,8 +201,12 @@ pub struct DaemonState {
 }
 
 /// The attached set the last CC-mode sweep saw, and when it ran. A sweep
-/// against an unchanged set within `gpu_cc::CC_MODE_TTL` is skipped whole,
-/// which is the cheap outer gate over the per-card freshness check inside.
+/// against an unchanged set within the shortest of the cache windows
+/// (`gpu_cc::CcCacheWindows::shortest`) is skipped whole, which is the
+/// cheap outer gate over the per-card freshness check inside. It is the
+/// shortest window and not the longest because one decision covers every
+/// card here, so it must not outlive the tier of the card that ages out
+/// first.
 #[derive(Debug, Default)]
 pub struct CcSweep {
     pub attached: HashSet<String>,
@@ -460,11 +465,14 @@ pub fn cc_mode_of(state: &DaemonState, pci_host: &str) -> Option<crate::gpu_cc::
 /// all. Runs on the blocking pool: mmap of a BAR is a syscall against
 /// device memory.
 pub fn refresh_cc_modes(state: &DaemonState) {
-    refresh_cc_modes_with(state, state.gpu_cc_probe, crate::gpu_cc::CC_MODE_TTL);
+    let windows = crate::gpu_cc::CcCacheWindows::with_mode_ttl(std::time::Duration::from_secs(
+        state.host.settings.gpu_cc_mode_ttl,
+    ));
+    refresh_cc_modes_with(state, state.gpu_cc_probe, windows);
 }
 
-/// `refresh_cc_modes` over an explicit probe and freshness window, so unit
-/// tests can hand in a closure that records what was probed and decide
+/// `refresh_cc_modes` over an explicit probe and explicit cache windows, so
+/// unit tests can hand in a closure that records what was probed and decide
 /// whether the last sweep and each card's last answer count as fresh.
 ///
 /// One pass at a time. The pass lock is taken before the world guard (a
@@ -488,23 +496,32 @@ pub fn refresh_cc_modes(state: &DaemonState) {
 /// (stale suspended cards) x 200 ms, and tokio's RwLock is
 /// write-preferring, so a CreateVm arriving mid-pass waits that long. What
 /// keeps that off the hot path is the freshness window below: a given card
-/// is read at most once a minute, whatever the request rate.
+/// is read at most once per the window its own last answer falls under,
+/// whatever the request rate.
 ///
-/// Two gates share the one `ttl`. The outer one skips the sweep whole when
-/// it last ran against the same attached set less than `ttl` ago: nothing
-/// the daemon does can have changed an answer since. The inner one skips
-/// any single card whose own last answer is younger than `ttl`, which is
-/// what covers a sweep the outer gate let through because some other card
-/// changed hands. Host info is served on an unauthenticated path, and
-/// reading device memory once per request is both a needless cost and a
-/// lever an outsider gets to pull; the mode itself only changes when an
-/// operator runs NVIDIA's tool against an idle card, which no request can
-/// do. The create gate does not come through here: it always reads the
-/// card.
+/// Two gates, over different windows. The outer one skips the sweep whole
+/// when it last ran against the same attached set less than
+/// `windows.shortest()` ago. It is one decision for every card at once, so
+/// it cannot be allowed to outlive the shortest tier any of them is held
+/// under: gated on the long window instead, a card cached as unreadable
+/// would sit behind the pass gate for an hour, and the short tier that is
+/// meant to bring it back within the minute would never be reached. The
+/// inner one skips any single card whose own last answer is fresh under
+/// its own tier, and that is where the long window for a decoded mode
+/// actually pays. Walking the cache to check every entry against its own
+/// tier before skipping the pass would be equally correct and buy nothing
+/// back, since the per-card gate walks the same cards anyway; the price of
+/// the short outer gate is one walk over the inventory with no register
+/// reads per short window. Host info is served on an unauthenticated path,
+/// and reading device memory once per request is both a needless cost and
+/// a lever an outsider gets to pull; both windows bound that the same way,
+/// and the mode itself only changes when an operator runs NVIDIA's tool
+/// against an idle card, which no request can do. The create gate does not
+/// come through here: it always reads the card.
 fn refresh_cc_modes_with(
     state: &DaemonState,
     probe: impl Fn(&str, &str) -> Result<Option<crate::gpu_cc::CcMode>, DaemonError>,
-    ttl: std::time::Duration,
+    windows: crate::gpu_cc::CcCacheWindows,
 ) {
     let _pass = state
         .gpu_cc_refresh
@@ -552,10 +569,12 @@ fn refresh_cc_modes_with(
         let sweep = state.gpu_cc_sweep.lock().expect("gpu_cc_sweep poisoned");
         if let Some(at) = sweep.at
             && sweep.attached == attached
-            && at.elapsed() < ttl
+            && at.elapsed() < windows.shortest()
         {
             // Nothing changed hands since that sweep, so it already seeded
-            // every confidential VM's cards and read every free one.
+            // every confidential VM's cards and read every free one, and no
+            // card's answer can have aged out of even the shortest window
+            // in between.
             return;
         }
     }
@@ -581,7 +600,7 @@ fn refresh_cc_modes_with(
             .lock()
             .expect("gpu_cc_modes poisoned")
             .get(&gpu.pci_host)
-            .is_some_and(|probed| probed.is_fresh(ttl));
+            .is_some_and(|probed| probed.is_fresh(windows));
         if fresh {
             continue;
         }
@@ -1645,7 +1664,7 @@ mod tests {
                 probed.lock().unwrap().push(pci_host.to_string());
                 Ok(Some(crate::gpu_cc::CcMode::On))
             },
-            crate::gpu_cc::CC_MODE_TTL,
+            default_windows(),
         );
 
         assert_eq!(
@@ -1706,9 +1725,9 @@ mod tests {
                 }),
                 _ => Ok(None),
             },
-            // The cached answers are seconds old, so only a zero window
-            // makes the refresh read the cards again.
-            std::time::Duration::ZERO,
+            // The cached answers are seconds old, so only zero-length
+            // windows make the refresh read the cards again.
+            expired_windows(),
         );
 
         let cache = state.gpu_cc_modes.lock().unwrap();
@@ -1753,39 +1772,38 @@ mod tests {
     fn refresh_cc_modes_repeats_a_sweep_only_when_a_card_changed_hands_or_the_ttl_passed() {
         // A public poller hitting GetHostInfo must not turn every request
         // into a register read: a sweep against the same attached set
-        // within the TTL is skipped whole, before any card is looked at. A
-        // card changing hands, or the TTL passing, brings the next sweep
-        // back.
+        // within the shortest window is skipped whole, before any card is
+        // looked at. A card changing hands, or the windows passing, brings
+        // the next sweep back.
         let state = two_free_cards();
         let probes = std::sync::atomic::AtomicUsize::new(0);
         let counting = |_: &str, _: &str| {
             probes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(Some(crate::gpu_cc::CcMode::On))
         };
-        let hour = std::time::Duration::from_secs(3600);
 
-        refresh_cc_modes_with(&state, counting, hour);
-        refresh_cc_modes_with(&state, counting, hour);
+        refresh_cc_modes_with(&state, counting, default_windows());
+        refresh_cc_modes_with(&state, counting, default_windows());
         assert_eq!(
             probes.load(std::sync::atomic::Ordering::SeqCst),
             2,
-            "the second sweep within the TTL against the same attached set is skipped"
+            "the second sweep inside the pass window against the same attached set is skipped"
         );
 
         // A card changes hands: the sweep runs again, over the free card
-        // only, and that card's own answer is an hour fresh, so nothing is
-        // read.
+        // only, and that card's own answer is a decoded mode, fresh for
+        // the long window, so nothing is read.
         let mut entry = fixture_entry(test_fixtures::QEMU_HASH, true);
         entry.config.gpus = vec![crate::controller_config::QemuGpu {
             pci_host: "06:00.0".to_string(),
             supports_x_vga: true,
         }];
         state.world.blocking_write().insert_entry(entry);
-        refresh_cc_modes_with(&state, counting, hour);
+        refresh_cc_modes_with(&state, counting, default_windows());
         assert_eq!(probes.load(std::sync::atomic::Ordering::SeqCst), 2);
 
-        // A zero TTL means every sweep runs and every card is read.
-        refresh_cc_modes_with(&state, counting, std::time::Duration::ZERO);
+        // Zero-length windows mean every sweep runs and every card is read.
+        refresh_cc_modes_with(&state, counting, expired_windows());
         assert_eq!(probes.load(std::sync::atomic::Ordering::SeqCst), 3);
     }
 
@@ -1812,9 +1830,9 @@ mod tests {
             }
         };
 
-        refresh_cc_modes_with(&state, probe, crate::gpu_cc::CC_MODE_TTL);
+        refresh_cc_modes_with(&state, probe, default_windows());
         force_next_sweep(&state);
-        refresh_cc_modes_with(&state, probe, crate::gpu_cc::CC_MODE_TTL);
+        refresh_cc_modes_with(&state, probe, default_windows());
         let after_two_refreshes = probed.lock().unwrap().clone();
         assert_eq!(
             after_two_refreshes.len(),
@@ -1832,15 +1850,33 @@ mod tests {
         );
 
         // An entry past its TTL is read again, both the mode and the failure.
-        refresh_cc_modes_with(&state, probe, std::time::Duration::ZERO);
+        refresh_cc_modes_with(&state, probe, expired_windows());
         assert_eq!(probed.into_inner().unwrap().len(), 4);
     }
 
     /// Drop the record of the last sweep so the next `refresh_cc_modes_with`
-    /// walks the cards whatever its `ttl` is, leaving only the per-card
+    /// walks the cards whatever its windows are, leaving only the per-card
     /// freshness check between a card and its register.
     fn force_next_sweep(state: &DaemonState) {
         state.gpu_cc_sweep.lock().unwrap().at = None;
+    }
+
+    /// The windows a daemon runs with out of the box: the default long
+    /// tier for a decoded mode, the fixed short one for an answer with no
+    /// mode.
+    fn default_windows() -> crate::gpu_cc::CcCacheWindows {
+        crate::gpu_cc::CcCacheWindows::with_mode_ttl(std::time::Duration::from_secs(
+            crate::gpu_cc::DEFAULT_CC_MODE_TTL_SECS,
+        ))
+    }
+
+    /// Windows that hold nothing, so every sweep runs and every card is
+    /// read again.
+    fn expired_windows() -> crate::gpu_cc::CcCacheWindows {
+        crate::gpu_cc::CcCacheWindows {
+            mode: std::time::Duration::ZERO,
+            unreadable: std::time::Duration::ZERO,
+        }
     }
 
     /// An adopted VM holding one card: SNP (measured-boot slice present)
@@ -1892,7 +1928,7 @@ mod tests {
         };
         std::thread::scope(|scope| {
             for _ in 0..2 {
-                scope.spawn(|| refresh_cc_modes_with(&state, probe, crate::gpu_cc::CC_MODE_TTL));
+                scope.spawn(|| refresh_cc_modes_with(&state, probe, default_windows()));
             }
         });
 
@@ -1990,7 +2026,7 @@ mod tests {
             |pci_host: &str, _device_id: &str| {
                 panic!("an attached card must never be probed: {pci_host}")
             },
-            crate::gpu_cc::CC_MODE_TTL,
+            default_windows(),
         );
 
         assert_eq!(
@@ -2046,7 +2082,7 @@ mod tests {
             |pci_host: &str, _device_id: &str| {
                 panic!("a card an entry still claims must never be probed: {pci_host}")
             },
-            crate::gpu_cc::CC_MODE_TTL,
+            default_windows(),
         );
 
         assert_eq!(
@@ -2089,7 +2125,7 @@ mod tests {
             |pci_host: &str, _device_id: &str| {
                 panic!("a card an entry still claims must never be probed: {pci_host}")
             },
-            crate::gpu_cc::CC_MODE_TTL,
+            default_windows(),
         );
 
         assert_eq!(

--- a/rust/crates/supervisor-daemon/src/service.rs
+++ b/rust/crates/supervisor-daemon/src/service.rs
@@ -178,10 +178,11 @@ pub struct DaemonState {
     /// The last CC mode probe of each card, keyed by pci_host. Populated
     /// at startup and by `refresh_cc_modes` (called from `get_host_info`)
     /// for every NVIDIA card no VM currently owns, and by the SEV-SNP GPU
-    /// gate when a create probes its cards. A card never probed has no
-    /// entry; a card whose last probe failed has an entry with no mode,
-    /// which advertises nothing and holds the retry off until the entry
-    /// goes stale.
+    /// gate when a create probes its cards. A card an adopted confidential
+    /// VM owns is entered as CC-on without a read, on the gate's word. A
+    /// card never probed has no entry; a card whose last probe failed has
+    /// an entry with no mode, which advertises nothing and holds the retry
+    /// off until the entry goes stale.
     pub gpu_cc_modes: std::sync::Mutex<HashMap<String, crate::gpu_cc::ProbedCcMode>>,
     /// How a card's CC mode is read: the BAR0 register in production,
     /// `gpu_cc::no_probe` on hermetic state so tests never open sysfs.
@@ -447,8 +448,10 @@ pub fn cc_mode_of(state: &DaemonState, pci_host: &str) -> Option<crate::gpu_cc::
 /// (the register is never read under a guest). A probe that errors, or that
 /// reads a register encoding with no mode, replaces the card's answer with
 /// "no mode": whatever it advertised before is no longer known to be true,
-/// and an unknown card advertises nothing. Runs on the blocking pool: mmap
-/// of a BAR is a syscall against device memory.
+/// and an unknown card advertises nothing. A card a confidential guest owns
+/// gets its mode from the create gate that admitted it, with no read at
+/// all. Runs on the blocking pool: mmap of a BAR is a syscall against
+/// device memory.
 pub fn refresh_cc_modes(state: &DaemonState) {
     refresh_cc_modes_with(state, state.gpu_cc_probe, crate::gpu_cc::CC_MODE_TTL);
 }
@@ -482,22 +485,51 @@ fn refresh_cc_modes_with(
     ttl: std::time::Duration,
 ) {
     let world = state.world.blocking_read();
-    let attached: HashSet<String> = world
-        .entries
-        .values()
-        .flat_map(|entry| entry.config.gpus.iter().map(|gpu| gpu.pci_host.clone()))
-        .collect();
+    let mut attached: HashSet<String> = HashSet::new();
+    // The subset a confidential guest owns. Those cards have a known mode
+    // without any read: a card enters an SEV-SNP VM only after the create
+    // gate has read CC-on from it, and the mode cannot change while the
+    // guest holds the card (switching it takes a reset of a free card). A
+    // daemon that adopts such a VM at boot has an empty cache and will
+    // never probe the card, so without this its mode would stay empty for
+    // the VM's whole life. Plain passthrough VMs went through no gate and
+    // get nothing.
+    let mut known_cc_on: HashSet<String> = HashSet::new();
+    for entry in world.entries.values() {
+        let confidential = entry.config.snp().is_some();
+        for gpu in &entry.config.gpus {
+            attached.insert(gpu.pci_host.clone());
+            if confidential {
+                known_cc_on.insert(gpu.pci_host.clone());
+            }
+        }
+    }
     {
         let sweep = state.gpu_cc_sweep.lock().expect("gpu_cc_sweep poisoned");
         if let Some(at) = sweep.at
             && sweep.attached == attached
             && at.elapsed() < ttl
         {
+            // Nothing changed hands since that sweep, so it already seeded
+            // every confidential VM's cards and read every free one.
             return;
         }
     }
     for gpu in &state.host.gpus {
-        if attached.contains(&gpu.pci_host) || gpu.vendor != "NVIDIA" {
+        if gpu.vendor != "NVIDIA" {
+            continue;
+        }
+        if attached.contains(&gpu.pci_host) {
+            if known_cc_on.contains(&gpu.pci_host) {
+                state
+                    .gpu_cc_modes
+                    .lock()
+                    .expect("gpu_cc_modes poisoned")
+                    .entry(gpu.pci_host.clone())
+                    .or_insert_with(|| {
+                        crate::gpu_cc::ProbedCcMode::now(Some(crate::gpu_cc::CcMode::On))
+                    });
+            }
             continue;
         }
         let fresh = state
@@ -1642,10 +1674,9 @@ mod tests {
         );
     }
 
-    /// Two free NVIDIA cards and nothing attached: the fixture both
-    /// freshness tests below build on.
-    fn two_free_cards() -> DaemonState {
-        let card = |pci_host: &str| GpuDevice {
+    /// One unprobed Blackwell card at `pci_host`.
+    fn nvidia_card(pci_host: &str) -> GpuDevice {
+        GpuDevice {
             vendor: "NVIDIA".to_string(),
             device_name: "GB202 [GeForce RTX 5090]".to_string(),
             device_class: "0300".to_string(),
@@ -1653,12 +1684,17 @@ mod tests {
             device_id: "10de:2b85".to_string(),
             cc_mode: None,
             arch: None,
-        };
+        }
+    }
+
+    /// Two free NVIDIA cards and nothing attached: the fixture both
+    /// freshness tests below build on.
+    fn two_free_cards() -> DaemonState {
         let host = HostState {
             settings: crate::config::Settings::from_vars(std::iter::empty()).unwrap(),
             host_ipv4: String::new(),
             network_interface: None,
-            gpus: vec![card("06:00.0"), card("07:00.0")],
+            gpus: vec![nvidia_card("06:00.0"), nvidia_card("07:00.0")],
             dns_nameservers: None,
         };
         DaemonState::hermetic(
@@ -1761,6 +1797,108 @@ mod tests {
     /// freshness check between a card and its register.
     fn force_next_sweep(state: &DaemonState) {
         state.gpu_cc_sweep.lock().unwrap().at = None;
+    }
+
+    /// An adopted VM holding one card: SNP (measured-boot slice present)
+    /// or plain QEMU passthrough, which is the distinction the seeding
+    /// turns on.
+    fn adopted_entry_holding(vm_hash: &str, pci_host: &str, snp: bool) -> VmEntry {
+        let mut entry = fixture_entry(vm_hash, true);
+        if snp {
+            let json = r#"{
+                "vm_id": 9, "vm_hash": "abcd", "settings": {},
+                "hypervisor": "qemu",
+                "vm_configuration": {
+                    "qemu_bin_path": "/usr/bin/qemu-system-x86_64",
+                    "image_path": "/img/rootfs.ext4",
+                    "monitor_socket_path": "/m.sock", "qmp_socket_path": "/q.sock",
+                    "vcpu_count": 2, "mem_size_mb": 2048,
+                    "host_volumes": [], "gpus": [],
+                    "sev_snp": true,
+                    "ovmf_path": "/img/OVMF.fd",
+                    "sev_policy": 196608,
+                    "kernel_path": "/img/bzImage",
+                    "initrd_path": "/img/initrd",
+                    "kernel_cmdline": "console=ttyS0 root=/dev/mapper/verity-root ro"
+                }
+            }"#;
+            let config = crate::controller_config::parse_controller_config(json).unwrap();
+            let crate::controller_config::VmConfiguration::Qemu(qemu) = config.vm else {
+                panic!("the payload is a QEMU configuration");
+            };
+            entry.config = *qemu;
+        }
+        entry.config.gpus = vec![crate::controller_config::QemuGpu {
+            pci_host: pci_host.to_string(),
+            supports_x_vga: true,
+        }];
+        entry.gpus = vec![crate::world::AttachedGpu {
+            pci_host: pci_host.to_string(),
+            device_id: "10de:2b85".to_string(),
+            supports_x_vga: true,
+        }];
+        entry
+    }
+
+    #[test]
+    fn an_adopted_snp_vms_card_reports_cc_on_without_reading_the_card() {
+        // A restart leaves the cache empty, and a card a guest owns is
+        // never probed (its register belongs to the guest), so a
+        // confidential VM adopted at boot used to report no cc_mode for
+        // the rest of its life. It does not need a probe: the create gate
+        // admits a card into an SNP VM only after reading CC-on from it,
+        // and nothing can change the mode while the guest holds the card.
+        // A plain passthrough VM went through no such gate, so its card
+        // stays unknown.
+        let host = HostState {
+            settings: crate::config::Settings::from_vars(std::iter::empty()).unwrap(),
+            host_ipv4: String::new(),
+            network_interface: None,
+            gpus: vec![nvidia_card("06:00.0"), nvidia_card("07:00.0")],
+            dns_nameservers: None,
+        };
+        let snp_entry = adopted_entry_holding(test_fixtures::QEMU_HASH, "06:00.0", true);
+        let mut world = WorldView::default();
+        world.insert_entry(snp_entry.clone());
+        world.insert_entry(adopted_entry_holding(
+            test_fixtures::GPU_HASH,
+            "07:00.0",
+            false,
+        ));
+        let state = DaemonState::hermetic(
+            host,
+            world,
+            Arc::new(crate::units::StaticUnitStates::default()),
+            Arc::new(crate::logs::StaticLogSource::new(Vec::new())),
+        );
+
+        // Any read of a card a guest owns is a bug, so the probe panics.
+        refresh_cc_modes_with(
+            &state,
+            |pci_host: &str, _device_id: &str| {
+                panic!("an attached card must never be probed: {pci_host}")
+            },
+            crate::gpu_cc::CC_MODE_TTL,
+        );
+
+        assert_eq!(
+            cc_mode_of(&state, "06:00.0"),
+            Some(crate::gpu_cc::CcMode::On),
+            "the confidential VM's card is known CC-on"
+        );
+        assert_eq!(
+            cc_mode_of(&state, "07:00.0"),
+            None,
+            "a plain passthrough card went through no gate and stays unknown"
+        );
+        // The VM's own report, which is where the empty mode showed.
+        let info = vm_info_message(&state, &snp_entry, true, snp_entry.times.started_at_ns);
+        assert_eq!(info.gpus.len(), 1);
+        assert_eq!(info.gpus[0].cc_mode, "on");
+        assert_eq!(
+            info.gpus[0].arch, "blackwell",
+            "the architecture comes from the device id, not from a probe"
+        );
     }
 
     #[test]

--- a/rust/crates/supervisor-daemon/src/service.rs
+++ b/rust/crates/supervisor-daemon/src/service.rs
@@ -1879,6 +1879,72 @@ mod tests {
         }
     }
 
+    /// A cached answer of `mode` that a probe gave `age` ago.
+    fn aged_answer(
+        mode: Option<crate::gpu_cc::CcMode>,
+        age: std::time::Duration,
+    ) -> crate::gpu_cc::ProbedCcMode {
+        crate::gpu_cc::ProbedCcMode {
+            mode,
+            probed_at: std::time::Instant::now()
+                .checked_sub(age)
+                .expect("the process started after the ages used here"),
+        }
+    }
+
+    #[test]
+    fn a_pass_rereads_the_unreadable_card_and_leaves_the_known_one_alone() {
+        // The point of the two tiers. Both cards were last read a minute
+        // and a second ago: the one that answered with a mode is still
+        // good for the rest of the long window, while the one that could
+        // not be read (a card being reset reads all ones) has aged out of
+        // the short one and must be tried again, rather than staying
+        // hidden until the long window passes. The pass gate has to let
+        // this sweep through for that to be reachable, which is why it
+        // runs on the shortest window.
+        let state = two_free_cards();
+        let age = std::time::Duration::from_secs(61);
+        {
+            let mut cache = state.gpu_cc_modes.lock().unwrap();
+            cache.insert(
+                "06:00.0".to_string(),
+                aged_answer(Some(crate::gpu_cc::CcMode::On), age),
+            );
+            cache.insert("07:00.0".to_string(), aged_answer(None, age));
+        }
+        state.gpu_cc_sweep.lock().unwrap().at = Some(
+            std::time::Instant::now()
+                .checked_sub(age)
+                .expect("the process started after the ages used here"),
+        );
+
+        let probed: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+        refresh_cc_modes_with(
+            &state,
+            |pci_host, _device_id| {
+                probed.lock().unwrap().push(pci_host.to_string());
+                Ok(Some(crate::gpu_cc::CcMode::Off))
+            },
+            default_windows(),
+        );
+
+        assert_eq!(
+            probed.into_inner().unwrap(),
+            vec!["07:00.0".to_string()],
+            "only the card that could not be read is tried again"
+        );
+        assert_eq!(
+            cc_mode_of(&state, "07:00.0"),
+            Some(crate::gpu_cc::CcMode::Off),
+            "the retry replaces the empty answer"
+        );
+        assert_eq!(
+            cc_mode_of(&state, "06:00.0"),
+            Some(crate::gpu_cc::CcMode::On),
+            "the card with a known mode keeps the answer it had"
+        );
+    }
+
     /// An adopted VM holding one card: SNP (measured-boot slice present)
     /// or plain QEMU passthrough, which is the distinction the seeding
     /// turns on.


### PR DESCRIPTION
## Summary
The NVIDIA CC-mode probe read BAR0 without taking a runtime-PM reference. vfio-pci runtime-suspends a card nobody has opened, a function in D3hot answers MMIO with all ones, and the low two bits of `0xffffffff` are the devtools encoding, so an idle card was advertised as `devtools` and then refused by the SEV-SNP create gate: a host with working CC hardware would look like a host with none. On top of that the refresh ran on every `GetHostInfo`, which the agent calls for every unauthenticated `/about/capability` request, so any internet client could make the host mmap device memory on every idle NVIDIA card it has, as often as it liked.

The probe now pins a suspended card awake for the read and restores the host's own `power/control` value afterwards, rejects an all-ones answer as unreadable instead of decoding it, and caches each card's answer (successful or not) for 60 seconds. The create gate is untouched: it still reads the card on every create, under the creation lock.

The third commit is the review fixes, listed under Changes.

The second commit closes the matching hole on the other side: a card a guest owns is never probed, so after a restart every adopted VM's cards reported an empty `cc_mode` for the rest of the VM's life. A card held by an SEV-SNP VM needs no read, because the create gate admitted it only after reading CC-on and the mode cannot change while the guest holds the card, so it is now entered as CC-on on the gate's word. Plain passthrough VMs went through no gate and their cards stay unknown.

## Changes
- `gpu_cc.rs`: `hold_runtime_power_on` writes `on` to `power/control` when `power/runtime_status` says the device is not active, waits up to 200 ms for it to come back, and puts the previous value back on drop. A device with no runtime-PM files, or one already active, is not written to at all. `probe_cc_mode` rejects `0xffffffff` as unreadable rather than reporting devtools. `read_bar0_u32` now returns the `io::Error` (annotated with the file it came from) so the caller can build a typed error around it.
- `error.rs`: `DaemonError::GpuRegisterRead { pci_host, source }` and `DaemonError::GpuUnreadable { pci_host }` replace the formatted string on the probe path.
- `service.rs`: `gpu_cc_modes` holds `ProbedCcMode { mode, probed_at }` instead of a bare mode. A card whose last answer is younger than `CC_MODE_TTL` (60 s) is not read again, and a failed probe is cached as "no mode" so an unreadable card is not retried on every request either. `cc_mode_of` is unchanged from a caller's point of view: an entry with no mode advertises nothing.
- `main.rs`: one probe pass on the blocking pool before the socket is bound, so a card that is free at boot has a mode from the first request.
- `service.rs` (third commit): a refresh pass takes a dedicated lock before the world read guard, so a burst of `GetHostInfo` calls costs one pass and the callers behind it read what it wrote. Overlapping passes were not just wasteful: both could read `power/control` before either wrote it, so the second restored `on` and left the card pinned awake with the host's setting lost (reproduced: the file came back `on\no`). The world read guard still covers the probes, since it is what stops a card being read after a concurrent create handed it to a guest, and its doc comment now states the real budget (up to 200 ms per stale suspended card, with tokio's write-preferring RwLock making a mid-pass `CreateVm` wait) instead of claiming microseconds. `main.rs` names the same bound for the pre-bind pass.
- `lifecycle.rs` (third commit): deleting a VM drops its cards' cache entries. The card is free hardware again and its mode can be switched, so the old answer must not be served for the rest of its freshness window.
- `gpu_cc.rs` (third commit): a device whose `power/control` cannot be read or written no longer fails the probe. The resume step is an improvement on the read, not a condition of it, so the register is read as it was before the step existed and an all-ones answer still fails closed.
- `service.rs` (second commit): the refresh enters CC-on for any NVIDIA card attached to a VM whose config resolves as SEV-SNP (`QemuVmConfig::snp()`), without reading the hardware. An existing entry is never overwritten, so a card probed before it was attached keeps its own answer and its own age; once the VM is deleted the card leaves the attached set, its entry is long stale, and the next refresh reads it as usual.

### Review follow-ups, round 3
- `src/lifecycle.rs`: a stop now evicts the VM's cards from the CC-mode
  cache, through the same `forget_cc_modes` helper `delete_tracked_vm`
  uses, on both the persistent-VM and the program stop paths. The seed
  guard alone only stopped a *new* seed; the entry the create gate wrote
  while the guest was live stayed and kept the card advertised CC-on after
  an in-session stop. Test: seed the card the way the gate does, stop the
  VM, `cc_mode_of` is `None`.
- `src/service.rs`: the seed requires `started_at_ns != 0` as well as
  `stopped_at_ns == 0`, so a VM adopted while the systemd bus was
  unreachable, or a Defined entry that never started, is not seeded CC-on.
  Test: a never-started SNP VM's card is not seeded.
- `src/lifecycle.rs`: the create gate's comment now states the write-lock
  cost: the probe resumes a suspended card under the world write lock, up
  to 200 ms per suspended card, during which every world reader stalls.
- `src/gpu_cc.rs`: `hold_runtime_power_on` writes `on` and polls only when
  `runtime_status` is `suspended`, `suspending` or `resuming`; `active`,
  `unsupported`, `disabled` or anything else reads immediately with no
  hold. Test: an `unsupported` card is neither written to nor waited for,
  and its register is still read.
- Known and left as is: `StartVm` after a stop re-seeds the card CC-on
  from the gate's pre-stop reading at the next refresh pass (up to the
  60 s TTL late) without re-probing. A card re-moded while the VM was
  down would be advertised stale until the next create; the guest's own
  boot-time GPU attestation is what catches it for the owner. Making
  StartVm re-probe under the VM lock would close that, and is a follow-up.

### Round 4: two cache windows, the long one a setting
- `src/gpu_cc.rs`, `src/config.rs`: a decoded mode is now served from the
  cache for `ALEPH_VM_GPU_CC_MODE_TTL` seconds (default 3600) and an answer
  with no mode (probe failed, all ones, reserved encoding) for a fixed
  60 s. The mode changes only when an operator runs NVIDIA's tool against
  an idle card, and admission never depends on the cache (the create gate,
  and the start gate in #1240, read the hardware), so the timer only bounds
  inventory staleness; a minute for every answer woke every idle card out
  of D3 once a minute for as long as the node lived, driven by host-info
  polling. The failed-read tier stays short because an operator's mode
  change ends with a card reset, and a sweep landing during it reads all
  ones: cached for an hour, that would hide the card for an hour.
- `src/service.rs`: the pass-level skip is gated on the shortest window,
  so a card cached as unreadable is re-read within the minute even when
  every other card is fresh for an hour; the per-card gate is where the
  long window pays.
- `docs/architecture/confidential.md`: states the two windows and the
  setting.
- Tests: a decoded mode is fresh past a minute and stale past the long
  window; an unreadable answer is stale past 60 s; a pass with one fresh
  decoded card and one stale unreadable card re-reads only the latter; the
  setting parses its default and an override.

## Test plan
- `gpu_cc.rs`: new tests over a fake sysfs tree under a temp dir. An all-ones register is rejected at probe level (the test also pins that the decoder alone would have said `devtools`); a `runtime_status = suspended` card gets `on` written to `power/control` and the previous value restored; an active card is never written to; a card with no runtime-PM files probes as before; a card with no CC architecture is neither written to nor read; the freshness window behaves.
- `service.rs`: two refreshes inside the TTL read each card once, a failed probe is remembered and not retried, and a zero window reads both cards again. The existing attached-set and stale-eviction tests were updated for the new cache value.
- `service.rs` (second commit): a fake world holding one adopted SEV-SNP VM and one adopted plain passthrough VM, each with a card, refreshed with a probe that panics if it is ever called. The confidential VM's card reports CC-on through both `cc_mode_of` and the VM's own `VmInfo.gpus[0].cc_mode`; the passthrough card stays unknown.
- `service.rs` (third commit): two refresh passes run concurrently against a fake sysfs card that never resumes. Asserts one register read and `power/control` back at `auto`. Without the pass lock this fails twice over: two reads, and `power/control` left as `on\no`.
- `lifecycle.rs` (third commit): a VM created with a card and a seeded cache entry, deleted; the card advertises nothing afterwards.
- `gpu_cc.rs` (third commit): a card that claims to be suspended but has no `power/control` still reads its register.
- Checks from `rust/`, re-run after all three commits: `cargo fmt --check` (0), `cargo clippy --locked --all-targets -- -D warnings` (0), `cargo test --locked -p supervisor-daemon` (0, 387 passed). No NVIDIA hardware here, so the register read itself is exercised against a regular file, as it already was.

## Rebased onto dev-2.1 (#1199 + #1200), plus a review fix

#1200 landed its own answer to the same rate-limiting problem: a sweep-level gate in `refresh_cc_modes_with` (`CcSweep` plus `CC_PROBE_TTL`) that skips the whole sweep when the attached set has not changed since the last one. Both gates are kept, and they now share one lifetime, `gpu_cc::CC_MODE_TTL`; the duplicate `CC_PROBE_TTL` constant is gone. The sweep gate is the cheap outer short circuit, the per-card `ProbedCcMode` freshness the inner one that still holds when the sweep runs because some other card changed hands. The two colliding tests were split into `refresh_cc_modes_repeats_a_sweep_only_when_a_card_changed_hands_or_the_ttl_passed` and `refresh_cc_modes_serves_a_fresh_answer_without_reading_the_card` over one shared fixture, the second forcing the sweep so it exercises the per-card gate alone. Every `GpuDevice` literal gained #1200's new `arch` field, and the adopted-SNP test now also asserts the architecture reaches `VmInfo`.

Review fix, as its own commit: the CC-on seed keyed on `entry.config.snp().is_some()`, which also seeded a stopped SNP VM's card. The seed is only sound under a live guest, where nothing can switch the mode the create gate read; a stopped VM's QEMU is gone and the card is idle hardware an operator can re-mode. The predicate now also requires no stop stamped (`entry.times.stopped_at_ns == 0`), the cheap indicator the status mapping itself uses. Such a card stays out of the sweep (the config still claims it) so it advertises nothing until the VM is deleted. New test: `a_stopped_snp_vms_card_is_not_seeded_cc_on`.

Checks re-run after the rebase: `cargo fmt --check` exit 0, `cargo clippy --locked --all-targets -- -D warnings` exit 0 (which type-checks every test). The test suites were not run locally this round (some need root to unwind DHCP servers); CI runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZyMqLgxxVfeDwiNy34sfM


