### PR TITLE
feat(agent): attach as many confidential GPUs as the V-PROGRAM names

### DIFF
--- a/docs/operators/nvidia-cc.md
+++ b/docs/operators/nvidia-cc.md
@@ -140,10 +140,15 @@ If `nvidia_cc` is absent from `/about/capability` while
   plain `gpu_device_id` shortage (`resolve_confidential_gpus`,
   `src/aleph/vm/agent/capacity.py`), so the log and the scheduler can tell
   a confidential-GPU shortage from an ordinary one.
-- **`VmSetupError ... asks for N GPUs; this CRN attaches one confidential
-  GPU per VM`.** The schema allows up to eight cards, but only single-GPU
-  passthrough is validated on the RTX PRO 6000 Blackwell Server Edition.
-  The scheduler should not have placed a multi-GPU V-PROGRAM here.
+- **A multi-card V-PROGRAM boots but the driver refuses one or more
+  cards.** The CRN attaches as many CC-mode cards as the message's `count`
+  names (up to the schema's eight), and every stage is per card. What is
+  not per card is NVIDIA's validation: multi-GPU confidential computing is
+  validated on HGX B200/B300 with driver R590 or newer over encrypted
+  NVLink, Hopper is one card per VM, and the RTX PRO 6000 Blackwell Server
+  Edition lists it as not yet validated. The guest's `swiotlb` reservation
+  is also sized per VM, not per card. Until a multi-card host has run the
+  hardware pass, expect a two-card V-PROGRAM to be an experiment.
 
 ## 6. What the CRN never does
 

--- a/src/aleph/vm/agent/vprogram_launch.py
+++ b/src/aleph/vm/agent/vprogram_launch.py
@@ -192,13 +192,10 @@ async def build_vprogram_spec(vm_hash: ItemHash, content: VerifiableProgramConte
 
     gpu = content.gpu
     if gpu is not None:
-        # The schema allows up to eight cards, the ceiling of NVIDIA's
-        # multi-GPU CC mode. One card per VM is the configuration this CRN
-        # validates: single-GPU passthrough on the RTX PRO 6000 Blackwell
-        # Server Edition, with no encrypted-NVLink topology to speak of.
-        if gpu.count > 1:
-            msg = f"V-PROGRAM {vm_hash} asks for {gpu.count} GPUs; this CRN attaches one confidential GPU per VM"
-            raise VmSetupError(msg)
+        # The count is the capacity resolver's business: every stage below
+        # (the daemon's per-card gate, the summed MMIO window, the guest's
+        # per-card device nodes and evidence) takes as many cards as the
+        # message names, up to the schema's ceiling of eight.
         if manifest.gpu is None:
             msg = f"V-PROGRAM {vm_hash} declares a GPU but runtime {content.runtime.ref} has no gpu block"
             raise VmSetupError(msg)

--- a/tests/supervisor/test_vprogram_launch.py
+++ b/tests/supervisor/test_vprogram_launch.py
@@ -774,14 +774,15 @@ async def test_gpu_vprogram_spec_leaves_gpus_for_run_to_resolve(tmp_path, storag
 
 
 @pytest.mark.asyncio
-async def test_gpu_vprogram_rejects_a_second_gpu(tmp_path, storage_files, snp_vcpu_types):
-    # One card per VM: the measured cmdline reserves a single swiotlb window
-    # and the guest verifies one device. The schema allows up to eight, so a
-    # count of two is a message this CRN must refuse on its own.
-    _stage_bundle(tmp_path, storage_files, gpu=GPU_BLOCK)
+async def test_gpu_vprogram_accepts_a_multi_card_count(tmp_path, storage_files, snp_vcpu_types):
+    # The count is resolved against the inventory later, by the capacity
+    # resolver; the launch checks only concern the runtime and the memory,
+    # which do not change with the number of cards.
+    _stage_bundle(tmp_path, storage_files, gpu=GPU_BLOCK, **{"boot.cmdline_template": VOLUME_SLOT_TEMPLATE})
     message = _with_gpu(load_vprogram_message(), count=2)
-    with pytest.raises(VmSetupError, match="one confidential GPU"):
-        await build_vprogram_spec(message.item_hash, message.content)
+    spec, _ = await build_vprogram_spec(message.item_hash, message.content)
+    assert spec.gpus == []  # two cards, resolved against the host in run.py
+    assert spec.memory_mib == 4096
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`build_vprogram_spec` refused any V-PROGRAM asking for more than one confidential GPU, with a comment that single-card passthrough was the configuration this CRN validates. That refusal was the only single-card assumption left in the stack, and it sat in the one place the scheduler cannot see: the capacity resolver already consumes any `count` of cards, all or nothing; the daemon's SNP gate probes every card in the spec and sizes the MMIO window from all of their BARs; the guest init creates one device node per card and nvattest collects evidence for every GPU, which the attestation route returns as an array; the message schema caps at eight, NVIDIA's own ceiling. So a two-card message was placed by a scheduler that counts cards and then refused at launch, an allocation that churns instead of failing early.

This PR lifts the cap. The count is the resolver's business.

What the cap encoded was NVIDIA's validation matrix, not a code limit: multi-GPU confidential computing is validated on HGX B200/B300 with driver R590 or newer over encrypted NVLink, Hopper is one card per VM, and the RTX PRO 6000 Blackwell Server Edition lists it as not yet validated. That is now stated in the operator runbook as a failure signature to expect, next to the note that the guest's `swiotlb` reservation is sized per VM rather than per card. Multi-card joins the hardware-unverified list for the Tier 2 pass. If a SKU turns out to refuse multi-card, the right fix is a per-VM maximum in the daemon's per-card architecture table, advertised under `tee.nvidia_cc` so the scheduler can honour it, not a blanket refusal here.

## Changes

- `src/aleph/vm/agent/vprogram_launch.py`: the `count > 1` refusal and its comment are gone; the remaining GPU checks (runtime has a gpu block, vendor and arch match, memory floor) are unchanged.
- `tests/supervisor/test_vprogram_launch.py`: `test_gpu_vprogram_rejects_a_second_gpu` becomes `test_gpu_vprogram_accepts_a_multi_card_count`, which builds a spec for a two-card message and checks that the cards are left for run.py to resolve.
- `docs/operators/nvidia-cc.md`: the `VmSetupError ... one confidential GPU per VM` failure signature is replaced by what a multi-card launch can actually run into.

The plan sketch under `docs/superpowers/plans/` still shows the old refusal; #1205 drops those documents, so it is left alone here.

## Verification

`ruff format --check` clean; `ruff check` reports the same pre-existing count on both files as dev-2.1; `tests/supervisor/test_vprogram_launch.py` and `test_snp_instance_run.py` pass locally (44 tests). No measured file changes, so the golden measurements do not move.
