### PR TITLE
feat(agent): advertise the allocation protocol version in /status/config

### DIFF
--- a/src/aleph/vm/agent/views/__init__.py
+++ b/src/aleph/vm/agent/views/__init__.py
@@ -521,6 +521,13 @@ async def status_check_version(request: web.Request):
         return web.HTTPForbidden(text=f"Outdated: version {current} < {reference}")
 
 
+# The highest /control/allocations protocol this node serves. The scheduler
+# reads it from /status/config, which it already polls, and calls
+# /v2/control/allocations from 2 up; a node without the field gets the
+# legacy call. Bump it when a newer allocation endpoint ships.
+ALLOCATIONS_API_VERSION = 2
+
+
 @cors_allow_all
 async def status_public_config(request: web.Request):
     """Expose the public fields from the configuration"""
@@ -537,6 +544,7 @@ async def status_public_config(request: web.Request):
             "DOMAIN_NAME": settings.DOMAIN_NAME,
             "node_hash": node_hash,
             "version": __version__,
+            "api": {"allocations": ALLOCATIONS_API_VERSION},
             "references": {
                 "API_SERVER": settings.API_SERVER,
                 "CHECK_FASTAPI_VM_ID": settings.CHECK_FASTAPI_VM_ID,

--- a/tests/supervisor/test_status_config.py
+++ b/tests/supervisor/test_status_config.py
@@ -1,0 +1,30 @@
+"""What /status/config tells the scheduler about this node's API."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aleph.vm.agent.supervisor import setup_webapp
+from aleph.vm.supervisor_interface.types import HostInfo
+
+
+def _app():
+    supervisor = MagicMock(
+        list_vms=AsyncMock(return_value=[]),
+        get_host_info=AsyncMock(return_value=HostInfo()),
+    )
+    return setup_webapp(supervisor=supervisor)
+
+
+@pytest.mark.asyncio
+async def test_public_config_advertises_the_allocation_protocol(aiohttp_client):
+    """The scheduler picks /v2/control/allocations from this field alone, so
+    absence means the legacy endpoint and the number is the highest version
+    this node serves."""
+    client = await aiohttp_client(_app())
+
+    response = await client.get("/status/config")
+
+    assert response.status == 200
+    body = await response.json()
+    assert body["api"] == {"allocations": 2}


### PR DESCRIPTION
Adds `"api": {"allocations": 2}` to `GET /status/config`.

The scheduler switches to `POST /v2/control/allocations` per node from this field: it already fetches `/status/config` every poll, so discovery costs no extra request and no per-node memory. A node without the block is a 2.0 node and keeps receiving the legacy call. Bump the number when a newer allocation endpoint ships.

One test through the real app.
