### PR TITLE
fix(vprogram): measure runtimes for EPYC-Genoa first, EPYC-v4 as fallback

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -267,7 +267,8 @@
 
       # Parameterized SEV-SNP launch measurement builder.
       # vcpus:            number of vCPUs (affects the launch measurement)
-      # vcpuType:         QEMU CPU model ("EPYC-v4" for Genoa, "EPYC-v3" for Milan)
+      # vcpuType:         QEMU CPU model. Note "EPYC-v4" is QEMU's Naples model
+      #   (family 23), not Genoa; Genoa is "EPYC-Genoa" (family 25, model 17).
       # workloadRoothash: when null (default), the cmdline is the
       #   platform-only form `...roothash=<platform>` (workload-less parity,
       #   what test_vm_snp and the baked `measurement` below expect). When

--- a/src/aleph/vm/vprogram/bundle.py
+++ b/src/aleph/vm/vprogram/bundle.py
@@ -204,7 +204,15 @@ CMDLINE_TEMPLATE_EXEC_V1 = (
     " workload_roothash={workload_roothash}"
     " verified_volumes={verified_volumes}"
 )
-DEFAULT_CPU_MODELS = ["EPYC-v4"]
+# QEMU CPU models the published runtimes are measured for, in preference
+# order: the CRN launches the first one its QEMU can run. Despite the name,
+# "EPYC-v4" is QEMU's Naples model (family 23, model 1): no AVX-512, so
+# vector-heavy workloads such as llama.cpp fall back to AVX2 and run several
+# times slower than on the host silicon. "EPYC-Genoa" (family 25, model 17)
+# exposes AVX-512 and is what every SEV-SNP CRN on the network advertises;
+# "EPYC-v4" stays as the fallback so a Milan or Rome host is never stranded.
+# Each entry costs one client-side measurement per launch; keep the list short.
+DEFAULT_CPU_MODELS = ["EPYC-Genoa", "EPYC-v4"]
 DEFAULT_ATTESTATION = [
     AttestationProtocol(protocol="aleph.ra-tls", version="1", transport=AttestationTransport(type="tcp", port=8443))
 ]

--- a/tests/vprogram/test_bundle.py
+++ b/tests/vprogram/test_bundle.py
@@ -138,7 +138,8 @@ def test_make_manifest_from_bundle_info(image_dir: Path, tmp_path: Path) -> None
     assert manifest.boot.platform_roothash == info.platform_roothash
     expected_cmdline = "console=ttyS0 root=/dev/mapper/verity-root ro roothash={platform_roothash}"
     assert manifest.boot.cmdline_template == expected_cmdline
-    assert manifest.boot.cpu_models == ["EPYC-v4"]
+    # Genoa first (AVX-512), Naples-era EPYC-v4 as the fallback for older hosts.
+    assert manifest.boot.cpu_models == ["EPYC-Genoa", "EPYC-v4"]
     assert manifest.attestation[0].protocol == "aleph.ra-tls"
     assert manifest.attestation[0].transport.port == 8443
     assert manifest.workload.contract == "aleph.builtin/1"


### PR DESCRIPTION
## Problem

A V-PROGRAM user reported llama.cpp running at 4.2 tok/s on a V-PROGRAM against 19.4 tok/s on a legacy confidential instance, same model (Hermes-3-8B Q5_K_M), same flags, same 16 vCPU. The guest reports `AMD EPYC-v4 Processor` with no AVX-512 flags.

QEMU's `EPYC-v4` is the **Naples** model (family 23, model 1), despite the name. Genoa is `EPYC-Genoa` (family 25, model 17). Verified with `query-cpu-model-expansion` on QEMU 10.2.1:

| model | family | model | avx512f |
|---|---|---|---|
| EPYC-v4 | 23 | 1 | no |
| EPYC-Genoa | 25 | 17 | yes |

The legacy confidential-instance path launches with `-cpu host`, which is why that side sees the full feature set. The SNP path pins the model from the runtime manifest, and every published manifest (exec-1.1, compose-1.1, snp-1.0) lists `["EPYC-v4"]` from `DEFAULT_CPU_MODELS`. The flake comment describing EPYC-v4 as "Genoa" is what let this through.

## Change

`DEFAULT_CPU_MODELS = ["EPYC-Genoa", "EPYC-v4"]`, Genoa first. #1145 already made the launch model message-driven: the agent launches the first listed model its QEMU supports, and the scheduler places a V-PROGRAM on any node matching at least one measurement. So Genoa-capable hosts get AVX-512 and older hosts fall back to EPYC-v4; nobody is stranded. All seven SEV-SNP CRNs live on the network (2.0.1 / 2.0.2, both contain #1145) advertise `EPYC-Genoa`.

`EPYC-Genoa` and `EPYC-Genoa-v2` share family/model/stepping, so the alias resolving to a different version per QEMU release does not move the launch measurement. The aleph-rs CLI (`sev` crate) and the nix `sev-snp-measure` both already accept `EPYC-Genoa`.

Also corrects the flake comment and pins the new list in the bundle test.

## Rollout

The republish is manifest-only: bundle contents do not depend on the CPU model, and clients compute one measurement per listed model at launch. New exec-1.2 / compose-1.2 / snp-1.1 manifests pointing at the existing bundle refs, then repoint the vm-images aggregate (keeping the old entries for running VMs). Cost: one extra client-side measurement per launch.

## Tests

`tests/vprogram/`, `test_vcpu_select.py`, `test_vprogram_launch.py`, `test_snp_instance_launch.py`: 134 passed locally. `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
