### PR TITLE
fix(agent): serialise the starts of one VM so one does not delete the other

### DIFF
--- a/src/aleph/vm/agent/create_lock.py
+++ b/src/aleph/vm/agent/create_lock.py
@@ -1,0 +1,64 @@
+"""One lock per VM hash, held across a whole create.
+
+A VM is started from several places at once: the allocation reconciler, the v1
+``/control/allocations`` handler and the single-VM ``notify_allocation``
+endpoint all run the same read, record, download, create sequence, and the
+download in the middle of it lasts seconds. With nothing serialising them, two
+callers read "this node does not have this VM", both record it, both download
+into the same directory and both create it. The supervisor refuses the second
+create, the create path reads that refusal as its own failure and retires the
+VM, and the retire deletes the VM the first caller had just brought up,
+forgets its record and, when the disks were fresh, purges its volumes.
+
+The lock is per hash, so starts of different VMs still run in parallel. It is
+created on demand and dropped once nobody holds or waits for it, so a node
+that has started thousands of VMs over its life keeps no lock for each.
+
+This is a different thing from ``creating()`` in the storage reconciler, which
+is a refcount on purpose: it tells a reconcile pass that a directory is being
+built and must count every span, including two that overlap. This one is
+mutual exclusion between the creates themselves.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+# Hash to the lock serialising its creates, and to the number of callers
+# holding or waiting for it. The count is what says when the lock can be
+# dropped: the last one out removes it.
+_locks: dict[str, asyncio.Lock] = {}
+_waiting: dict[str, int] = {}
+
+
+@asynccontextmanager
+async def vm_create_lock(namespace: str) -> AsyncIterator[None]:
+    """Serialise the creates of one VM hash.
+
+    Wraps the whole read-record-create sequence, not just the create call: it
+    is the window between reading the supervisor and creating the VM that lets
+    a second caller decide the VM is missing.
+    """
+    lock = _locks.get(namespace)
+    if lock is None:
+        # There is no await between the miss and the insert, so the event loop
+        # cannot interleave here and two callers cannot end up holding two
+        # different locks for one hash.
+        lock = asyncio.Lock()
+        _locks[namespace] = lock
+    # Counted before the acquire: a caller queued behind the lock has to keep
+    # it alive, or the holder's release would drop it and the next caller
+    # would build a second one and walk straight in.
+    _waiting[namespace] = _waiting.get(namespace, 0) + 1
+    try:
+        async with lock:
+            yield
+    finally:
+        remaining = _waiting[namespace] - 1
+        if remaining:
+            _waiting[namespace] = remaining
+        else:
+            del _waiting[namespace]
+            del _locks[namespace]

--- a/src/aleph/vm/agent/run.py
+++ b/src/aleph/vm/agent/run.py
@@ -24,6 +24,7 @@ from multidict import CIMultiDict
 
 from aleph.vm.agent.aggregate import get_user_settings
 from aleph.vm.agent.capacity import CapacityManager, requested_gpu_ids
+from aleph.vm.agent.create_lock import vm_create_lock
 from aleph.vm.agent.expiry import ExpiryManager
 from aleph.vm.agent.snp_instance_launch import (
     build_snp_instance_spec,
@@ -48,6 +49,7 @@ from aleph.vm.supervisor_interface.abc import Supervisor
 from aleph.vm.supervisor_interface.errors import (
     FileTooLargeError,
     ResourceDownloadError,
+    VmAlreadyExistsError,
     VmNotFoundError,
     VmSetupError,
 )
@@ -463,6 +465,19 @@ async def _retire_after_create_failure(
         logger.exception("Teardown of half-started %s %s failed", what, vm_hash)
 
 
+def _log_lost_create_race(vm_hash: ItemHash, what: str) -> None:
+    """Say that this create found the VM already there.
+
+    The supervisor refuses a create for an id it already holds, which means
+    another start path built this VM while this one was downloading. That VM
+    is the live one: this create has nothing left to do, and must not treat
+    the refusal as its own failure. The teardown that would follow deletes
+    the VM the other caller just brought up, drops its record and, when the
+    disks were fresh, purges its volumes.
+    """
+    logger.info("%s %s already exists: another start built it, leaving it alone", what, vm_hash)
+
+
 async def create_vm_execution(
     vm_hash: ItemHash,
     *,
@@ -515,6 +530,9 @@ async def create_vm_execution(
                 spec, _resources = await build_program_create_vm_spec(vm_hash, content)
                 info = await supervisor.create_vm(spec)
                 await _wait_until_running(supervisor, info.vm_id)
+            except VmAlreadyExistsError:
+                _log_lost_create_race(vm_hash, "Program VM")
+                return None
             except Exception:
                 # Admission, build, create or readiness failed: retire the
                 # record and whatever was started, but never let a teardown
@@ -579,6 +597,9 @@ async def create_vm_execution(
                         resolved_gpus = await capacity.resolve_gpus(requested_gpus, owner=content.address)
                         spec = replace(spec, gpus=resolved_gpus)
                 info = await supervisor.create_vm(spec)
+            except VmAlreadyExistsError:
+                _log_lost_create_race(vm_hash, "Instance")
+                return None
             except Exception:
                 # build or create failed: retire the early record so a failed
                 # create never leaves a dangling owner-identity entry behind (a
@@ -652,6 +673,9 @@ async def create_vm_execution(
                     )
                     spec = replace(spec, gpus=resolved)
                 info = await supervisor.create_vm(spec)
+            except VmAlreadyExistsError:
+                _log_lost_create_race(vm_hash, "V-PROGRAM")
+                return None
             except Exception:
                 # build, GPU resolution or create failed: retire the early
                 # record, and drop any bundle build_vprogram_spec may have
@@ -1092,73 +1116,84 @@ async def start_persistent_vm(
     expiry: ExpiryManager,
     update_watcher: UpdateWatcher,
 ) -> None:
-    vm_id = VmId(str(vm_hash))
-    try:
-        info: VmInfo | None = await supervisor.get_vm(vm_id)
-    except VmNotFoundError:
-        info = None
+    """Bring a scheduled VM up, whatever state this node holds it in.
 
-    if info is not None:
-        if info.awaiting_confidential_init:
-            # Only the owner can start it, by uploading the session certificates
-            # via /confidential/initialize. Waiting for RUNNING or recreating it
-            # would loop forever, so leave it untouched.
-            logger.info(f"{vm_hash} is waiting for its owner to initialize the confidential session")
-        elif info.status == VmStatus.RUNNING:
-            logger.info(f"{vm_hash} is already running")
-        elif info.status in (VmStatus.DEFINED, VmStatus.BOOTING):
-            logger.info(f"{vm_hash} is already starting")
-            await _wait_until_running(supervisor, vm_id)
-        elif info.status == VmStatus.STOPPING:
-            logger.info(f"{vm_hash} is stopping, waiting before restart")
-            await _wait_until_gone(supervisor, vm_id)
-            info = None
-        elif info.status == VmStatus.STOPPED:
-            # A cleanly stopped VM is resumed in place: stop/start is a
-            # pause/resume that preserves the definition and disks, not a
-            # delete + recreate.
-            logger.info(f"{vm_hash} is stopped, starting it")
-            await supervisor.start_vm(vm_id)
-            await _wait_until_running(supervisor, vm_id)
-        else:  # FAILED
-            logger.info(f"{vm_hash} in terminal state {info.status}, recreating")
-            # Crash recovery is a delete+recreate cycle, not a dealloc:
-            # RECREATE keeps the persisted host-port forwards (the owner's
-            # SSH forward among them) and the disks.
-            await retire_vm(vm_hash, RetireReason.RECREATE, supervisor=supervisor)
-            info = None
-        if info is not None and not info.awaiting_confidential_init:
-            # Every branch that kept `info` ends with a RUNNING VM this agent
-            # did not create in its own lifetime. Only the create path applies
-            # forwards, so heal them here: a previous life crashing between
-            # RUNNING and the forward setup leaves the VM up but unreachable
-            # forever otherwise. Best-effort; never fails the allocation.
-            # The recreate branches (info = None) reconcile in the create path.
-            await reconcile_adopted_port_forwards(supervisor, registry, vm_hash)
-
-    if info is None:
-        logger.info(f"Starting persistent virtual machine with id: {vm_hash}")
-        await create_vm_execution(
-            vm_hash=vm_hash, supervisor=supervisor, registry=registry, capacity=capacity, persistent=True
-        )
-        # A confidential VM is created but left awaiting its owner's session
-        # (only the owner can start it via /confidential/initialize). Waiting
-        # for RUNNING would block forever, so re-read the status and skip the
-        # readiness barrier when it is awaiting init.
+    Serialised per hash. Every start path runs the same read, record,
+    download, create sequence, and the download between the read and the
+    create lasts seconds: two of them running at once both read "this node
+    does not have it" and both built it. The second create was then refused
+    by the supervisor, and the teardown that followed deleted the VM the
+    first one had just brought up. Taking the lock here rather than at the
+    call sites means a new caller cannot forget it.
+    """
+    async with vm_create_lock(str(vm_hash)):
+        vm_id = VmId(str(vm_hash))
         try:
-            info = await supervisor.get_vm(vm_id)
+            info: VmInfo | None = await supervisor.get_vm(vm_id)
         except VmNotFoundError:
             info = None
-        if info is not None and info.awaiting_confidential_init:
-            logger.info(f"{vm_hash} is waiting for its owner to initialize the confidential session")
-        else:
-            # create_vm_execution blocks until RUNNING in-process today; this
-            # re-poll is the explicit readiness barrier (and stays correct if a
-            # future out-of-process create returns before the VM is RUNNING).
-            await _wait_until_running(supervisor, vm_id)
 
-    # Scheduled long-running: it must not idle-expire.
-    expiry.cancel(vm_id)
+        if info is not None:
+            if info.awaiting_confidential_init:
+                # Only the owner can start it, by uploading the session certificates
+                # via /confidential/initialize. Waiting for RUNNING or recreating it
+                # would loop forever, so leave it untouched.
+                logger.info(f"{vm_hash} is waiting for its owner to initialize the confidential session")
+            elif info.status == VmStatus.RUNNING:
+                logger.info(f"{vm_hash} is already running")
+            elif info.status in (VmStatus.DEFINED, VmStatus.BOOTING):
+                logger.info(f"{vm_hash} is already starting")
+                await _wait_until_running(supervisor, vm_id)
+            elif info.status == VmStatus.STOPPING:
+                logger.info(f"{vm_hash} is stopping, waiting before restart")
+                await _wait_until_gone(supervisor, vm_id)
+                info = None
+            elif info.status == VmStatus.STOPPED:
+                # A cleanly stopped VM is resumed in place: stop/start is a
+                # pause/resume that preserves the definition and disks, not a
+                # delete + recreate.
+                logger.info(f"{vm_hash} is stopped, starting it")
+                await supervisor.start_vm(vm_id)
+                await _wait_until_running(supervisor, vm_id)
+            else:  # FAILED
+                logger.info(f"{vm_hash} in terminal state {info.status}, recreating")
+                # Crash recovery is a delete+recreate cycle, not a dealloc:
+                # RECREATE keeps the persisted host-port forwards (the owner's
+                # SSH forward among them) and the disks.
+                await retire_vm(vm_hash, RetireReason.RECREATE, supervisor=supervisor)
+                info = None
+            if info is not None and not info.awaiting_confidential_init:
+                # Every branch that kept `info` ends with a RUNNING VM this agent
+                # did not create in its own lifetime. Only the create path applies
+                # forwards, so heal them here: a previous life crashing between
+                # RUNNING and the forward setup leaves the VM up but unreachable
+                # forever otherwise. Best-effort; never fails the allocation.
+                # The recreate branches (info = None) reconcile in the create path.
+                await reconcile_adopted_port_forwards(supervisor, registry, vm_hash)
 
-    if pubsub and settings.WATCH_FOR_UPDATES:
-        update_watcher.watch(vm_id, vm_hash, pubsub)
+        if info is None:
+            logger.info(f"Starting persistent virtual machine with id: {vm_hash}")
+            await create_vm_execution(
+                vm_hash=vm_hash, supervisor=supervisor, registry=registry, capacity=capacity, persistent=True
+            )
+            # A confidential VM is created but left awaiting its owner's session
+            # (only the owner can start it via /confidential/initialize). Waiting
+            # for RUNNING would block forever, so re-read the status and skip the
+            # readiness barrier when it is awaiting init.
+            try:
+                info = await supervisor.get_vm(vm_id)
+            except VmNotFoundError:
+                info = None
+            if info is not None and info.awaiting_confidential_init:
+                logger.info(f"{vm_hash} is waiting for its owner to initialize the confidential session")
+            else:
+                # create_vm_execution blocks until RUNNING in-process today; this
+                # re-poll is the explicit readiness barrier (and stays correct if a
+                # future out-of-process create returns before the VM is RUNNING).
+                await _wait_until_running(supervisor, vm_id)
+
+        # Scheduled long-running: it must not idle-expire.
+        expiry.cancel(vm_id)
+
+        if pubsub and settings.WATCH_FOR_UPDATES:
+            update_watcher.watch(vm_id, vm_hash, pubsub)

--- a/tests/supervisor/test_run_create_lock.py
+++ b/tests/supervisor/test_run_create_lock.py
@@ -205,6 +205,37 @@ async def test_the_second_start_waits_for_the_first_to_finish(monkeypatch) -> No
 
 
 @pytest.mark.asyncio
+async def test_a_start_that_raises_still_releases_the_lock(monkeypatch, purge) -> None:
+    """The release is in a finally and has to stay there. A create that raises
+    while holding the lock would keep it for the life of the process, and every
+    later start of that hash, from the reconciler and from both v1 handlers,
+    would wait on a lock nobody is going to release: a VM the plan lists would
+    never be built again and nothing would say why."""
+    _patch_instance_path(monkeypatch)
+    supervisor = _RacingSupervisor()
+    registry = AgentVmRegistry()
+    real_create = supervisor.create_vm
+
+    async def create_then_recover(spec: Any):
+        supervisor.create_vm = real_create  # type: ignore[method-assign]
+        msg = "the hypervisor refused this one"
+        raise RuntimeError(msg)
+
+    supervisor.create_vm = create_then_recover  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError):
+        await _start(supervisor, registry)
+
+    assert create_lock._locks == {}
+
+    # The timeout is the assertion: a leaked lock makes this wait forever.
+    await asyncio.wait_for(_start(supervisor, registry), timeout=5)
+
+    assert supervisor.created is True
+    assert create_lock._locks == {}
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("content", "build", "spec"),
     [

--- a/tests/supervisor/test_run_create_lock.py
+++ b/tests/supervisor/test_run_create_lock.py
@@ -1,0 +1,244 @@
+"""Two start paths racing on one hash must not delete each other's VM.
+
+``start_persistent_vm`` reads the supervisor, records the VM, downloads its
+resources and creates it, with several seconds of I/O between the read and the
+create. Nothing serialised that sequence per hash: the allocation reconciler
+and the v1 ``/control/allocations`` handler (or ``notify_allocation``) could
+both run it for the same hash, both see the VM as unknown, and both build it.
+The second ``create_vm`` then failed with VmAlreadyExistsError, which the
+create path treated like any other create failure: it retired the VM, and the
+retire deleted the winner's live VM, dropped its record and, with fresh disks,
+purged its volumes.
+
+These tests pin the two halves of the fix: the per-hash lock that makes the
+second caller wait and then find the VM up, and the VmAlreadyExistsError
+handling that keeps a create which lost the race from tearing anything down.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aleph_message.models import ItemHash
+from aleph_message.models.execution.environment import HypervisorType
+from test_supervisor_run_routing import _info, _spec
+from test_supervisor_translate import _make_qemu_instance_message
+
+from aleph.vm.agent import create_lock
+from aleph.vm.agent import run as run_module
+from aleph.vm.agent.vm import retire as retire_module
+from aleph.vm.agent.vm_registry import AgentVmRegistry
+from aleph.vm.supervisor_interface.errors import VmAlreadyExistsError, VmNotFoundError
+from aleph.vm.supervisor_interface.types import VmId
+from aleph.vm.utils import get_message_executable_content
+
+_HASH = ItemHash("deadbeef" * 8)
+
+
+@pytest.fixture(autouse=True)
+def _no_db_write(monkeypatch) -> None:
+    """A retire drops the VM's DB records, which needs an app-level session
+    these unit tests do not set up. Stubbed out: what matters here is whether
+    the retire runs at all."""
+    monkeypatch.setattr(retire_module, "delete_records_for_vm", AsyncMock())
+
+
+@pytest.fixture
+def purge(monkeypatch) -> MagicMock:
+    """Spy on the volume purge a FAILED_CREATE retire ends with."""
+    spy = MagicMock()
+    monkeypatch.setattr(retire_module, "purge_vm_storage", spy)
+    return spy
+
+
+def _program_content():
+    with open("examples/program_message_from_aleph.json") as fd:
+        return get_message_executable_content(json.load(fd)["content"])
+
+
+def _vprogram_content():
+    from test_vprogram import load_vprogram_message
+
+    return load_vprogram_message().content
+
+
+def _capacity() -> SimpleNamespace:
+    return SimpleNamespace(check_message=MagicMock(), resolve_gpus=AsyncMock(return_value=[]))
+
+
+def _patch_message(monkeypatch, content) -> None:
+    message = MagicMock(content=content)
+    monkeypatch.setattr(
+        run_module, "load_updated_message", AsyncMock(return_value=(message, MagicMock(content=content)))
+    )
+
+
+async def _slow_build(*_args, **_kwargs):
+    """A spec build that yields to the loop, standing in for the download: it
+    is the seconds between reading the supervisor and creating the VM that a
+    concurrent start walks into."""
+    for _ in range(5):
+        await asyncio.sleep(0)
+    return _spec()
+
+
+def _patch_instance_path(monkeypatch) -> None:
+    """Everything the instance create path does besides talking to the
+    supervisor: message load, spec build, volume probe, record persistence and
+    the port-forward tail."""
+    _patch_message(monkeypatch, _make_qemu_instance_message(hypervisor=HypervisorType.qemu))
+    monkeypatch.setattr(run_module, "build_create_vm_spec", _slow_build)
+    monkeypatch.setattr(run_module, "vm_has_volumes", MagicMock(return_value=False))
+    monkeypatch.setattr(run_module, "persist_record", AsyncMock())
+    monkeypatch.setattr(run_module, "resolve_instance_desired_forwards", AsyncMock(return_value=[]))
+    monkeypatch.setattr(run_module, "reconcile_adopted_port_forwards", AsyncMock())
+
+
+class _RacingSupervisor:
+    """A supervisor that knows nothing until a create returns, and whose create
+    is slow enough for a second caller to walk into it.
+
+    ``create_vm`` yields to the loop several times, which is the download and
+    boot window in miniature: without a per-hash lock the second start slips
+    into it, and its own create then hits the VM the first one committed.
+    """
+
+    def __init__(self) -> None:
+        self.created = False
+        self.create_calls = 0
+        self.deleted: list[VmId] = []
+
+    async def get_vm(self, vm_id: VmId):
+        if not self.created:
+            msg = f"{vm_id} not found"
+            raise VmNotFoundError(msg)
+        return _info()
+
+    async def create_vm(self, spec: Any):
+        self.create_calls += 1
+        if self.created:
+            msg = f"{spec.vm_id} already exists"
+            raise VmAlreadyExistsError(msg)
+        # The id is taken as soon as the create is accepted, as it is on the
+        # daemon: a second create for the same id is refused from here on.
+        self.created = True
+        return _info()
+
+    async def delete_vm(self, vm_id: VmId, keep_port_mappings: bool = False) -> None:
+        self.deleted.append(vm_id)
+        self.created = False
+
+    async def add_port_forward(self, forward: Any) -> None:
+        return None
+
+
+async def _start(supervisor: Any, registry: AgentVmRegistry) -> None:
+    await run_module.start_persistent_vm(
+        _HASH,
+        None,
+        supervisor=supervisor,
+        registry=registry,
+        capacity=_capacity(),
+        expiry=MagicMock(),
+        update_watcher=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_starts_create_the_vm_once(monkeypatch) -> None:
+    """The reconciler and the v1 handler starting the same hash at the same
+    time: one builds it, the other waits and finds it running."""
+    _patch_instance_path(monkeypatch)
+    supervisor = _RacingSupervisor()
+    registry = AgentVmRegistry()
+
+    results = await asyncio.gather(_start(supervisor, registry), _start(supervisor, registry), return_exceptions=True)
+
+    # The loser's create used to raise VmAlreadyExistsError, and the retire
+    # that followed deleted the VM the winner had just brought up.
+    assert supervisor.deleted == []
+    assert [result for result in results if isinstance(result, BaseException)] == []
+    assert supervisor.create_calls == 1
+    assert supervisor.created is True
+    assert registry.get(_HASH) is not None
+    # And the lock is gone once both callers are out: a node that has started
+    # thousands of VMs over its life keeps no lock for each.
+    assert create_lock._locks == {}
+
+
+@pytest.mark.asyncio
+async def test_the_second_start_waits_for_the_first_to_finish(monkeypatch) -> None:
+    """The lock covers the whole check-record-create sequence, not just the
+    create call: the second start must not even read the supervisor while the
+    first one is building."""
+    _patch_instance_path(monkeypatch)
+    supervisor = _RacingSupervisor()
+    registry = AgentVmRegistry()
+    order: list[str] = []
+
+    real_create = supervisor.create_vm
+
+    async def watched_create(spec: Any):
+        order.append("create")
+        return await real_create(spec)
+
+    real_get = supervisor.get_vm
+
+    async def watched_get(vm_id: VmId):
+        order.append("get")
+        return await real_get(vm_id)
+
+    supervisor.create_vm = watched_create  # type: ignore[method-assign]
+    supervisor.get_vm = watched_get  # type: ignore[method-assign]
+
+    await asyncio.gather(_start(supervisor, registry), _start(supervisor, registry))
+
+    # The winner's own sequence (get, create, then the readiness polls) runs
+    # to completion before the loser's first get.
+    assert order[:2] == ["get", "create"]
+    assert order.count("create") == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("content", "build", "spec"),
+    [
+        pytest.param(_program_content, "build_program_create_vm_spec", lambda: (_spec(), None), id="program"),
+        pytest.param(
+            lambda: _make_qemu_instance_message(hypervisor=HypervisorType.qemu),
+            "build_create_vm_spec",
+            _spec,
+            id="instance",
+        ),
+        pytest.param(_vprogram_content, "build_vprogram_spec", lambda: (_spec(), None), id="vprogram"),
+    ],
+)
+async def test_a_create_that_lost_the_race_keeps_the_winners_vm(monkeypatch, purge, content, build, spec) -> None:
+    """VmAlreadyExistsError means somebody else built this VM. Retiring it
+    would delete a VM that is running and, on fresh disks, purge its volumes."""
+    _patch_message(monkeypatch, content())
+    monkeypatch.setattr(run_module, build, AsyncMock(return_value=spec()))
+    monkeypatch.setattr(run_module, "vm_has_volumes", MagicMock(return_value=False))
+    monkeypatch.setattr(run_module, "persist_record", AsyncMock())
+    supervisor = SimpleNamespace(
+        create_vm=AsyncMock(side_effect=VmAlreadyExistsError(f"{_HASH} already exists")),
+        get_vm=AsyncMock(return_value=_info()),
+        delete_vm=AsyncMock(),
+        add_port_forward=AsyncMock(),
+    )
+
+    await run_module.create_vm_execution(
+        _HASH,
+        supervisor=supervisor,
+        registry=AgentVmRegistry(),
+        capacity=_capacity(),
+        persistent=True,
+    )
+
+    supervisor.delete_vm.assert_not_awaited()
+    purge.assert_not_called()


### PR DESCRIPTION
## Summary
Every start path (the allocation reconciler, the v1 `/control/allocations` handler, `notify_allocation`) runs the same read, record, download, create sequence, and the download in the middle of it lasts seconds. Nothing serialised that per hash, so a push landing on two paths at once left both callers reading "this node does not have this VM", both recording it and both downloading into the same directory. The supervisor refused the second create with `VmAlreadyExistsError`, the create path read that refusal as its own failure and retired the VM, and the retire deleted the VM the first caller had just brought up, forgot its record and, on fresh disks, purged its volumes.

`start_persistent_vm` now takes a per-hash lock around the whole sequence, and a create refused because the VM already exists returns instead of retiring.

Stacked on #1217.

## Changes
- `src/aleph/vm/agent/create_lock.py` (new): `vm_create_lock(namespace)`, one `asyncio.Lock` per hash, created on demand and dropped once nobody holds or waits for it. Starts of different VMs still run in parallel. It is deliberately not the storage reconciler's `creating()`, which is a refcount because a reconcile pass must count overlapping spans; this one excludes them.
- `src/aleph/vm/agent/run.py`: `start_persistent_vm` runs its whole body under that lock, placed inside the function rather than at the call sites so a new caller cannot forget it. The three create branches in `create_vm_execution` (program, instance, V-PROGRAM) catch `VmAlreadyExistsError` before the generic teardown branch, log it and return: that covers the create paths the lock does not reach (an operator recreate, a migration import racing a scheduler push) and makes the destructive outcome impossible rather than merely unreachable.

## Test plan
- `tests/supervisor/test_run_create_lock.py` (new, 6 tests): two concurrent `start_persistent_vm` calls on one hash create it once, delete nothing and raise nothing, and leave no lock behind; the second start does not even read the supervisor until the first is done; a create whose `create_vm` raises `VmAlreadyExistsError` neither deletes the VM nor purges its volumes, on all three create paths. All five fail on the base commit, the first one on `deleted == []` (the winner's VM was deleted). A sixth pins the release itself: a start whose `create_vm` raises, then a second start of the same hash under a timeout, since a lock left held by a raising body would make every later start of that hash wait forever rather than fail an assert.
- `ruff format --diff`, `isort --check-only --profile black` on the changed files and `mypy src/aleph/vm/ tests/` from the worktree root: all exit 0. The test suites are left to CI on this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZyMqLgxxVfeDwiNy34sfM

