### PR TITLE
refactor(agent): storage code quality: enums, shared helpers, honest comments

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -545,7 +545,12 @@ truth as the body lands, since the bytes on disk are counted the moment they
 are written. A ceiling never sets the eviction target either: a root's usage
 counts a guessed reservation only at the bytes it has actually written when
 the question is how much to evict, and at the full figure when the question
-is whether the next download fits. What is admitted is then charged to
+is whether the next download fits. A body bigger than its reserve therefore
+takes its root over the budget while the extra bytes land: a `.part` is not an
+entry and nothing may unlink it under the download writing it. The overshoot
+is transient rather than permitted. Those bytes are a measurement, so the next
+pass counts them and evicts least recently used for them, and once the
+download finishes its entry is evictable like any other. What is admitted is then charged to
 the download's `.part` path (`reserve_download`) until `download_file`
 releases it, so a second create arriving while the first is still writing
 sees the room the first was promised rather than only the bytes it has

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -685,7 +685,7 @@ in its `--help` epilog) needs no running *agent process*:
   - **The agent is down and the supervisor answers.** The full pass runs.
     Nothing is being created, so the age of the directory is a sound guard
     again, and the live set is a known one (registry union `list_vms`), so
-    `_teardown_orphan_devices` removes the dm devices of every namespace no
+    `teardown_orphan_devices` removes the dm devices of every namespace no
     live VM owns before the walk, or the purge that follows would be refused
     on a volume file a target still holds.
   - **The supervisor does not answer.** The live set is the registry alone,

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -353,6 +353,12 @@ turn retained disks into an owner-less orphan directory with no parent-image
 pins and a timestamp that resets on every attempt. A directory the failed
 create's own teardown purged is not re-marked, and a marker written while
 the create ran (a retire of the same hash) is the newer record and stays.
+Two creates of one hash can overlap (a scheduler push beside an operator
+reinstall), and only the first of them finds a marker to adopt, so what was
+adopted is held per namespace rather than per create: while any create is
+still running nothing goes back, a create that returns drops the markers for
+good (the directory is a live VM's now), and the last create to leave with
+none of them committed restores whatever any of them adopted.
 
 ### The reconciler
 

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -414,7 +414,7 @@ Everything a pass touches is under a directory the agent created and is
 keyed by a hash that `storage.vm_namespace` accepted: the name has to parse
 as an `ItemHash` (64 lowercase hex characters, or an IPFS CID), so a
 directory an operator dropped on a volume pool is never a VM. The delete
-paths go through `purge._checked_namespace`, which refuses on the same rule
+paths go through `purge.checked_namespace`, which refuses on the same rule
 before any filesystem access; the passes that walk the pools ask
 `is_vm_namespace` first and skip what the guard would refuse.
 

--- a/src/aleph/vm/agent/capacity.py
+++ b/src/aleph/vm/agent/capacity.py
@@ -26,7 +26,7 @@ from aleph_message.models import ExecutableContent, ItemHash, VerifiableProgramC
 from aleph_message.models.execution.instance import InstanceContent
 
 from aleph.vm import storage_pools
-from aleph.vm.agent.vm.purge import ROOTFS_STEM, _checked_namespace
+from aleph.vm.agent.vm.purge import ROOTFS_STEM, checked_namespace
 from aleph.vm.agent.vm.reclaimable import (
     MARKER_NAME,
     file_size_bytes,
@@ -228,7 +228,7 @@ def existing_volume_files(vm_hash: ItemHash | str) -> dict[str, Path]:
     Symlinks and the marker are skipped, and pools are walked in order with
     the first match winning, so the result does not depend on iteration luck.
     """
-    namespace = _checked_namespace(vm_hash)
+    namespace = checked_namespace(vm_hash)
     files: dict[str, Path] = {}
     for directory in storage_pools.iter_namespace_dirs(namespace):
         try:

--- a/src/aleph/vm/agent/vm/backup.py
+++ b/src/aleph/vm/agent/vm/backup.py
@@ -30,7 +30,7 @@ from typing import BinaryIO
 
 from aleph_message.models import ItemHash
 
-from aleph.vm.agent.vm.purge import ROOTFS_STEM, _checked_namespace, iter_volume_files
+from aleph.vm.agent.vm.purge import ROOTFS_STEM, checked_namespace, iter_volume_files
 from aleph.vm.backup.archive import (
     backup_metadata,
     check_disk_space_for_multiple,
@@ -85,7 +85,7 @@ def purge_vm_backups(vm_hash: ItemHash | str) -> int:
     primitive: it is interpolated into a glob pattern here, and a delete path
     never builds a pattern or a path out of an unchecked name.
     """
-    namespace = _checked_namespace(vm_hash)
+    namespace = checked_namespace(vm_hash)
     backup_dir = get_backup_directory()
     removed = 0
     for archive in backup_dir.glob(f"{namespace}-*.tar"):

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -38,7 +38,7 @@ import json
 import logging
 import os
 import shutil
-from collections.abc import Callable, Collection, Iterable
+from collections.abc import Callable, Collection, Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -357,27 +357,30 @@ def parent_refs_of(evicted: list[Path]) -> list[str]:
     return [path.name for path in evicted if path.parent == runtime]
 
 
-def _loop_devices_backing(path: Path) -> list[str]:
-    """The loop devices backed by ``path``, found through sysfs.
+def _iter_loop_backings() -> Iterator[tuple[str, str]]:
+    """``(loop device, backing file)`` for every loop device the kernel lists.
 
-    ``storage.detach_loop_devices`` asks ``losetup -j``, which has to stat
-    the backing file; an evicted cache entry is already unlinked, and the
-    loop that still pins its blocks is exactly the one that has to go. sysfs
-    keeps the path, marked " (deleted)".
+    Read from sysfs rather than with ``losetup -j``, which has to stat the
+    backing file: an evicted cache entry is already unlinked, and the loop
+    that still pins its blocks is exactly the one that has to go. sysfs keeps
+    the path of an unlinked file, marked " (deleted)", and the marker is left
+    on the string here because it is what tells the two callers apart.
     """
-    devices: list[str] = []
     try:
         backing_files = sorted(SYS_BLOCK.glob("loop*/loop/backing_file"))
     except OSError:
-        return devices
+        return
     for backing_file in backing_files:
         try:
             backing = backing_file.read_text().strip()
         except OSError:
             continue
-        if backing.removesuffix(DELETED_SUFFIX) == str(path):
-            devices.append(f"/dev/{backing_file.parent.parent.name}")
-    return devices
+        yield f"/dev/{backing_file.parent.parent.name}", backing
+
+
+def _loop_devices_backing(path: Path) -> list[str]:
+    """The loop devices backed by ``path``, unlinked or not."""
+    return [device for device, backing in _iter_loop_backings() if backing.removesuffix(DELETED_SUFFIX) == str(path)]
 
 
 async def remove_parent_device(ref: str) -> None:
@@ -832,20 +835,12 @@ def _deleted_cache_backings() -> list[tuple[str, Path]]:
     cache entry that is already unlinked."""
     roots = cache_roots()
     leaked: list[tuple[str, Path]] = []
-    try:
-        backing_files = sorted(SYS_BLOCK.glob("loop*/loop/backing_file"))
-    except OSError:
-        return leaked
-    for backing_file in backing_files:
-        try:
-            backing = backing_file.read_text().strip()
-        except OSError:
-            continue
+    for device, backing in _iter_loop_backings():
         if not backing.endswith(DELETED_SUFFIX):
             continue
         path = Path(backing.removesuffix(DELETED_SUFFIX))
         if path.parent in roots:
-            leaked.append((f"/dev/{backing_file.parent.parent.name}", path))
+            leaked.append((device, path))
     return leaked
 
 

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -50,6 +50,7 @@ from aleph.vm.agent.vm.reclaimable import (
     ReclaimableMarker,
     file_size_bytes,
     iter_content_refs,
+    namespace_size_bytes,
     reclaimable_entries,
     refs_from_content,
 )
@@ -484,6 +485,10 @@ class _RootBudget:
     budget: int
     usage: int
     evicted: list[Path]
+    # Namespace to the bytes its retained volumes gave back, for the caller's
+    # report: reclaiming a VM to free its parent image deletes disks, and a
+    # pass that does not say so reports only the cache entries it unlinked.
+    reclaimed_bytes: dict[str, int]
     live_only: set[str]
     is_live: Callable[[str], bool]
     dry_run: bool
@@ -507,6 +512,7 @@ def evict_caches(
     dry_run: bool = False,
     is_live: Callable[[str], bool] | None = None,
     reclaim_retained: bool = True,
+    reclaimed_bytes: dict[str, int] | None = None,
 ) -> list[Path]:
     """Bring every cache root under ``CACHE_BUDGET``; return what was evicted.
 
@@ -521,9 +527,14 @@ def evict_caches(
     to free the parent images they pin. Admission turns it off: it runs on the
     event loop inside a download, where an rmtree of a retained VM's disks
     does not belong. What it cannot free there, the next pass frees.
+
+    ``reclaimed_bytes`` is filled with the retained VMs that second phase
+    purged and what each gave back. The return value covers cache entries
+    alone, and those are the smaller half of what this can delete.
     """
     needed = needed or {}
     evicted: list[Path] = []
+    reclaimed_bytes = reclaimed_bytes if reclaimed_bytes is not None else {}
     is_live = is_live or (lambda namespace: namespace in registry)
     live_only = live_refs(registry)
     for root in cache_roots():
@@ -543,6 +554,7 @@ def evict_caches(
             # eviction it does cause is the one its own body earned.
             usage=_root_usage(root, entries, count_ceilings=False) + needed.get(root, 0),
             evicted=evicted,
+            reclaimed_bytes=reclaimed_bytes,
             live_only=live_only,
             is_live=is_live,
             dry_run=dry_run,
@@ -645,6 +657,9 @@ def _reclaim_for_parents(
         # and the VM has no registry record yet for ``is_live`` to find.
         logger.warning("Not reclaiming %s for its parent images: a create is using it", namespace)
         return False
+    # Measured before the purge, and over every pool: this is what the pass
+    # gave back, and after the rmtree there is nothing left to measure.
+    size = namespace_size_bytes(namespace)
     if not state.dry_run:
         purge_vm_storage(namespace)
         if has_namespace_dirs(namespace):
@@ -654,7 +669,8 @@ def _reclaim_for_parents(
             logger.warning("Not evicting the parent images of %s: its purge left directories behind", namespace)
             return False
     reclaimed.add(namespace)
-    logger.info("Reclaimed the retained volumes of %s to free its parent images", namespace)
+    state.reclaimed_bytes[namespace] = size
+    logger.info("Reclaimed the retained volumes of %s (%d bytes) to free its parent images", namespace, size)
     return True
 
 

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -50,7 +50,7 @@ from aleph.vm.agent.vm.reclaimable import (
     ReclaimableMarker,
     file_size_bytes,
     iter_content_refs,
-    iter_reclaimable,
+    reclaimable_entries,
     refs_from_content,
 )
 from aleph.vm.agent.vm_registry import AgentVmRegistry
@@ -59,7 +59,6 @@ from aleph.vm.resources import InsufficientResourcesError
 from aleph.vm.storage import (
     DEVICE_MAPPER_DIRECTORY,
     DEVICE_NAME_MAX_BYTES,
-    is_vm_namespace,
     reserve_download,
     reserved_downloads,
 )
@@ -291,21 +290,13 @@ def _is_creating(namespace: str) -> bool:
     return is_creating(namespace)
 
 
-def _markers() -> list[tuple[Path, ReclaimableMarker]]:
-    """The reclaimable directories, oldest marker first, implausibly named
-    ones dropped (they can never be handed to ``purge_vm_storage``)."""
-    entries = [(directory, marker) for directory, marker in iter_reclaimable() if is_vm_namespace(directory.name)]
-    entries.sort(key=lambda item: item[1].reclaimable_since)
-    return entries
-
-
 def _marker_refs(markers: Iterable[tuple[Path, ReclaimableMarker]]) -> set[str]:
     return {ref for _directory, marker in markers for ref in marker.depends_on}
 
 
 def referenced_hashes(registry: AgentVmRegistry) -> set[str]:
     """Live refs plus what the ``.reclaimable`` markers pin."""
-    return live_refs(registry) | _marker_refs(_markers())
+    return live_refs(registry) | _marker_refs(reclaimable_entries())
 
 
 def cache_budget_bytes(root: Path) -> int:
@@ -557,7 +548,7 @@ def evict_caches(
             continue
         # Re-read the markers per root: what was reclaimed for the previous
         # root changes what this one is allowed to touch.
-        markers = _markers()
+        markers = reclaimable_entries()
         _evict_unreferenced(state, entries, state.live_only | _marker_refs(markers))
         if state.over_budget and reclaim_retained:
             _reclaim_pinning_dirs(state, entries, markers)

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -63,7 +63,7 @@ from aleph.vm.storage import (
     reserved_downloads,
 )
 from aleph.vm.storage_budget import parse_budget
-from aleph.vm.storage_pools import iter_namespace_dirs
+from aleph.vm.storage_pools import has_namespace_dirs
 from aleph.vm.utils import create_task_log_exceptions, run_in_subprocess
 
 logger = logging.getLogger(__name__)
@@ -644,7 +644,7 @@ def _reclaim_for_parents(
         return False
     if not state.dry_run:
         purge_vm_storage(namespace)
-        if any(True for _ in iter_namespace_dirs(namespace)):
+        if has_namespace_dirs(namespace):
             # purge_vm_storage refuses a directory a device-mapper target
             # still holds: those volumes still need their parent image, so
             # the parent stays too.

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -42,6 +42,8 @@ from collections.abc import Callable, Collection, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
+from aleph_message.models import ExecutableContent, ItemHash
+
 from aleph.vm.agent.vm.purge import purge_vm_storage
 from aleph.vm.agent.vm.reclaimable import (
     MANIFEST_REF_KINDS,
@@ -253,7 +255,7 @@ def _manifest_bundle_ref(ref: str) -> str | None:
     return str(bundle_ref) if bundle_ref else None
 
 
-def _record_refs(content, vm_hash: object) -> set[str]:
+def _record_refs(content: ExecutableContent, vm_hash: ItemHash) -> set[str]:
     """Every cache entry one live record names.
 
     ``reclaimable.iter_content_refs`` is the enumeration; this adds what only

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -445,18 +445,21 @@ def release_parent_devices(evicted: list[Path]) -> None:
     create_task_log_exceptions(remove_parent_devices(refs), name="remove parent devices")
 
 
-def _may_evict(entry: CacheEntry) -> bool:
+def _may_evict(entry: CacheEntry, *, log: bool = True) -> bool:
     """Whether this entry's file can be unlinked right now.
 
     Only parent images have devices on top of them, and only they can be
-    refused here.
+    refused here. ``log`` is off for the callers that are only counting what
+    could go, so an estimate does not fill the journal with refusals nobody
+    acted on.
     """
     runtime = _runtime_cache()
     if runtime is None or entry.path.parent != runtime:
         return True
     if parent_device_is_free(entry.path.name):
         return True
-    logger.warning("Not evicting %s: its device-mapper device is still held", entry.path)
+    if log:
+        logger.warning("Not evicting %s: its device-mapper device is still held", entry.path)
     return False
 
 
@@ -592,10 +595,25 @@ def _evict_unreferenced(state: _RootBudget, entries: list[CacheEntry], reference
     for entry in entries:
         if not state.over_budget:
             return
-        if _entry_refs(entry.path) & referenced:
-            continue
-        if _may_evict(entry):
+        if _is_evictable(entry, referenced):
             state.take(entry)
+
+
+def _is_evictable(entry: CacheEntry, referenced: set[str], *, log: bool = True) -> bool:
+    """Whether this entry may go: nobody names it and no device holds it."""
+    return not (_entry_refs(entry.path) & referenced) and _may_evict(entry, log=log)
+
+
+def _evictable_bytes(registry: AgentVmRegistry, entries: list[CacheEntry]) -> int:
+    """The most an eviction could free among ``entries``, without reclaiming
+    a retained VM's disks (which admission does not do).
+
+    An estimate, and an optimistic one: an entry that turns out not to unlink
+    is counted here. That is the right way round for the caller, which uses
+    it to decide not to evict at all rather than to decide to.
+    """
+    referenced = live_refs(registry) | _marker_refs(reclaimable_entries())
+    return sum(entry.size_bytes for entry in entries if _is_evictable(entry, referenced, log=False))
 
 
 def _reclaim_pinning_dirs(
@@ -737,9 +755,16 @@ def admit_download(
 
     Registered on ``storage.set_cache_admission`` so it runs inside
     ``download_file_in_chunks`` as soon as the response headers are in.
-    Evicting first is the point: the budget is a cap on what is kept, not on
-    what may be fetched, and only a load that stays over the budget with
-    nothing safely evictable left is refused.
+    Evicting is the point: the budget is a cap on what is kept, not on what
+    may be fetched, and only a load that would stay over the budget with
+    everything safely evictable gone is refused.
+
+    The refusal is decided before any of it, against what a full eviction
+    would leave. Deciding it afterwards meant measuring two different things:
+    the eviction stops as soon as the bytes really on disk fit, while the
+    refusal also counts the room an unmeasured download is holding, so a
+    download could take entries with it on the way to being refused. Nothing
+    is evicted for a download that is not admitted.
 
     An admitted download is then charged to its ``.part`` path until
     ``download_file`` releases it, so the next admission sees the room this
@@ -776,21 +801,28 @@ def admit_download(
     if content_length is None:
         _admit_unknown_length(tmp_path, root, budget, max_bytes)
         return
-    if _may_evict_for_admission(registry):
+    entries = cache_entries(root)
+    usage = _root_usage(root, entries) + content_length
+    may_evict = _may_evict_for_admission(registry)
+    evictable = _evictable_bytes(registry, entries) if may_evict else 0
+    if usage - evictable > budget:
+        # Decided before anything is unlinked. The eviction below stops as
+        # soon as the bytes really on disk fit, while this total also counts
+        # the room an unmeasured download is holding, so a refusal taken
+        # after the eviction could leave entries gone and the download failed
+        # all the same. Nothing is evicted for a download that cannot fit.
+        free = max(budget - (usage - content_length), 0)
+        msg = f"Cache {root} cannot hold a {content_length} byte download within CACHE_BUDGET"
+        raise InsufficientResourcesError(
+            msg,
+            required={"disk_mib": content_length // MIB},
+            available={"disk_mib": free // MIB},
+        )
+    if may_evict:
         release_parent_devices(
             evict_caches(registry, needed={root: content_length}, reclaim_retained=False),
         )
-    usage = _root_usage(root, cache_entries(root)) + content_length
-    if usage <= budget:
-        reserve_download(tmp_path, content_length, measured=True)
-        return
-    free = max(budget - (usage - content_length), 0)
-    msg = f"Cache {root} cannot hold a {content_length} byte download within CACHE_BUDGET"
-    raise InsufficientResourcesError(
-        msg,
-        required={"disk_mib": content_length // MIB},
-        available={"disk_mib": free // MIB},
-    )
+    reserve_download(tmp_path, content_length, measured=True)
 
 
 def _admit_unknown_length(tmp_path: Path, root: Path, budget: int, max_bytes: int | None) -> None:

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -818,7 +818,11 @@ def admit_download(
     entries = cache_entries(root)
     usage = _root_usage(root, entries) + content_length
     may_evict = _may_evict_for_admission(registry)
-    evictable = _evictable_bytes(registry, entries) if may_evict else 0
+    # Only asked when the answer can change anything: a root already inside
+    # its budget cannot be refused whatever is evictable, and the estimate
+    # costs a walk of every pool's markers plus a sysfs stat per runtime
+    # entry, on the event loop, inside the download.
+    evictable = _evictable_bytes(registry, entries) if may_evict and usage > budget else 0
     if usage - evictable > budget:
         # Decided before anything is unlinked. The eviction below stops as
         # soon as the bytes really on disk fit, while this total also counts

--- a/src/aleph/vm/agent/vm/cache.py
+++ b/src/aleph/vm/agent/vm/cache.py
@@ -300,8 +300,18 @@ def referenced_hashes(registry: AgentVmRegistry) -> set[str]:
     return live_refs(registry) | _marker_refs(reclaimable_entries())
 
 
+def cache_disk_total(root: Path) -> int:
+    """The size of the filesystem a cache root sits on.
+
+    Raises OSError when it cannot be read, which each caller answers for
+    itself: the pass leaves that root's budget unapplied, admission lets the
+    download through.
+    """
+    return shutil.disk_usage(str(root)).total
+
+
 def cache_budget_bytes(root: Path) -> int:
-    return parse_budget(settings.CACHE_BUDGET, shutil.disk_usage(str(root)).total)
+    return parse_budget(settings.CACHE_BUDGET, cache_disk_total(root))
 
 
 def _safe_ref(ref: str) -> bool:
@@ -792,14 +802,18 @@ def admit_download(
         logger.debug("Not a download cache, so not subject to CACHE_BUDGET: %s", root)
         return
     try:
-        budget = cache_budget_bytes(root)
+        # Read once and carried down: everything below is a share of this
+        # figure, and a second read is a second chance to fail on a question
+        # already answered.
+        total = cache_disk_total(root)
     except OSError:
         logger.warning("Cache directory %s is not accessible; admitting the download", root, exc_info=True)
         if content_length is not None:
             reserve_download(tmp_path, content_length, measured=True)
         return
+    budget = parse_budget(settings.CACHE_BUDGET, total)
     if content_length is None:
-        _admit_unknown_length(tmp_path, root, budget, max_bytes)
+        _admit_unknown_length(tmp_path, root, total, budget, max_bytes)
         return
     entries = cache_entries(root)
     usage = _root_usage(root, entries) + content_length
@@ -825,7 +839,7 @@ def admit_download(
     reserve_download(tmp_path, content_length, measured=True)
 
 
-def _admit_unknown_length(tmp_path: Path, root: Path, budget: int, max_bytes: int | None) -> None:
+def _admit_unknown_length(tmp_path: Path, root: Path, total: int, budget: int, max_bytes: int | None) -> None:
     """Admit a download whose size the server did not state.
 
     All that is known is the cap the caller is downloading under, and a cap is
@@ -858,21 +872,18 @@ def _admit_unknown_length(tmp_path: Path, root: Path, budget: int, max_bytes: in
             required={"disk_mib": (usage - budget) // MIB},
             available={"disk_mib": 0},
         )
-    reserve_download(tmp_path, _unknown_length_charge(root, budget, max_bytes), measured=False)
+    reserve_download(tmp_path, _unknown_length_charge(total, budget, max_bytes), measured=False)
 
 
-def _unknown_length_charge(root: Path, budget: int, max_bytes: int | None) -> int:
+def _unknown_length_charge(total: int, budget: int, max_bytes: int | None) -> int:
     """The room to hold for a body nobody measured: the smallest of the
-    reserve, this download's own cap and the budget."""
-    try:
-        total = shutil.disk_usage(str(root)).total
-    except OSError:
-        # A disk nobody can measure must not resurrect the whole-budget hold:
-        # resolve the reserve against a zero total instead, which yields the
-        # configured size when it is written as an absolute one and nothing
-        # when it is a percentage of the disk that just failed to answer.
-        logger.warning("Cache directory %s is not accessible; holding only the reserve", root, exc_info=True)
-        total = 0
+    reserve, this download's own cap and the budget.
+
+    ``total`` is the size of the cache disk, which the caller has already
+    read: the reserve may be a percentage of it. It used to be read a second
+    time here, with a fallback for a failure that cannot happen, since the
+    caller's own read of the very same disk had just succeeded. One reading,
+    one answer, and no unreachable branch left to reason about."""
     reserve = parse_budget(settings.UNKNOWN_LENGTH_RESERVE, total)
     figures = [reserve, budget] if max_bytes is None else [reserve, budget, max_bytes]
     return min(figures)

--- a/src/aleph/vm/agent/vm/purge.py
+++ b/src/aleph/vm/agent/vm/purge.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 ROOTFS_STEM = "rootfs"
 
 
-def _checked_namespace(vm_hash: ItemHash | str) -> ItemHash:
+def checked_namespace(vm_hash: ItemHash | str) -> ItemHash:
     """The item hash to purge, or a refusal before any filesystem access.
 
     A namespace is an item hash and nothing else, so the check is ItemHash's
@@ -70,7 +70,7 @@ def iter_volume_files(
     Only regular files directly inside ``{pool}/{vm_hash}/`` are yielded, so
     this can never reach a cache entry or another VM's volume.
     """
-    namespace = _checked_namespace(vm_hash)
+    namespace = checked_namespace(vm_hash)
     for volumes_dir in iter_namespace_dirs(namespace):
         try:
             entries = sorted(volumes_dir.iterdir())
@@ -127,7 +127,7 @@ def purge_vm_volumes(
     ``storage_pools.pin_layout`` so each volume is rebuilt on the pool it
     came from.
     """
-    namespace = _checked_namespace(vm_hash)
+    namespace = checked_namespace(vm_hash)
     deleted: list[Path] = []
     for volume in iter_volume_files(
         namespace,
@@ -164,7 +164,7 @@ def purge_vm_staging(vm_hash: ItemHash | str) -> None:
     Covers both the V-PROGRAM and the confidential-instance staging
     directories; each is a no-op for a VM of the other type.
     """
-    item_hash = _checked_namespace(vm_hash)
+    item_hash = checked_namespace(vm_hash)
     remove_vprogram_staging(item_hash)
     remove_snp_instance_staging(item_hash)
 
@@ -208,7 +208,7 @@ def purge_vm_storage(vm_hash: ItemHash | str) -> PurgeResult:
     guess from a directory that is still there. Idempotent: purging a VM with
     nothing on disk is a no-op.
     """
-    namespace = _checked_namespace(vm_hash)
+    namespace = checked_namespace(vm_hash)
     # File by file first, then the directories: rmtree alone would do, but
     # the per-file pass logs each volume and yields the count, which is the
     # audit trail an erase should leave.
@@ -252,7 +252,7 @@ def purge_vm_side_dirs(vm_hash: ItemHash | str) -> None:
     """Delete the per-VM directories that are not volumes: the confidential
     session directory and the staging directories. Rebuilt by the next
     create, so a retained (reclaimable) VM keeps only its volumes."""
-    namespace = _checked_namespace(vm_hash)
+    namespace = checked_namespace(vm_hash)
     if settings.CONFIDENTIAL_SESSION_DIRECTORY:
         session_dir = Path(settings.CONFIDENTIAL_SESSION_DIRECTORY) / namespace
         if session_dir.exists():

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -25,6 +25,7 @@ from typing import Literal, get_args
 from aleph_message.models import ExecutableContent
 
 from aleph.vm.agent.vm.purge import _checked_namespace
+from aleph.vm.storage import is_vm_namespace
 from aleph.vm.storage_pools import get_pools, iter_namespace_dirs
 
 logger = logging.getLogger(__name__)
@@ -440,6 +441,27 @@ def iter_reclaimable(*, repair: bool = True) -> Iterator[tuple[Path, Reclaimable
         marker = read_marker(directory, repair=repair)
         if marker is not None:
             yield directory, marker
+
+
+def reclaimable_entries(pool_path: Path | None = None) -> list[tuple[Path, ReclaimableMarker]]:
+    """The marked directories, oldest marker first, or one pool's alone.
+
+    The eviction order every reclaiming pass uses, in one place: the
+    retention budget takes a pool at a time, the cache pass takes them all,
+    and both have to agree on which directory goes first.
+
+    Implausibly named directories are dropped here rather than left to fail
+    the purge guard mid-pass: a hand-made marker under a directory nobody
+    named after a VM must not abort a reconcile, and could never be handed
+    to ``purge_vm_storage`` anyway.
+    """
+    entries = [
+        (directory, marker)
+        for directory, marker in iter_reclaimable()
+        if is_vm_namespace(directory.name) and (pool_path is None or directory.parent == pool_path)
+    ]
+    entries.sort(key=lambda item: item[1].reclaimable_since)
+    return entries
 
 
 # reclaimable_bytes runs on every admission check and every capacity report,

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -147,6 +147,11 @@ def directory_size_bytes(directory: Path) -> int:
     return sum(file_size_bytes(entry) for entry in entries if entry.name != MARKER_NAME)
 
 
+def namespace_size_bytes(namespace: str) -> int:
+    """Allocated bytes of a VM's volumes, on every pool it spans."""
+    return sum(directory_size_bytes(directory) for directory in iter_namespace_dirs(namespace))
+
+
 def read_marker(namespace_dir: Path, *, repair: bool = True) -> ReclaimableMarker | None:
     """The directory's marker, or None when it has none.
 

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import stat
 import time
 from collections.abc import Iterator, Mapping
 from dataclasses import asdict, dataclass, replace
@@ -119,12 +120,17 @@ def file_size_bytes(path: Path) -> int:
 
     The single definition of "how much disk does this file actually hold" for
     the agent: everything that measures a VM's storage goes through here or
-    through ``directory_size_bytes``."""
+    through ``directory_size_bytes``.
+
+    One lstat answers all of it, which matters because the callers run this
+    over every file of every cache and every pool: the mode says whether it
+    is a regular file (a symlink is not, so it is refused without following
+    it) and the same result carries the blocks."""
     try:
         st = path.lstat()
     except OSError:
         return 0
-    if path.is_symlink() or not path.is_file():
+    if not stat.S_ISREG(st.st_mode):
         return 0
     return st.st_blocks * 512
 

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -20,7 +20,7 @@ from collections.abc import Iterator, Mapping
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal
+from typing import Literal, get_args
 
 from aleph_message.models import ExecutableContent
 
@@ -33,6 +33,16 @@ MARKER_NAME = ".reclaimable"
 MARKER_VERSION = 1
 
 ReclaimReason = Literal["gone", "orphan"]
+RECLAIM_REASONS: frozenset[str] = frozenset(get_args(ReclaimReason))
+
+
+class UnsupportedMarkerVersion(ValueError):
+    """A marker written to a schema this agent does not know.
+
+    Distinct from a corrupt marker: the file is intact, a newer agent wrote
+    it, and the fields it holds may not mean what this version thinks they
+    do. The reader keeps such a file rather than removing it.
+    """
 
 
 @dataclass(frozen=True)
@@ -58,9 +68,25 @@ class ReclaimableMarker:
 
     @classmethod
     def from_json(cls, text: str) -> ReclaimableMarker:
+        """Parse a marker, refusing anything this agent did not write.
+
+        The reason and the version are checked rather than taken on trust:
+        both decide what happens to the directory (an orphan marker is
+        claimed exclusively and carries no owner, a gone one authorizes the
+        owner's erase), and a value from outside the set this agent knows
+        would be carried into those decisions unread.
+        """
         data = json.loads(text)
         if not isinstance(data, dict):
             msg = f"marker is not a JSON object: {type(data).__name__}"
+            raise ValueError(msg)
+        version = int(data.get("version", MARKER_VERSION))
+        if version != MARKER_VERSION:
+            msg = f"marker version {version} is not the version {MARKER_VERSION} this agent writes"
+            raise UnsupportedMarkerVersion(msg)
+        reason = data["reason"]
+        if reason not in RECLAIM_REASONS:
+            msg = f"marker reason {reason!r} is not one of {', '.join(sorted(RECLAIM_REASONS))}"
             raise ValueError(msg)
         owner = data.get("owner")
         since = datetime.fromisoformat(data["reclaimable_since"])
@@ -74,11 +100,11 @@ class ReclaimableMarker:
             since = since.replace(tzinfo=timezone.utc)
         return cls(
             reclaimable_since=since,
-            reason=data["reason"],
+            reason=reason,
             size_bytes=int(data["size_bytes"]),
             depends_on=tuple(data.get("depends_on", ())),
             owner=str(owner) if owner else None,
-            version=int(data.get("version", MARKER_VERSION)),
+            version=version,
         )
 
 
@@ -129,6 +155,12 @@ def read_marker(namespace_dir: Path, *, repair: bool = True) -> ReclaimableMarke
     cannot unlink it at all, and an operator inspecting a node has not asked
     for anything on disk to change). The reconciler keeps the repair, since
     it is the pass that has to be able to move the directory on.
+
+    A marker whose schema version this agent does not know is the exception:
+    it is intact, a newer agent wrote it, and removing it would hand a
+    retained directory to the orphan flow, which re-marks it without the
+    owner and the parent-image pins it was carrying. It is kept and reported
+    instead, and the operator is told which agent has to look at it.
     """
     path = namespace_dir / MARKER_NAME
     if not path.is_file():
@@ -137,6 +169,9 @@ def read_marker(namespace_dir: Path, *, repair: bool = True) -> ReclaimableMarke
         return ReclaimableMarker.from_json(path.read_text())
     except OSError:
         logger.warning("Unreadable reclaimable marker at %s, ignoring it", path)
+        return None
+    except UnsupportedMarkerVersion as error:
+        logger.error("Reclaimable marker at %s is in a schema this agent does not know (%s); keeping it", path, error)
         return None
     except (ValueError, KeyError, TypeError, AttributeError):
         if not repair:

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -25,7 +25,7 @@ from typing import Literal, get_args
 
 from aleph_message.models import ExecutableContent
 
-from aleph.vm.agent.vm.purge import _checked_namespace
+from aleph.vm.agent.vm.purge import checked_namespace
 from aleph.vm.storage import is_vm_namespace
 from aleph.vm.storage_pools import get_pools, iter_namespace_dirs
 
@@ -349,7 +349,7 @@ def mark_reclaimable(
     owner: str | None = None,
 ) -> list[Path]:
     """Write one marker per namespace directory (one per pool the VM spans)."""
-    namespace = _checked_namespace(namespace)
+    namespace = checked_namespace(namespace)
     since = now or datetime.now(tz=timezone.utc)
     written: list[Path] = []
     for directory in iter_namespace_dirs(namespace):
@@ -381,7 +381,7 @@ def adopt(namespace: str) -> dict[Path, ReclaimableMarker]:
     whose marker was unreadable or corrupt is adopted like any other and
     simply has nothing to give back.
     """
-    namespace = _checked_namespace(namespace)
+    namespace = checked_namespace(namespace)
     adopted: dict[Path, ReclaimableMarker] = {}
     for directory in iter_namespace_dirs(namespace):
         marker = read_marker(directory)
@@ -432,7 +432,7 @@ def retained_marker(namespace: str) -> ReclaimableMarker | None:
     still holds anything for a hash it otherwise knows nothing about, and
     who it belongs to.
     """
-    namespace = _checked_namespace(namespace)
+    namespace = checked_namespace(namespace)
     for directory in iter_namespace_dirs(namespace):
         marker = read_marker(directory)
         if marker is not None:

--- a/src/aleph/vm/agent/vm/reclaimable.py
+++ b/src/aleph/vm/agent/vm/reclaimable.py
@@ -38,7 +38,7 @@ ReclaimReason = Literal["gone", "orphan"]
 RECLAIM_REASONS: frozenset[str] = frozenset(get_args(ReclaimReason))
 
 
-class UnsupportedMarkerVersion(ValueError):
+class UnsupportedMarkerVersionError(ValueError):
     """A marker written to a schema this agent does not know.
 
     Distinct from a corrupt marker: the file is intact, a newer agent wrote
@@ -85,7 +85,7 @@ class ReclaimableMarker:
         version = int(data.get("version", MARKER_VERSION))
         if version != MARKER_VERSION:
             msg = f"marker version {version} is not the version {MARKER_VERSION} this agent writes"
-            raise UnsupportedMarkerVersion(msg)
+            raise UnsupportedMarkerVersionError(msg)
         reason = data["reason"]
         if reason not in RECLAIM_REASONS:
             msg = f"marker reason {reason!r} is not one of {', '.join(sorted(RECLAIM_REASONS))}"
@@ -182,7 +182,7 @@ def read_marker(namespace_dir: Path, *, repair: bool = True) -> ReclaimableMarke
     except OSError:
         logger.warning("Unreadable reclaimable marker at %s, ignoring it", path)
         return None
-    except UnsupportedMarkerVersion as error:
+    except UnsupportedMarkerVersionError as error:
         logger.error("Reclaimable marker at %s is in a schema this agent does not know (%s); keeping it", path, error)
         return None
     except (ValueError, KeyError, TypeError, AttributeError):

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -66,6 +66,7 @@ from aleph.vm.agent.vm.reclaimable import (
     clear_marker,
     directory_size_bytes,
     mark_reclaimable,
+    namespace_size_bytes,
     read_marker,
     reclaimable_entries,
     restore_markers,
@@ -179,11 +180,6 @@ def is_creating(namespace: str) -> bool:
 
 def _mtime(path: Path) -> datetime:
     return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
-
-
-def _dir_bytes(namespace: str) -> int:
-    """Allocated bytes of a VM's volumes, on every pool it spans."""
-    return sum(directory_size_bytes(directory) for directory in iter_namespace_dirs(namespace))
 
 
 def live_hashes(registry: AgentVmRegistry) -> set[str]:
@@ -432,7 +428,7 @@ def _reconcile_namespace(
     # Measured before the last liveness check rather than after it: this walks
     # every pool the VM is on, and the answer that decides whether the disks
     # go has to be the one taken after the longest pause, not before it.
-    freed = 0 if keep else _dir_bytes(namespace)
+    freed = 0 if keep else namespace_size_bytes(namespace)
     if is_live(namespace) or is_creating(namespace):
         # A create that committed, or entered creating(), between the live
         # snapshot and this walk. Asked here and not where _is_orphan has
@@ -658,7 +654,7 @@ def _evict(
     if not has_namespace_dirs(namespace):
         logger.debug("Not evicting %s: its directories are already gone", namespace)
         return 0
-    size = _dir_bytes(namespace)
+    size = namespace_size_bytes(namespace)
     if not dry_run:
         purge_vm_storage(namespace)
         if has_namespace_dirs(namespace):
@@ -757,7 +753,16 @@ def _enforce_cache_budget(
             ", ".join(unknown[:3]),
         )
         return
-    report.cache_evicted = evict_caches(registry, dry_run=dry_run, is_live=is_live)
+    reclaimed_bytes: dict[str, int] = {}
+    report.cache_evicted = evict_caches(registry, dry_run=dry_run, is_live=is_live, reclaimed_bytes=reclaimed_bytes)
+    for namespace, size in reclaimed_bytes.items():
+        # The retained VMs the cache pass gave back to free the parent images
+        # they pinned. They are evictions of the same kind the retention
+        # budget makes, and the pass's own figures have to include them.
+        if namespace in report.evicted:
+            continue
+        report.evicted.append(namespace)
+        report.bytes_freed += size
 
 
 def make_room(pool: StoragePool, needed_bytes: int, *, live: Collection[str] | None = None) -> int:

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -93,11 +93,29 @@ logger = logging.getLogger(__name__)
 
 STAGING_KINDS = ("vprogram", "snp-instance")
 
-# Namespace to the number of creates in flight for it. A count rather than
-# a set: a scheduler push and an operator reinstall take no common per-hash
-# lock, so two creating() spans for one hash can overlap, and the first to
-# exit must not unguard the second.
-_creating: dict[str, int] = {}
+
+@dataclass
+class _CreateState:
+    """What the creates in flight for one namespace share.
+
+    A count rather than a set of creates: a scheduler push and an operator
+    reinstall take no common per-hash lock, so two ``creating()`` spans for
+    one hash can overlap, and the first to exit must not unguard the second.
+
+    The adopted markers are shared for the same reason. Only the first create
+    in finds a marker to adopt, so a per-create record of it would be lost the
+    moment that create failed while a later one was still running: the later
+    one adopted nothing and would have nothing to put back. Held here, the
+    markers belong to the namespace, and the last create to leave without
+    committing restores whatever any of them adopted.
+    """
+
+    creates: int = 0
+    adopted: dict[Path, ReclaimableMarker] = field(default_factory=dict)
+
+
+# Namespace to the creates in flight for it.
+_creating: dict[str, _CreateState] = {}
 
 
 @dataclass
@@ -138,10 +156,16 @@ def creating(namespace: str) -> Iterator[None]:
     so a retained directory keeps its owner (who may still ask for it to be
     erased), the parent images its volumes depend on, and its place in the
     eviction queue. That matters because a failing create is retried: the
-    allocation reconciler pushes it again on every cycle. The one exception
-    is a failure while another create for the same hash is still running:
-    that one owns the directory now, and it puts back what it adopted if it
-    fails in its turn.
+    allocation reconciler pushes it again on every cycle.
+
+    Overlapping creates of one hash share what was adopted, and the last one
+    out answers for it. While any create is still running nothing is put back,
+    because a marker on a directory a create is writing says its disks are
+    reclaimable capacity, which the node would then sell to somebody else. A
+    create that returns normally commits, and then the markers are dropped for
+    good: the directory belongs to a live VM. Only when the last create leaves
+    and none of them committed do the markers go back, whichever create had
+    adopted them.
     """
     # Register before adopting: between clear_marker and the add there would
     # otherwise be an instant where the directory is protected by neither
@@ -149,40 +173,37 @@ def creating(namespace: str) -> Iterator[None]:
     # unmarked, not-creating orphan. Registered first, a pass that read
     # is_creating as False must have read it before this line, and then
     # still sees the marker adopt() has yet to clear.
-    _creating[namespace] = _creating.get(namespace, 0) + 1
-    adopted: dict[Path, ReclaimableMarker] = {}
+    state = _creating.setdefault(namespace, _CreateState())
+    state.creates += 1
+    committed = False
     try:
         # Inside the try: an adopt that raises (a marker that cannot be
         # unlinked) must not leave the guard up for good, which would exempt
         # the namespace from every future pass.
-        adopted = adopt(namespace)
+        state.adopted.update(adopt(namespace))
         yield
-    except BaseException:
-        # Any way out other than a normal return means the create did not
-        # commit: an exception, and a cancellation of the task running it.
-        # The restore runs before the guard comes down below, so no pass can
-        # see the directory unmarked and unguarded in between.
-        if _creating[namespace] > 1:
-            # Except when another create for this hash is still running: the
-            # directory is that one's now, and a marker on a directory a
-            # create is writing says its disks are reclaimable capacity, which
-            # the node would then sell to somebody else. The create that
-            # holds it restores what it adopted if it fails in its turn.
-            logger.info("Not restoring the markers of %s: another create still holds it", namespace)
-            raise
-        try:
-            restore_markers(adopted)
-        except Exception:
-            # Deliberately swallowed: the create's own failure is what the
-            # caller has to see. A directory left unmarked is picked up as an
-            # orphan by the next pass, which is what used to happen anyway.
-            logger.exception("Could not restore the reclaimable markers of %s", namespace)
-        raise
+        # Reached on a normal return only, so not on an exception and not on a
+        # cancellation of the task running the create.
+        committed = True
     finally:
-        remaining = _creating[namespace] - 1
-        if remaining:
-            _creating[namespace] = remaining
+        state.creates -= 1
+        if committed:
+            state.adopted.clear()
+        if state.creates:
+            if not committed:
+                logger.info("Not restoring the markers of %s yet: another create still holds it", namespace)
         else:
+            if state.adopted:
+                try:
+                    restore_markers(state.adopted)
+                except Exception:
+                    # Deliberately swallowed: the create's own failure is what
+                    # the caller has to see. A directory left unmarked is
+                    # picked up as an orphan by the next pass, which is what
+                    # used to happen anyway.
+                    logger.exception("Could not restore the reclaimable markers of %s", namespace)
+            # The guard comes down last, after the restore, so no pass can see
+            # the directory unmarked and unguarded in between.
             del _creating[namespace]
 
 

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -14,9 +14,9 @@ A live set the supervisor could not confirm also stops the cache pass (see
 ``_enforce_cache_budget``) and the device teardown below.
 
 Two parts of a pass run on the event loop rather than in the walk's worker
-thread, because both shell out to dmsetup: ``_teardown_orphan_devices``
+thread, because both shell out to dmsetup: ``teardown_orphan_devices``
 before it (a volume a dm target still holds cannot be reclaimed, so the
-devices go first) and ``_release_cache_devices`` after it (the devices of
+devices go first) and ``release_cache_devices`` after it (the devices of
 the parent images the cache pass evicted).
 
 Loop-triggered passes are serialized, not coalesced: a sweep that retires N
@@ -177,15 +177,6 @@ def is_creating(namespace: str) -> bool:
     return namespace in _creating
 
 
-def _plausible(name: str) -> bool:
-    """Whether a directory or device name is a VM namespace at all.
-
-    The same question the purge guard asks, so the passes that walk the
-    pools skip what the guard would refuse instead of raising on it.
-    """
-    return is_vm_namespace(name)
-
-
 def _mtime(path: Path) -> datetime:
     return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
 
@@ -193,11 +184,6 @@ def _mtime(path: Path) -> datetime:
 def _dir_bytes(namespace: str) -> int:
     """Allocated bytes of a VM's volumes, on every pool it spans."""
     return sum(directory_size_bytes(directory) for directory in iter_namespace_dirs(namespace))
-
-
-# The storage CLI imports this name from here; the check itself lives with
-# the pools it reads.
-_still_on_disk = has_namespace_dirs
 
 
 def live_hashes(registry: AgentVmRegistry) -> set[str]:
@@ -404,7 +390,7 @@ def _reconcile_namespaces(
     seen: set[str] = set()
     for directory in list(iter_namespace_dirs()):
         namespace = directory.name
-        if not _plausible(namespace):
+        if not is_vm_namespace(namespace):
             # A pool is usually a mountpoint, so lost+found is expected here:
             # debug, not a warning repeated every VOLUME_RECONCILE_INTERVAL.
             logger.debug("Ignoring %s: not a VM directory", directory)
@@ -560,7 +546,7 @@ def _is_stale_side_dir(
     if not child.is_dir():
         return False
     namespace = naming.namespace_of(child)
-    if not _plausible(namespace) or namespace in live or is_creating(namespace):
+    if not is_vm_namespace(namespace) or namespace in live or is_creating(namespace):
         return False
     try:
         if now - _mtime(child) < guard:
@@ -874,9 +860,9 @@ async def reconcile_now(app: web.Application, *, dry_run: bool = False) -> Recon
     async with _pass_lock(app):
         live, running = await _live_set(app)
         if not dry_run and running is not None:
-            await _teardown_orphan_devices(live)
+            await teardown_orphan_devices(live)
         report = await _pass(registry, live, dry_run=dry_run, live_known=running is not None)
-    await _release_cache_devices(report, dry_run=dry_run)
+    await release_cache_devices(report, dry_run=dry_run)
     return report
 
 
@@ -907,7 +893,7 @@ def orphan_device_namespaces(live: Collection[str]) -> list[str]:
         return []
     for device in devices:
         namespace = device.name.split("_", 1)[0]
-        if not _plausible(namespace) or namespace in live or is_creating(namespace):
+        if not is_vm_namespace(namespace) or namespace in live or is_creating(namespace):
             continue
         if _within_create_guard(namespace, now, guard):
             continue
@@ -928,7 +914,7 @@ def _within_create_guard(namespace: str, now: datetime, guard: timedelta) -> boo
     return False
 
 
-async def _teardown_orphan_devices(live: Collection[str]) -> list[str]:
+async def teardown_orphan_devices(live: Collection[str]) -> list[str]:
     """Tear down the devices of the VMs the walk is about to find unowned.
 
     ``retire_vm`` is the normal inverse of ``create_devmapper``, and it reads
@@ -953,7 +939,7 @@ async def _teardown_orphan_devices(live: Collection[str]) -> list[str]:
     return namespaces
 
 
-async def _release_cache_devices(report: ReconcileReport, *, dry_run: bool) -> None:
+async def release_cache_devices(report: ReconcileReport, *, dry_run: bool) -> None:
     """Tear down the devices of the parent images the pass evicted, then sweep
     the ones an earlier teardown left behind.
 
@@ -1058,9 +1044,9 @@ async def reconcile_at_startup(app: web.Application) -> None:
             _log_startup_preview(await _pass(registry, live, dry_run=True, live_known=live_known), refusal=refusal)
             if refusal is not None:
                 return
-            await _teardown_orphan_devices(live)
+            await teardown_orphan_devices(live)
             report = await _pass(registry, live, dry_run=False, live_known=live_known)
-        await _release_cache_devices(report, dry_run=False)
+        await release_cache_devices(report, dry_run=False)
     except Exception:
         # Housekeeping never blocks the boot: an on_startup hook that raises
         # stops the agent, and a full or read-only pool is exactly what this
@@ -1096,3 +1082,13 @@ async def stop_storage_reconcile_task(app: web.Application) -> None:
         await task
     except asyncio.CancelledError:
         logger.debug("Task storage_reconcile is cancelled now")
+
+
+# The storage CLI runs the same pass out of process and imports four of the
+# names above. They carried an underscore while the reconciler was their only
+# caller, which they have not been for some time; these aliases keep that
+# module importing while it is pointed at the names themselves.
+_plausible = is_vm_namespace
+_still_on_disk = has_namespace_dirs
+_teardown_orphan_devices = teardown_orphan_devices
+_release_cache_devices = release_cache_devices

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -439,20 +439,27 @@ def _reconcile_namespace(
     namespace = directory.name
     if not _is_orphan(directory, is_live, now, guard, dry_run=dry_run):
         return False
-    if is_live(namespace) or is_creating(namespace):
-        # A create that committed, or entered creating(), between the
-        # live snapshot and this walk.
-        logger.info("Skipping %s: a VM claimed it while this pass was walking", namespace)
-        return True
     if not dry_run and not has_namespace_dirs(namespace):
         logger.debug("Skipping %s: another pass got there first", namespace)
         return True
-    if settings.VOLUME_RETENTION == "keep":
+    keep = settings.VOLUME_RETENTION == "keep"
+    # Measured before the last liveness check rather than after it: this walks
+    # every pool the VM is on, and the answer that decides whether the disks
+    # go has to be the one taken after the longest pause, not before it.
+    freed = 0 if keep else _dir_bytes(namespace)
+    if is_live(namespace) or is_creating(namespace):
+        # A create that committed, or entered creating(), between the live
+        # snapshot and this walk. Asked here and not where _is_orphan has
+        # just asked it: a pass runs in a worker thread while creates land on
+        # the event loop, so what counts is the last answer before the
+        # directory is marked or removed.
+        logger.info("Skipping %s: a VM claimed it while this pass was walking", namespace)
+        return True
+    if keep:
         if not dry_run:
             mark_reclaimable(namespace, "orphan", now=now)
         report.marked_orphans.append(namespace)
         return True
-    freed = _dir_bytes(namespace)
     if dry_run:
         report.purged_orphans.append(namespace)
         report.bytes_freed += freed

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -254,6 +254,18 @@ async def _live_set(app: web.Application) -> tuple[set[str], int | None]:
 _last_supervisor_hashes: set[str] = set()
 
 
+def forget_supervisor_hash(namespace: str) -> None:
+    """Drop a VM the agent has just retired from the last listing it heard.
+
+    ``known_live_hashes`` protects everything in that listing, and the room
+    maker asks it on the placement path, where nothing can ask the supervisor
+    again. A retired hash left here protects the disks of a VM that is gone,
+    against the create that is trying to make room for itself, until the next
+    pass replaces the listing an hour later.
+    """
+    _last_supervisor_hashes.discard(namespace)
+
+
 def known_live_hashes(registry: AgentVmRegistry) -> set[str]:
     """``live_hashes`` plus the supervisor's VMs as of the last pass.
 

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -80,6 +80,7 @@ from aleph.vm.storage_budget import parse_budget
 from aleph.vm.storage_pools import (
     StoragePool,
     get_pools,
+    has_namespace_dirs,
     iter_namespace_dirs,
     pool_usage_bytes,
 )
@@ -194,16 +195,9 @@ def _dir_bytes(namespace: str) -> int:
     return sum(directory_size_bytes(directory) for directory in iter_namespace_dirs(namespace))
 
 
-def _still_on_disk(namespace: str) -> bool:
-    """False when the namespace's directories vanished between being listed
-    and being acted on.
-
-    Passes can overlap (a GONE fires one while the periodic pass runs, and
-    ``make_room`` evicts from the create path), so losing a race is normal.
-    It is not an error, and it is not space this pass may claim to have
-    freed.
-    """
-    return any(True for _ in iter_namespace_dirs(namespace))
+# The storage CLI imports this name from here; the check itself lives with
+# the pools it reads.
+_still_on_disk = has_namespace_dirs
 
 
 def live_hashes(registry: AgentVmRegistry) -> set[str]:
@@ -450,7 +444,7 @@ def _reconcile_namespace(
         # live snapshot and this walk.
         logger.info("Skipping %s: a VM claimed it while this pass was walking", namespace)
         return True
-    if not dry_run and not _still_on_disk(namespace):
+    if not dry_run and not has_namespace_dirs(namespace):
         logger.debug("Skipping %s: another pass got there first", namespace)
         return True
     if settings.VOLUME_RETENTION == "keep":
@@ -464,7 +458,7 @@ def _reconcile_namespace(
         report.bytes_freed += freed
         return True
     purge_vm_storage(namespace)
-    if _still_on_disk(namespace):
+    if has_namespace_dirs(namespace):
         # purge_vm_storage refuses a directory a device-mapper target
         # still holds. Nothing was freed, so nothing may be reported
         # as freed; the next pass tries again.
@@ -668,13 +662,13 @@ def _evict(
     # open; the window is a few instructions wide and needs the pool to be
     # over budget at that instant. The room maker's evictions run on the
     # event loop itself, where creating() cannot interleave at all.
-    if not _still_on_disk(namespace):
+    if not has_namespace_dirs(namespace):
         logger.debug("Not evicting %s: its directories are already gone", namespace)
         return 0
     size = _dir_bytes(namespace)
     if not dry_run:
         purge_vm_storage(namespace)
-        if _still_on_disk(namespace):
+        if has_namespace_dirs(namespace):
             # Same rule as the namespace pass: a directory the purge refuses
             # (a device-mapper target still holds its volumes) is not space
             # anyone got back, so make_room must not count it towards the
@@ -719,7 +713,7 @@ def _enforce_retention_budget(
                 total -= marker.size_bytes
                 continue
             evicted = _evict(directory.name, report, dry_run=dry_run, is_live=is_live)
-            if evicted or not _still_on_disk(directory.name):
+            if evicted or not has_namespace_dirs(directory.name):
                 # Only bytes that actually left the disk count against the
                 # excess. A declined eviction (a live or in-flight re-create,
                 # a dm-held purge refusal) keeps its bytes: spending them

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -138,7 +138,10 @@ def creating(namespace: str) -> Iterator[None]:
     so a retained directory keeps its owner (who may still ask for it to be
     erased), the parent images its volumes depend on, and its place in the
     eviction queue. That matters because a failing create is retried: the
-    allocation reconciler pushes it again on every cycle.
+    allocation reconciler pushes it again on every cycle. The one exception
+    is a failure while another create for the same hash is still running:
+    that one owns the directory now, and it puts back what it adopted if it
+    fails in its turn.
     """
     # Register before adopting: between clear_marker and the add there would
     # otherwise be an instant where the directory is protected by neither
@@ -159,6 +162,14 @@ def creating(namespace: str) -> Iterator[None]:
         # commit: an exception, and a cancellation of the task running it.
         # The restore runs before the guard comes down below, so no pass can
         # see the directory unmarked and unguarded in between.
+        if _creating[namespace] > 1:
+            # Except when another create for this hash is still running: the
+            # directory is that one's now, and a marker on a directory a
+            # create is writing says its disks are reclaimable capacity, which
+            # the node would then sell to somebody else. The create that
+            # holds it restores what it adopted if it fails in its turn.
+            logger.info("Not restoring the markers of %s: another create still holds it", namespace)
+            raise
         try:
             restore_markers(adopted)
         except Exception:

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -65,9 +65,9 @@ from aleph.vm.agent.vm.reclaimable import (
     adopt,
     clear_marker,
     directory_size_bytes,
-    iter_reclaimable,
     mark_reclaimable,
     read_marker,
+    reclaimable_entries,
     restore_markers,
 )
 from aleph.vm.agent.vm.retire import teardown_namespace_devices
@@ -642,22 +642,6 @@ def _retention_budget(pool: StoragePool) -> int | None:
     return parse_budget(settings.VOLUME_RETENTION_BUDGET, usage.total)
 
 
-def _reclaimable_on(pool: StoragePool) -> list[tuple[Path, ReclaimableMarker]]:
-    """The pool's reclaimable directories, oldest marker first.
-
-    Implausibly named directories are dropped here rather than left to fail
-    the ``_checked_namespace`` guard mid-pass: a hand-made marker under a
-    directory nobody named after a VM must not abort a reconcile.
-    """
-    entries = [
-        (directory, marker)
-        for directory, marker in iter_reclaimable()
-        if directory.parent == pool.path and _plausible(directory.name)
-    ]
-    entries.sort(key=lambda item: item[1].reclaimable_since)
-    return entries
-
-
 def _evict(
     namespace: str,
     report: ReconcileReport,
@@ -710,7 +694,7 @@ def _enforce_retention_budget(
 ) -> None:
     reap = settings.VOLUME_RETENTION == "reap"
     for pool in get_pools():
-        entries = _reclaimable_on(pool)
+        entries = reclaimable_entries(pool.path)
         if not entries:
             continue
         budget = _retention_budget(pool)
@@ -826,7 +810,7 @@ def make_room(pool: StoragePool, needed_bytes: int, *, live: Collection[str] | N
     free = usage.free
     if free >= needed_bytes:
         return 0
-    entries = _reclaimable_on(pool)
+    entries = reclaimable_entries(pool.path)
     reclaimable = sum(directory_size_bytes(directory) for directory, _marker in entries)
     if free + reclaimable < needed_bytes:
         logger.info(

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -61,6 +61,7 @@ from aleph.vm.agent.vm.cache import (
 )
 from aleph.vm.agent.vm.purge import purge_vm_storage
 from aleph.vm.agent.vm.reclaimable import (
+    MARKER_NAME,
     ReclaimableMarker,
     adopt,
     clear_marker,
@@ -911,6 +912,15 @@ def _within_create_guard(namespace: str, now: datetime, guard: timedelta) -> boo
     in flight. A namespace with no directory at all is not: its devices are
     what a create left behind, not what one is building on."""
     for directory in iter_namespace_dirs(namespace):
+        if (directory / MARKER_NAME).exists():
+            # A reclaimable directory is not one a create is building:
+            # creating() adopts a namespace, which clears its markers, before
+            # the create writes anything. Reading its mtime instead would put
+            # every retired VM inside the guard, because writing the marker
+            # is itself a write to the directory and moves that mtime. Its
+            # devices would then stand for a whole VOLUME_CREATE_GUARD, and
+            # they are what stops its volumes being reclaimed at all.
+            continue
         try:
             if now - _mtime(directory) < guard:
                 return True

--- a/src/aleph/vm/agent/vm/reconciler.py
+++ b/src/aleph/vm/agent/vm/reconciler.py
@@ -44,6 +44,7 @@ from collections.abc import Callable, Collection, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 from pathlib import Path
 
 from aiohttp import web
@@ -524,16 +525,30 @@ def _sweep_parts(now: datetime, guard: timedelta, report: ReconcileReport, *, dr
                 logger.warning("Failed to remove %s", part, exc_info=True)
 
 
-def _side_dir_roots() -> Iterator[tuple[Path, str]]:
+class SideDirNaming(Enum):
+    """How a side directory's name yields the VM hash that owns it."""
+
+    # The directory is the hash: {root}/{namespace}
+    EXACT = "exact"
+    # The hash is the first field of the name: /mnt/{namespace}_{volume name}
+    PREFIX = "prefix"
+
+    def namespace_of(self, child: Path) -> str:
+        return child.name if self is SideDirNaming.EXACT else child.name.split("_", 1)[0]
+
+
+def _side_dir_roots() -> Iterator[tuple[Path, SideDirNaming]]:
     """(root, how the hash is derived from the child name)."""
     if settings.CONFIDENTIAL_SESSION_DIRECTORY:
-        yield Path(settings.CONFIDENTIAL_SESSION_DIRECTORY), "exact"
+        yield Path(settings.CONFIDENTIAL_SESSION_DIRECTORY), SideDirNaming.EXACT
     for kind in STAGING_KINDS:
-        yield Path(settings.EXECUTION_ROOT) / kind, "exact"
-    yield MOUNT_ROOT, "prefix"  # /mnt/{namespace}_{volume name}
+        yield Path(settings.EXECUTION_ROOT) / kind, SideDirNaming.EXACT
+    yield MOUNT_ROOT, SideDirNaming.PREFIX
 
 
-def _is_stale_side_dir(child: Path, mode: str, live: Collection[str], now: datetime, guard: timedelta) -> bool:
+def _is_stale_side_dir(
+    child: Path, naming: SideDirNaming, live: Collection[str], now: datetime, guard: timedelta
+) -> bool:
     """True when this side directory belongs to a VM that is not here any more.
 
     Same three questions as the namespace pass, in the same order: is the
@@ -543,7 +558,7 @@ def _is_stale_side_dir(child: Path, mode: str, live: Collection[str], now: datet
     """
     if not child.is_dir():
         return False
-    namespace = child.name if mode == "exact" else child.name.split("_", 1)[0]
+    namespace = naming.namespace_of(child)
     if not _plausible(namespace) or namespace in live or is_creating(namespace):
         return False
     try:
@@ -551,15 +566,15 @@ def _is_stale_side_dir(child: Path, mode: str, live: Collection[str], now: datet
             return False
     except OSError:
         return False
-    return _side_dir_is_removable(child, mode)
+    return _side_dir_is_removable(child, naming)
 
 
-def _side_dir_is_removable(child: Path, mode: str) -> bool:
+def _side_dir_is_removable(child: Path, naming: SideDirNaming) -> bool:
     """The last two questions, about the directory rather than its owner."""
     if os.path.ismount(child):
         logger.warning("Not removing %s: it is a mount point", child)
         return False
-    if mode == "prefix" and not _is_empty(child):
+    if naming is SideDirNaming.PREFIX and not _is_empty(child):
         # /mnt belongs to the operator, not to the agent: the only thing the
         # agent puts there is a mount point (storage.create_devmapper mkdirs
         # it and unmounts after the resize), which is empty by construction
@@ -587,20 +602,20 @@ def _sweep_side_dirs(
     dry_run: bool,
     is_live: Callable[[str], bool],
 ) -> None:
-    for root, mode in _side_dir_roots():
+    for root, naming in _side_dir_roots():
         if not root.is_dir():
             continue
         for child in list(root.iterdir()):
-            if not _is_stale_side_dir(child, mode, live, now, guard):
+            if not _is_stale_side_dir(child, naming, live, now, guard):
                 continue
-            namespace = child.name if mode == "exact" else child.name.split("_", 1)[0]
+            namespace = naming.namespace_of(child)
             if is_live(namespace) or is_creating(namespace):
                 # Claimed since the listing: the same re-check the namespace
                 # pass and the evictor make immediately before removing.
                 continue
             if not dry_run:
                 try:
-                    if mode == "exact":
+                    if naming is SideDirNaming.EXACT:
                         shutil.rmtree(child)
                     else:
                         # Never an rmtree here: see _is_stale_side_dir.

--- a/src/aleph/vm/agent/vm/retire.py
+++ b/src/aleph/vm/agent/vm/retire.py
@@ -33,7 +33,7 @@ from aleph.vm.agent.metrics import delete_records_for_vm
 from aleph.vm.agent.vm.backup import purge_vm_backups
 from aleph.vm.agent.vm.cache import forget_live
 from aleph.vm.agent.vm.purge import (
-    _checked_namespace,
+    checked_namespace,
     purge_vm_side_dirs,
     purge_vm_storage,
 )
@@ -94,7 +94,7 @@ async def teardown_namespace_devices(namespace: str) -> None:
     no snapshot at all (a create that died between the two ``dmsetup create``
     calls) is the one case that never reaches, so it is removed at the end.
     """
-    namespace = _checked_namespace(namespace)
+    namespace = checked_namespace(namespace)
     mapper = Path(DEVICE_MAPPER_DIRECTORY)
     try:
         devices = sorted(mapper.glob(f"{namespace}_*"))
@@ -141,7 +141,7 @@ async def teardown_vm_devices(namespace: str, record: AgentVmRecord | None) -> N
             logger.exception("Device teardown of %s failed", namespace)
         return
     try:
-        namespace = _checked_namespace(namespace)
+        namespace = checked_namespace(namespace)
     except ValueError:
         # Unreachable from the callers, which pass an ItemHash, but the
         # best-effort contract holds for the check too: a teardown that

--- a/src/aleph/vm/agent/vm/retire.py
+++ b/src/aleph/vm/agent/vm/retire.py
@@ -143,10 +143,12 @@ async def teardown_vm_devices(namespace: str, record: AgentVmRecord | None) -> N
     try:
         namespace = checked_namespace(namespace)
     except ValueError:
-        # Unreachable from the callers, which pass an ItemHash, but the
-        # best-effort contract holds for the check too: a teardown that
-        # cannot run must not abort the retire between the forget and the
-        # storage release.
+        # Reachable: this is called straight from the reinstall path as well
+        # as from retire_vm, and neither its signature nor the module
+        # boundary promises a hash anyone has parsed. The best-effort
+        # contract covers the check with the rest: a teardown that cannot
+        # run must not abort the retire between the forget and the storage
+        # release.
         logger.exception("Device teardown of %r skipped", namespace)
         return
     for volume in getattr(record.message, "volumes", None) or []:

--- a/src/aleph/vm/agent/vm/retire.py
+++ b/src/aleph/vm/agent/vm/retire.py
@@ -201,6 +201,12 @@ async def retire_vm(
     # racing a live VM the agent has no message for, so nothing is evicted and
     # a download that needs room is refused.
     forget_live(str(vm_hash))
+    # And the other half of the same set. Imported here rather than at the
+    # top: the reconciler imports this module for the device teardown, so it
+    # cannot be imported back at load time.
+    from aleph.vm.agent.vm.reconciler import forget_supervisor_hash
+
+    forget_supervisor_hash(str(vm_hash))
     await delete_records_for_vm(str(vm_hash))
     # Before the storage pass: a volume file held by a live dm target cannot
     # be unlinked usefully, and the marker written for a kept volume would

--- a/src/aleph/vm/storage.py
+++ b/src/aleph/vm/storage.py
@@ -710,36 +710,32 @@ async def remove_devmapper(namespace: str, volume_name: str) -> None:
 
     # The base device is per VM but shared by all of its parent-backed
     # volumes (create_devmapper builds it once, from the first one), so it
-    # only goes once the last snapshot of this VM is gone.
-    base_name = f"{namespace}_base"
-    siblings = [path for path in mapper.glob(f"{namespace}_*") if path.name != base_name and path.is_block_device()]
-    if not siblings and (mapper / base_name).is_block_device():
-        await run_in_subprocess(["dmsetup", "remove", "--retry", base_name])
-        logger.info("Removed device-mapper base %s", base_name)
+    # only goes once the last snapshot of this VM is gone, which is the
+    # question remove_base_device answers.
+    await remove_base_device(namespace)
 
 
 async def remove_base_device(namespace: str) -> None:
     """Remove ``<namespace>_base`` when no snapshot of this VM is left.
 
-    ``create_devmapper`` builds the base device before the snapshot stacked on
-    it, so a create that died between the two leaves a base device with
-    nothing above it. ``remove_devmapper`` removes the base as the last step
-    of removing a snapshot, which is exactly the step that never runs in that
-    case, and the base holds the parent image's device, and through it the
-    runtime cache entry, for good (``cache.parent_device_is_free`` sees a
-    holder and keeps the image).
+    The last step of removing a snapshot, and the whole of the recovery for a
+    base with nothing above it: ``create_devmapper`` builds the base device
+    before the snapshot stacked on it, so a create that died between the two
+    leaves one behind, and that step never runs. Until it does the base holds
+    the parent image's device, and through it the runtime cache entry, for
+    good (``cache.parent_device_is_free`` sees a holder and keeps the image).
     """
     if not is_vm_namespace(namespace):
         logger.error("Refusing to remove an implausible device-mapper base: %r", namespace)
         return
     mapper = Path(DEVICE_MAPPER_DIRECTORY)
     base_name = f"{namespace}_base"
-    siblings = [path for path in mapper.glob(f"{namespace}_*") if path.name != base_name and path.is_block_device()]
-    if siblings:
+    snapshots = [path for path in mapper.glob(f"{namespace}_*") if path.name != base_name and path.is_block_device()]
+    if snapshots:
         return
     if (mapper / base_name).is_block_device():
         await run_in_subprocess(["dmsetup", "remove", "--retry", base_name])
-        logger.info("Removed the orphan device-mapper base %s", base_name)
+        logger.info("Removed the device-mapper base %s: no snapshot of this VM is left", base_name)
 
 
 async def get_existing_file(ref: str) -> Path:

--- a/src/aleph/vm/storage_pools.py
+++ b/src/aleph/vm/storage_pools.py
@@ -494,6 +494,18 @@ def iter_namespace_dirs(namespace: str | None = None) -> Iterator[Path]:
                 yield entry
 
 
+def has_namespace_dirs(namespace: str) -> bool:
+    """Whether any pool still holds a directory for this VM.
+
+    False when the namespace's directories vanished between being listed and
+    being acted on. Passes can overlap (a GONE retire fires one while the
+    periodic pass runs, and the room maker evicts from the create path), so
+    losing that race is normal: it is not an error, and it is not space the
+    losing pass may claim to have freed.
+    """
+    return any(True for _ in iter_namespace_dirs(namespace))
+
+
 def pools_disk_usage() -> tuple[int, int]:
     """(total, free) bytes across pools, filesystems deduplicated by st_dev
     so two pool directories on one filesystem count once."""

--- a/tests/supervisor/test_cache_eviction.py
+++ b/tests/supervisor/test_cache_eviction.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
 import time
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
@@ -29,6 +30,11 @@ from aleph.vm.storage import DownloadReservation
 
 NOW = datetime(2026, 8, 24, tzinfo=timezone.utc)
 OLDER = datetime(2026, 8, 23, tzinfo=timezone.utc)
+
+
+def _unreadable_disk(path):
+    """``shutil.disk_usage`` on a cache root whose filesystem will not answer."""
+    raise OSError(13, "Permission denied", str(path))
 
 
 @pytest.fixture(autouse=True)
@@ -689,34 +695,45 @@ def test_two_unknown_length_downloads_are_both_charged_the_capped_figure(pools, 
         admit_download(registry, pools["runtime"] / "c.part", None, 4096)
 
 
-def test_an_unreadable_cache_disk_still_charges_only_the_reserve(pools, monkeypatch, caplog):
-    """The fallback must not be the bug it replaces: a disk whose total cannot
-    be read leaves an absolute reserve holding, never the whole budget."""
-    monkeypatch.setattr(settings, "UNKNOWN_LENGTH_RESERVE", "4096")
+def test_an_unreadable_cache_disk_admits_a_measured_download(pools, monkeypatch, caplog):
+    """The disk is read once, and a read that fails ends the admission there:
+    the download goes through on its own figure, and nothing on the root is
+    evicted for a budget nobody could compute."""
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    old = _entry(pools["runtime"], "old", size=4096, age=1000)
+    part = pools["runtime"] / "new.part"
 
-    def unreadable(path):
-        raise OSError(13, "Permission denied")
-
-    monkeypatch.setattr(cache_module.shutil, "disk_usage", unreadable)
+    monkeypatch.setattr(cache_module.shutil, "disk_usage", _unreadable_disk)
 
     with caplog.at_level(logging.WARNING):
-        charge = cache_module._unknown_length_charge(pools["runtime"], 1024**3, None)
+        admit_download(registry, part, 4096)
 
-    assert charge == 4096
+    assert old.exists()
+    assert storage_module.reserved_downloads() == {part: DownloadReservation(4096, measured=True)}
     assert "not accessible" in caplog.text
 
 
-def test_an_unreadable_cache_disk_holds_nothing_for_a_percentage_reserve(pools, monkeypatch):
-    """A percentage of a disk nobody could measure resolves to nothing, which
-    is still better than holding the root against every other download."""
+def test_an_unreadable_cache_disk_holds_nothing_for_an_unmeasured_download(pools, monkeypatch):
+    """The whole budget must not come back through the back door: the budget
+    is a share of a disk size nobody could read, so there is no figure to
+    hold, and one chunked response does not get the root to itself."""
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+
+    monkeypatch.setattr(cache_module.shutil, "disk_usage", _unreadable_disk)
+
+    admit_download(registry, pools["runtime"] / "new.part", None, 100 * 1024**3)
+
+    assert storage_module.reserved_downloads() == {}
+
+
+def test_the_reserve_is_a_share_of_the_total_the_caller_read(pools, monkeypatch):
+    """A percentage reserve is resolved against the disk size the admission
+    already measured, not against a reading of its own."""
     monkeypatch.setattr(settings, "UNKNOWN_LENGTH_RESERVE", "10%")
 
-    def unreadable(path):
-        raise OSError(13, "Permission denied")
-
-    monkeypatch.setattr(cache_module.shutil, "disk_usage", unreadable)
-
-    assert cache_module._unknown_length_charge(pools["runtime"], 1024**3, None) == 0
+    assert cache_module._unknown_length_charge(80_000, 1024**3, None) == 8000
 
 
 def test_a_measured_download_still_evicts_to_make_room(pools, monkeypatch):
@@ -730,6 +747,34 @@ def test_a_measured_download_still_evicts_to_make_room(pools, monkeypatch):
     admit_download(registry, pools["code"] / "new.part", 8000)
 
     assert not old.exists()
+
+
+def test_the_cache_disk_is_read_once_per_admission(pools, monkeypatch):
+    """Both the budget and the reserve held for an unmeasured body are shares
+    of the cache disk's size. Reading it twice gave the second read its own
+    failure path, which could not be reached (the first had just succeeded)
+    and held the entire budget when it was."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "50%")
+    monkeypatch.setattr(settings, "UNKNOWN_LENGTH_RESERVE", "10%")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    root = pools["runtime"]
+    reads: list[str] = []
+    real_usage = shutil.disk_usage
+
+    def counting_usage(path):
+        reads.append(str(path))
+        return real_usage(path)
+
+    monkeypatch.setattr(cache_module.shutil, "disk_usage", counting_usage)
+
+    admit_download(registry, root / "chunked.part", None, 100 * 1024**3)
+
+    assert reads.count(str(root)) == 1
+    total = real_usage(root).total
+    assert storage_module.reserved_downloads()[root / "chunked.part"] == DownloadReservation(
+        total // 10, measured=False
+    )
 
 
 def test_a_refused_download_evicts_nothing(pools, monkeypatch):

--- a/tests/supervisor/test_cache_eviction.py
+++ b/tests/supervisor/test_cache_eviction.py
@@ -732,6 +732,24 @@ def test_a_measured_download_still_evicts_to_make_room(pools, monkeypatch):
     assert not old.exists()
 
 
+def test_a_refused_download_evicts_nothing(pools, monkeypatch):
+    """Admission evicted against one measure and refused against another: it
+    stopped evicting once the bytes really on disk fitted, then refused on a
+    total that counts the room an unmeasured download is holding. The entry
+    was gone and the download failed anyway, which is the worst of both."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    monkeypatch.setattr(settings, "UNKNOWN_LENGTH_RESERVE", "8192")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    old = _entry(pools["code"], "old", size=8192, age=1000)
+    admit_download(registry, pools["code"] / "chunked.part", None, 100 * 1024**3)
+
+    with pytest.raises(InsufficientResourcesError):
+        admit_download(registry, pools["code"] / "measured.part", 4096)
+
+    assert old.exists()
+
+
 def test_a_measured_download_fits_beside_an_unknown_length_one(pools, monkeypatch):
     """The whole budget used to go to the chunked response, so the next
     measured download found the root at its cap: it evicted every unreferenced

--- a/tests/supervisor/test_cache_eviction.py
+++ b/tests/supervisor/test_cache_eviction.py
@@ -749,6 +749,33 @@ def test_a_measured_download_still_evicts_to_make_room(pools, monkeypatch):
     assert not old.exists()
 
 
+def test_a_body_bigger_than_its_reserve_is_recovered_by_the_next_pass(pools, monkeypatch):
+    """The reserve is a guess, so a chunked body can outgrow it. The root is
+    over its budget while the extra bytes land, and nothing may unlink the
+    .part under the download writing it; what the pass does instead is count
+    those bytes (they are a measurement, unlike the reserve) and evict least
+    recently used for them, and once the download finishes its own entry is
+    evictable like any other."""
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "8192")
+    monkeypatch.setattr(settings, "UNKNOWN_LENGTH_RESERVE", "4096")
+    registry = AgentVmRegistry()
+    cache_module.record_live_snapshot(set())
+    root = pools["code"]
+    old = _entry(root, "old", size=4096, age=1000)
+    chunked = root / "chunked.part"
+
+    admit_download(registry, chunked, None, 100 * 1024**3)
+    chunked.write_bytes(b"x" * 8192)
+
+    assert cache_module._root_usage(root, cache_entries(root)) > 8192
+    assert evict_caches(registry) == [old]
+
+    storage_module.release_download(chunked)
+    chunked.rename(root / "chunked")
+
+    assert cache_module._root_usage(root, cache_entries(root)) <= 8192
+
+
 def test_the_cache_disk_is_read_once_per_admission(pools, monkeypatch):
     """Both the budget and the reserve held for an unmeasured body are shares
     of the cache disk's size. Reading it twice gave the second read its own

--- a/tests/supervisor/test_cache_eviction.py
+++ b/tests/supervisor/test_cache_eviction.py
@@ -555,7 +555,7 @@ def test_a_retained_dir_a_create_is_using_is_not_reclaimed_for_its_parent(pools,
     parent = _entry(pools["runtime"], "parent", size=4096)
     adopted = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
     mark_reclaimable(VM_HASH, "gone", ("parent",), now=NOW)
-    monkeypatch.setattr(reconciler_module, "_creating", {VM_HASH: 1})
+    monkeypatch.setattr(reconciler_module, "_creating", {VM_HASH: reconciler_module._CreateState(creates=1)})
 
     assert evict_caches(registry) == []
     assert parent.exists() and adopted.exists()

--- a/tests/supervisor/test_reclaimable.py
+++ b/tests/supervisor/test_reclaimable.py
@@ -21,6 +21,7 @@ from aleph.vm.agent.vm.reclaimable import (
     clear_marker,
     depends_on_from_content,
     directory_size_bytes,
+    file_size_bytes,
     iter_reclaimable,
     mark_reclaimable,
     read_marker,
@@ -173,6 +174,26 @@ def test_mark_reclaimable_writes_one_marker_per_pool_dir(pools):  # noqa: F811
 def test_mark_reclaimable_refuses_an_implausible_namespace(pools):  # noqa: F811, ARG001
     with pytest.raises(ValueError):
         mark_reclaimable("../etc", "gone")
+
+
+def test_file_size_counts_regular_files_and_nothing_else(pools, tmp_path):  # noqa: F811, ARG001
+    """A symlink counts 0 whatever it points at: what it points at is not
+    this directory's space, and counting it would let one link inflate every
+    figure derived from here."""
+    real = tmp_path / "rootfs.qcow2"
+    real.write_bytes(b"x" * 8192)
+    link = tmp_path / "link.qcow2"
+    link.symlink_to(real)
+    dangling = tmp_path / "dangling.qcow2"
+    dangling.symlink_to(tmp_path / "never-existed")
+    directory = tmp_path / "sub"
+    directory.mkdir()
+
+    assert file_size_bytes(real) >= 8192
+    assert file_size_bytes(link) == 0
+    assert file_size_bytes(dangling) == 0
+    assert file_size_bytes(directory) == 0
+    assert file_size_bytes(tmp_path / "not-there") == 0
 
 
 def test_directory_size_counts_only_regular_files_directly_inside(pools):  # noqa: F811

--- a/tests/supervisor/test_reclaimable.py
+++ b/tests/supervisor/test_reclaimable.py
@@ -16,7 +16,7 @@ from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
 from aleph.vm.agent.vm.reclaimable import (
     MARKER_NAME,
     ReclaimableMarker,
-    UnsupportedMarkerVersion,
+    UnsupportedMarkerVersionError,
     adopt,
     clear_marker,
     depends_on_from_content,
@@ -100,7 +100,7 @@ def test_a_marker_from_a_newer_schema_does_not_parse():
         }
     )
 
-    with pytest.raises(UnsupportedMarkerVersion, match="version 2"):
+    with pytest.raises(UnsupportedMarkerVersionError, match="version 2"):
         ReclaimableMarker.from_json(text)
 
 

--- a/tests/supervisor/test_reclaimable.py
+++ b/tests/supervisor/test_reclaimable.py
@@ -16,6 +16,7 @@ from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
 from aleph.vm.agent.vm.reclaimable import (
     MARKER_NAME,
     ReclaimableMarker,
+    UnsupportedMarkerVersion,
     adopt,
     clear_marker,
     depends_on_from_content,
@@ -67,6 +68,65 @@ def test_a_marker_written_before_the_owner_field_still_parses():
 
     assert marker.owner is None
     assert marker.reason == "orphan" and marker.size_bytes == 7
+
+
+def test_a_marker_with_an_unknown_reason_does_not_parse():
+    """The reason drives policy (an orphan marker is written exclusively, a
+    gone one carries the owner), so a value this agent never writes is not a
+    marker it may act on."""
+    text = json.dumps(
+        {
+            "version": 1,
+            "reclaimable_since": "2026-08-24T12:00:00+00:00",
+            "reason": "whatever",
+            "size_bytes": 7,
+            "depends_on": [],
+        }
+    )
+
+    with pytest.raises(ValueError, match="reason"):
+        ReclaimableMarker.from_json(text)
+
+
+def test_a_marker_from_a_newer_schema_does_not_parse():
+    text = json.dumps(
+        {
+            "version": 2,
+            "reclaimable_since": "2026-08-24T12:00:00+00:00",
+            "reason": "gone",
+            "size_bytes": 7,
+            "depends_on": [],
+        }
+    )
+
+    with pytest.raises(UnsupportedMarkerVersion, match="version 2"):
+        ReclaimableMarker.from_json(text)
+
+
+def test_a_marker_with_an_unknown_reason_is_removed_as_corrupt(pools):  # noqa: F811
+    directory = pools["pool0"] / VM_HASH
+    directory.mkdir()
+    (directory / MARKER_NAME).write_text(
+        json.dumps({"version": 1, "reclaimable_since": NOW.isoformat(), "reason": "whatever", "size_bytes": 7})
+    )
+
+    assert read_marker(directory) is None
+    assert not (directory / MARKER_NAME).exists()
+
+
+def test_a_marker_from_a_newer_schema_is_kept_rather_than_removed(pools, caplog):  # noqa: F811
+    """A version this agent does not know is not corruption: a newer agent
+    wrote it, and unlinking it would hand its directory to the orphan flow,
+    which re-marks it without the owner it carried."""
+    directory = pools["pool0"] / VM_HASH
+    directory.mkdir()
+    (directory / MARKER_NAME).write_text(
+        json.dumps({"version": 2, "reclaimable_since": NOW.isoformat(), "reason": "gone", "size_bytes": 7})
+    )
+
+    assert read_marker(directory) is None
+    assert (directory / MARKER_NAME).exists()
+    assert "does not know" in caplog.text
 
 
 def test_read_marker_is_none_without_file(pools):  # noqa: F811

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -1259,6 +1259,30 @@ async def test_a_young_directory_keeps_its_devices_without_the_in_process_guard(
 
 
 @pytest.mark.asyncio
+async def test_a_marker_write_does_not_re_age_a_directory(pools, registry, monkeypatch, tmp_path):  # noqa: F811
+    """Writing a marker into a directory bumps that directory's mtime, so a
+    VM retired minutes ago read as a create in flight and kept its
+    device-mapper devices for a whole VOLUME_CREATE_GUARD, which is the one
+    thing that stops its volumes being reclaimed. A directory carrying a
+    marker is not one a create is building, whatever its mtime says: a
+    create adopts the namespace, which clears the marker, first."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    old = volume(pools["pool0"], VM_HASH, "rootfs.btrfs")
+    stamp = time.time() - 10_000
+    os.utime(old.parent, (stamp, stamp))
+    _fake_mapper(monkeypatch, tmp_path, f"{VM_HASH}_rootfs")
+    torn: list[str] = []
+    monkeypatch.setattr(reconciler_module, "teardown_namespace_devices", AsyncMock(side_effect=torn.append))
+
+    mark_reclaimable(VM_HASH, "gone", now=NOW)
+    assert old.parent.stat().st_mtime > stamp  # the marker moved the directory
+
+    await reconcile_now(_app(registry, _supervisor()))
+
+    assert torn == [VM_HASH]
+
+
+@pytest.mark.asyncio
 async def test_no_device_is_torn_down_when_the_supervisor_cannot_be_listed(pools, registry, monkeypatch, tmp_path):  # noqa: F811
     """A VM the supervisor would have listed is live; removing its dm device
     takes its disk with it."""

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -145,14 +145,14 @@ def test_a_create_that_lands_mid_walk_keeps_its_directory(pools, registry, monke
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
     old = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
     _age(old.parent, 10_000)
-    measured = reconciler_module._dir_bytes
+    measured = reconciler_module.namespace_size_bytes
 
     def measure_then_create(namespace: str) -> int:
         size = measured(namespace)
         reconciler_module._creating[namespace] = 1
         return size
 
-    monkeypatch.setattr(reconciler_module, "_dir_bytes", measure_then_create)
+    monkeypatch.setattr(reconciler_module, "namespace_size_bytes", measure_then_create)
 
     report = reconcile_storage(registry, now=NOW)
 
@@ -1062,6 +1062,27 @@ def test_reconcile_runs_the_cache_pass(pools, registry, monkeypatch):  # noqa: F
 
     assert report.cache_evicted == [stale]
     assert not stale.exists()
+
+
+def test_a_vm_the_cache_pass_reclaims_is_counted_in_the_report(pools, registry, monkeypatch):  # noqa: F811
+    """The cache pass gives back retained volumes to free the parent images
+    they pin, which is an eviction like any other: it has to reach the pass's
+    own figures, or the log says the pass freed a few kilobytes of cache
+    entries on a run that also deleted a VM's disks."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    monkeypatch.setattr(settings, "CACHE_BUDGET", "1024")
+    _fake_disk_usage(monkeypatch, 8 * GIB)
+    parent = pools["runtime"] / "parent"
+    parent.write_bytes(b"x" * 4096)
+    retained = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
+    mark_reclaimable(VM_HASH, "gone", ("parent",), now=NOW)
+
+    report = reconcile_storage(registry, now=NOW)
+
+    assert not retained.exists()
+    assert report.cache_evicted == [parent]
+    assert report.evicted == [VM_HASH]
+    assert report.bytes_freed >= 8192
 
 
 def test_the_cache_pass_is_skipped_when_a_live_vm_has_no_record(pools, registry, monkeypatch, caplog):  # noqa: F811

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -149,7 +149,7 @@ def test_a_create_that_lands_mid_walk_keeps_its_directory(pools, registry, monke
 
     def measure_then_create(namespace: str) -> int:
         size = measured(namespace)
-        reconciler_module._creating[namespace] = 1
+        reconciler_module._creating[namespace] = reconciler_module._CreateState(creates=1)
         return size
 
     monkeypatch.setattr(reconciler_module, "namespace_size_bytes", measure_then_create)
@@ -336,6 +336,55 @@ def test_a_failed_create_leaves_the_marker_to_the_create_still_running(pools, mo
             raise RuntimeError("the inner create failed")
         assert read_marker(pools["pool0"] / VM_HASH) is None
     assert read_marker(pools["pool0"] / VM_HASH) is None
+
+
+@pytest.mark.asyncio
+async def test_the_last_of_two_overlapping_creates_restores_what_either_adopted(pools, monkeypatch):  # noqa: F811
+    """The overlap that is not nested: two creates of one hash in two tasks,
+    as a scheduler push and an operator reinstall arrive together.
+
+    The first adopted the marker and fails while the second still runs, so it
+    leaves the restore to the second, and the second adopted nothing because
+    the first had already cleared it. Unless the two share what was adopted,
+    nobody puts the marker back: the next pass then re-marks the directory as
+    an orphan with no owner and no depends_on, which is exactly the loss the
+    restore exists to prevent."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    mark_reclaimable(VM_HASH, "gone", (OTHER_HASH,), now=NOW, owner=OWNER)
+    first_adopted = asyncio.Event()
+    second_started = asyncio.Event()
+    first_finished = asyncio.Event()
+
+    async def push():
+        with creating(VM_HASH):
+            first_adopted.set()
+            await second_started.wait()
+            raise RuntimeError("the first create failed")
+
+    async def reinstall():
+        await first_adopted.wait()
+        with creating(VM_HASH):
+            second_started.set()
+            await first_finished.wait()
+            raise RuntimeError("the second create failed too")
+
+    first = asyncio.create_task(push())
+    second = asyncio.create_task(reinstall())
+    with pytest.raises(RuntimeError, match="the first create failed"):
+        await first
+    # The second create is still writing the directory, so nothing is back yet.
+    assert read_marker(pools["pool0"] / VM_HASH) is None
+    first_finished.set()
+    with pytest.raises(RuntimeError, match="the second create failed too"):
+        await second
+
+    restored = read_marker(pools["pool0"] / VM_HASH)
+    assert restored is not None
+    assert restored.owner == OWNER
+    assert restored.depends_on == (OTHER_HASH,)
+    assert restored.reclaimable_since == NOW
+    assert not is_creating(VM_HASH)
 
 
 def test_old_orphan_is_purged_under_reap(pools, registry, monkeypatch):  # noqa: F811
@@ -542,7 +591,7 @@ def test_a_hash_entering_creating_mid_pass_is_not_purged(pools, registry, monkey
     def orphan_then_claim(directory, is_live, now, guard, *, dry_run):
         result = real_is_orphan(directory, is_live, now, guard, dry_run=dry_run)
         if result:
-            reconciler_module._creating[directory.name] = 1
+            reconciler_module._creating[directory.name] = reconciler_module._CreateState(creates=1)
         return result
 
     monkeypatch.setattr(reconciler_module, "_is_orphan", orphan_then_claim)
@@ -1344,7 +1393,7 @@ def test_make_room_never_evicts_a_directory_a_create_is_using(pools, monkeypatch
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
     retained = volume(pools["pool0"], VM_HASH, "rootfs.qcow2", size=8192)
     mark_reclaimable(VM_HASH, "gone", now=NOW - timedelta(days=2))
-    monkeypatch.setattr(reconciler_module, "_creating", {VM_HASH: 1})
+    monkeypatch.setattr(reconciler_module, "_creating", {VM_HASH: reconciler_module._CreateState(creates=1)})
     _fake_disk_usage(monkeypatch, 0)
 
     freed = make_room(get_pools()[0], needed_bytes=8192)

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -320,6 +320,24 @@ def test_a_failed_inner_create_does_not_re_mark_a_directory_the_outer_holds(pool
         assert read_marker(pools["pool0"] / VM_HASH) is None
 
 
+def test_a_failed_create_leaves_the_marker_to_the_create_still_running(pools, monkeypatch):  # noqa: F811
+    """The same overlap, with something for the inner create to adopt: a GONE
+    retire of this hash lands while the outer create runs. The inner failure
+    must still not put the marker back, because the directory now belongs to
+    the create that is still writing it, and a marker on it counts its disks
+    as reclaimable capacity the node would sell twice. The create that holds
+    it restores what it adopted if it fails in its turn."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
+    volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+
+    with creating(VM_HASH):
+        mark_reclaimable(VM_HASH, "gone", now=NOW, owner=OWNER)
+        with pytest.raises(RuntimeError), creating(VM_HASH):
+            raise RuntimeError("the inner create failed")
+        assert read_marker(pools["pool0"] / VM_HASH) is None
+    assert read_marker(pools["pool0"] / VM_HASH) is None
+
+
 def test_old_orphan_is_purged_under_reap(pools, registry, monkeypatch):  # noqa: F811
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
     old = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")

--- a/tests/supervisor/test_reconciler.py
+++ b/tests/supervisor/test_reconciler.py
@@ -137,6 +137,30 @@ def test_in_flight_create_is_never_an_orphan(pools, registry, monkeypatch):  # n
     assert not is_creating(VM_HASH)
 
 
+def test_a_create_that_lands_mid_walk_keeps_its_directory(pools, registry, monkeypatch):  # noqa: F811
+    """The pass runs in a worker thread while creates land on the event loop,
+    so the liveness question has to be asked again immediately before the
+    purge and not only when the directory was judged an orphan: the walk
+    that measures it takes as long as the directories are big."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    old = volume(pools["pool0"], VM_HASH, "rootfs.qcow2")
+    _age(old.parent, 10_000)
+    measured = reconciler_module._dir_bytes
+
+    def measure_then_create(namespace: str) -> int:
+        size = measured(namespace)
+        reconciler_module._creating[namespace] = 1
+        return size
+
+    monkeypatch.setattr(reconciler_module, "_dir_bytes", measure_then_create)
+
+    report = reconcile_storage(registry, now=NOW)
+
+    assert old.exists()
+    assert report.purged_orphans == []
+    reconciler_module._creating.clear()
+
+
 def test_creating_adopts_retained_dirs(pools, monkeypatch):  # noqa: F811
     monkeypatch.setattr(settings, "VOLUME_RETENTION", "keep")
     volume(pools["pool0"], VM_HASH, "rootfs.qcow2")

--- a/tests/supervisor/test_retire.py
+++ b/tests/supervisor/test_retire.py
@@ -12,6 +12,7 @@ from aleph_message.models import InstanceContent, ItemHash
 from reclaim_fixtures import OTHER_HASH, VM_HASH, pools, volume  # noqa: F401
 
 import aleph.vm.agent.vm.cache as cache_module
+import aleph.vm.agent.vm.reconciler as reconciler_module
 import aleph.vm.agent.vm.retire as retire_module
 import aleph.vm.storage as storage_module
 from aleph.vm.agent.vm.cache import admit_download
@@ -380,6 +381,32 @@ async def test_a_record_dropping_retire_drops_the_vm_from_the_live_snapshot(env,
     await retire_vm(VM_HASH, reason, supervisor=env["supervisor"], registry=env["registry"])
 
     assert cache_module.live_snapshot() == frozenset({OTHER_HASH})
+
+
+@pytest.mark.asyncio
+async def test_a_record_dropping_retire_drops_the_vm_from_the_last_listing(env, monkeypatch):
+    """The other half of the same staleness: the room maker runs on the
+    placement path and cannot ask the supervisor, so it protects whatever the
+    last pass heard it was running. A hash left there protects a VM that is
+    gone, and the create that made room could not have it."""
+    monkeypatch.setattr(settings, "VOLUME_RETENTION", "reap")
+    monkeypatch.setattr(reconciler_module, "_last_supervisor_hashes", {VM_HASH, OTHER_HASH})
+
+    await retire_vm(VM_HASH, RetireReason.GONE, supervisor=env["supervisor"], registry=env["registry"])
+
+    assert reconciler_module._last_supervisor_hashes == {OTHER_HASH}
+    assert VM_HASH not in reconciler_module.known_live_hashes(env["registry"])
+
+
+@pytest.mark.asyncio
+async def test_a_recreate_keeps_the_vm_in_the_last_listing(env, monkeypatch):
+    """RECREATE means the same VM comes straight back, so nothing about it is
+    stale."""
+    monkeypatch.setattr(reconciler_module, "_last_supervisor_hashes", {VM_HASH})
+
+    await retire_vm(VM_HASH, RetireReason.RECREATE, supervisor=env["supervisor"], registry=env["registry"])
+
+    assert reconciler_module._last_supervisor_hashes == {VM_HASH}
 
 
 @pytest.mark.asyncio

--- a/tests/supervisor/test_retire.py
+++ b/tests/supervisor/test_retire.py
@@ -342,6 +342,7 @@ async def test_device_teardown_of_an_implausible_hash_is_skipped_not_raised(mock
     assert "skipped" in caplog.text
 
 
+@pytest.mark.asyncio
 async def test_a_retire_without_a_record_asks_device_mapper_instead(env, monkeypatch, mocker):
     """FAILED_CREATE fires before the registry commit and a GONE can name a VM
     the registry never knew: there is no message to read the volumes from, and

--- a/tests/supervisor/test_vm_purge.py
+++ b/tests/supervisor/test_vm_purge.py
@@ -174,12 +174,14 @@ def test_purge_storage_refuses_an_operator_directory_before_touching_it(pools, n
 @pytest.mark.parametrize("namespace", ["cafe" * 16, "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco"])
 def test_purge_storage_accepts_every_shape_of_item_hash(pools, namespace):
     """A storage hash and an IPFS CID are both VM namespaces."""
-    _volume(pools["pool0"], namespace, "rootfs.qcow2")
+    rootfs = _volume(pools["pool0"], namespace, "rootfs.qcow2")
 
-    result = purge_vm_storage(namespace)
+    purge_vm_storage(namespace)
 
-    assert result.deleted == 1
-    assert result.kept == ()
+    # What the purge left on disk, not what it reported: this test is about
+    # which names the guard accepts, and asserting on the return value ties it
+    # to that value's shape as well.
+    assert not rootfs.exists()
     assert not (pools["pool0"] / namespace).exists()
 
 


### PR DESCRIPTION
## Summary

The code-quality pass over the agent's storage modules for 2.1: the duplicated
helpers, the untyped and unvalidated boundaries, the stale comments, and the
small correctness items the S3, S4 and S5 reviews left behind. Twenty commits,
one per item, each with its own tests.

Six of them are behaviour fixes rather than refactors, and they are the reason
this is not a pure cleanup:

- The cache pass purges retained VM directories to free the parent images they
  pin and reported none of it, so a pass that deleted a VM's disks logged
  `evicted=0, freed=<a few kilobytes of cache entries>`, and so did the startup
  preview an operator reads before an upgrade's first pass.
- Writing the reclaimable marker moves the directory's mtime, so every VM
  retired under `keep` looked like a create in flight for the next
  `VOLUME_CREATE_GUARD` and kept its device-mapper devices, which are precisely
  what makes the purge refuse the directory: the marker delayed the reclamation
  it announced.
- Download admission evicted against one measure (bytes really on disk) and
  refused against another (those plus the room an unmeasured download is
  holding), so a measured download could evict every unreferenced entry on a
  root and still be refused. Cache lost, create failed.
- A retire cleared the live snapshot the admission hook reads but not the last
  supervisor listing the room maker reads, so a placement could refuse to take
  back the disks of a VM that is gone until the next pass, up to an hour later.
- A create that failed while another create for the same hash was still running
  restored a reclaimable marker onto the directory that create was building,
  and a marker on a live directory is counted as reclaimable capacity the node
  offers to someone else.
- `_reconcile_namespace` re-asked the liveness question on the line after
  `_is_orphan` had answered it, and then walked every pool measuring the VM
  before purging it: the repeat could catch nothing, and the window that does
  exist (the pass runs in a worker thread, creates enter `creating()` on the
  event loop) spanned the measurement and the purge unguarded.

Stacked on #1219.

## Changes

- `agent/vm/reconciler.py`: `SideDirNaming` enum replaces the `"exact"` /
  `"prefix"` mode strings threaded through three functions and owns the
  name-to-hash conversion that was open-coded twice; the last liveness check
  moves to immediately before the mark or the purge; `_within_create_guard`
  skips a directory that carries a marker; `forget_supervisor_hash`;
  `creating()` leaves the marker to a create still running; the cache pass's
  reclaims are folded into the report; `_dir_bytes`, `_still_on_disk`,
  `_plausible` and `_reclaimable_on` give way to shared implementations;
  `teardown_orphan_devices` and `release_cache_devices` lose their underscore.
- `agent/vm/reclaimable.py`: `from_json` validates the reason and the schema
  version (an unknown version is kept and reported, not removed as corrupt);
  `file_size_bytes` uses one lstat and `S_ISREG` instead of three stats;
  `reclaimable_entries` is the single listing (and eviction order) the cache
  pass and the retention budget share; `namespace_size_bytes` moves here.
- `agent/vm/cache.py`: `admit_download` decides the refusal before evicting and
  reads the cache disk once; `_unknown_length_charge` loses a dead OSError
  branch that held the whole budget; `_iter_loop_backings` is the one sysfs
  walk; `_record_refs` is typed; the reclaim ledger reaches the caller.
- `storage.py`: `remove_devmapper` calls `remove_base_device` for its last step
  rather than repeating the sibling scan that function is.
- `storage_pools.py`: `has_namespace_dirs`, the one answer to whether a VM
  still has directories.
- `agent/vm/retire.py`: drops the retired hash from the last supervisor
  listing; the teardown guard's comment no longer claims to be unreachable
  (the reinstall path calls that function directly).
- `docs/architecture/storage.md`: the transient overshoot when a chunked body
  outgrows its reserve, and the renamed helpers.

`agent/storage_cli.py` is owned by another change in flight and is untouched.
The four reconciler names it imports (`_plausible`, `_still_on_disk`,
`_teardown_orphan_devices`, `_release_cache_devices`) are kept as aliases at
the bottom of the module; they go when that module is pointed at the real
names.

## Test plan

- `tests/supervisor/test_reclaimable.py`: an unknown marker reason does not
  parse and is removed as corrupt, a marker from a newer schema does not parse
  and is kept; a symlink, a dangling symlink, a directory and a missing file
  all measure 0.
- `tests/supervisor/test_reconciler.py`: a create landing during the
  measurement keeps its directory; a VM the cache pass reclaims reaches
  `report.evicted` and `bytes_freed`; a marker write does not re-age a
  directory for the device teardown; a failed create leaves the marker to the
  create still running.
- `tests/supervisor/test_cache_eviction.py`: a refused download evicts nothing;
  the cache disk is read once per admission and the reserve comes from that
  figure; a body bigger than its reserve is recovered by the next pass.
- `tests/supervisor/test_retire.py`: a record-dropping retire drops the hash
  from the last supervisor listing and a RECREATE does not; the record-less
  teardown test now has its asyncio marker and actually runs (it was silently
  skipped).
- `pytest tests/supervisor`: 1226 passed, 1 failed. The failure is
  `test_log.py::test_make_logs_queue` (journald stub), identical to the base
  commit's run (1211 passed, 1 skipped, same single failure). Fifteen tests
  added, and the base's one skip is gone.
- `ruff format --diff`, `isort --check-only --profile black`, `mypy src/aleph/vm/`
  and `mypy src/aleph/vm/ tests/`: all clean. No Rust touched.

## Not done, and why

`get_existing_file` bounding immutable volumes at `MAX_RUNTIME_ARCHIVE_SIZE`
"instead of the message's `size_mib`" is not implementable as described:
`aleph_message`'s `ImmutableVolume` has no size field (only `ref` and
`use_latest`), and neither does a V-PROGRAM's verified volume. Every other
caller of that function (runtime manifests, bundle tarballs, workload images
and hash trees, TEE firmware) fetches something no message states a size for
either. The cap stays, and its comment already explains why it is the runtime
one.

## Review follow-up (rebased onto dev-2.1 at 973b8fd7)
- `reconciler.py`: two overlapping creates of one hash could lose the markers between them. Only the first create in finds a marker to adopt, so when it failed with a second still running it left the restore to that one, which had adopted nothing. What was adopted is now held per namespace beside the count of creates in flight: nothing goes back while any create runs, a create that returns normally drops the markers for good, and the last create out with none committed restores whatever any of them adopted. The docstring and `docs/architecture/storage.md` say so, and a test drives the two-task overlap in the order that used to lose the marker.
- `cache.py`: `_evictable_bytes` is only computed when the root is over its budget, so an admission on a healthy cache no longer walks every pool's markers and stats sysfs per runtime entry on the event loop.
- `reclaimable.py`: `UnsupportedMarkerVersion` becomes `UnsupportedMarkerVersionError` (ruff N818), with its two references.
- Rebase note: the merged base moved under `agent/vm/cache.py`; this branch's own commit that threads the cache disk total down from `admit_download` removes the OSError fallback that #1211 had just reworded, so #1211's two fallback tests were adapted to the admission level, where the unreadable-disk path now lives.
- Checks on the rebased branch: `ruff format --diff`, `isort --check-only --profile black`, `mypy src/aleph/vm/ tests/` clean. Test suites are left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZyMqLgxxVfeDwiNy34sfM

