### PR TITLE
fix(agent): tell a push the truth about a VM whose teardown is running

### DIFF
--- a/src/aleph/vm/agent/allocation/reconciler.py
+++ b/src/aleph/vm/agent/allocation/reconciler.py
@@ -95,6 +95,14 @@ class AllocationReconciler:
         self._wakeup = asyncio.Event()
         self._failures: dict[ItemHash, FailureRecord] = {}
         self._states: dict[ItemHash, AllocationState] = {}
+        # The VMs whose teardown is running right now. A delete parks for as
+        # long as the VM takes to stop, and the supervisor keeps listing it
+        # meanwhile, so a push arriving in that window reads a VM that is up
+        # and is in fact on its way to GONE with its disks reaped. The pass
+        # re-reads the plan before it starts a teardown, so a push that gets
+        # there first is honoured; past that point the retire cannot be
+        # called off, and the answer has to say so.
+        self._removing: set[ItemHash] = set()
 
     # ── Public surface ──
 
@@ -148,6 +156,16 @@ class AllocationReconciler:
         if self._desired is None:
             return set()
         return {vm_hash for vm_hash, planned in self._desired.entries.items() if planned.verified is None}
+
+    def removing_hashes(self) -> frozenset[ItemHash]:
+        """The VMs whose teardown is in flight, for the answer to a push.
+
+        A hash in here is one the supervisor still lists and this node is
+        already committed to destroying, so a push that re-adds it is asking
+        for the VM to be built again rather than left alone. Read by the
+        verdict, which must not answer "unchanged" for any of them.
+        """
+        return frozenset(self._removing)
 
     def state_for(self, vm_hash: ItemHash) -> tuple[AllocationState | None, FailureRecord | None]:
         """What the agent is doing about this VM, for the executions list."""
@@ -215,6 +233,11 @@ class AllocationReconciler:
             if record is None or not is_removable_by_allocation(record, info):
                 continue
             logger.info("Plan %s dropped %s; tearing it down", current.plan_id, vm_hash)
+            # Marked before the await and cleared however it ends, including
+            # on a delete the supervisor refuses: that one is retried on the
+            # next pass, and a hash left behind here would have every later
+            # push answered as a rebuild of a VM that is up and staying up.
+            self._removing.add(vm_hash)
             try:
                 await teardown_vm(vm_hash, supervisor=self.supervisor, registry=self.registry)
             except Exception:
@@ -223,6 +246,8 @@ class AllocationReconciler:
                 # before a single start ran, and teardowns carry no backoff, so
                 # it did that on every interval for as long as it kept failing.
                 logger.exception("Tearing down %s failed; leaving it for the next pass", vm_hash)
+            finally:
+                self._removing.discard(vm_hash)
 
     async def _start_missing(self, plan: AllocationPlan, known: dict[ItemHash, VmInfo]) -> None:
         live = {

--- a/src/aleph/vm/agent/allocation/verdict.py
+++ b/src/aleph/vm/agent/allocation/verdict.py
@@ -162,6 +162,7 @@ def compute_verdict(
     capacity: _Capacity,
     node_hash: str | None = None,
     available_gpus: list[GpuDevice] | None = None,
+    removing_now: frozenset[ItemHash] = frozenset(),
 ) -> PlanVerdict:
     """The immediate answer: what we take, what we drop, what we refuse.
 
@@ -170,6 +171,11 @@ def compute_verdict(
     the top of the module, so the handler reads them first and hands them in.
     Without them simulate refuses every candidate that asks for a card, which
     is the right answer to give when the cards were not looked at.
+
+    ``removing_now`` is the set of VMs the convergence loop is deleting as
+    this answer is computed. The supervisor goes on listing such a VM until
+    its delete returns, so its status alone would have this call report it as
+    running and untouched.
     """
     verdict = PlanVerdict()
     known = by_hash(infos)
@@ -185,7 +191,18 @@ def compute_verdict(
             # sizing it as a candidate would let a node that is tight on room
             # refuse a VM it is already holding, and a refusal is what takes
             # the VM out of the plan the loop converges on.
-            if info.status in LIVE_STATUSES or info.status in STOPPED_STATUSES or info.awaiting_confidential_init:
+            #
+            # A VM whose teardown is already running is the exception, however
+            # alive or however stopped the supervisor says it is: the retire is
+            # past the point where a push can call it off, so the VM is going
+            # away with its disks and this node will have to build it again.
+            # Judged as a candidate instead, it is answered accepted, or
+            # pending while the push carried no message to size it by, which is
+            # what the loop will actually do about it on the pass after the
+            # delete returns.
+            if (
+                info.status in LIVE_STATUSES or info.status in STOPPED_STATUSES or info.awaiting_confidential_init
+            ) and vm_hash not in removing_now:
                 unchanged.add(vm_hash)
                 verdict.unchanged.append(vm_hash)
             # A planned VM the supervisor holds dead is about to be created

--- a/src/aleph/vm/agent/views/allocations_v2.py
+++ b/src/aleph/vm/agent/views/allocations_v2.py
@@ -58,6 +58,7 @@ async def update_allocations_v2(request: web.Request) -> web.Response:
     # invalidate the answer about to be returned; see allocation.verdict.
     infos = await app["supervisor"].list_vms()
     available_gpus = await app["capacity"].available_gpus()
+    reconciler = app["allocation_reconciler"]
     verdict = compute_verdict(
         plan,
         infos=infos,
@@ -65,9 +66,13 @@ async def update_allocations_v2(request: web.Request) -> web.Response:
         capacity=app["capacity"],
         node_hash=node_identity.get_node_hash() if node_identity else None,
         available_gpus=available_gpus,
+        # Read after the two awaits, in the same turn as the verdict, so a
+        # teardown that starts while this handler is parked in list_vms is
+        # still accounted for: the list it holds says that VM is running.
+        removing_now=reconciler.removing_hashes(),
     )
     verdict.rejected.update(rejected)
-    app["allocation_reconciler"].submit(narrow_plan(plan, verdict))
+    reconciler.submit(narrow_plan(plan, verdict))
 
     logger.info(
         "Plan %s: %d accepted, %d pending, %d unchanged, %d rejected, %d removing, %d retained",

--- a/tests/supervisor/test_allocation_reconciler.py
+++ b/tests/supervisor/test_allocation_reconciler.py
@@ -794,6 +794,97 @@ async def test_a_vm_waiting_on_its_confidential_session_is_not_started_again(rec
     assert starts.attempts == 0
 
 
+# ── A teardown that is still in flight ─────────────────────────────────────
+
+
+def _park_the_teardown(reconciler, monkeypatch):
+    """Hold the teardown of a VM inside the supervisor's delete.
+
+    A real delete takes as long as the VM takes to stop, and that is the
+    window a re-push lands in. Returns the event that lets it finish and the
+    one that says it has started.
+    """
+    entered = asyncio.Event()
+    gate = asyncio.Event()
+
+    async def parked_delete(vm_id, **_kwargs):
+        entered.set()
+        await gate.wait()
+
+    async def teardown_through_the_supervisor(vm_hash, *, supervisor, registry):
+        await supervisor.delete_vm(str(vm_hash))
+
+    reconciler.supervisor.delete_vm = parked_delete
+    monkeypatch.setattr(reconciler_module, "teardown_vm", teardown_through_the_supervisor)
+    return entered, gate
+
+
+@pytest.mark.asyncio
+async def test_a_teardown_in_flight_is_visible_while_it_runs(reconciler, monkeypatch):
+    """The window the answer has to know about. The pass re-reads the plan
+    before it starts a teardown, so a push that arrives first is honoured, but
+    once the delete is under way the retire is past the point where a push can
+    stop it: the VM will be retired GONE and its disks reaped whatever the
+    scheduler is told. Answering "unchanged" for it, which is what the
+    supervisor's list says while the delete runs, tells the scheduler a VM is
+    up that is on its way to being destroyed and rebuilt from scratch."""
+    _record_starts(reconciler, monkeypatch)
+    entered, gate = _park_the_teardown(reconciler, monkeypatch)
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_B)]
+    reconciler.submit(_plan())
+
+    assert reconciler.removing_hashes() == frozenset()
+    pass_one = asyncio.create_task(reconciler._converge_once())
+    # Bounds on failure, not a wait: the pass reaches the delete at once.
+    await asyncio.wait_for(entered.wait(), timeout=5)
+
+    assert reconciler.removing_hashes() == frozenset({HASH_B})
+
+    reconciler.submit(_plan(HASH_B))
+    gate.set()
+    await asyncio.wait_for(pass_one, timeout=5)
+
+    assert reconciler.removing_hashes() == frozenset()
+    # The pass worked off the plan that dropped the VM, so it started nothing.
+    assert reconciler.started == []
+
+
+@pytest.mark.asyncio
+async def test_a_vm_re_added_while_it_was_being_torn_down_is_started_again(reconciler, monkeypatch):
+    """The other half of the answer: telling the scheduler the VM is accepted
+    is only honest if the loop then builds it."""
+    _record_starts(reconciler, monkeypatch)
+    entered, gate = _park_the_teardown(reconciler, monkeypatch)
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_B)]
+    reconciler.submit(_plan())
+    pass_one = asyncio.create_task(reconciler._converge_once())
+    await asyncio.wait_for(entered.wait(), timeout=5)
+    reconciler.submit(_plan(HASH_B))
+    gate.set()
+    await asyncio.wait_for(pass_one, timeout=5)
+
+    # The delete went through, so the supervisor no longer lists it.
+    reconciler.supervisor.list_vms.return_value = []
+    await reconciler._converge_once()
+
+    assert reconciler.started == [HASH_B]
+
+
+@pytest.mark.asyncio
+async def test_a_teardown_that_fails_leaves_no_vm_marked_removing(reconciler, monkeypatch):
+    """A delete the supervisor refuses is retried on the next pass, so the
+    hash must not stay in the in-flight set: it would make every later push
+    answer accepted for a VM that is up and staying up."""
+    _record_starts(reconciler, monkeypatch)
+    monkeypatch.setattr(reconciler_module, "teardown_vm", AsyncMock(side_effect=RuntimeError("delete failed")))
+    reconciler.supervisor.list_vms.return_value = [_info(HASH_B)]
+    reconciler.submit(_plan())
+
+    await reconciler._converge_once()
+
+    assert reconciler.removing_hashes() == frozenset()
+
+
 # ── The loop around a pass ─────────────────────────────────────────────────
 
 

--- a/tests/supervisor/test_allocation_verdict.py
+++ b/tests/supervisor/test_allocation_verdict.py
@@ -215,6 +215,55 @@ def test_a_vm_waiting_on_its_confidential_session_is_left_alone():
     assert verdict.accepted == []
 
 
+def test_a_vm_whose_teardown_is_in_flight_is_not_answered_unchanged():
+    """The supervisor still lists a VM whose delete is running, so the status
+    alone says "up" for one that is on its way to GONE with its disks reaped.
+    Answering unchanged would tell the scheduler nothing is happening to a VM
+    the loop is about to rebuild from scratch, so the push is judged as what
+    it is: a request to have this VM here again."""
+    verdict = compute_verdict(
+        _plan(HASH_A),
+        infos=[_info(HASH_A)],
+        registry=_registry({HASH_A: _record()}),
+        capacity=_capacity([AdmissionVerdict(HASH_A, True)]),
+        removing_now=frozenset({HASH_A}),
+    )
+
+    assert verdict.unchanged == []
+    assert verdict.accepted == [HASH_A]
+    # Named by the push, so never reported as something this push stops.
+    assert verdict.removing == []
+
+
+def test_a_vm_being_torn_down_with_no_message_is_pending_not_unchanged():
+    """The same rule where the push carries no message to size: the honest
+    answer is that the agent has not judged it yet, not that it is up."""
+    verdict = compute_verdict(
+        _plan(HASH_A, verified=False),
+        infos=[_info(HASH_A)],
+        registry=_registry({HASH_A: _record()}),
+        capacity=_capacity([]),
+        removing_now=frozenset({HASH_A}),
+    )
+
+    assert verdict.unchanged == []
+    assert verdict.pending == [HASH_A]
+
+
+def test_a_vm_being_torn_down_that_the_push_drops_is_still_removing():
+    """The in-flight set only speaks about VMs the push names. One it does not
+    name is being removed, which is exactly what the answer already said."""
+    verdict = compute_verdict(
+        _plan(),
+        infos=[_info(HASH_B)],
+        registry=_registry({HASH_B: _record()}),
+        capacity=_capacity([]),
+        removing_now=frozenset({HASH_B}),
+    )
+
+    assert verdict.removing == [HASH_B]
+
+
 @pytest.mark.parametrize(
     ("record", "info"),
     [

--- a/tests/supervisor/test_allocations_v2.py
+++ b/tests/supervisor/test_allocations_v2.py
@@ -238,6 +238,62 @@ async def test_a_corrupt_message_for_a_running_vm_does_not_delete_it(
 
 
 @pytest.mark.asyncio
+async def test_a_push_re_adding_a_vm_mid_teardown_is_answered_accepted(
+    aiohttp_client, scheduler_auth, signed_message, monkeypatch, mocker
+):
+    """The scheduler changing its mind while the delete runs. An empty plan
+    starts the teardown, which parks in the supervisor's delete for as long as
+    the VM takes to stop; a push re-adding the VM lands in that window. The
+    supervisor still lists the VM as running, so the answer used to be
+    unchanged while the retire went on to GONE and reaped the disks: the
+    scheduler believed the VM had never moved, and the node rebuilt it from
+    nothing on the next pass. The honest answer is accepted, and the loop then
+    makes it true."""
+    _stub_host(mocker)
+    message = signed_message()
+    vm_hash = ItemHash(message["item_hash"])
+    entered = asyncio.Event()
+    gate = asyncio.Event()
+    started = asyncio.Event()
+
+    async def parked_delete(vm_id, **_kwargs):
+        entered.set()
+        await gate.wait()
+
+    async def teardown_through_the_supervisor(hash_, *, supervisor, registry):
+        await supervisor.delete_vm(str(hash_))
+
+    async def fake_start(*_args, **_kwargs):
+        started.set()
+
+    monkeypatch.setattr(reconciler_module, "teardown_vm", teardown_through_the_supervisor)
+    monkeypatch.setattr(reconciler_module, "start_persistent_vm", fake_start)
+    app = _app(real_reconciler=True)
+    app["supervisor"].delete_vm = parked_delete
+    app["supervisor"].list_vms.return_value = [_running(vm_hash)]
+    running = _make_qemu_instance_message()
+    app["vm_registry"].record(vm_hash, message=running, original=running, persistent=True)
+    client = await aiohttp_client(app)
+
+    body, headers = scheduler_auth({"vms": []}, path=PLAN)
+    dropped = await client.post(PLAN, data=body, headers=headers)
+    assert (await dropped.json())["removing"] == [str(vm_hash)]
+    # Bounds on failure, not waits: the loop reaches the delete in milliseconds.
+    await asyncio.wait_for(entered.wait(), timeout=10)
+
+    body, headers = scheduler_auth({"vms": [_entry(message)]}, path=PLAN)
+    response = await client.post(PLAN, data=body, headers=headers)
+
+    payload = await response.json()
+    assert payload["unchanged"] == []
+    assert payload["accepted"] == [str(vm_hash)]
+    # The delete goes through, so the supervisor no longer lists the VM.
+    app["supervisor"].list_vms.return_value = []
+    gate.set()
+    await asyncio.wait_for(started.wait(), timeout=10)
+
+
+@pytest.mark.asyncio
 async def test_the_hosts_cards_reach_the_verdict(aiohttp_client, scheduler_auth, signed_message, mocker):
     """The one read the pure verdict cannot do for itself: the handler reads
     the inventory from the supervisor and hands it in, so a GPU VM can be


### PR DESCRIPTION
## Summary
A reconciler pass re-reads the plan right before it tears a VM down, so a push that arrives first is honoured, but the delete itself parks for as long as the VM takes to stop and the supervisor keeps listing the VM while it runs. A push that re-added that VM in the window was answered `unchanged`, read straight off that listing, while the retire went on to GONE and reaped the disks: the scheduler believed nothing had happened to a VM this node was destroying and would rebuild from scratch on the next pass.

The reconciler now keeps the hashes whose teardown is in flight, and the verdict consults them: a planned VM being removed is judged as a candidate rather than reported unchanged, so the answer is `accepted` (or `pending`, when the push carried no message to size it by), which is what the loop actually does about it once the delete returns.

Stacked on #1222.

## Changes
- `allocation/reconciler.py`: `_removing`, a set of the hashes whose teardown is running, added before the await in `_teardown_dropped` and cleared in a `finally` so a delete the supervisor refuses (retried on the next pass) leaves nothing behind. `removing_hashes()` exposes it to the answer.
- `allocation/verdict.py`: `compute_verdict` takes `removing_now` and skips the `unchanged` branch for any planned hash in it, so the VM falls through to the candidate loop and is answered accepted or pending. A VM the push does not name is untouched by the set and is still reported as `removing`.
- `views/allocations_v2.py`: the handler reads the set after its two awaits, in the same turn as the verdict, so a teardown that started while it was parked in `list_vms` is accounted for (the list it holds says that VM is running).

## Test plan
- `tests/supervisor/test_allocations_v2.py`: the whole scenario through HTTP. An empty plan starts the teardown, which parks in the supervisor's delete; the push re-adding the VM lands in that window and must answer `accepted` with an empty `unchanged`; once the delete returns the loop starts the VM again. Failed before the fix on `unchanged == []`.
- `tests/supervisor/test_allocation_reconciler.py`: the hash is reported removing only while the delete is parked, a teardown that raises leaves the set empty, and a VM re-added mid-teardown is started by the next pass.
- `tests/supervisor/test_allocation_verdict.py`: a planned VM in `removing_now` is accepted (or pending with no message) and never unchanged; one the push drops is still `removing`.
- Checks: 6 new tests failed before the fix; after it, the allocation, verdict, v2, teardown, verify and executions-list files pass (154), the wider set that imports the touched modules passes (414), and `tests/supervisor tests/migration` is `1 failed, 1237 passed, 1 skipped`, the one failure being the pre-existing journald `test_log.py::test_make_logs_queue`. `ruff format --diff`, `isort --check-only --profile black` and `mypy` on the three sources and the three test files: all exit 0. No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZyMqLgxxVfeDwiNy34sfM
