### PR TITLE
fix(agent): skip a pool whose size or free space cannot be read

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -384,7 +384,12 @@ message. One pass does, in order:
 4. Enforce the retention budget per pool: sum the markers' `size_bytes` and
    evict oldest-first (by `reclaimable_since`) until under
    `VOLUME_RETENTION_BUDGET`. Under `reap` everything marked is given back,
-   which is how a node switched from `keep` to `reap` drains.
+   which is how a node switched from `keep` to `reap` drains. A pool whose
+   size cannot be read is skipped with a warning under `keep`: the budget is
+   a share of that size, so an unreadable pool would come out as zero bytes
+   allowed and evict everything it retains. Staying over budget until the
+   next pass costs a pass; guessing costs the data. `reap` needs no size and
+   still drains such a pool.
 5. Bring the four download caches under `CACHE_BUDGET` (see below). Skipped
    entirely, with an ERROR, when the supervisor could not be listed: what a
    cache holds for a live VM is read from that VM's message, so a live set

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -120,7 +120,10 @@ Admission counts retained (reclaimable) bytes as free:
 and `select_pool`, before refusing a placement, calls the room maker the
 agent registered at startup (`storage_pools.set_room_maker`, wired to
 `reconciler.make_room`) so the retained directories on the target pool are
-evicted oldest-first until the create fits. See "Reclamation" below: a
+evicted oldest-first until the create fits. A pool whose free space cannot
+be read is left alone there too: free space is the whole measure of "does
+this create fit", so without it there is no telling a pool that already fits
+the create from one that never will. See "Reclamation" below: a
 retained disk is a cache entry, not usage, so counting it as used would sell
 less capacity than the node actually has. The rule holds for all three disk
 figures the agent produces, and they have to agree: the aggregate

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -76,7 +76,12 @@ from aleph.vm.conf import settings
 # MOUNT_ROOT is /mnt, where a volume's mount point is {namespace}_{volume name}.
 from aleph.vm.storage import DEVICE_MAPPER_DIRECTORY, MOUNT_ROOT, is_vm_namespace
 from aleph.vm.storage_budget import parse_budget
-from aleph.vm.storage_pools import StoragePool, get_pools, iter_namespace_dirs
+from aleph.vm.storage_pools import (
+    StoragePool,
+    get_pools,
+    iter_namespace_dirs,
+    pool_usage_bytes,
+)
 from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.utils import create_task_log_exceptions
 
@@ -607,21 +612,29 @@ def _sweep_side_dirs(
             report.side_dirs_removed += 1
 
 
-def _pool_total(pool: StoragePool) -> int:
-    try:
-        return shutil.disk_usage(str(pool.path)).total
-    except OSError:
+def _retention_budget(pool: StoragePool) -> int | None:
+    """Bytes of retained data ``pool`` may hold, or ``None`` when its size
+    cannot be read and the budget therefore cannot be worked out.
+
+    Reap needs no size at all: it retains nothing, so a node switched from
+    keep to reap gives back everything marked, whatever the pool reports.
+    """
+    if settings.VOLUME_RETENTION == "reap":
         return 0
+    usage = pool_usage_bytes(pool)
+    if usage is None:
+        return None
+    return parse_budget(settings.VOLUME_RETENTION_BUDGET, usage.total)
 
 
 def _pool_free(pool: StoragePool) -> int:
-    try:
-        return shutil.disk_usage(str(pool.path)).free
-    except OSError:
+    usage = pool_usage_bytes(pool)
+    if usage is None:
         # Unknown free space: report none, so make_room falls back to its
         # "stop once needed_bytes have been freed" bound instead of looping.
         logger.warning("Volume pool %s not accessible; freeing on the evicted bytes alone", pool.path)
         return 0
+    return usage.free
 
 
 def _reclaimable_on(pool: StoragePool) -> list[tuple[Path, ReclaimableMarker]]:
@@ -695,9 +708,19 @@ def _enforce_retention_budget(
         entries = _reclaimable_on(pool)
         if not entries:
             continue
-        # Under reap nothing is retained: a node switched from keep to reap
-        # gives back everything marked, whatever the budget says.
-        budget = 0 if reap else parse_budget(settings.VOLUME_RETENTION_BUDGET, _pool_total(pool))
+        budget = _retention_budget(pool)
+        if budget is None:
+            # A budget is a share of the pool's size, so a size nobody can
+            # read would come out as zero bytes allowed and take every
+            # marked directory here with it. Enforcement is only ever a
+            # deletion: leaving the pool over budget until it can be
+            # measured again costs a pass, guessing costs the data.
+            logger.warning(
+                "Volume pool %s not accessible; leaving the %d directory(ies) it retains alone this pass",
+                pool.path,
+                len(entries),
+            )
+            continue
         total = sum(marker.size_bytes for _, marker in entries)
         for directory, marker in entries:
             if not reap and total <= budget:

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -627,16 +627,6 @@ def _retention_budget(pool: StoragePool) -> int | None:
     return parse_budget(settings.VOLUME_RETENTION_BUDGET, usage.total)
 
 
-def _pool_free(pool: StoragePool) -> int:
-    usage = pool_usage_bytes(pool)
-    if usage is None:
-        # Unknown free space: report none, so make_room falls back to its
-        # "stop once needed_bytes have been freed" bound instead of looping.
-        logger.warning("Volume pool %s not accessible; freeing on the evicted bytes alone", pool.path)
-        return 0
-    return usage.free
-
-
 def _reclaimable_on(pool: StoragePool) -> list[tuple[Path, ReclaimableMarker]]:
     """The pool's reclaimable directories, oldest marker first.
 
@@ -796,7 +786,8 @@ def make_room(pool: StoragePool, needed_bytes: int, *, live: Collection[str] | N
     tries). The third bound (``freed >= needed_bytes``) only exists so a
     lying filesystem cannot turn this into a loop over every retained VM on
     the pool; a pool whose free space cannot be read at all is never evicted
-    from.
+    from, on the same rule the retention budget applies to a pool whose size
+    it cannot read: unknown is not zero, and the guess deletes data.
 
     A marker on a directory a live VM owns is a bug (``_is_orphan`` clears
     those on every pass), but this runs on its own, off the create path, so
@@ -809,7 +800,15 @@ def make_room(pool: StoragePool, needed_bytes: int, *, live: Collection[str] | N
     why every removal here tolerates a directory that vanished first.
     """
     protected = _snapshot_is_live(live or ())
-    free = _pool_free(pool)
+    usage = pool_usage_bytes(pool)
+    if usage is None:
+        # Free space is the whole measure here: what has to reach
+        # needed_bytes. Without it there is no way to tell a pool that
+        # already fits the create from one that never will, and evicting on
+        # that guess deletes retained data for nothing.
+        logger.warning("Not making room on %s: its free space cannot be read", pool.path)
+        return 0
+    free = usage.free
     if free >= needed_bytes:
         return 0
     entries = _reclaimable_on(pool)
@@ -826,7 +825,13 @@ def make_room(pool: StoragePool, needed_bytes: int, *, live: Collection[str] | N
     freed = 0
     report = ReconcileReport()
     for directory, _marker in entries:
-        if _pool_free(pool) >= needed_bytes or freed >= needed_bytes:
+        remaining = pool_usage_bytes(pool)
+        if remaining is None:
+            # The pool stopped answering between two evictions: the same
+            # measurement the entry check made, and the same answer to it.
+            logger.warning("Stopping the room making on %s: its free space can no longer be read", pool.path)
+            break
+        if remaining.free >= needed_bytes or freed >= needed_bytes:
             break
         if not directory.is_dir():
             # A concurrent pass took it between the listing and now.

--- a/src/aleph/vm/storage_pools.py
+++ b/src/aleph/vm/storage_pools.py
@@ -24,6 +24,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import NamedTuple
 
 from aleph.vm.conf import settings
 from aleph.vm.resources import InsufficientResourcesError
@@ -278,12 +279,32 @@ def reset_pools() -> None:
     _pools = None
 
 
-def _pool_free_bytes(pool: StoragePool) -> int | None:
+class PoolUsage(NamedTuple):
+    total: int
+    free: int
+
+
+def pool_usage_bytes(pool: StoragePool) -> PoolUsage | None:
+    """The pool filesystem's total and free bytes, or ``None`` when they
+    cannot be read.
+
+    Deliberately silent: what an unreadable pool means differs by caller
+    (leave it out of the capacity it advertises, refuse to evict from it),
+    so each one logs its own consequence.
+    """
     try:
-        return shutil.disk_usage(str(pool.path)).free
+        usage = shutil.disk_usage(str(pool.path))
     except OSError:
+        return None
+    return PoolUsage(total=usage.total, free=usage.free)
+
+
+def _pool_free_bytes(pool: StoragePool) -> int | None:
+    usage = pool_usage_bytes(pool)
+    if usage is None:
         logger.error("Volume pool %s not accessible, skipping", pool.path)
         return None
+    return usage.free
 
 
 RoomMaker = Callable[["StoragePool", int], int]

--- a/src/aleph/vm/storage_pools.py
+++ b/src/aleph/vm/storage_pools.py
@@ -338,26 +338,30 @@ def _select_from(candidates: list[StoragePool], size_mib: int) -> StoragePool:
     evicted.
     """
     required_bytes = size_mib * 1024 * 1024
+    eligible = [pool for pool in candidates if pool.vm_eligible]
+    # Measured once for the whole attempt: read again inside the sort key
+    # below, every pool would be interrogated twice per placement and a dead
+    # one would log its error twice as often.
+    free_by_pool = {pool: _pool_free_bytes(pool) for pool in eligible}
     best: StoragePool | None = None
     best_free = -1
-    for pool in candidates:
-        if not pool.vm_eligible:
-            continue
-        free = _pool_free_bytes(pool)
+    for pool in eligible:
+        free = free_by_pool[pool]
         if free is None:
             continue
         if free > best_free:
             best, best_free = pool, free
     if (best is None or best_free < required_bytes) and _room_maker is not None:
         # Free-descending order asks the pool that needs the least eviction
-        # first; a pool that reports no free space at all (dead disk,
-        # unmounted) still gets a turn last, since it is where this placement
-        # would land if the evictor brings it back.
+        # first. A pool whose free space could not be read sorts last and
+        # make_room refuses it outright, so the only pool the evictor can
+        # still turn into a home for this volume is one that answered and is
+        # merely full.
         def known_free(pool: StoragePool) -> int:
-            free = _pool_free_bytes(pool)
+            free = free_by_pool[pool]
             return -1 if free is None else free
 
-        for target in sorted((pool for pool in candidates if pool.vm_eligible), key=known_free, reverse=True):
+        for target in sorted(eligible, key=known_free, reverse=True):
             if _room_maker(target, required_bytes) <= 0:
                 continue
             free = _pool_free_bytes(target)

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -693,6 +693,45 @@ def test_make_room_evicts_nothing_when_the_create_could_never_fit(pools, monkeyp
     assert retained.exists() and other.exists()
 
 
+def test_make_room_evicts_nothing_on_a_pool_it_cannot_measure(pools, monkeypatch):  # noqa: F811
+    """Free space is what has to reach needed_bytes, so a pool that cannot be
+    measured cannot be told apart from one that already fits the create."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    retained = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
+    mark_reclaimable(VM_HASH, "gone", now=NOW - timedelta(days=2))
+    _fake_disk_usage(monkeypatch, 0, unreadable=(pools["pool0"],))
+
+    freed = make_room(get_pools()[0], needed_bytes=8192)
+
+    assert freed == 0
+    assert retained.exists()
+
+
+def test_make_room_stops_when_the_pool_stops_answering(pools, monkeypatch):  # noqa: F811
+    """The re-check between two evictions is the same measurement as the
+    entry one, and gets the same answer when it fails: stop deleting."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    oldest = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
+    newest = volume(pools["pool0"], OTHER_HASH, "rootfs.qcow2", size=8192)
+    mark_reclaimable(VM_HASH, "gone", now=NOW - timedelta(days=2))
+    mark_reclaimable(OTHER_HASH, "gone", now=NOW - timedelta(days=1))
+
+    def free(path):
+        if not (path / VM_HASH).is_dir():
+            # The pool goes away once the first eviction has run.
+            msg = "Input/output error"
+            raise OSError(5, msg, str(path))
+        return 0
+
+    _fake_disk_usage(monkeypatch, free)
+
+    freed = make_room(get_pools()[0], needed_bytes=16384)
+
+    assert freed == 8192
+    assert not oldest.exists()
+    assert newest.exists()
+
+
 def test_make_room_never_evicts_a_live_namespace(pools, monkeypatch):  # noqa: F811
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
     running = volume(pools["pool0"], LIVE, "rootfs.qcow2", size=8192)

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -37,13 +37,19 @@ NOW = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
 GIB = 1024**3
 
 
-def _fake_disk_usage(monkeypatch, free_bytes):
-    """Pin the free space every pool reports. ``free_bytes`` is either a
-    number or a callable, so a test can let evictions give space back."""
+def _fake_disk_usage(monkeypatch, free_bytes, *, total: int = 10 * GIB, unreadable: tuple[Path, ...] = ()):
+    """Pin the disk usage every pool reports. ``free_bytes`` is either a
+    number or a callable, so a test can let evictions give space back.
+    A path at or under one of ``unreadable`` raises instead, the way a pool
+    whose filesystem cannot be interrogated does."""
 
     def usage(path):
-        free = free_bytes(Path(path)) if callable(free_bytes) else free_bytes
-        return SimpleNamespace(total=10 * GIB, used=10 * GIB - free, free=free)
+        path = Path(path)
+        for gone in unreadable:
+            if path == gone or gone in path.parents:
+                raise OSError(5, "Input/output error", str(path))
+        free = free_bytes(path) if callable(free_bytes) else free_bytes
+        return SimpleNamespace(total=total, used=total - free, free=free)
 
     monkeypatch.setattr(reconciler_module.shutil, "disk_usage", usage)
 
@@ -591,6 +597,39 @@ def test_switching_to_reap_evicts_everything_marked(pools, registry, monkeypatch
     reconcile_storage(registry, now=NOW)
 
     assert not kept.exists()
+
+
+def test_a_pool_whose_size_cannot_be_read_keeps_what_it_retains(pools, registry, monkeypatch):  # noqa: F811
+    """The budget is a share of the pool's size, so a size nobody can read
+    makes it zero, and a zero budget evicts every marked directory on the
+    pool. The pool is skipped instead, and the other pools still enforced."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    monkeypatch.setattr(settings, "VOLUME_RETENTION_BUDGET", "10%")
+    unmeasurable = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
+    over_budget = volume(pools["pool1"], OTHER_HASH, "rootfs.qcow2", size=8192)
+    mark_reclaimable(VM_HASH, "gone", now=NOW - timedelta(days=2))
+    mark_reclaimable(OTHER_HASH, "gone", now=NOW - timedelta(days=1))
+    # 10% of 64 KiB is well under the 8 KiB each pool holds for the reclaimer.
+    _fake_disk_usage(monkeypatch, 0, total=64 * 1024, unreadable=(pools["pool0"],))
+
+    report = reconcile_storage(registry, now=NOW)
+
+    assert unmeasurable.exists()
+    assert not over_budget.exists()
+    assert report.evicted == [OTHER_HASH]
+
+
+def test_reap_still_reclaims_on_a_pool_whose_size_cannot_be_read(pools, registry, monkeypatch):  # noqa: F811
+    """Reap retains nothing whatever the pool's size, so an unreadable pool
+    must not turn into one that holds on to its marked directories."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    marked = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+    _fake_disk_usage(monkeypatch, 0, unreadable=(pools["pool0"],))
+
+    reconcile_storage(registry, now=NOW)
+
+    assert not marked.exists()
 
 
 def test_make_room_evicts_oldest_first_until_the_create_fits(pools, monkeypatch):  # noqa: F811

--- a/tests/supervisor/test_storage_pools_room_maker.py
+++ b/tests/supervisor/test_storage_pools_room_maker.py
@@ -157,3 +157,21 @@ class TestRoomMaker:
             select_pool(size_mib=1)
 
         assert calls == [0, 1, 2]
+
+    def test_each_pool_is_measured_once_per_attempt(self, three_pools, monkeypatch, room_maker):
+        """Reading a pool that cannot answer logs an error, and this read
+        every pool twice: once to find the roomiest, once more to order the
+        eviction targets. One measurement per pool, reused by both."""
+        reads = []
+
+        def free(pool):
+            reads.append(pool.index)
+            return None
+
+        monkeypatch.setattr(storage_pools_module, "_pool_free_bytes", free)
+        room_maker(lambda pool, needed: 0)
+
+        with pytest.raises(InsufficientResourcesError):
+            select_pool(size_mib=1)
+
+        assert reads == [0, 1, 2]


### PR DESCRIPTION
## Summary
Two places measured a storage pool with a call that reported 0 on an `OSError`, and 0 is indistinguishable from a real measurement: a full pool, or a pool with no room to retain anything. Both then deleted retained data on that guess.

The per-pool retention budget is a share of the pool's size (`VOLUME_RETENTION_BUDGET`, `10%` by default), and `parse_budget("10%", 0)` is 0. A zero budget means every directory marked reclaimable on the pool is evicted, so a pool the agent could not measure for a moment (an unmounted disk, a stale handle, an EIO from a failing device) had all of its retained volumes purged, with the owner recorded on the marker (the erase authorization) and the parent-image pins it carried.

`make_room` had the same failure, bounded rather than total: with free space reported as 0 it took the path it takes for a full pool, summed the retained directories, and evicted them oldest-first until it had freed `needed_bytes`. That is retained data deleted for a create that may already have fitted, repeated on the next placement attempt. Its docstring already claimed such a pool is never evicted from; now that is true.

Both now treat an unreadable pool as unknown rather than zero: log a warning, touch nothing there, carry on with the other pools. Enforcement and room making are only ever deletions, so waiting for the pool to be readable again costs a pass, while guessing costs the data. Reap needs no size at all and still drains such a pool, so a node switched from `keep` to `reap` empties as before.

Stacked on #1216.

## Changes
- `src/aleph/vm/storage_pools.py`: `pool_usage_bytes()` returns the pool filesystem's `(total, free)` as a `PoolUsage` named tuple, or `None` when it cannot be read, instead of a zero that looks like a real measurement. It stays silent, since what an unreadable pool means differs per caller; `_pool_free_bytes` keeps its own log line and now builds on it.
- `src/aleph/vm/agent/vm/reconciler.py`:
  - `_pool_total` is replaced by `_retention_budget(pool)`, which returns `None` when the size is unknown (and 0 under `reap`, which needs no size). `_enforce_retention_budget` skips such a pool with a warning naming how many directories it left alone.
  - `make_room` reads the pool through the same helper: it returns 0 without evicting when the entry measurement fails, and breaks out of the eviction loop when the re-check between two evictions fails. `_pool_free` had no other caller and is gone.
- `docs/architecture/storage.md`: the admission section and step 4 of a pass both document the skip and why an unmeasurable pool is a reason to keep the data, not to delete it.

## Test plan
- `tests/supervisor/test_reconciler.py::test_a_pool_whose_size_cannot_be_read_keeps_what_it_retains`: `disk_usage` raises for pool 0 and answers for pool 1, both over budget; pool 0's retained volume survives and pool 1's is still evicted in the same pass. Fails on the parent commit (the volume is gone).
- `::test_reap_still_reclaims_on_a_pool_whose_size_cannot_be_read`: the guard on the other side, `reap` drains an unmeasurable pool. Passes before and after, deliberately.
- `::test_make_room_evicts_nothing_on_a_pool_it_cannot_measure`: fails without the fix (`assert 8192 == 0`, the retained VM was evicted).
- `::test_make_room_stops_when_the_pool_stops_answering`: the pool answers for the entry check and the first eviction, then raises; only the first directory goes. Fails without the fix (`assert 16384 == 8192`, both went).
- `_fake_disk_usage` in that file grew a `total` and an `unreadable` argument so a test can pin a small pool and make one path raise.
- Checks: `pytest tests/supervisor` (1211 passed, 1 skipped, and the pre-existing journald-stub failure in `test_log.py`); `pytest` on `test_reconciler.py`, `test_cache_eviction.py`, `test_storage_pools_room_maker.py` (133 passed) and earlier on `test_storage_cli.py`, `test_agent_capacity.py`, `test_retire.py`, `test_allocation_verdict.py`, `test_allocations_v2.py`; `ruff format --diff`, `isort --check-only --profile black`, `mypy` on the Python files, all clean. No Rust touched.

## Review follow-up (rebased onto dev-2.1 at 973b8fd7)
- `storage_pools.py`: the comment promising a dead or unmounted pool a last chance from the evictor is now accurate, since `make_room` refuses a pool whose free space cannot be read.
- `storage_pools.py`: every eligible pool's free space is measured once per placement attempt instead of twice (once for the roomiest pool, once inside the sort key ordering the eviction targets), so a pool that cannot answer logs its error half as often. Behaviour otherwise identical.
- `tests/supervisor/test_storage_pools_room_maker.py`: a test that pins one reading per pool per attempt; it fails with the double read.
- Checks on the rebased branch: `ruff format --diff`, `isort --check-only --profile black`, `mypy` clean. Test suites are left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZyMqLgxxVfeDwiNy34sfM

