### PR TITLE
fix(cli): make aleph-vm storage status and list truly read-only

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -334,8 +334,12 @@ because the marker outlives every other record of it (the registry record is
 forgotten and the DB rows are deleted), and it is what lets the node
 authorize the owner's own erase of retained data; it is optional, so markers
 written before the field and orphan markers for a VM whose message the node
-never held simply have none. Under `reap` no marker is ever written: the
-purge is immediate.
+never held simply have none. `reclaimable_since` is written in UTC with an
+offset; a timestamp that arrives without one (a marker restored or edited by
+hand) is read as UTC rather than as a naive datetime, since a naive one
+cannot be compared with the aware clock the rest of the agent uses and every
+subtraction against it raises, costing a whole listing or eviction pass for
+one marker. Under `reap` no marker is ever written: the purge is immediate.
 A create for the same hash adopts the directory (the marker is unlinked and
 the volumes are reused through the existing sticky placement in
 `volume_path_for`), which is what `reconciler.creating()` does on entry.
@@ -585,6 +589,25 @@ in its `--help` epilog) needs no running *agent process*:
   `live` when the registry knows its hash and `unmarked` otherwise (an
   orphan no pass has reached yet is not a live VM). Read-only, registry
   live set only.
+
+  Read-only here is literal, and it took work to make it so, because three
+  writes were hiding under a listing. `settings.setup()` makes every
+  configured directory, so the two verbs skip it entirely and refuse a
+  missing database before it would have run (an operator who mistyped the
+  execution root used to get the refusal and a tree of empty directories at
+  the typo; nothing these verbs read needs `setup()`, since every path is
+  derived when the settings object is built). `setup_pools()` adopts a pool
+  on first sight, writing the in-pool marker and the adoption registry, so
+  they call it with `read_only=True`: it still validates and classifies, and
+  still refuses a pool whose marker vanished after adoption, but it adopts
+  nothing (on a node whose second disk is not mounted, adopting that path is
+  precisely the write the guard exists to prevent). And a `.reclaimable`
+  marker that does not parse is read with `repair=False`: removing it is the
+  reconciler's repair, a listing that unlinks a file is not read-only, and
+  the unlink raises for an operator without the agent's privileges, which
+  cost the whole command rather than that one row. The one write they do
+  make is the schema migration of a database that is already there, without
+  which the registry cannot be read at all.
 - `storage reclaim <hash> [--trust-registry]`: purge one reclaimable
   directory now. Checks the name and the `.reclaimable` marker first, purely
   locally, so a typo or an unrelated hash fails instantly rather than
@@ -601,12 +624,16 @@ in its `--help` epilog) needs no running *agent process*:
   retained directories by clearing their markers, and one that started
   while the supervisor was being asked is in no answer this process holds,
   so the second read is what keeps the purge off the disks a create is at
-  that moment building on. Finally, if the purge itself leaves the
-  directory behind (a device-mapper target still holds one of its volumes,
-  the same guard `purge_vm_storage` always applies), reclaim reports that
-  and exits non-zero rather than claiming success. `reclaim` never tears
-  devices down itself: `storage reconcile` is the CLI path that does, for
-  every VM nothing owns, so the refusal points the operator there.
+  that moment building on. Finally, if the purge itself leaves a directory
+  behind, reclaim names each one with the reason `purge_vm_storage` gives
+  for it and exits non-zero rather than claiming success. There are two
+  such reasons and they need different answers: a live device-mapper target
+  holding the volumes (the guard `purge_vm_storage` always applies), which
+  is freed by tearing that target down, and the removal itself failing (a
+  read-only filesystem, an immutable file, a directory this user may not
+  write), which no teardown fixes. Only the first sends the operator to
+  `storage reconcile`, which is the CLI path that tears devices down, for
+  every VM nothing owns; `reclaim` never does it itself.
 - `storage reconcile [--dry-run] [--trust-registry]`: run one
   `reconcile_storage()` pass. Two processes decide what it may do, and they
   are not the same one. The **agent** is this Python service
@@ -707,7 +734,10 @@ anything:
   `.env` in the working directory. The CLI therefore loads that file itself
   (`--env-file`, else `$ALEPH_VM_ENV_FILE`, else the packaged path) and
   rebuilds the settings singleton from it, logging which file it used or
-  that there was none. Values already in the environment win, so a one-off
+  that there was none. The file is read without `${}` expansion, the way
+  systemd's `EnvironmentFile=` reads it, so the CLI sees exactly the value
+  the daemon sees and a secret containing a dollar sign is not silently
+  truncated. Values already in the environment win, so a one-off
   override on the command line still works, and a `--env-file` that does
   not exist is an error rather than a silent fall back to the defaults: a
   pass run with `VOLUME_RETENTION` at its `reap` default on a node
@@ -723,7 +753,10 @@ anything:
   with a raw sqlite error. `status` and `list` are the exception; being
   read-only, they refuse a database that does not exist and exit `1` rather
   than create an empty one, so an operator pointed at the wrong execution
-  root sees the mistake instead of an empty listing.
+  root sees the mistake instead of an empty listing. That refusal is the
+  first thing they do, before the configuration is turned into directories
+  and before the pools are set up, so the wrong execution root is reported
+  rather than created.
 
 `reconcile` and `reclaim` can purge, so they apply the same fail-closed rule
 `reconciler._startup_refusal` applies to the daemon's own startup pass: a

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -583,7 +583,15 @@ subparser on `agent/cli.py`'s own parser, which points at `storage --help`
 in its `--help` epilog) needs no running *agent process*:
 
 - `storage status`: per pool, live / reclaimable / cache / free bytes
-  against the budgets. Read-only, registry live set only.
+  against the budgets. Read-only, registry live set only. A figure this
+  process could not measure prints `unknown`, never `0 B`: the free space and
+  the budget of a pool whose filesystem cannot be stat'ed (a mountpoint that
+  went away, a directory this user may not read) would otherwise be
+  indistinguishable from a pool that is genuinely full, which is the state an
+  operator runs this command to find. The cache budget is a share of the
+  filesystem holding the cache root, so it says `unknown` for the same
+  reason. A budget under `VOLUME_RETENTION=reap` is a real zero and prints
+  as one.
 - `storage list [--reclaimable]`: hash, pool, size, reason, age. The reason
   is the marker's for a reclaimable directory; an unmarked directory reads
   `live` when the registry knows its hash and `unmarked` otherwise (an

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -527,6 +527,43 @@ def _cli_live_set(registry: AgentVmRegistry) -> LiveSet:
     )
 
 
+def _pool_usage(path: Path) -> tuple[int | None, int | None]:
+    """(total, free) bytes of the filesystem holding ``path``, or (None,
+    None) when it cannot be read: a mountpoint that went away, a directory
+    this user may not stat, a filesystem that is gone."""
+    try:
+        usage = shutil.disk_usage(str(path))
+    except OSError:
+        logger.warning("Could not read the usage of %s", path, exc_info=True)
+        return None, None
+    return usage.total, usage.free
+
+
+def _retention_budget(total: int | None) -> int | None:
+    """The retention budget in bytes, or None when it cannot be computed.
+
+    Under ``reap`` it is zero and nothing else, whatever the filesystem
+    says. Otherwise it is measured against the pool's size (typically a
+    percentage of it), so a size this process could not read leaves the
+    budget unknown rather than zero.
+    """
+    if settings.VOLUME_RETENTION == "reap":
+        return 0
+    if total is None:
+        return None
+    return parse_budget(settings.VOLUME_RETENTION_BUDGET, total)
+
+
+def _figure(size: int | None) -> str:
+    """A byte figure, or ``unknown`` for one this process could not measure.
+
+    Zero is a measurement, and a pool printed as 0 bytes free with a 0 byte
+    budget looks exactly like a full pool, which is the state an operator
+    runs this command to find. An unreadable pool has to say so.
+    """
+    return "unknown" if size is None else _human(size)
+
+
 def _status(registry: AgentVmRegistry, out: TextIO) -> int:
     live = live_hashes(registry)
     out.write("POOL\tLIVE\tRECLAIMABLE\tBUDGET\tFREE\n")
@@ -536,24 +573,22 @@ def _status(registry: AgentVmRegistry, out: TextIO) -> int:
             for directory in iter_namespace_dirs()
             if directory.parent == pool.path and directory.name in live
         )
-        try:
-            usage = shutil.disk_usage(str(pool.path))
-            total, free = usage.total, usage.free
-        except OSError:
-            total = free = 0
-        budget = 0 if settings.VOLUME_RETENTION == "reap" else parse_budget(settings.VOLUME_RETENTION_BUDGET, total)
+        total, free = _pool_usage(pool.path)
         out.write(
             f"{pool.path}\t{_human(live_bytes)}\t{_human(reclaimable_bytes(pool.path, repair=False))}\t"
-            f"{_human(budget)}\t{_human(free)}\n"
+            f"{_figure(_retention_budget(total))}\t{_figure(free)}\n"
         )
     out.write("CACHE\tUSED\tBUDGET\n")
     for root in cache_roots():
         used = sum(entry.size_bytes for entry in cache_entries(root))
+        # The cache budget is a share of the filesystem holding the root, so
+        # it is unknown for exactly the same reason a pool's is.
         try:
-            budget = cache_budget_bytes(root)
+            budget: int | None = cache_budget_bytes(root)
         except OSError:
-            budget = 0
-        out.write(f"{root}\t{_human(used)}\t{_human(budget)}\n")
+            logger.warning("Could not compute the cache budget of %s", root, exc_info=True)
+            budget = None
+        out.write(f"{root}\t{_human(used)}\t{_figure(budget)}\n")
     return 0
 
 
@@ -584,7 +619,15 @@ def _list(registry: AgentVmRegistry, out: TextIO, *, reclaimable_only: bool) -> 
 
 
 def _is_marked_reclaimable(vm_hash: str) -> bool:
-    return any(directory.name == vm_hash for directory, _marker in iter_reclaimable())
+    """Whether any pool holds a marker for this hash.
+
+    repair=False, like every marker read this process makes: the walk covers
+    every directory on the node, and it runs before the refusals, so with
+    the repair on, a reclaim that is about to be refused would first unlink
+    the corrupt markers of unrelated VMs. Both callers (the refusal, and the
+    second read immediately before the purge) go through here.
+    """
+    return any(directory.name == vm_hash for directory, _marker in iter_reclaimable(repair=False))
 
 
 @dataclass(frozen=True)

--- a/src/aleph/vm/agent/storage_cli.py
+++ b/src/aleph/vm/agent/storage_cli.py
@@ -66,9 +66,19 @@ systemd units set it up for the daemon: the node's environment file is read
 here (nothing else injects it into an operator's shell, and running a pass
 on the built-in defaults would reconcile a node against a configuration it
 does not have), the log records go to stderr, and the agent database is
-created and migrated before anything reads it. The read-only verbs are the
-exception to the last one: they refuse a database that is not there rather
-than create it.
+created and migrated before anything reads it.
+
+``status`` and ``list`` are the exception, and they are read-only in the
+literal sense: they refuse a database that is not there rather than create
+one, and they refuse it before any of that setup runs, since
+``settings.setup()`` makes every configured directory and the pool setup
+adopts a pool on first sight (an operator who mistyped the execution root
+got the refusal and a tree of empty directories at the typo, and a node
+whose second disk was not mounted got that path adopted as a pool). They
+also read a marker that does not parse without removing it, which is the
+reconciler's repair and not a listing's. The one write they do make is the
+schema migration of the database that is already there: the registry cannot
+be read out of a database older than the code.
 """
 
 from __future__ import annotations
@@ -95,7 +105,7 @@ from aleph.vm import storage_pools
 from aleph.vm.agent import metrics
 from aleph.vm.agent.cli import LOG_LEVEL_NAMES, initialise_database
 from aleph.vm.agent.vm.cache import cache_budget_bytes, cache_entries, cache_roots
-from aleph.vm.agent.vm.purge import purge_vm_storage
+from aleph.vm.agent.vm.purge import PurgeResult, purge_vm_storage
 from aleph.vm.agent.vm.reclaimable import (
     directory_size_bytes,
     iter_reclaimable,
@@ -106,7 +116,6 @@ from aleph.vm.agent.vm.reconciler import (
     _plausible,
     _release_cache_devices,
     _startup_refusal,
-    _still_on_disk,
     _teardown_orphan_devices,
     live_hashes,
     reconcile_storage,
@@ -252,7 +261,11 @@ def _human(size: int) -> str:
 
 def _age(since: datetime) -> str:
     delta = datetime.now(tz=timezone.utc) - since
-    days, rem = divmod(int(delta.total_seconds()), 86400)
+    # Clamped at zero: a marker dated in the future (a node whose clock went
+    # backwards, a marker copied from another host) would otherwise print an
+    # age like "-1d 23h", which reads as a parsing bug to whoever sees it.
+    seconds = max(int(delta.total_seconds()), 0)
+    days, rem = divmod(seconds, 86400)
     hours = rem // 3600
     return f"{days}d {hours}h"
 
@@ -530,7 +543,7 @@ def _status(registry: AgentVmRegistry, out: TextIO) -> int:
             total = free = 0
         budget = 0 if settings.VOLUME_RETENTION == "reap" else parse_budget(settings.VOLUME_RETENTION_BUDGET, total)
         out.write(
-            f"{pool.path}\t{_human(live_bytes)}\t{_human(reclaimable_bytes(pool.path))}\t"
+            f"{pool.path}\t{_human(live_bytes)}\t{_human(reclaimable_bytes(pool.path, repair=False))}\t"
             f"{_human(budget)}\t{_human(free)}\n"
         )
     out.write("CACHE\tUSED\tBUDGET\n")
@@ -553,7 +566,12 @@ def _list(registry: AgentVmRegistry, out: TextIO, *, reclaimable_only: bool) -> 
     live = live_hashes(registry)
     out.write("HASH\tPOOL\tSIZE\tREASON\tAGE\n")
     for directory in iter_namespace_dirs():
-        marker = read_marker(directory)
+        # repair=False: removing a marker that does not parse is the
+        # reconciler's job, and a listing that unlinks a file is not the
+        # read-only command this is documented to be (it may also be run by
+        # a user who cannot unlink it, and the error would abort the whole
+        # listing over one row).
+        marker = read_marker(directory, repair=False)
         if reclaimable_only and marker is None:
             continue
         if marker:
@@ -661,15 +679,34 @@ def _reclaim(registry: AgentVmRegistry, vm_hash: str, out: TextIO, err: TextIO, 
             "supervisor was being asked. Refusing to purge it\n"
         )
         return 1
-    deleted = purge_vm_storage(vm_hash)
-    if _still_on_disk(vm_hash):
-        err.write(
-            f"Purge of {vm_hash} left directories behind: a device-mapper target still holds its volumes. "
-            "Run 'storage reconcile' to tear down the devices of every VM nothing owns, then retry\n"
-        )
+    result = purge_vm_storage(vm_hash)
+    if result.kept:
+        err.write(_incomplete_purge_report(vm_hash, result))
         return 1
-    out.write(f"Purged {vm_hash}: {deleted} volume file(s)\n")
+    out.write(f"Purged {vm_hash}: {result.deleted} volume file(s)\n")
     return 0
+
+
+def _incomplete_purge_report(vm_hash: str, result: PurgeResult) -> str:
+    """What the purge could not remove, named, with advice that fits it.
+
+    A device-mapper hold and a failed removal (a read-only filesystem, an
+    immutable file, a directory this user may not write) leave the same
+    thing on disk, so the directory alone cannot tell them apart. Only the
+    first is fixed by tearing devices down, and sending an operator to
+    'storage reconcile' for the others is advice that cannot work.
+    """
+    lines = [f"Purge of {vm_hash} left {len(result.kept)} directory(ies) behind:\n"]
+    lines.extend(f"  {kept.path}: {kept.reason}\n" for kept in result.kept)
+    lines.append(f"Deleted {result.deleted} volume file(s)\n")
+    if any(kept.device_mapper for kept in result.kept):
+        lines.append("Run 'storage reconcile' to tear down the devices of every VM nothing owns, then retry\n")
+    else:
+        lines.append(
+            "No device-mapper target is holding these: the errors above are what stopped the removal, "
+            "so fix those and retry\n"
+        )
+    return "".join(lines)
 
 
 def _agent_at_work_reason(probe: AgentProbe) -> str:
@@ -876,7 +913,11 @@ def _load_env_file(explicit: str | None) -> bool:
             return False
         logger.info("No environment file at %s; using the process environment alone", path)
         return True
-    load_dotenv(path, override=False)
+    # interpolate=False: systemd's EnvironmentFile= does no ${} expansion,
+    # so the node's file is written with literal values. Expanding them here
+    # would read a value the daemon never sees, and would silently truncate
+    # any secret containing a dollar sign to whatever ${...} resolves to.
+    load_dotenv(path, override=False, interpolate=False)
     _reload_settings()
     logger.info("Loaded the node configuration from %s", path)
     return True
@@ -895,19 +936,36 @@ def run_parsed(args: argparse.Namespace) -> int:
             field = ".".join(str(part) for part in field_error["loc"])
             print(f"Invalid node configuration for {field}: {field_error['msg']}", file=sys.stderr)
         return 2
-    settings.setup()
-    storage_pools.setup_pools()
 
+    read_only = args.storage_command in READ_ONLY_COMMANDS
     database = settings.EXECUTION_DATABASE
-    if not database.exists():
-        if args.storage_command in READ_ONLY_COMMANDS:
-            logger.error(
-                "No agent database at %s: nothing has run on this node yet, or the execution root is not the one "
-                "the agent uses",
-                database,
-            )
-            return 1
-        logger.info("Creating the agent database at %s", database)
+    if read_only and not database.exists():
+        # Before anything else: settings.setup() makes every configured
+        # directory, so an operator who mistyped the execution root used to
+        # get this refusal and a tree of empty directories at the typo.
+        logger.error(
+            "No agent database at %s: nothing has run on this node yet, or the execution root is not the one "
+            "the agent uses",
+            database,
+        )
+        return 1
+    if read_only:
+        # settings.setup() creates the caches, the execution root, the pool
+        # directory and the session directory, and resolves the node's DNS;
+        # setup_pools() adopts a pool on first sight, marker file and
+        # adoption registry both. None of that belongs in a command that
+        # reports on a node. The settings themselves are complete without
+        # setup(): every path these verbs read is derived when the settings
+        # object is built.
+        storage_pools.setup_pools(read_only=True)
+    else:
+        settings.setup()
+        storage_pools.setup_pools()
+        if not database.exists():
+            logger.info("Creating the agent database at %s", database)
+    # Read-only included: the registry cannot be read out of a database
+    # whose schema predates the code, and the migration writes only to the
+    # database file that is already there.
     initialise_database()
 
     registry = asyncio.run(_load_registry())

--- a/src/aleph/vm/agent/vm/purge.py
+++ b/src/aleph/vm/agent/vm/purge.py
@@ -214,9 +214,9 @@ def purge_vm_storage(vm_hash: ItemHash | str) -> PurgeResult:
     # audit trail an erase should leave.
     deleted = len(purge_vm_volumes(namespace))
     kept: list[KeptDirectory] = []
+    held = [volume for volume in iter_volume_files(namespace) if _held_by_device_mapper(namespace, volume)]
 
     for volumes_dir in list(iter_namespace_dirs(namespace)):
-        held = [volume for volume in iter_volume_files(namespace) if _held_by_device_mapper(namespace, volume)]
         held_here = [volume.name for volume in held if volume.parent == volumes_dir]
         if held_here:
             # Same rule as purge_vm_volumes: an rmtree here would unlink the

--- a/src/aleph/vm/agent/vm/purge.py
+++ b/src/aleph/vm/agent/vm/purge.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import logging
 import shutil
 from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 
 from aleph_message.models import ItemHash
@@ -168,7 +169,31 @@ def purge_vm_staging(vm_hash: ItemHash | str) -> None:
     remove_snp_instance_staging(item_hash)
 
 
-def purge_vm_storage(vm_hash: ItemHash | str) -> int:
+@dataclass(frozen=True)
+class KeptDirectory:
+    """A namespace directory the purge did not remove, and why.
+
+    ``device_mapper`` is the distinction that matters to whoever reads this:
+    a directory held by a live dm target is freed by tearing that target
+    down, and nothing else is. Every other reason is the removal itself
+    failing (a read-only filesystem, an immutable file, a directory this
+    process may not write), which no teardown fixes.
+    """
+
+    path: Path
+    reason: str
+    device_mapper: bool
+
+
+@dataclass(frozen=True)
+class PurgeResult:
+    """What a purge deleted, and what it left behind."""
+
+    deleted: int
+    kept: tuple[KeptDirectory, ...] = ()
+
+
+def purge_vm_storage(vm_hash: ItemHash | str) -> PurgeResult:
     """Delete everything this VM owns on disk, for a VM that is gone for good.
 
     Covers the per-VM volume directories on every pool, the confidential
@@ -178,7 +203,9 @@ def purge_vm_storage(vm_hash: ItemHash | str) -> int:
     (device-mapper targets, jailer chroot, sockets) during DeleteVm, and this
     runs after that returns.
 
-    Returns the number of volume files deleted. Idempotent: purging a VM with
+    Returns the volume files deleted and the directories that survived, each
+    with its reason, so a caller can report what really happened rather than
+    guess from a directory that is still there. Idempotent: purging a VM with
     nothing on disk is a no-op.
     """
     namespace = _checked_namespace(vm_hash)
@@ -186,10 +213,12 @@ def purge_vm_storage(vm_hash: ItemHash | str) -> int:
     # the per-file pass logs each volume and yields the count, which is the
     # audit trail an erase should leave.
     deleted = len(purge_vm_volumes(namespace))
+    kept: list[KeptDirectory] = []
 
     for volumes_dir in list(iter_namespace_dirs(namespace)):
         held = [volume for volume in iter_volume_files(namespace) if _held_by_device_mapper(namespace, volume)]
-        if any(volume.parent == volumes_dir for volume in held):
+        held_here = [volume.name for volume in held if volume.parent == volumes_dir]
+        if held_here:
             # Same rule as purge_vm_volumes: an rmtree here would unlink the
             # dm-held file behind the guard's back, pinning its blocks behind
             # a target nothing removes. Leave the directory for the operator
@@ -197,18 +226,26 @@ def purge_vm_storage(vm_hash: ItemHash | str) -> int:
             logger.error(
                 "Not removing %s: it still holds device-mapper-backed volumes %s",
                 volumes_dir,
-                ", ".join(volume.name for volume in held if volume.parent == volumes_dir),
+                ", ".join(held_here),
+            )
+            kept.append(
+                KeptDirectory(
+                    volumes_dir,
+                    f"a device-mapper target still holds {', '.join(held_here)}",
+                    device_mapper=True,
+                )
             )
             continue
         try:
             shutil.rmtree(volumes_dir)
             logger.info("Removed volume directory %s", volumes_dir)
-        except OSError:
+        except OSError as error:
             logger.warning("Failed to remove volume directory %s", volumes_dir, exc_info=True)
+            kept.append(KeptDirectory(volumes_dir, f"{type(error).__name__}: {error}", device_mapper=False))
 
     purge_vm_side_dirs(namespace)
 
-    return deleted
+    return PurgeResult(deleted, tuple(kept))
 
 
 def purge_vm_side_dirs(vm_hash: ItemHash | str) -> None:

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -63,8 +63,17 @@ class ReclaimableMarker:
             msg = f"marker is not a JSON object: {type(data).__name__}"
             raise ValueError(msg)
         owner = data.get("owner")
+        since = datetime.fromisoformat(data["reclaimable_since"])
+        if since.tzinfo is None:
+            # Everything this node writes carries an offset, but a marker an
+            # operator restored or edited by hand may not. Parsed naive it
+            # cannot be compared with the aware clock the rest of the agent
+            # uses: every subtraction raises TypeError, and one such marker
+            # would abort a whole listing or eviction pass. The writers all
+            # use UTC, so that is what a bare timestamp means.
+            since = since.replace(tzinfo=timezone.utc)
         return cls(
-            reclaimable_since=datetime.fromisoformat(data["reclaimable_since"]),
+            reclaimable_since=since,
             reason=data["reason"],
             size_bytes=int(data["size_bytes"]),
             depends_on=tuple(data.get("depends_on", ())),
@@ -105,7 +114,7 @@ def directory_size_bytes(directory: Path) -> int:
     return sum(file_size_bytes(entry) for entry in entries if entry.name != MARKER_NAME)
 
 
-def read_marker(namespace_dir: Path) -> ReclaimableMarker | None:
+def read_marker(namespace_dir: Path, *, repair: bool = True) -> ReclaimableMarker | None:
     """The directory's marker, or None when it has none.
 
     A marker that does not parse is removed, not just ignored: writes are
@@ -113,6 +122,13 @@ def read_marker(namespace_dir: Path) -> ReclaimableMarker | None:
     place it would wedge the directory (the exclusive orphan write backs off
     from any existing file, so nothing could ever re-mark or evict it). Gone,
     the directory re-enters the orphan flow on the next pass.
+
+    That removal is a write, and not every reader is allowed to make one:
+    ``repair=False`` reads the same marker without touching the file, for
+    the commands that only report on a node (they may be run by a user who
+    cannot unlink it at all, and an operator inspecting a node has not asked
+    for anything on disk to change). The reconciler keeps the repair, since
+    it is the pass that has to be able to move the directory on.
     """
     path = namespace_dir / MARKER_NAME
     if not path.is_file():
@@ -123,9 +139,17 @@ def read_marker(namespace_dir: Path) -> ReclaimableMarker | None:
         logger.warning("Unreadable reclaimable marker at %s, ignoring it", path)
         return None
     except (ValueError, KeyError, TypeError, AttributeError):
+        if not repair:
+            logger.warning("Corrupt reclaimable marker at %s, ignoring it", path)
+            return None
         logger.warning("Corrupt reclaimable marker at %s, removing it", path)
         invalidate_reclaimable_cache()
-        path.unlink(missing_ok=True)
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            # Best effort: a read-only filesystem or a marker this user does
+            # not own must not raise out of a caller that was only reading.
+            logger.warning("Could not remove the corrupt marker at %s", path, exc_info=True)
         return None
 
 
@@ -335,9 +359,11 @@ def retained_marker(namespace: str) -> ReclaimableMarker | None:
     return None
 
 
-def iter_reclaimable() -> Iterator[tuple[Path, ReclaimableMarker]]:
+def iter_reclaimable(*, repair: bool = True) -> Iterator[tuple[Path, ReclaimableMarker]]:
+    """Every marked directory and its marker. ``repair=False`` leaves a
+    corrupt marker where it is, for a read-only caller."""
     for directory in iter_namespace_dirs():
-        marker = read_marker(directory)
+        marker = read_marker(directory, repair=repair)
         if marker is not None:
             yield directory, marker
 
@@ -369,8 +395,11 @@ def _pools_fingerprint() -> tuple:
     return tuple(stamps)
 
 
-def reclaimable_bytes(pool_path: Path | None = None) -> int:
-    """Sum of marker size_bytes, across every pool or for one pool."""
+def reclaimable_bytes(pool_path: Path | None = None, *, repair: bool = True) -> int:
+    """Sum of marker size_bytes, across every pool or for one pool.
+
+    ``repair=False`` is for a caller that may not write: the walk then reads
+    a corrupt marker without removing it."""
     now = time.monotonic()
     fingerprint = _pools_fingerprint()
     cached = _reclaimable_cache.get(pool_path)
@@ -378,7 +407,7 @@ def reclaimable_bytes(pool_path: Path | None = None) -> int:
         return cached[2]
     total = sum(
         marker.size_bytes
-        for directory, marker in iter_reclaimable()
+        for directory, marker in iter_reclaimable(repair=repair)
         if pool_path is None or directory.parent == pool_path
     )
     _reclaimable_cache[pool_path] = (now, fingerprint, total)

--- a/src/aleph/vm/storage_pools.py
+++ b/src/aleph/vm/storage_pools.py
@@ -193,13 +193,19 @@ def _record_adopted(path: Path) -> None:
     os.replace(tmp_path, registry)
 
 
-def _adopt_pool(path: Path, media_class: MediaClass) -> None:
+def _adopt_pool(path: Path, media_class: MediaClass, *, read_only: bool = False) -> None:
     """Write the in-pool marker on first use; refuse a pool whose marker
     vanished after adoption (the disk is very likely not mounted and writes
-    would silently land on the filesystem below the mountpoint)."""
+    would silently land on the filesystem below the mountpoint).
+
+    Under ``read_only`` the checks still run (a pool whose marker vanished is
+    still refused) but nothing is written: adopting a pool is a decision the
+    agent makes when it starts, not something a command that only reports on
+    a node should make on its behalf."""
     marker = path / POOL_MARKER_NAME
     if marker.is_file():
-        _record_adopted(path)  # heal the registry after e.g. a restore
+        if not read_only:
+            _record_adopted(path)  # heal the registry after e.g. a restore
         return
     if _canonical(path) in _load_adopted():
         msg = (
@@ -207,16 +213,22 @@ def _adopt_pool(path: Path, media_class: MediaClass) -> None:
             "Most likely the disk is not mounted; refusing to write to whatever is at that path."
         )
         raise StoragePoolConfigError(msg)
+    if read_only:
+        logger.info("Not adopting %s: this pass may not write", path)
+        return
     marker.write_text(json.dumps({"version": POOL_MARKER_VERSION, "media_class": media_class.value}) + "\n")
     _record_adopted(path)
     logger.info("Adopted %s as a %s volume pool", path, media_class.value)
 
 
-def setup_pools(sys_root: Path = Path("/sys")) -> list[StoragePool]:
+def setup_pools(sys_root: Path = Path("/sys"), *, read_only: bool = False) -> list[StoragePool]:
     """Validate, classify and adopt the configured pools.
 
     Call once at agent startup, after ``settings.setup()``. Raises
     StoragePoolConfigError on any misconfiguration: never degrade silently.
+
+    ``read_only`` validates and classifies without adopting anything, for a
+    command that reports on the pools rather than running VMs on them.
     """
     global _pools  # noqa: PLW0603
     pools: list[StoragePool] = []
@@ -247,7 +259,7 @@ def setup_pools(sys_root: Path = Path("/sys")) -> list[StoragePool]:
                 "Point CACHE_ROOT or BACKUP_DIRECTORY at it instead."
             )
             raise StoragePoolConfigError(msg)
-        _adopt_pool(path, media_class)
+        _adopt_pool(path, media_class, read_only=read_only)
         pools.append(StoragePool(path=path, media_class=media_class, index=position))
 
     orphaned = _load_adopted() - {_canonical(pool.path) for pool in pools}

--- a/tests/supervisor/test_reclaimable.py
+++ b/tests/supervisor/test_reclaimable.py
@@ -239,9 +239,9 @@ def test_reclaimable_bytes_is_cached_between_marker_changes(pools, monkeypatch):
     walks = []
     real_iter = reclaimable_module.iter_reclaimable
 
-    def counting_iter():
+    def counting_iter(**kwargs):
         walks.append(1)
-        return real_iter()
+        return real_iter(**kwargs)
 
     monkeypatch.setattr(reclaimable_module, "iter_reclaimable", counting_iter)
     volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
@@ -385,3 +385,59 @@ def test_depends_on_is_the_parent_subset_of_the_same_enumeration(mocker):
 
     assert depends_on_from_content(content) == ("parent",)
     assert set(depends_on_from_content(content)) <= refs_from_content(content)
+
+
+def test_a_reader_that_may_not_repair_keeps_a_corrupt_marker(pools):  # noqa: F811
+    """The repair is the reconciler's, not every reader's. A read-only caller
+    (the storage CLI's status and list) must leave the file where it is: it
+    may be running as a user who cannot unlink it at all, and an operator
+    inspecting a node has not asked for anything on disk to change."""
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    marker_path = pools["pool0"] / VM_HASH / MARKER_NAME
+    marker_path.write_text("{not json")
+
+    assert read_marker(pools["pool0"] / VM_HASH, repair=False) is None
+    assert marker_path.exists()
+    assert reclaimable_bytes(repair=False) == 0
+    assert marker_path.exists()
+
+
+def test_a_corrupt_marker_that_cannot_be_removed_still_reads_as_none(pools, monkeypatch, caplog):  # noqa: F811
+    """Removing the corrupt marker is best effort: a read-only filesystem or
+    a marker this user does not own must not raise out of a pass that was
+    only reading."""
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    marker_path = pools["pool0"] / VM_HASH / MARKER_NAME
+    marker_path.write_text("{not json")
+    real_unlink = Path.unlink
+
+    def refuse(self, *args, **kwargs):
+        if self.name == MARKER_NAME:
+            raise PermissionError("not yours to remove")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", refuse)
+
+    assert read_marker(pools["pool0"] / VM_HASH) is None
+    assert "Could not remove" in caplog.text
+
+
+def test_a_timestamp_without_an_offset_reads_as_utc():
+    """A hand-edited marker (an operator restoring one, an older writer) can
+    carry a naive timestamp. Parsed naive it mixes with the aware clock
+    everything else uses, and every subtraction raises TypeError."""
+    text = json.dumps(
+        {
+            "version": 1,
+            "reclaimable_since": "2026-08-24T12:00:00",
+            "reason": "gone",
+            "size_bytes": 7,
+            "depends_on": [],
+        }
+    )
+
+    marker = ReclaimableMarker.from_json(text)
+
+    assert marker.reclaimable_since == NOW
+    assert marker.reclaimable_since.tzinfo is not None
+    assert (datetime.now(tz=timezone.utc) - marker.reclaimable_since).total_seconds() > 0

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import errno
 import io
 import json
 import logging
 import os
 import re
+import shutil
 import socket
 import time
 from datetime import datetime, timedelta, timezone
@@ -1205,3 +1207,62 @@ def test_the_env_file_path_prefers_the_flag_then_the_variable_then_the_default(m
     monkeypatch.setenv(cli.ENV_FILE_VARIABLE, str(tmp_path / "from-variable.env"))
     assert cli._env_file_path(None) == (tmp_path / "from-variable.env", True)
     assert cli._env_file_path(str(tmp_path / "explicit.env")) == (tmp_path / "explicit.env", True)
+
+
+def test_status_says_unknown_for_a_pool_it_cannot_measure(pools, registry, monkeypatch):  # noqa: F811
+    """A pool whose usage cannot be read (a mountpoint that went away, a
+    directory this user may not stat) printed FREE 0.0 B and BUDGET 0.0 B,
+    which is exactly what a full pool prints: the one state an operator runs
+    this command to find."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    monkeypatch.setattr(settings, "VOLUME_RETENTION_BUDGET", "10%")
+    real_disk_usage = shutil.disk_usage
+
+    def refuse(path, *args, **kwargs):
+        if Path(path) == pools["pool0"]:
+            raise OSError(errno.EACCES, "Permission denied")
+        return real_disk_usage(path, *args, **kwargs)
+
+    monkeypatch.setattr(cli.shutil, "disk_usage", refuse)
+
+    code, out, _err = _run(["status"], registry)
+
+    assert code == 0
+    rows = {line.split("\t")[0]: line.split("\t") for line in out.splitlines()[1:]}
+    assert rows[str(pools["pool0"])][3:] == ["unknown", "unknown"]
+    assert rows[str(pools["pool1"])][3:] != ["unknown", "unknown"], "a readable pool still shows figures"
+
+
+def test_status_says_unknown_for_a_cache_budget_it_cannot_compute(pools, registry, monkeypatch):  # noqa: F811
+    """Same arithmetic on the cache table: the budget is a share of a
+    filesystem size, so a size that cannot be read is not a budget of zero."""
+
+    def refuse(root):
+        raise OSError(errno.EACCES, "Permission denied")
+
+    monkeypatch.setattr(cli, "cache_budget_bytes", refuse)
+
+    code, out, _err = _run(["status"], registry)
+
+    assert code == 0
+    cache_rows = [line.split("\t") for line in out.splitlines() if line.startswith(str(pools["runtime"]))]
+    assert cache_rows and all(row[2] == "unknown" for row in cache_rows)
+
+
+def test_a_refused_reclaim_removes_no_marker(pools, registry, monkeypatch):  # noqa: F811
+    """The marker check walks every pool, and it runs before the refusal. A
+    reclaim refused because the agent is running must not have unlinked a
+    corrupt marker on the way to refusing: that is the reconciler's repair,
+    and it is a write the operator did not ask for."""
+    monkeypatch.setattr(cli, "_probe_agent", _agent_up())
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+    # On the same pool and sorting first, so the walk reaches it before it
+    # finds the hash it was asked about and stops.
+    corrupt = _corrupt_marker(pools["pool0"], OTHER_HASH)
+
+    code, _out, err = _run(["reclaim", VM_HASH], registry)
+
+    assert code == 3
+    assert "the agent is running" in err
+    assert corrupt.exists()

--- a/tests/supervisor/test_storage_cli.py
+++ b/tests/supervisor/test_storage_cli.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import io
+import json
 import logging
 import os
+import re
 import socket
 import time
 from datetime import datetime, timedelta, timezone
@@ -833,7 +835,7 @@ def plumbing(tmp_path, monkeypatch, registry):
     the way of the tests that are about something else."""
     monkeypatch.setattr(cli, "DEFAULT_ENV_FILE", tmp_path / "no-such-file.env")
     monkeypatch.setattr(type(settings), "setup", lambda _self: None)
-    monkeypatch.setattr(storage_pools, "setup_pools", lambda: None)
+    monkeypatch.setattr(storage_pools, "setup_pools", lambda **_: None)
     monkeypatch.setattr(cli, "initialise_database", lambda: None)
     monkeypatch.setattr(cli, "_load_registry", AsyncMock(return_value=registry))
     database = tmp_path / "executions.sqlite3"
@@ -957,7 +959,7 @@ def test_an_unmigrated_database_is_brought_up_to_date(pools, tmp_path, monkeypat
     monkeypatch.setattr(settings, "EXECUTION_DATABASE", database)
     monkeypatch.setattr(cli, "DEFAULT_ENV_FILE", tmp_path / "no-such-file.env")
     monkeypatch.setattr(type(settings), "setup", lambda _self: None)
-    monkeypatch.setattr(storage_pools, "setup_pools", lambda: None)
+    monkeypatch.setattr(storage_pools, "setup_pools", lambda **_: None)
 
     assert cli.main(["list"]) == 0
 
@@ -1032,3 +1034,174 @@ def test_a_write_verb_creates_a_missing_database(pools, tmp_path, monkeypatch, c
 
     assert database.exists()
     assert any("Creating the agent database" in record.message for record in caplog.records)
+
+
+def _corrupt_marker(pool: Path, namespace: str) -> Path:
+    volume(pool, namespace, "rootfs.qcow2")
+    marker = pool / namespace / ".reclaimable"
+    marker.write_text("{not json")
+    return marker
+
+
+def test_list_keeps_a_corrupt_marker_and_lists_the_other_rows(pools, registry):  # noqa: F811
+    """status and list are documented read-only. Reading a marker that does
+    not parse used to unlink it, which is a write on a listing, and one an
+    operator running without the agent's privileges cannot even make: the
+    PermissionError aborted the whole command."""
+    corrupt = _corrupt_marker(pools["pool0"], OTHER_HASH)
+    volume(pools["pool1"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+
+    code, out, _err = _run(["list"], registry)
+
+    assert code == 0
+    rows = {line.split("\t")[0]: line.split("\t")[3] for line in out.splitlines()[1:]}
+    assert rows == {VM_HASH: "gone", OTHER_HASH: "unmarked"}
+    assert corrupt.exists(), "a read-only listing must not remove anything"
+
+
+def test_status_keeps_a_corrupt_marker(pools, registry):  # noqa: F811
+    """The reclaimable byte sum walks every marker too, so status removed
+    the file just as list did."""
+    corrupt = _corrupt_marker(pools["pool0"], OTHER_HASH)
+
+    code, _out, _err = _run(["status"], registry)
+
+    assert code == 0
+    assert corrupt.exists()
+
+
+def test_a_marker_without_an_offset_shows_an_age(pools, registry):  # noqa: F811
+    """A hand-edited marker whose timestamp carries no offset parsed naive,
+    and subtracting it from the aware clock raised TypeError, which aborted
+    the whole listing instead of costing that one row its age."""
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    naive = (datetime.now(tz=timezone.utc) - timedelta(days=3)).replace(tzinfo=None)
+    (pools["pool0"] / VM_HASH / ".reclaimable").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "reclaimable_since": naive.isoformat(),
+                "reason": "gone",
+                "size_bytes": 1,
+                "depends_on": [],
+            }
+        )
+    )
+
+    code, out, _err = _run(["list"], registry)
+
+    assert code == 0
+    age = [line.split("\t")[4] for line in out.splitlines()[1:] if line.startswith(VM_HASH)]
+    assert age == ["3d 0h"]
+
+
+def test_a_future_dated_marker_never_shows_a_negative_age(pools, registry):  # noqa: F811
+    """A node whose clock ran backwards, or a marker copied from elsewhere:
+    an age of "-1d 23h" reads as a parsing bug to whoever sees it."""
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", now=datetime.now(tz=timezone.utc) + timedelta(days=2))
+
+    code, out, _err = _run(["list"], registry)
+
+    assert code == 0
+    age = [line.split("\t")[4] for line in out.splitlines()[1:] if line.startswith(VM_HASH)]
+    assert age == ["0d 0h"]
+
+
+def test_reclaim_names_the_error_that_kept_a_directory(pools, registry, monkeypatch):  # noqa: F811
+    """The purge leaves a directory behind on any failure to remove it (a
+    read-only filesystem, an immutable file, a directory this user may not
+    write), not only on a device-mapper hold. Sending the operator to
+    'storage reconcile' for those is advice that cannot work."""
+    import errno
+    import shutil as shutil_module
+
+    import aleph.vm.agent.vm.purge as purge_module
+
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    volume(pools["pool1"], VM_HASH, "data.ext4")
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+    real_rmtree = shutil_module.rmtree
+
+    def refuse(path, *args, **kwargs):
+        if Path(path).parent == pools["pool0"]:
+            raise OSError(errno.EROFS, "Read-only file system")
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(purge_module.shutil, "rmtree", refuse)
+
+    code, out, err = _run(["reclaim", VM_HASH], registry)
+
+    assert code == 1
+    assert out == "", "a purge that did not finish leaves stdout empty"
+    assert "Read-only file system" in err
+    assert "No device-mapper target is holding these" in err
+    assert "storage reconcile" not in err, "a teardown cannot fix a removal that failed"
+    assert re.search(r"Deleted \d+ volume file\(s\)", err), "the partial count belongs in the report"
+
+
+def test_status_adopts_no_pool_and_writes_no_pool_file(pools, tmp_path, monkeypatch, registry):  # noqa: F811
+    """A read-only verb ran the agent's own pool setup, which adopts a pool
+    on first sight: it writes the in-pool marker and the adoption registry.
+    On a node whose second disk is not mounted, that adoption is exactly the
+    write the guard exists to prevent."""
+    monkeypatch.setattr(settings, "VOLUME_POOLS", [f"{pools['pool1']}=ssd"])
+    monkeypatch.setattr(cli, "DEFAULT_ENV_FILE", tmp_path / "no-such-file.env")
+    monkeypatch.setattr(cli, "initialise_database", lambda: None)
+    monkeypatch.setattr(cli, "_load_registry", AsyncMock(return_value=registry))
+    database = pools["execution_root"] / "executions.sqlite3"
+    database.touch()
+    monkeypatch.setattr(settings, "EXECUTION_DATABASE", database)
+
+    assert cli.main(["status"]) == 0
+
+    assert not (pools["pool1"] / ".aleph-vm-pool").exists()
+    assert not (pools["execution_root"] / "volume-pools.json").exists()
+
+
+def test_status_creates_no_directory_before_refusing_a_missing_database(tmp_path, monkeypatch, capsys):
+    """The refusal came after settings.setup(), which makes every configured
+    directory. An operator who mistyped the execution root got the refusal
+    and a tree of empty directories at the typo."""
+    execution_root = tmp_path / "typo"
+    monkeypatch.setattr(settings, "EXECUTION_ROOT", execution_root)
+    monkeypatch.setattr(settings, "PERSISTENT_VOLUMES_DIR", execution_root / "volumes" / "persistent")
+    monkeypatch.setattr(settings, "EXECUTION_DATABASE", execution_root / "executions.sqlite3")
+    monkeypatch.setattr(cli, "DEFAULT_ENV_FILE", tmp_path / "no-such-file.env")
+
+    code = cli.main(["status"])
+
+    assert code == 1
+    assert not execution_root.exists(), "nothing may be created under the root it refused"
+    assert str(execution_root / "executions.sqlite3") in capsys.readouterr().err
+
+
+def test_the_env_file_is_not_interpolated(tmp_path, monkeypatch, isolated_environ, plumbing):
+    """systemd's EnvironmentFile= does no ${} expansion, so a node's file is
+    written with literal values. Expanding them here silently truncates any
+    secret containing a dollar sign to the empty string."""
+    env_file = tmp_path / "supervisor.env"
+    env_file.write_text(
+        f"ALEPH_VM_EXECUTION_DATABASE={plumbing}\nALEPH_VM_SENTRY_DSN=https://key:pa${{sswd}}@sentry.example/1\n"
+    )
+    isolated_environ["sswd"] = "leaked"
+    monkeypatch.setattr(cli, "run", lambda *_: 0)
+
+    assert cli.main(["--env-file", str(env_file), "status"]) == 0
+
+    assert isolated_environ["ALEPH_VM_SENTRY_DSN"] == "https://key:pa${sswd}@sentry.example/1"
+
+
+def test_the_env_file_path_prefers_the_flag_then_the_variable_then_the_default(monkeypatch, tmp_path):
+    """The second element says whether the path was named (by --env-file or
+    $ALEPH_VM_ENV_FILE) rather than defaulted to: both namings are equally
+    explicit operator intent, so a missing file is a refusal either way."""
+    monkeypatch.setattr(cli, "DEFAULT_ENV_FILE", tmp_path / "packaged.env")
+    monkeypatch.delenv(cli.ENV_FILE_VARIABLE, raising=False)
+
+    assert cli._env_file_path(None) == (tmp_path / "packaged.env", False)
+
+    monkeypatch.setenv(cli.ENV_FILE_VARIABLE, str(tmp_path / "from-variable.env"))
+    assert cli._env_file_path(None) == (tmp_path / "from-variable.env", True)
+    assert cli._env_file_path(str(tmp_path / "explicit.env")) == (tmp_path / "explicit.env", True)

--- a/tests/supervisor/test_vm_purge.py
+++ b/tests/supervisor/test_vm_purge.py
@@ -176,7 +176,10 @@ def test_purge_storage_accepts_every_shape_of_item_hash(pools, namespace):
     """A storage hash and an IPFS CID are both VM namespaces."""
     _volume(pools["pool0"], namespace, "rootfs.qcow2")
 
-    assert purge_vm_storage(namespace) == 1
+    result = purge_vm_storage(namespace)
+
+    assert result.deleted == 1
+    assert result.kept == ()
     assert not (pools["pool0"] / namespace).exists()
 
 

--- a/tests/supervisor/test_vm_purge.py
+++ b/tests/supervisor/test_vm_purge.py
@@ -139,8 +139,8 @@ def test_purge_storage_removes_the_directories_and_session_dir(pools):
 
 
 def test_purge_is_idempotent(pools):
-    assert purge_vm_storage(VM_HASH) == 0
-    assert purge_vm_storage(VM_HASH) == 0
+    assert purge_vm_storage(VM_HASH).deleted == 0
+    assert purge_vm_storage(VM_HASH).deleted == 0
 
 
 @pytest.mark.parametrize(
@@ -331,3 +331,55 @@ def test_purge_side_dirs_leaves_the_volumes(pools):
 
     assert rootfs.exists()
     assert not session_dir.exists()
+
+
+def test_the_purge_result_names_the_dm_target_that_kept_a_directory(pools, monkeypatch):
+    """A caller has to be able to tell the two ways a directory survives
+    apart: only a device-mapper hold is fixed by tearing a target down."""
+    _volume(pools["pool0"], VM_HASH, "data.btrfs")
+    _volume(pools["pool1"], VM_HASH, "extra.ext4")
+    dm_path = Path("/dev/mapper") / f"{VM_HASH}_data"
+    real_is_block_device = Path.is_block_device
+    monkeypatch.setattr(Path, "is_block_device", lambda self: self == dm_path or real_is_block_device(self))
+
+    result = purge_vm_storage(VM_HASH)
+
+    assert result.deleted == 1, "the volume on the other pool was deleted"
+    assert [kept.path for kept in result.kept] == [pools["pool0"] / VM_HASH]
+    assert result.kept[0].device_mapper is True
+    assert "data.btrfs" in result.kept[0].reason
+
+
+def test_the_purge_result_names_the_error_that_kept_a_directory(pools, monkeypatch):
+    """A read-only filesystem, an immutable file, a directory this user may
+    not write: the purge leaves the directory exactly as a device-mapper hold
+    does, and used to be indistinguishable from one."""
+    import errno
+    import shutil
+
+    import aleph.vm.agent.vm.purge as purge_module
+
+    _volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    real_rmtree = shutil.rmtree
+
+    def refuse(path, *args, **kwargs):
+        if Path(path).name == VM_HASH:
+            raise OSError(errno.EROFS, "Read-only file system")
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(purge_module.shutil, "rmtree", refuse)
+
+    result = purge_vm_storage(VM_HASH)
+
+    assert [kept.path for kept in result.kept] == [pools["pool0"] / VM_HASH]
+    assert result.kept[0].device_mapper is False
+    assert "Read-only file system" in result.kept[0].reason
+
+
+def test_a_complete_purge_keeps_nothing(pools):
+    _volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+
+    result = purge_vm_storage(VM_HASH)
+
+    assert result.deleted == 1
+    assert result.kept == ()


### PR DESCRIPTION
## Summary
`aleph-vm storage status` and `list` are documented read-only, and were not. Reading a `.reclaimable` marker that does not parse unlinked it, `settings.setup()` created every configured directory before the missing-database refusal, and `setup_pools()` adopted a pool on first sight (in-pool marker plus adoption registry). Run by an operator without the agent's privileges the unlink raised an uncaught PermissionError and killed the command; run against a mistyped execution root, `status` refused and left a tree of empty directories at the typo; run on a node whose second disk is not mounted, it adopted that mountpoint as a pool, which is the write the adoption guard exists to prevent. Two more ways the listing lied: a marker timestamp without a UTC offset parsed naive, so subtracting it from the aware clock raised TypeError and aborted the whole listing over one row, and a future-dated marker printed a negative age. Finally `reclaim` blamed device-mapper for any directory the purge left behind and sent the operator to `storage reconcile`, but the purge also leaves a directory on any rmtree/unlink OSError (EACCES, EROFS, EBUSY, an immutable file), which no teardown fixes.

Stacked on #1215.

## Changes
- `agent/vm/reclaimable.py`: `read_marker(dir, *, repair=True)`, threaded through `iter_reclaimable` and `reclaimable_bytes`, so a caller that may not write reads a corrupt marker without removing it; the removal itself is now best effort instead of an exception out of a read. `from_json` reads a timestamp with no offset as UTC (every writer here uses UTC).
- `storage_pools.py`: `setup_pools(read_only=False)` and `_adopt_pool(read_only=...)`. Read-only still validates, classifies and refuses a pool whose marker vanished after adoption; it just adopts nothing.
- `agent/vm/purge.py`: `purge_vm_storage` returns a `PurgeResult` (files deleted, and the `KeptDirectory` entries with their reason and whether a dm target is the cause) instead of a bare count. Callers that ignored the count are unaffected. Foxpatch review: the device-mapper hold used to be recomputed inside the per-directory loop, re-walking every pool on each iteration; hoisted above the loop, computed once per purge.
- `agent/storage_cli.py`: `status`/`list` refuse a missing database before any setup runs, skip `settings.setup()` entirely and call `setup_pools(read_only=True)`; they read markers with `repair=False`. `_age` clamps at zero. `reclaim` reports each surviving directory with its real reason and the partial count on stderr, and only points at `storage reconcile` when a dm target is actually the cause. The env file loads with `interpolate=False`, matching systemd's `EnvironmentFile=`, so a value containing `${...}` reaches the settings intact.
- `agent/storage_cli.py` (second commit): `_pool_usage` and `_retention_budget` return `None` when the pool's filesystem cannot be stat'ed, and `_figure` prints `unknown` rather than `0 B`, so an unreadable pool is no longer indistinguishable from a full one; the cache budget takes the same treatment, and a `reap` budget stays a real zero. `_is_marked_reclaimable` reads with `repair=False`, so a reclaim about to be refused (a running agent) no longer unlinks the corrupt markers of unrelated VMs on its way to refusing.
- `docs/architecture/storage.md`: what read-only means for these two verbs, the two reasons a purge leaves a directory and the different answers they need, the UTC rule for a bare marker timestamp, and the no-interpolation rule for the env file.

## Test plan
- `tests/supervisor/test_storage_cli.py`: a corrupt marker survives `list` and `status` (exit 0, other rows printed); a naive marker timestamp shows a real age and a future-dated one shows `0d 0h`; `reclaim` under a monkeypatched `rmtree` raising EROFS names the OSError, never mentions device-mapper as the cause and does not advise `storage reconcile`, with stdout empty; `status` adopts no pool and writes no `volume-pools.json`; `status` creates no directory before refusing a missing database; the env file is not `${}` expanded; `_env_file_path` covers the flag, `$ALEPH_VM_ENV_FILE` and the packaged default.
- `tests/supervisor/test_vm_purge.py`: the result names a dm-held directory (`device_mapper=True`) and an EROFS one (`device_mapper=False`), and a complete purge keeps nothing.
- `tests/supervisor/test_reclaimable.py`: `repair=False` keeps a corrupt marker (through `read_marker` and `reclaimable_bytes`), a marker that cannot be removed still reads as None, and a timestamp with no offset reads as UTC.
- Review round: `test_status_says_unknown_for_a_pool_it_cannot_measure` (disk_usage raising EACCES on one pool; BUDGET and FREE read `unknown`, the other pool still shows figures), `test_status_says_unknown_for_a_cache_budget_it_cannot_compute`, and `test_a_refused_reclaim_removes_no_marker` (agent running, exit 3, a corrupt marker on a directory sorting before the target survives).
- Foxpatch review round: the device-mapper hold hoist is behaviour-preserving, pinned by the existing `test_vm_purge.py` coverage (`held`/`held_here` are unchanged in what they classify, only in when they are computed).
- Checks: `pytest tests/supervisor/test_storage_cli.py tests/supervisor/test_vm_purge.py tests/supervisor/test_reclaimable.py tests/supervisor/test_reconciler.py` = 188 passed; `ruff format --diff`, `isort --check-only --profile black`, and `mypy src/aleph/vm/ tests/` all clean. A whole-`tests/supervisor` collection currently fails to collect on this checkout (`test_snp_instance_run.py`, `test_vprogram_launch.py`: `ImportError: cannot import name 'ConfidentialGpuRequirement'`), from the confidential-GPU feature merged into `dev-2.1` after this chain was opened (#1200) needing a newer `aleph_message` than this venv has installed; unrelated to this PR's files. Also driven by hand against a real execution root: the refusal creates nothing, `reconcile --dry-run` adopts the pool and migrates the DB, and a following `list` leaves a corrupt marker in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZyMqLgxxVfeDwiNy34sfM

